### PR TITLE
Fix aws permissions docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -88,7 +88,10 @@ Here's the full list of AWS permissions the `dstack` CLI needs:
         "secretsmanager:TagResource",
         "secretsmanager:DeleteSecret"
       ],
-      "Resource": "arn:*:secretsmanager:*:*:secret:/dstack/{bucket_name}/secrets/*"
+      "Resource": [
+        "arn:aws:secretsmanager:*:*:secret:/dstack/{bucket_name}/credentials/*",
+        "arn:aws:secretsmanager:*:*:secret:/dstack/{bucket_name}/secrets/*"
+      ]
     },
     {
       "Effect": "Allow",

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -85,7 +85,8 @@ Here's the full list of AWS permissions the `dstack` CLI needs:
         "secretsmanager:GetSecretValue",
         "secretsmanager:CreateSecret",
         "secretsmanager:PutResourcePolicy",
-        "secretsmanager:TagResource"
+        "secretsmanager:TagResource",
+        "secretsmanager:DeleteSecret"
       ],
       "Resource": "arn:*:secretsmanager:*:*:secret:/dstack/{bucket_name}/secrets/*"
     },

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -93,6 +93,7 @@ Here's the full list of AWS permissions the `dstack` CLI needs:
       "Action": [
         "ec2:DescribeInstanceTypes",
         "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSubnets",
         "ec2:DescribeImages",
         "ec2:DescribeInstances",
         "ec2:DescribeSpotInstanceRequests"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -160,7 +160,10 @@ Here's the full list of AWS permissions the `dstack` CLI needs:
         "iam:CreateInstanceProfile",
         "iam:AddRoleToInstanceProfile"
       ],
-      "Resource": "arn:aws:iam::*:role/dstack_role_{bucket_name_under_score}*"
+      "Resource": [
+        "arn:aws:iam::*:instance-profile/dstack_role_{bucket_name_under_score}*",
+        "arn:aws:iam::*:role/dstack_role_{bucket_name_under_score}*"
+      ]
     }
   ]
 }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -110,30 +110,12 @@ Here's the full list of AWS permissions the `dstack` CLI needs:
         "ec2:DescribeSubnets",
         "ec2:DescribeImages",
         "ec2:DescribeInstances",
-        "ec2:DescribeSpotInstanceRequests"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
+        "ec2:DescribeSpotInstanceRequests",
+        "ec2:RunInstances",
+        "ec2:CreateTags",
         "ec2:CreateSecurityGroup",
         "ec2:AuthorizeSecurityGroupIngress",
         "ec2:AuthorizeSecurityGroupEgress"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:RunInstances"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:CreateTags"
       ],
       "Resource": "*"
     },

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,7 +48,18 @@ Here's the full list of AWS permissions the `dstack` CLI needs:
   "Statement": [
     {
       "Effect": "Allow",
-      "Action": "*",
+      "Action": [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:GetLifecycleConfiguration",
+          "s3:PutLifecycleConfiguration",
+          "s3:PutObjectTagging",
+          "s3:GetObjectTagging",
+          "s3:DeleteObjectTagging",
+          "s3:GetBucketAcl"
+      ],
       "Resources": [
         "s3://{bucket_name}",
         "s3://{bucket_name}*"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -142,14 +142,14 @@ Here's the full list of AWS permissions the `dstack` CLI needs:
         "iam:CreateRole",
         "iam:AttachRolePolicy"
       ],
-      "Resource": "arn:aws:iam::*:role/dstack_role_{bucket_name}*"
+      "Resource": "arn:aws:iam::*:role/dstack_role_{bucket_name_under_score}*"
     },
     {
       "Effect": "Allow",
       "Action": [
         "iam:CreatePolicy"
       ],
-      "Resource": "arn:aws:iam::*:role/dstack_policy_{bucket_name}*"
+      "Resource": "arn:aws:iam::*:role/dstack_policy_{bucket_name_under_score}*"
     },
     {
       "Effect": "Allow",
@@ -158,11 +158,12 @@ Here's the full list of AWS permissions the `dstack` CLI needs:
         "iam:CreateInstanceProfile",
         "iam:AddRoleToInstanceProfile"
       ],
-      "Resource": "arn:aws:iam::*:role/dstack_role_{bucket_name}*"
+      "Resource": "arn:aws:iam::*:role/dstack_role_{bucket_name_under_score}*"
     }
   ]
 }
 ```
 
 !!! info "NOTE:"
-    Replace `{bucket_name}` substring with the name of the S3 bucket configured in `~/.dstack/config.yaml`.
+    Replace `{bucket_name}` substring with the name of the S3 bucket configured in `~/.dstack/config.yaml` and replace `{bucket_name_under_score}` with the name of the name of the bucket sanitized with underscores
+    (for instance `special-dstack-bucket` becomes `special_dstack_bucket`)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -68,8 +68,16 @@ Here's the full list of AWS permissions the `dstack` CLI needs:
     {
       "Effect": "Allow",
       "Action": [
+        "logs:DescribeLogGroups"
+      ],
+      "Resource": [
+        "arn:aws:logs:*:*:log-group:*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "logs:FilterLogEvents",
-        "logs:DescribeLogGroups",
         "logs:CreateLogGroup",
         "logs:CreateLogStream"
       ],

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -84,7 +84,8 @@ Here's the full list of AWS permissions the `dstack` CLI needs:
         "secretsmanager:UpdateSecret",
         "secretsmanager:GetSecretValue",
         "secretsmanager:CreateSecret",
-        "secretsmanager:PutResourcePolicy"
+        "secretsmanager:PutResourcePolicy",
+        "secretsmanager:TagResource"
       ],
       "Resource": "arn:*:secretsmanager:*:*:secret:/dstack/{bucket_name}/secrets/*"
     },

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -140,7 +140,8 @@ Here's the full list of AWS permissions the `dstack` CLI needs:
       "Action": [
         "iam:GetRole",
         "iam:CreateRole",
-        "iam:AttachRolePolicy"
+        "iam:AttachRolePolicy",
+        "iam:TagRole"
       ],
       "Resource": "arn:aws:iam::*:role/dstack_role_{bucket_name_under_score}*"
     },

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -158,7 +158,8 @@ Here's the full list of AWS permissions the `dstack` CLI needs:
       "Action": [
         "iam:GetInstanceProfile",
         "iam:CreateInstanceProfile",
-        "iam:AddRoleToInstanceProfile"
+        "iam:AddRoleToInstanceProfile",
+        "iam:TagInstaceProfile",
       ],
       "Resource": [
         "arn:aws:iam::*:instance-profile/dstack_role_{bucket_name_under_score}*",

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -78,6 +78,7 @@ Here's the full list of AWS permissions the `dstack` CLI needs:
       "Effect": "Allow",
       "Action": [
         "logs:FilterLogEvents",
+        "logs:TagLogGroup",
         "logs:CreateLogGroup",
         "logs:CreateLogStream"
       ],

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -164,7 +164,8 @@ Here's the full list of AWS permissions the `dstack` CLI needs:
         "iam:GetInstanceProfile",
         "iam:CreateInstanceProfile",
         "iam:AddRoleToInstanceProfile",
-        "iam:TagInstaceProfile",
+        "iam:TagInstanceProfile",
+        "iam:PassRole"
       ],
       "Resource": [
         "arn:aws:iam::*:instance-profile/dstack_role_{bucket_name_under_score}*",

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -122,7 +122,7 @@ Here's the full list of AWS permissions the `dstack` CLI needs:
     {
       "Effect": "Allow",
       "Action": [
-        "ec2:CancelSpotRequests",
+        "ec2:CancelSpotInstanceRequests",
         "ec2:TerminateInstances"
       ],
       "Condition": {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -148,7 +148,8 @@ Here's the full list of AWS permissions the `dstack` CLI needs:
     {
       "Effect": "Allow",
       "Action": [
-        "iam:CreatePolicy"
+        "iam:CreatePolicy",
+        "iam:TagPolicy"
       ],
       "Resource": "arn:aws:iam::*:role/dstack_policy_{bucket_name_under_score}*"
     },


### PR DESCRIPTION
The documentation for the required AWS permissions was under specified/incorrect. This updates the documentation to correct these errors and includes the following fixes:

1. List specific actions for S3 to remove the warning in the AWS console about the S3 permissions being not specific enough. It includes the actions needed to create/read/update/delete objects in S3.
2. Adds the ec2 permission to list subnets.
3. Adds permissions to create and use the created `InstanceProfile` and `Role` also clarify the naming of the created role and instance profile and how dstack manipulates the bucket name.
4. Completes the permissions required to access the `secretsmanager` and create/update/read secrets by the user.
5. Gives the `DescribeLogGroup` action access to the wild card (`*`) resource otherwise it won't work.
6. Adds the `TagLogGroup` permissions that is required to start runs.
7. Groups the `ec2` actions that have a wildcard resource.