### PR TITLE
AWS sample IAM policy: add `secretsmanager:PutSecretValue`

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -238,6 +238,7 @@ the permissions to perform actions on `s3`, `logs`, `secretsmanager`, `ec2`, and
             "secretsmanager:UpdateSecret",
             "secretsmanager:GetSecretValue",
             "secretsmanager:CreateSecret",
+            "secretsmanager:PutSecretValue",
             "secretsmanager:PutResourcePolicy",
             "secretsmanager:TagResource",
             "secretsmanager:DeleteSecret"


### PR DESCRIPTION
Without `secretsmanager:PutSecretValue` permission we can't update credentials, e.g. change an SSH key with `dstack init`