### PR TITLE
Hub+SSH credentials: pass through ssh_key_path

### DIFF
--- a/cli/dstack/backend/hub/client.py
+++ b/cli/dstack/backend/hub/client.py
@@ -86,11 +86,7 @@ class HubClient:
             resp = requests.get(url=url, headers=self._headers(), data=repo_address.json())
             if resp.ok:
                 json_data = resp.json()
-                return RepoCredentials(
-                    protocol=json_data["protocol"],
-                    private_key=json_data["private_key"],
-                    oauth_token=json_data["oauth_token"],
-                )
+                return RepoCredentials(**json_data)
             if resp.status_code == 401:
                 print("Unauthorized. Please set correct token")
                 return None


### PR DESCRIPTION
Closes #277

* Use all values to create `RepoCredentials`
  * `ssh_key_path` is passed back to the user from the vault