### PR TITLE
Set SSH keys with init command

### DIFF
--- a/cli/dstack/backend/base/repos.py
+++ b/cli/dstack/backend/base/repos.py
@@ -81,11 +81,7 @@ def get_repo_credentials(
     if credentials_value is None:
         return None
     credentials_data = json.loads(credentials_value)
-    return RepoCredentials(
-        protocol=RepoProtocol(credentials_data["protocol"]),
-        private_key=credentials_data.get("private_key"),
-        oauth_token=credentials_data.get("oauth_token"),
-    )
+    return RepoCredentials(**credentials_data)
 
 
 def save_repo_credentials(
@@ -101,6 +97,8 @@ def save_repo_credentials(
             credentials_data["private_key"] = repo_credentials.private_key
         else:
             raise Exception("No private key is specified")
+    if repo_credentials.ssh_key_path:
+        credentials_data["ssh_key_path"] = repo_credentials.ssh_key_path
 
     credentials_value = secrets_manager.get_credentials(repo_address)
     if credentials_value is not None:

--- a/cli/dstack/cli/commands/init/__init__.py
+++ b/cli/dstack/cli/commands/init/__init__.py
@@ -61,6 +61,12 @@ class InitCommand(BasicCommand):
         for backend in list_backends():
             backend.save_repo_credentials(local_repo_data, repo_credentials)
             if backend.name != "local" and repo_credentials.ssh_key_path is None:
-                console.print(f"[red]Missing SSH keypair (backend: {backend.name})[/]")
+                console.print(
+                    f"[red]SSH keypair is not found[/] [gray58](backend: {backend.name})[/]"
+                )
+                console.print(
+                    f"  [gray58]Make sure {args.ssh_identity_file or '~/.ssh/id_rsa'} exists "
+                    "or provide a different keypair with --ssh-identity[/]"
+                )
             else:
-                console.print(f"[grey58]OK (backend: {backend.name})[/]")
+                console.print(f"[green]OK[/] [gray58](backend: {backend.name})[/]")

--- a/cli/dstack/cli/commands/init/__init__.py
+++ b/cli/dstack/cli/commands/init/__init__.py
@@ -60,4 +60,7 @@ class InitCommand(BasicCommand):
         repo_credentials.ssh_key_path = get_ssh_keypair(args.ssh_identity_file)
         for backend in list_backends():
             backend.save_repo_credentials(local_repo_data, repo_credentials)
-        console.print(f"[grey58]OK[/]")
+            if backend.name != "local" and repo_credentials.ssh_key_path is None:
+                console.print(f"[red]Missing SSH keypair (backend: {backend.name})[/]")
+            else:
+                console.print(f"[grey58]OK (backend: {backend.name})[/]")

--- a/cli/dstack/cli/commands/init/__init__.py
+++ b/cli/dstack/cli/commands/init/__init__.py
@@ -61,12 +61,10 @@ class InitCommand(BasicCommand):
         for backend in list_backends():
             backend.save_repo_credentials(local_repo_data, repo_credentials)
             if backend.name != "local" and repo_credentials.ssh_key_path is None:
+                console.print(f"[red]FAILED[/] [gray58](backend: {backend.name})[/]")
                 console.print(
-                    f"[red]SSH keypair is not found[/] [gray58](backend: {backend.name})[/]"
-                )
-                console.print(
-                    f"  [gray58]Make sure {args.ssh_identity_file or '~/.ssh/id_rsa'} exists "
-                    "or provide a different keypair with --ssh-identity[/]"
+                    f"  [gray58]Make sure `{args.ssh_identity_file or '~/.ssh/id_rsa'}` exists "
+                    "or call `dstack init --ssh-identity PATH`[/]"
                 )
             else:
                 console.print(f"[green]OK[/] [gray58](backend: {backend.name})[/]")

--- a/cli/dstack/cli/commands/init/__init__.py
+++ b/cli/dstack/cli/commands/init/__init__.py
@@ -1,11 +1,23 @@
 from argparse import Namespace
-
-from rich import print
+from pathlib import Path
+from typing import Optional
 
 from dstack.api.backend import list_backends
 from dstack.api.repo import load_repo_data
 from dstack.cli.commands import BasicCommand
+from dstack.cli.common import console
 from dstack.core.error import check_config, check_git
+
+
+def get_ssh_keypair(key_path: Optional[str], default: str = "~/.ssh/id_rsa") -> Optional[str]:
+    """Returns path to the private key if keypair exists"""
+    key_path = Path(key_path or default).expanduser().resolve()
+    pub_key = (
+        key_path if key_path.suffix == ".pub" else key_path.with_suffix(key_path.suffix + ".pub")
+    )
+    private_key = pub_key.with_suffix("")
+    if pub_key.exists() and private_key.exists():
+        return str(private_key)
 
 
 class InitCommand(BasicCommand):
@@ -25,19 +37,27 @@ class InitCommand(BasicCommand):
             dest="gh_token",
         )
         self._parser.add_argument(
-            "-i",
-            "--identity",
+            "--git-identity",
             metavar="SSH_PRIVATE_KEY",
-            help="A path to the private SSH key file",
+            help="A path to the private SSH key file for non-public repositories",
             type=str,
-            dest="identity_file",
+            dest="git_identity_file",
+        )
+        self._parser.add_argument(
+            "--ssh-identity",
+            metavar="SSH_PRIVATE_KEY",
+            help="A path to the private SSH key file for SSH tunneling",
+            type=str,
+            dest="ssh_identity_file",
         )
 
     @check_config
     @check_git
     def _command(self, args: Namespace):
-        local_repo_data = load_repo_data(args.gh_token, args.identity_file)
+        local_repo_data = load_repo_data(args.gh_token, args.git_identity_file)
         local_repo_data.ls_remote()
+        repo_credentials = local_repo_data.repo_credentials()
+        repo_credentials.ssh_key_path = get_ssh_keypair(args.ssh_identity_file)
         for backend in list_backends():
-            backend.save_repo_credentials(local_repo_data, local_repo_data.repo_credentials())
-        print(f"[grey58]OK[/]")
+            backend.save_repo_credentials(local_repo_data, repo_credentials)
+        console.print(f"[grey58]OK[/]")

--- a/cli/dstack/cli/commands/run/__init__.py
+++ b/cli/dstack/cli/commands/run/__init__.py
@@ -298,7 +298,7 @@ class RunCommand(BasicCommand):
             repo_credentials = backend.get_repo_credentials(repo_data)
             if not repo_credentials:
                 sys.exit(f"Call `dstack init` first")
-            if backend != "local":
+            if backend != "local" and not args.detach:
                 if not repo_credentials.ssh_key_path:
                     console.print(
                         "[error]Can't attach to remote: run `dstack init` to set SSH keypair[/error]"

--- a/cli/dstack/cli/commands/run/__init__.py
+++ b/cli/dstack/cli/commands/run/__init__.py
@@ -63,20 +63,9 @@ def _load_workflows():
     return workflows
 
 
-def _resolve_ssh_key_path(path: Path) -> Path:
-    if path.suffix != ".pub":
-        path = path.with_suffix(path.suffix + ".pub")
-    return path.expanduser().resolve()
-
-
-def _read_ssh_key_pub(path: Path, required: bool) -> Optional[str]:
-    try:
-        key = path.read_text().strip("\n")
-        assert "PRIVATE KEY" not in key
-        return key
-    except FileNotFoundError:
-        if required:
-            raise
+def _read_ssh_key_pub(key_path: str) -> str:
+    path = Path(key_path)
+    return path.with_suffix(path.suffix + ".pub").read_text().strip("\n")
 
 
 def parse_run_args(
@@ -99,10 +88,6 @@ def parse_run_args(
             sys.exit(f"No workflow or provider '{args.workflow_or_provider}' is found")
 
         provider_name = args.workflow_or_provider
-
-    workflow_data["ssh_key_pub"] = _read_ssh_key_pub(
-        _resolve_ssh_key_path(args.identity_file), required=args.remote is not None
-    )
 
     return provider_name, provider_args, workflow_name, workflow_data
 
@@ -155,7 +140,9 @@ def poll_logs_ws(backend: Backend, repo_address: RepoAddress, job: Job, ports: D
             console.print(f"[grey58]OK[/]")
 
 
-def poll_run(repo_address: RepoAddress, job_heads: List[JobHead], backend: Backend, ssh_key: Path):
+def poll_run(
+    repo_address: RepoAddress, job_heads: List[JobHead], backend: Backend, ssh_key: Optional[str]
+):
     run_name = job_heads[0].run_name
     try:
         console.print()
@@ -268,14 +255,6 @@ class RunCommand(BasicCommand):
             action="store_true",
         )
         self._parser.add_argument(
-            "-i",
-            metavar="IDENTITY_FILE",
-            help="A path to ssh identity file",
-            type=Path,
-            default=Path("~/.ssh/id_rsa"),
-            dest="identity_file",
-        )
-        self._parser.add_argument(
             "args",
             metavar="ARGS",
             nargs=argparse.ZERO_OR_MORE,
@@ -316,23 +295,29 @@ class RunCommand(BasicCommand):
                 provider.help(workflow_name)
                 sys.exit()
 
-            if backend.get_repo_credentials(repo_data):
-                run_name = backend.create_run(repo_data)
-                provider.load(backend, provider_args, workflow_name, workflow_data, run_name)
-                if args.tag_name:
-                    tag_head = backend.get_tag_head(repo_data, args.tag_name)
-                    if tag_head:
-                        backend.delete_tag_head(repo_data, tag_head)
-                jobs = provider.submit_jobs(backend, args.tag_name)
-                backend.update_repo_last_run_at(
-                    repo_data, last_run_at=int(round(time.time() * 1000))
-                )
-                print_runs(list_runs_with_merged_backends([backend], run_name=run_name))
-                if not args.detach:
-                    ssh_key_private = _resolve_ssh_key_path(args.identity_file).with_suffix("")
-                    poll_run(repo_data, jobs, backend, ssh_key_private)
-            else:
+            repo_credentials = backend.get_repo_credentials(repo_data)
+            if not repo_credentials:
                 sys.exit(f"Call `dstack init` first")
+            if backend != "local":
+                if not repo_credentials.ssh_key_path:
+                    console.print(
+                        "[error]Can't attach to remote: run `dstack init` to set SSH keypair[/error]"
+                    )
+                    exit(1)
+                else:
+                    workflow_data["ssh_key_pub"] = _read_ssh_key_pub(repo_credentials.ssh_key_path)
+
+            run_name = backend.create_run(repo_data)
+            provider.load(backend, provider_args, workflow_name, workflow_data, run_name)
+            if args.tag_name:
+                tag_head = backend.get_tag_head(repo_data, args.tag_name)
+                if tag_head:
+                    backend.delete_tag_head(repo_data, tag_head)
+            jobs = provider.submit_jobs(backend, args.tag_name)
+            backend.update_repo_last_run_at(repo_data, last_run_at=int(round(time.time() * 1000)))
+            print_runs(list_runs_with_merged_backends([backend], run_name=run_name))
+            if not args.detach:
+                poll_run(repo_data, jobs, backend, ssh_key=repo_credentials.ssh_key_path)
         except ValidationError as e:
             sys.exit(
                 f"There a syntax error in one of the files inside the {os.getcwd()}/.dstack/workflows directory:\n\n{e}"

--- a/cli/dstack/cli/commands/run/ssh_tunnel.py
+++ b/cli/dstack/cli/commands/run/ssh_tunnel.py
@@ -1,7 +1,7 @@
 import socket
 import subprocess
 from contextlib import closing
-from pathlib import Path
+from os import PathLike
 from typing import Dict, List
 
 from dstack.cli.common import console
@@ -27,7 +27,7 @@ def allocate_local_ports(jobs: List[Job]) -> Dict[int, int]:
     return ports
 
 
-def make_ssh_tunnel_args(ssh_key: Path, hostname: str, ports: Dict[int, int]) -> List[str]:
+def make_ssh_tunnel_args(ssh_key: PathLike, hostname: str, ports: Dict[int, int]) -> List[str]:
     args = [
         "ssh",
         "-o",
@@ -45,7 +45,7 @@ def make_ssh_tunnel_args(ssh_key: Path, hostname: str, ports: Dict[int, int]) ->
     return args
 
 
-def run_ssh_tunnel(ssh_key: Path, hostname: str, ports: Dict[int, int]):
+def run_ssh_tunnel(ssh_key: PathLike, hostname: str, ports: Dict[int, int]):
     args = make_ssh_tunnel_args(ssh_key, hostname, ports)
     ports_mapping = ", ".join(
         f"{local_port}->{remote_port}" for remote_port, local_port in ports.items()

--- a/cli/dstack/core/repo.py
+++ b/cli/dstack/core/repo.py
@@ -59,14 +59,13 @@ class RepoCredentials(BaseModel):
     protocol: RepoProtocol
     private_key: Union[str, None]
     oauth_token: Union[str, None]
-
-    def __init__(self, **data: Any) -> None:
-        super().__init__(**data)
+    ssh_key_path: Optional[str] = None
 
     def __str__(self) -> str:
         return (
             f"RepoCredentials(protocol=RepoProtocol.{self.protocol.name}, "
             f"private_key_length={len(self.private_key) if self.private_key else None}, "
+            f"ssh_key_path={self.ssh_key_path}, "
             f"oauth_token={_quoted_masked(self.oauth_token)})"
         )
 


### PR DESCRIPTION
Closes #273

* `dstack init`
  * Rename `--identity` to `--git-identity`
  * Add `--ssh-identity`
  * Store `ssh_identity_file` path in RepoCredentials
* `dstack run`
  * Get SSH keypair from `repo_credentials`
  * Allow local runs without SSH keys
  * Allow detached runs without SSH keys