### PR TITLE
Reuse Provisioning line for SSH tunnel message

### DIFF
--- a/cli/dstack/cli/commands/run/__init__.py
+++ b/cli/dstack/cli/commands/run/__init__.py
@@ -201,11 +201,14 @@ def poll_run(repo_address: RepoAddress, job_heads: List[JobHead], backend: Backe
         jobs = [backend.get_job(repo_address, job_head.job_id) for job_head in job_heads]
         ports = {}
         if backend.name != "local":
-            console.print("Provisioning... Starting SSH tunnel.")
+            console.print("Starting SSH tunnel... It may take a while.")
             ports = allocate_local_ports(jobs)
-            run_ssh_tunnel(
+            if run_ssh_tunnel(
                 ssh_key, jobs[0].host_name, ports
-            )  # todo: cleanup explicitly (stop tunnel)
+            ):  # todo: cleanup explicitly (stop tunnel)
+                console.print("SSH tunnel [green]✓[/]")
+            else:
+                console.print("SSH tunnel [red]✗[/]")
         else:
             console.print("Provisioning... It may take up to a minute. [green]✓[/]")
         console.print()

--- a/cli/dstack/cli/commands/run/__init__.py
+++ b/cli/dstack/cli/commands/run/__init__.py
@@ -197,18 +197,21 @@ def poll_run(repo_address: RepoAddress, job_heads: List[JobHead], backend: Backe
                         task, description="Provisioning... It may take up to a minute."
                     )
                     request_errors_printed = False
-        console.print("Provisioning... It may take up to a minute. [green]✓[/]")
-        console.print()
-        console.print("[grey58]To interrupt, press Ctrl+C.[/]")
-        console.print()
 
         jobs = [backend.get_job(repo_address, job_head.job_id) for job_head in job_heads]
         ports = {}
         if backend.name != "local":
+            console.print("Provisioning... Starting SSH tunnel.")
             ports = allocate_local_ports(jobs)
             run_ssh_tunnel(
                 ssh_key, jobs[0].host_name, ports
             )  # todo: cleanup explicitly (stop tunnel)
+        else:
+            console.print("Provisioning... It may take up to a minute. [green]✓[/]")
+        console.print()
+        console.print("[grey58]To interrupt, press Ctrl+C.[/]")
+        console.print()
+
         run = backend.list_run_heads(repo_address, run_name)[0]
         if len(job_heads) == 1 and run and run.status == JobStatus.RUNNING:
             poll_logs_ws(backend, repo_address, jobs[0], ports)

--- a/cli/dstack/cli/commands/run/ssh_tunnel.py
+++ b/cli/dstack/cli/commands/run/ssh_tunnel.py
@@ -4,7 +4,6 @@ from contextlib import closing
 from pathlib import Path
 from typing import Dict, List
 
-from dstack.cli.common import console
 from dstack.core.job import Job
 
 
@@ -45,6 +44,8 @@ def make_ssh_tunnel_args(ssh_key: Path, hostname: str, ports: Dict[int, int]) ->
     return args
 
 
-def run_ssh_tunnel(ssh_key: Path, hostname: str, ports: Dict[int, int]):
+def run_ssh_tunnel(ssh_key: Path, hostname: str, ports: Dict[int, int]) -> bool:
     args = make_ssh_tunnel_args(ssh_key, hostname, ports)
-    subprocess.run(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    return (
+        subprocess.run(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0
+    )

--- a/cli/dstack/cli/commands/run/ssh_tunnel.py
+++ b/cli/dstack/cli/commands/run/ssh_tunnel.py
@@ -47,8 +47,4 @@ def make_ssh_tunnel_args(ssh_key: Path, hostname: str, ports: Dict[int, int]) ->
 
 def run_ssh_tunnel(ssh_key: Path, hostname: str, ports: Dict[int, int]):
     args = make_ssh_tunnel_args(ssh_key, hostname, ports)
-    ports_mapping = ", ".join(
-        f"{local_port}->{remote_port}" for remote_port, local_port in ports.items()
-    )
-    console.print(f"Opening SSH tunnel to {hostname}, ports mapping: {ports_mapping}")
     subprocess.run(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)


### PR DESCRIPTION
Closes #275

* Remove unnecessary details about opening the SSH tunnel

> We can't use a spinner with “Opening SSH tunnel”, because animation rewrites the passphrase prompt