### PR TITLE
Add local RepoUserConfig

### DIFF
--- a/cli/dstack/backend/base/repos.py
+++ b/cli/dstack/backend/base/repos.py
@@ -97,8 +97,6 @@ def save_repo_credentials(
             credentials_data["private_key"] = repo_credentials.private_key
         else:
             raise Exception("No private key is specified")
-    if repo_credentials.ssh_key_path:
-        credentials_data["ssh_key_path"] = repo_credentials.ssh_key_path
 
     credentials_value = secrets_manager.get_credentials(repo_address)
     if credentials_value is not None:

--- a/cli/dstack/cli/commands/run/__init__.py
+++ b/cli/dstack/cli/commands/run/__init__.py
@@ -302,7 +302,7 @@ class RunCommand(BasicCommand):
             repo_credentials = backend.get_repo_credentials(repo_data)
             if not repo_credentials:
                 sys.exit(f"Call `dstack init` first")
-            if backend != "local" and not args.detach:
+            if backend.name != "local" and not args.detach:
                 if not repo_credentials.ssh_key_path:
                     console.print("Call `dstack init` first")
                     exit(1)

--- a/cli/dstack/cli/commands/run/__init__.py
+++ b/cli/dstack/cli/commands/run/__init__.py
@@ -25,10 +25,12 @@ from dstack.backend.base.logs import fix_urls
 from dstack.cli.commands import BasicCommand
 from dstack.cli.commands.run.ssh_tunnel import allocate_local_ports, run_ssh_tunnel
 from dstack.cli.common import console, print_runs
+from dstack.cli.config import BaseConfig
 from dstack.core.error import check_backend, check_config, check_git
 from dstack.core.job import Job, JobHead, JobStatus
 from dstack.core.repo import RepoAddress
 from dstack.core.request import RequestStatus
+from dstack.core.userconfig import RepoUserConfig
 from dstack.utils.common import since
 
 __all__ = "RunCommand"
@@ -273,6 +275,7 @@ class RunCommand(BasicCommand):
             self._parser.print_help()
             exit(1)
         try:
+            config = BaseConfig()
             repo_data = load_repo_data()
             backend = get_local_backend()
             if args.remote is not None:
@@ -300,14 +303,19 @@ class RunCommand(BasicCommand):
                 sys.exit()
 
             repo_credentials = backend.get_repo_credentials(repo_data)
+            repo_user_config = config.read(
+                config.repos / f"{repo_data.path(delimiter='.')}.yaml",
+                RepoUserConfig,
+                non_empty=False,
+            )
             if not repo_credentials:
                 sys.exit(f"Call `dstack init` first")
             if backend.name != "local" and not args.detach:
-                if not repo_credentials.ssh_key_path:
+                if not repo_user_config.ssh_key_path:
                     console.print("Call `dstack init` first")
                     exit(1)
                 else:
-                    workflow_data["ssh_key_pub"] = _read_ssh_key_pub(repo_credentials.ssh_key_path)
+                    workflow_data["ssh_key_pub"] = _read_ssh_key_pub(repo_user_config.ssh_key_path)
 
             run_name = backend.create_run(repo_data)
             provider.load(backend, provider_args, workflow_name, workflow_data, run_name)
@@ -319,7 +327,7 @@ class RunCommand(BasicCommand):
             backend.update_repo_last_run_at(repo_data, last_run_at=int(round(time.time() * 1000)))
             print_runs(list_runs_with_merged_backends([backend], run_name=run_name))
             if not args.detach:
-                poll_run(repo_data, jobs, backend, ssh_key=repo_credentials.ssh_key_path)
+                poll_run(repo_data, jobs, backend, ssh_key=repo_user_config.ssh_key_path)
         except ValidationError as e:
             sys.exit(
                 f"There a syntax error in one of the files inside the {os.getcwd()}/.dstack/workflows directory:\n\n{e}"

--- a/cli/dstack/cli/config.py
+++ b/cli/dstack/cli/config.py
@@ -1,0 +1,35 @@
+from os import PathLike
+from pathlib import Path
+from typing import Type, TypeVar
+
+import yaml
+from pydantic import BaseModel
+
+Model = TypeVar("Model", bound=BaseModel)
+
+
+class BaseConfig:
+    def __init__(self, home: PathLike = "~/.dstack"):
+        self.home = Path(home).expanduser().resolve()
+
+    @property
+    def repos(self) -> Path:
+        return self.home / "repos"
+
+    @staticmethod
+    def write(path: PathLike, model: BaseModel, *, mkdir: bool = False, **kwargs):
+        path = Path(path)
+        if mkdir:
+            path.parent.mkdir(exist_ok=True, parents=True)
+        with path.open("w") as f:
+            yaml.dump(model.dict(**kwargs), f)
+
+    @staticmethod
+    def read(path: PathLike, model: Type[Model], *, non_empty: bool = True) -> Model:
+        try:
+            with open(path, "r") as f:
+                return model(**yaml.load(f, yaml.SafeLoader))
+        except FileNotFoundError:
+            if non_empty:
+                raise
+        return model()

--- a/cli/dstack/core/repo.py
+++ b/cli/dstack/core/repo.py
@@ -59,13 +59,11 @@ class RepoCredentials(BaseModel):
     protocol: RepoProtocol
     private_key: Union[str, None]
     oauth_token: Union[str, None]
-    ssh_key_path: Optional[str] = None
 
     def __str__(self) -> str:
         return (
             f"RepoCredentials(protocol=RepoProtocol.{self.protocol.name}, "
             f"private_key_length={len(self.private_key) if self.private_key else None}, "
-            f"ssh_key_path={self.ssh_key_path}, "
             f"oauth_token={_quoted_masked(self.oauth_token)})"
         )
 

--- a/cli/dstack/core/userconfig.py
+++ b/cli/dstack/core/userconfig.py
@@ -1,0 +1,7 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class RepoUserConfig(BaseModel):
+    ssh_key_path: Optional[str] = None


### PR DESCRIPTION
Fixes #290 

* Remove `ssh_key_path` from `RepoCredentials`
* Add `BaseConfig` for managing local paths and writing/reading yaml configs
* Add `RepoUserConfig` with `ssh_private_key`
* Change status `FAILED` to `WARNING` in `dstack init` for missing keypair
* Fix key presence validation in `dstack run`