### PR TITLE
Run all traffic through SSH tunnel

### DIFF
--- a/cli/dstack/backend/aws/compute.py
+++ b/cli/dstack/backend/aws/compute.py
@@ -49,6 +49,7 @@ class AWSCompute(Compute):
             local_repo_user_name=job.local_repo_user_name,
             local_repo_user_email=job.local_repo_user_email,
             repo_address=job.repo_address,
+            ssh_key_pub=job.ssh_key_pub,
         )
 
     def terminate_instance(self, request_id: str):

--- a/cli/dstack/backend/aws/runners.py
+++ b/cli/dstack/backend/aws/runners.py
@@ -105,21 +105,12 @@ def _get_security_group_id(ec2_client: BaseClient, bucket_name: str, subnet_id: 
         security_group_id = security_group["GroupId"]
         ip_permissions = [
             {
-                "FromPort": 3000,
-                "ToPort": 4000,
+                "FromPort": 22,
+                "ToPort": 22,
                 "IpProtocol": "tcp",
                 "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
             }
         ]
-        if not version.__is_release__:
-            ip_permissions.append(
-                {
-                    "FromPort": 22,
-                    "ToPort": 22,
-                    "IpProtocol": "tcp",
-                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
-                }
-            )
         ec2_client.authorize_security_group_ingress(
             GroupId=security_group_id, IpPermissions=ip_permissions
         )
@@ -166,6 +157,7 @@ def _user_data(
     region_name,
     runner_id: str,
     resources: Resources,
+    ssh_key_pub: str,
     port_range_from: int = 3000,
     port_range_to: int = 4000,
 ) -> str:
@@ -188,6 +180,7 @@ echo $'{_serialize_runner_yaml(runner_id, resources, runner_port_range_from, run
 die() {{ status=$1; shift; echo "FATAL: $*"; exit $status; }}
 EC2_PUBLIC_HOSTNAME="`wget -q -O - http://169.254.169.254/latest/meta-data/public-hostname || die \"wget public-hostname has failed: $?\"`"
 echo "hostname: $EC2_PUBLIC_HOSTNAME" >> /root/.dstack/runner.yaml
+mkdir ~/.ssh; chmod 700 ~/.ssh; echo "{ssh_key_pub}" > ~/.ssh/authorized_keys; chmod 600 ~/.ssh/authorized_keys
 HOME=/root nohup dstack-runner --log-level 6 start --http-port 4000 &
 """
     return user_data
@@ -351,6 +344,7 @@ def _run_instance(
     local_repo_user_name: Optional[str],
     local_repo_user_email: Optional[str],
     repo_address: RepoAddress,
+    ssh_key_pub: str,
 ) -> str:
     launch_specification = {}
     if not version.__is_release__:
@@ -402,7 +396,9 @@ def _run_instance(
         IamInstanceProfile={
             "Arn": _get_instance_profile_arn(iam_client, bucket_name),
         },
-        UserData=_user_data(bucket_name, region_name, runner_id, instance_type.resources),
+        UserData=_user_data(
+            bucket_name, region_name, runner_id, instance_type.resources, ssh_key_pub=ssh_key_pub
+        ),
         TagSpecifications=[
             {
                 "ResourceType": "instance",
@@ -430,6 +426,7 @@ def run_instance_retry(
     local_repo_user_name: Optional[str],
     local_repo_user_email: Optional[str],
     repo_address: RepoAddress,
+    ssh_key_pub: str,
     attempts: int = 3,
 ) -> str:
     try:
@@ -444,6 +441,7 @@ def run_instance_retry(
             local_repo_user_name,
             local_repo_user_email,
             repo_address,
+            ssh_key_pub,
         )
     except Exception as e:
         if (
@@ -464,6 +462,7 @@ def run_instance_retry(
                     local_repo_user_name,
                     local_repo_user_email,
                     repo_address,
+                    ssh_key_pub,
                     attempts - 1,
                 )
             else:

--- a/cli/dstack/backend/base/logs.py
+++ b/cli/dstack/backend/base/logs.py
@@ -54,7 +54,9 @@ def fix_urls(log: bytes, job: Job) -> bytes:
     return log
 
 
-def _fix_url_for_app(log: bytes, job: Job, app_spec: AppSpec) -> bytes:
+def _fix_url_for_app(
+    log: bytes, job: Job, app_spec: AppSpec
+) -> bytes:  # todo ssh tunneling, ports mapping
     port = job.ports[app_spec.port_index]
     url_pattern = f"http://(localhost|0.0.0.0|127.0.0.1|{job.host_name}):{port}\S*".encode()
     match = re.search(url_pattern, log)

--- a/cli/dstack/backend/gcp/logs.py
+++ b/cli/dstack/backend/gcp/logs.py
@@ -65,7 +65,7 @@ def _log_entry_to_log_event(
     if job is None:
         job = jobs.get_job(storage, repo_address, job_id)
         jobs_cache[job_id] = job
-    log = fix_urls(log.encode(), job).decode()
+    log = fix_urls(log.encode(), job, {}).decode()
     timestamp = int(log_entry.timestamp.timestamp())
     return LogEvent(
         event_id=log_entry.insert_id,

--- a/cli/dstack/cli/commands/run/__init__.py
+++ b/cli/dstack/cli/commands/run/__init__.py
@@ -209,6 +209,7 @@ def poll_run(repo_address: RepoAddress, job_heads: List[JobHead], backend: Backe
             run_ssh_tunnel(
                 ssh_key, jobs[0].host_name, ports
             )  # todo: cleanup explicitly (stop tunnel)
+        run = backend.list_run_heads(repo_address, run_name)[0]
         if len(job_heads) == 1 and run and run.status == JobStatus.RUNNING:
             poll_logs_ws(backend, repo_address, jobs[0], ports)
         else:

--- a/cli/dstack/cli/commands/run/ssh_tunnel.py
+++ b/cli/dstack/cli/commands/run/ssh_tunnel.py
@@ -2,7 +2,7 @@ import socket
 import subprocess
 from contextlib import closing
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Dict, List
 
 from dstack.core.job import Job
 
@@ -26,9 +26,7 @@ def allocate_local_ports(jobs: List[Job]) -> Dict[int, int]:
     return ports
 
 
-def make_ssh_tunnel_args(
-    ssh_key: Path, hostname: str, ports: Dict[int, int]
-) -> List[Union[str, Path]]:
+def make_ssh_tunnel_args(ssh_key: Path, hostname: str, ports: Dict[int, int]) -> List[str]:
     args = [
         "ssh",
         "-o",
@@ -36,7 +34,7 @@ def make_ssh_tunnel_args(
         "-o",
         "UserKnownHostsFile=/dev/null",
         "-i",
-        ssh_key,
+        str(ssh_key),
         f"root@{hostname}",
         "-N",
         "-f",
@@ -48,4 +46,5 @@ def make_ssh_tunnel_args(
 
 def run_ssh_tunnel(ssh_key: Path, hostname: str, ports: Dict[int, int]):
     args = make_ssh_tunnel_args(ssh_key, hostname, ports)
+    print(*(arg.replace(" ", "\\ ") for arg in args))
     subprocess.run(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/cli/dstack/cli/commands/run/ssh_tunnel.py
+++ b/cli/dstack/cli/commands/run/ssh_tunnel.py
@@ -47,5 +47,8 @@ def make_ssh_tunnel_args(ssh_key: Path, hostname: str, ports: Dict[int, int]) ->
 
 def run_ssh_tunnel(ssh_key: Path, hostname: str, ports: Dict[int, int]):
     args = make_ssh_tunnel_args(ssh_key, hostname, ports)
-    console.print(*(arg.replace(" ", "\\ ") for arg in args))
+    ports_mapping = ", ".join(
+        f"{local_port}->{remote_port}" for remote_port, local_port in ports.items()
+    )
+    console.print(f"Opening SSH tunnel to {hostname}, ports mapping: {ports_mapping}")
     subprocess.run(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/cli/dstack/cli/commands/run/ssh_tunnel.py
+++ b/cli/dstack/cli/commands/run/ssh_tunnel.py
@@ -4,6 +4,7 @@ from contextlib import closing
 from pathlib import Path
 from typing import Dict, List
 
+from dstack.cli.common import console
 from dstack.core.job import Job
 
 
@@ -20,7 +21,7 @@ def allocate_local_ports(jobs: List[Job]) -> Dict[int, int]:
         ws_logs_port = int(job.env.get("WS_LOGS_PORT"))
         if ws_logs_port:
             ports[ws_logs_port] = get_free_port()
-        for app_spec in job.app_specs:
+        for app_spec in job.app_specs or []:
             port = job.ports[app_spec.port_index]
             ports[port] = get_free_port()
     return ports
@@ -46,5 +47,5 @@ def make_ssh_tunnel_args(ssh_key: Path, hostname: str, ports: Dict[int, int]) ->
 
 def run_ssh_tunnel(ssh_key: Path, hostname: str, ports: Dict[int, int]):
     args = make_ssh_tunnel_args(ssh_key, hostname, ports)
-    print(*(arg.replace(" ", "\\ ") for arg in args))
+    console.print(*(arg.replace(" ", "\\ ") for arg in args))
     subprocess.run(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/cli/dstack/cli/commands/run/ssh_tunnel.py
+++ b/cli/dstack/cli/commands/run/ssh_tunnel.py
@@ -1,19 +1,28 @@
+import socket
 import subprocess
+from contextlib import closing
 from pathlib import Path
 from typing import Dict, List, Union
 
 from dstack.core.job import Job
 
 
+def get_free_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.getsockname()[1]
+
+
 def allocate_local_ports(jobs: List[Job]) -> Dict[int, int]:
     ports = {}
-    for job in jobs:  # todo: allocate local ports
-        ws_logs_port = job.env.get("WS_LOGS_PORT")
+    for job in jobs:
+        ws_logs_port = int(job.env.get("WS_LOGS_PORT"))
         if ws_logs_port:
-            ports[ws_logs_port] = ws_logs_port
+            ports[ws_logs_port] = get_free_port()
         for app_spec in job.app_specs:
             port = job.ports[app_spec.port_index]
-            ports[port] = port
+            ports[port] = get_free_port()
     return ports
 
 

--- a/cli/dstack/cli/commands/run/ssh_tunnel.py
+++ b/cli/dstack/cli/commands/run/ssh_tunnel.py
@@ -1,0 +1,42 @@
+import subprocess
+from pathlib import Path
+from typing import Dict, List, Union
+
+from dstack.core.job import Job
+
+
+def allocate_local_ports(jobs: List[Job]) -> Dict[int, int]:
+    ports = {}
+    for job in jobs:  # todo: allocate local ports
+        ws_logs_port = job.env.get("WS_LOGS_PORT")
+        if ws_logs_port:
+            ports[ws_logs_port] = ws_logs_port
+        for app_spec in job.app_specs:
+            port = job.ports[app_spec.port_index]
+            ports[port] = port
+    return ports
+
+
+def make_ssh_tunnel_args(
+    ssh_key: Path, hostname: str, ports: Dict[int, int]
+) -> List[Union[str, Path]]:
+    args = [
+        "ssh",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "UserKnownHostsFile=/dev/null",
+        "-i",
+        ssh_key,
+        f"root@{hostname}",
+        "-N",
+        "-f",
+    ]
+    for port_remote, local_port in ports.items():
+        args.extend(["-L", f"{local_port}:{hostname}:{port_remote}"])
+    return args
+
+
+def run_ssh_tunnel(ssh_key: Path, hostname: str, ports: Dict[int, int]):
+    args = make_ssh_tunnel_args(ssh_key, hostname, ports)
+    subprocess.run(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/cli/dstack/core/job.py
+++ b/cli/dstack/core/job.py
@@ -192,6 +192,7 @@ class Job(JobHead):
     runner_id: Optional[str]
     request_id: Optional[str]
     tag_name: Optional[str]
+    ssh_key_pub: Optional[str]
 
     def __init__(self, **data: Any):
         # TODO Ugly style
@@ -225,6 +226,7 @@ class Job(JobHead):
         artifact_specs = format_list(self.artifact_specs)
         app_specs = format_list(self.app_specs)
         dep_specs = format_list(self.dep_specs)
+        ssk_key_pub = f"...{self.ssh_key_pub[-16:]}" if self.ssh_key_pub else None
         return (
             f'Job(job_id="{self.job_id}", repo_data={self.repo_data}, '
             f'run_name="{self.run_name}", workflow_name={_quoted(self.workflow_name)}, '
@@ -249,7 +251,8 @@ class Job(JobHead):
             f"app_specs={app_specs}, "
             f"runner_id={_quoted(self.runner_id)}, "
             f"request_id={_quoted(self.request_id)}, "
-            f"tag_name={_quoted(self.tag_name)})"
+            f"tag_name={_quoted(self.tag_name)}"
+            f"ssh_key_pub={_quoted(ssk_key_pub)})"
         )
 
     def serialize(self) -> dict:
@@ -315,6 +318,7 @@ class Job(JobHead):
             "runner_id": self.runner_id or "",
             "request_id": self.request_id or "",
             "tag_name": self.tag_name or "",
+            "ssh_key_pub": self.ssh_key_pub or "",
         }
         return job_data
 
@@ -428,6 +432,7 @@ class Job(JobHead):
             runner_id=job_data.get("runner_id") or None,
             request_id=job_data.get("request_id") or None,
             tag_name=job_data.get("tag_name") or None,
+            ssh_key_pub=job_data.get("ssh_key_pub") or None,
         )
         return job
 

--- a/cli/dstack/providers/__init__.py
+++ b/cli/dstack/providers/__init__.py
@@ -57,6 +57,7 @@ class Provider:
         self.run_as_provider: Optional[bool] = None
         self.run_name: Optional[str] = None
         self.dep_specs: Optional[List[DepSpec]] = None
+        self.ssh_key_pub: Optional[str] = None
         self.loaded = False
 
     def __str__(self) -> str:
@@ -124,7 +125,7 @@ class Provider:
         workflow_name: Optional[str],
         provider_data: Dict[str, Any],
         run_name: str,
-    ):
+    ):  # todo: read ssh key
         self.provider_args = provider_args
         self.workflow_name = workflow_name
         self.provider_data = provider_data
@@ -133,6 +134,7 @@ class Provider:
         self.parse_args()
         self._inject_context()
         self.dep_specs = self._dep_specs(backend)
+        self.ssh_key_pub = self.provider_data.get("ssh_key_pub")
         self.loaded = True
 
     @abstractmethod
@@ -248,6 +250,7 @@ class Provider:
                 runner_id=None,
                 request_id=None,
                 tag_name=tag_name,
+                ssh_key_pub=self.ssh_key_pub,
             )
             backend.submit_job(job)
             jobs.append(job)

--- a/cli/tests/backend/base/test_logs.py
+++ b/cli/tests/backend/base/test_logs.py
@@ -1,0 +1,88 @@
+import unittest
+from dataclasses import dataclass
+from typing import List
+
+from dstack.backend.base.logs import fix_urls
+from dstack.core.job import AppSpec
+
+localhost = "127.0.0.1"
+
+
+@dataclass
+class JobMock:
+    host_name: str
+    ports: List[int]
+    app_specs: List[AppSpec]
+
+
+class TestFixUrls(unittest.TestCase):
+    def test_empty_mapping(self):
+        log = b"http://0.0.0.0:3001/qwerty"
+        expected = b"http://127.0.0.1:3001/qwerty"
+        job = JobMock("host.name", [3001], [AppSpec(port_index=0, app_name="qwerty")])
+        self.assertEqual(expected, fix_urls(log, job, {}, hostname=localhost))
+
+    def test_default_hostname(self):
+        log = b"http://0.0.0.0:3001/qwerty"
+        expected = b"http://host.name:3001/qwerty"
+        job = JobMock("host.name", [3001], [AppSpec(port_index=0, app_name="qwerty")])
+        self.assertEqual(expected, fix_urls(log, job, {}))
+
+    def test_unique_mapping(self):
+        log = b"http://0.0.0.0:3001/qwerty"
+        expected = b"http://127.0.0.1:5501/qwerty"
+        job = JobMock("host.name", [3001], [AppSpec(port_index=0, app_name="qwerty")])
+        self.assertEqual(
+            expected, fix_urls(log, job, {4000: 5000, 3001: 5501}, hostname=localhost)
+        )
+
+    def test_with_query_params(self):
+        log = b"http://0.0.0.0:3001/qwerty"
+        expected = b"http://127.0.0.1:5501/qwerty?q=foobar"
+        job = JobMock(
+            "host.name",
+            [3001],
+            [AppSpec(port_index=0, app_name="qwerty", url_query_params={"q": "foobar"})],
+        )
+        self.assertEqual(
+            expected, fix_urls(log, job, {4000: 5000, 3001: 5501}, hostname=localhost)
+        )
+
+    def test_same_url(self):
+        log = b"http://0.0.0.0:3001/qwerty and http://0.0.0.0:3001/foobar"
+        expected = b"http://127.0.0.1:5501/qwerty and http://127.0.0.1:5501/foobar"
+        job = JobMock("host.name", [3001], [AppSpec(port_index=0, app_name="qwerty")])
+        self.assertEqual(
+            expected, fix_urls(log, job, {4000: 5000, 3001: 5501}, hostname=localhost)
+        )
+
+    def test_different_urls(self):
+        log = b"http://0.0.0.0:3001/qwerty and http://0.0.0.0:3002/foobar"
+        expected = b"http://127.0.0.1:5501/qwerty and http://127.0.0.1:5502/foobar"
+        job = JobMock(
+            "host.name",
+            [3001, 3002],
+            [AppSpec(port_index=0, app_name="qwerty"), AppSpec(port_index=1, app_name="foobar")],
+        )
+        self.assertEqual(
+            expected, fix_urls(log, job, {4000: 5000, 3001: 5501, 3002: 5502}, hostname=localhost)
+        )
+
+    def test_circular_mapping(self):
+        log = b"http://0.0.0.0:3001/qwerty and http://0.0.0.0:3002/foobar and http://0.0.0.0:3003/asdasd"
+        expected = b"http://127.0.0.1:3002/qwerty and http://127.0.0.1:3003/foobar and http://127.0.0.1:3001/asdasd"
+        job = JobMock(
+            "host.name",
+            [3001, 3002, 3003],
+            [
+                AppSpec(port_index=0, app_name="qwerty"),
+                AppSpec(port_index=1, app_name="foobar"),
+                AppSpec(port_index=2, app_name="asdasd"),
+            ],
+        )
+        self.assertEqual(
+            expected,
+            fix_urls(
+                log, job, {4000: 5000, 3001: 3002, 3002: 3003, 3003: 3001}, hostname=localhost
+            ),
+        )

--- a/docs/reference/cli/run.md
+++ b/docs/reference/cli/run.md
@@ -26,6 +26,7 @@ Optional Arguments:
   --remote              Run the workflow remotely
   -t, --tag TAG         A tag name. Warning, if the tag exists, it will be overridden.
   -d, --detach          Do not poll for status update and logs
+  -i IDENTITY_FILE      A path to ssh identity file
 ```
 
 </div>
@@ -39,14 +40,16 @@ The following arguments are required:
 
 The following arguments are optional:
 
-- `-t TAG`, `--tag TAG` - (Optional) A tag name. Warning, if the tag exists, it will be overridden.
-- `-r`, `--remote`, - (Optional) Run the workflow in the cloud.
--  `-d`, `--detach` - (Optional) Run the workflow in the detached mode. Means, the `run` command doesn't
-  poll for logs and workflow status, but exits immediately. 
+- `-t TAG`, `--tag TAG` – (Optional) A tag name. Warning, if the tag exists, it will be overridden.
+- `-r`, `--remote` – (Optional) Run the workflow in the cloud.
+- `-d`, `--detach` – (Optional) Run the workflow in the detached mode. Means, the `run` command doesn't
+  poll for logs and workflow status, but exits immediately.
+- `-i IDENTITY_FILE` – (Optional) A path to ssh identity file. Used to establish ssh tunnel with a remote
+  runner. Default to `~/.ssh/id_rsa`
 - `OPTIONS` – (Optional) Use `OPTIONS` to override workflow parameters defined in the workflow YAML file
 - `ARGS` – (Optional) Use `ARGS` to [pass arguments](../../usage/args.md) to the workflow
   (can be accessed via `${{ run.args }}` from the workflow YAML file).
--  `-h`, `--help` - (Optional) Shows help for the `dstack run` command. Combine it with the name of the workflow
+-  `-h`, `--help` – (Optional) Shows help for the `dstack run` command. Combine it with the name of the workflow
    to see how to override workflow parameters defined in the workflow YAML file
 
 !!! info "NOTE:"


### PR DESCRIPTION
Closes #229

Details:
1. Add `-i IDENTITY_FILE` to `dstack run` to provide SSH keypair
2. Allow connections to port 22 and disallow connections to ports 3000–4000 (AWS, GCP)
3. Run SSH tunnel to forward local ports (random, available) to remote ports (Logs Web Socket, Apps)
    - Print SSH tunnel command to a user
    - Asks for passphrase if needed
    - No tunneling for `local` backend
4. Rewrite urls in logs with a local address
    - Add tests

Limitations:
1. Can't run remote jobs without a keypair
2. SSH tunnel could be closed only by terminating the remote instance
3. Existing security rules wouldn't be overwritten, which could leave ports 3000–4000 open
4. Implicitly assuming *nix OS

Not implemented (transferred to #269):
1. Direct SSH connection into the container