### PR TITLE
Execute background commands

### DIFF
--- a/docs/reference/providers/bash.md
+++ b/docs/reference/providers/bash.md
@@ -110,3 +110,20 @@ workflows:
 ```
 
 </div>
+
+### Run task in a background
+
+<div editor-title=".dstack/workflows/ping-background.yaml">
+
+```yaml
+workflows:
+  - name: ping-background
+    provider: bash
+    commands:
+      - apt update && apt -y install iputils-ping
+      - ping -c8 8.8.8.8 &
+      - echo "wait!"
+      - sleep 10
+```
+
+</div>

--- a/runner/internal/container/engine.go
+++ b/runner/internal/container/engine.go
@@ -286,8 +286,21 @@ func ShellCommands(commands []string) []string {
 	if len(commands) == 0 {
 		return []string{}
 	}
-	arg := strings.Join(commands, " && ")
-	return []string{arg}
+	var sb strings.Builder
+	for i, cmd := range commands {
+		cmd := strings.TrimSpace(cmd)
+		if i > 0 {
+			sb.WriteString(" && ")
+		}
+		if strings.HasSuffix(cmd, "&") {
+			sb.WriteString("{ ")
+			sb.WriteString(cmd)
+			sb.WriteString(" }")
+		} else {
+			sb.WriteString(cmd)
+		}
+	}
+	return []string{sb.String()}
 }
 
 func BytesToMiB(bytesCount int64) uint64 {

--- a/runner/internal/container/engine_test.go
+++ b/runner/internal/container/engine_test.go
@@ -1,9 +1,32 @@
 package container
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
-func TestShellCommands(t *testing.T) {
+func TestShellCommandsEmpty(t *testing.T) {
+	cmd := ShellCommands([]string{})
+	assert.Equal(t, 0, len(cmd))
+}
 
+func TestShellCommandsSingle(t *testing.T) {
+	cmd := "echo 123"
+	args := ShellCommands([]string{cmd})[0]
+	assert.Equal(t, cmd, args)
+}
+
+func TestShellCommandsAnd(t *testing.T) {
+	args := ShellCommands([]string{"echo 123", "whoami"})[0]
+	assert.Equal(t, "echo 123 && whoami", args)
+}
+
+func TestShellCommandsBackground(t *testing.T) {
+	args := ShellCommands([]string{"sleep 5 &", "echo 123"})[0]
+	assert.Equal(t, "{ sleep 5 & } && echo 123", args)
+}
+
+func TestShellCommandsBackgroundSpaced(t *testing.T) {
+	args := ShellCommands([]string{"sleep 5 & ", "echo 123"})[0]
+	assert.Equal(t, "{ sleep 5 & } && echo 123", args)
 }


### PR DESCRIPTION
Closes #257

* Allow background commands
  * Wraps command ending with `&` in curly brackets (`sleep 5 & && echo 123` --> `{ sleep 5 & } && echo 123`)
* Add tests for `engine.ShellCommands`