### PR TITLE
feat: add -w --watch argument for ps command

### DIFF
--- a/cli/dstack/cli/commands/ps/__init__.py
+++ b/cli/dstack/cli/commands/ps/__init__.py
@@ -1,10 +1,17 @@
+import time
 from argparse import Namespace
+
+from rich.live import Live
 
 from dstack.api.backend import list_backends
 from dstack.api.run import list_runs_with_merged_backends
 from dstack.cli.commands import BasicCommand
-from dstack.cli.common import print_runs
+from dstack.cli.common import generate_runs_table, print_runs
 from dstack.core.error import check_config, check_git
+
+LIVE_PROVISION_INTERVAL_SECS = 2
+
+REFRESH_RATE_PER_SEC = 3
 
 
 class PSCommand(BasicCommand):
@@ -25,8 +32,29 @@ class PSCommand(BasicCommand):
             "By default, it shows only status for unfinished runs, or the last finished.",
             action="store_true",
         )
+        self._parser.add_argument(
+            "-w",
+            "--watch",
+            help="Show live status for runs in realtime.",
+            action="store_true",
+        )
 
     @check_config
     @check_git
     def _command(self, args: Namespace):
-        print_runs(list_runs_with_merged_backends(list_backends(), args.run_name, args.all))
+        list_runs = list_runs_with_merged_backends(list_backends(), args.run_name, args.all)
+        if args.watch:
+            try:
+                with Live(
+                    generate_runs_table(list_runs), refresh_per_second=REFRESH_RATE_PER_SEC
+                ) as live:
+                    while True:
+                        time.sleep(LIVE_PROVISION_INTERVAL_SECS)
+                        list_runs = list_runs_with_merged_backends(
+                            list_backends(), args.run_name, args.all
+                        )
+                        live.update(generate_runs_table(list_runs))
+            except KeyboardInterrupt:
+                pass
+        else:
+            print_runs(list_runs)

--- a/cli/dstack/cli/common.py
+++ b/cli/dstack/cli/common.py
@@ -70,7 +70,7 @@ def ask_choice(
                 return ask_choice(title, labels, values, selected_value, show_choices)
 
 
-def print_runs(runs_with_backends: List[Tuple[RunHead, List[Backend]]]):
+def generate_runs_table(runs_with_backends: List[Tuple[RunHead, List[Backend]]]):
     table = Table(box=None)
     table.add_column("RUN", style="bold", no_wrap=True)
     table.add_column("WORKFLOW", style="grey58", max_width=16)
@@ -91,7 +91,11 @@ def print_runs(runs_with_backends: List[Tuple[RunHead, List[Backend]]]):
             _status_color(run, run.tag_name or "", False, False),
             _status_color(run, ", ".join(b.name for b in backends), False, False),
         )
+    return table
 
+
+def print_runs(runs_with_backends: List[Tuple[RunHead, List[Backend]]]):
+    table = generate_runs_table(runs_with_backends)
     console.print(table)
 
 


### PR DESCRIPTION
Fix for  #101

added `Live` inside *ps* command with continously polling the list_run and creating new table.