### PR TITLE
Stop run on Ctrl+C, abort on the second Ctr+C

### DIFF
--- a/cli/dstack/backend/base/runners.py
+++ b/cli/dstack/backend/base/runners.py
@@ -16,9 +16,9 @@ def get_runner(storage: Storage, runner_id: str) -> Optional[Runner]:
 
 
 def create_runner(storage: Storage, runner: Runner):
-    metadata = {}
+    metadata = None
     if runner.job.status == JobStatus.STOPPING:
-        metadata["status"] = "stopping"
+        metadata = {"status": "stopping"}
     storage.put_object(
         key=_get_runner_filename(runner.runner_id),
         content=yaml.dump(runner.serialize()),

--- a/cli/dstack/backend/local/storage.py
+++ b/cli/dstack/backend/local/storage.py
@@ -3,6 +3,8 @@ import shutil
 from pathlib import Path
 from typing import Callable, Dict, List, Optional
 
+import yaml
+
 from dstack.backend.base.storage import Storage
 from dstack.core.storage import StorageFile
 from dstack.utils.common import removeprefix
@@ -18,6 +20,12 @@ class LocalStorage(Storage):
             Key=key,
             Body=content,
         )
+        if metadata is not None:
+            _put_object(
+                Root=self.root_path,
+                Key=_metadata_key(key),
+                Body=yaml.dump(metadata),
+            )
 
     def get_object(self, key: str) -> Optional[str]:
         try:
@@ -123,3 +131,8 @@ def _delete_object(Root: str, Key: str):
             shutil.rmtree(path, ignore_errors=True)
         else:
             os.remove(path)
+
+
+def _metadata_key(key: str) -> str:
+    parts = key.split("/")
+    return "/".join(parts[:-1] + [f"m;{parts[-1]}"])

--- a/cli/dstack/cli/commands/run/__init__.py
+++ b/cli/dstack/cli/commands/run/__init__.py
@@ -89,7 +89,7 @@ class RunCommand(BasicCommand):
                 hub_client.repo.repo_data.repo_type != "local"
                 and not hub_client.get_repo_credentials()
             ):
-                raise RepoNotInitializedError("No credentials")
+                raise RepoNotInitializedError("No credentials", project_name=hub_client.project)
 
             if not config.repo_user_config.ssh_key_path:
                 ssh_pub_key = None
@@ -220,7 +220,9 @@ def _poll_run(
             task = progress.add_task("Stopping...", total=None)
             for run in poll_run_head(hub_client, run_name):
                 if run.status == JobStatus.UPLOADING and not uploading:
-                    progress.update(task, description="Uploading... It may take a while.")
+                    progress.update(
+                        task, description="Uploading artifacts and cache... It may take a while."
+                    )
                     uploading = True
                 elif run.status.is_finished():
                     progress.update(task, total=100)

--- a/cli/dstack/cli/common.py
+++ b/cli/dstack/cli/common.py
@@ -102,8 +102,11 @@ def check_init(func):
     def decorator(*args, **kwargs):
         try:
             func(*args, **kwargs)
-        except RepoNotInitializedError:
-            console.print(f"The repository is not initialized. Call `dstack init` first.")
+        except RepoNotInitializedError as e:
+            command = "dstack init"
+            if e.project_name is not None:
+                command += f" --project {e.project_name}"
+            console.print(f"The repository is not initialized. Call `{command}` first.")
             exit(1)
 
     return decorator

--- a/cli/dstack/core/error.py
+++ b/cli/dstack/core/error.py
@@ -16,7 +16,9 @@ class NoMatchingInstanceError(BackendError):
 
 
 class RepoNotInitializedError(DstackError):
-    pass
+    def __init__(self, message: Optional[str] = None, project_name: Optional[str] = None):
+        super().__init__(message)
+        self.project_name = project_name
 
 
 class NameNotFoundError(DstackError):

--- a/cli/dstack/providers/__init__.py
+++ b/cli/dstack/providers/__init__.py
@@ -123,7 +123,7 @@ class Provider:
 
     def load(
         self,
-        hub_client,
+        hub_client: "hub.HubClient",
         args: Optional[Namespace],
         workflow_name: Optional[str],
         provider_data: Dict[str, Any],
@@ -146,7 +146,9 @@ class Provider:
             if self.openssh_server or (
                 hub_client.get_project_backend_type() != "local" and not args.detach
             ):
-                raise RepoNotInitializedError("No valid SSH identity")
+                raise RepoNotInitializedError(
+                    "No valid SSH identity", project_name=hub_client.project
+                )
         self._inject_context()
         self.dep_specs = self._dep_specs(hub_client)
         self.cache_specs = self._cache_specs()

--- a/runner/internal/backend/local/backend.go
+++ b/runner/internal/backend/local/backend.go
@@ -132,7 +132,7 @@ func (l Local) UpdateState(ctx context.Context) error {
 }
 
 func (l Local) CheckStop(ctx context.Context) (bool, error) {
-	pathStateFile := fmt.Sprintf("runners/m;%s;status", l.runnerID)
+	pathStateFile := fmt.Sprintf("runners/m;%s.yaml", l.runnerID)
 	log.Trace(ctx, "Reading metadata from state file", "path", pathStateFile)
 	if _, err := os.Stat(filepath.Join(l.path, pathStateFile)); err == nil {
 		file, err := os.Open(filepath.Join(l.path, pathStateFile))
@@ -143,7 +143,11 @@ func (l Local) CheckStop(ctx context.Context) (bool, error) {
 		if err != nil {
 			return false, gerrors.Wrap(err)
 		}
-		if string(body) == states.Stopping {
+		metadata := new(models.RunnerMetadata)
+		if err = yaml.Unmarshal(body, metadata); err != nil {
+			return false, gerrors.Wrap(err)
+		}
+		if metadata.Status == states.Stopping {
 			log.Trace(ctx, "Status equals stopping")
 			return true, nil
 		}

--- a/runner/internal/executor/executor.go
+++ b/runner/internal/executor/executor.go
@@ -190,11 +190,7 @@ func (ex *Executor) Run(ctx context.Context) error {
 }
 
 func (ex *Executor) Stop() {
-	select {
-	case <-ex.stoppedCh:
-		return
-	default:
-	}
+	ex.stoppedCh <- struct{}{}
 	close(ex.stoppedCh)
 }
 
@@ -296,7 +292,7 @@ func (ex *Executor) runJob(ctx context.Context, erCh chan error, stoppedCh chan 
 			return
 		}
 
-		if err = ex.processJob(ctx, stoppedCh); err != nil {
+		if err = ex.processJob(ctx, stoppedCh); err != nil { // todo
 			erCh <- gerrors.Wrap(err)
 			return
 		}

--- a/runner/internal/executor/executor.go
+++ b/runner/internal/executor/executor.go
@@ -190,7 +190,11 @@ func (ex *Executor) Run(ctx context.Context) error {
 }
 
 func (ex *Executor) Stop() {
-	ex.stoppedCh <- struct{}{}
+	select {
+	case <-ex.stoppedCh:
+		return
+	default:
+	}
 	close(ex.stoppedCh)
 }
 

--- a/runner/internal/executor/executor.go
+++ b/runner/internal/executor/executor.go
@@ -296,7 +296,7 @@ func (ex *Executor) runJob(ctx context.Context, erCh chan error, stoppedCh chan 
 			return
 		}
 
-		if err = ex.processJob(ctx, stoppedCh); err != nil { // todo
+		if err = ex.processJob(ctx, stoppedCh); err != nil {
 			erCh <- gerrors.Wrap(err)
 			return
 		}

--- a/runner/internal/models/backend.go
+++ b/runner/internal/models/backend.go
@@ -116,6 +116,10 @@ type RegistryAuth struct {
 	Password string `yaml:"password,omitempty"`
 }
 
+type RunnerMetadata struct {
+	Status string `yaml:"status"`
+}
+
 func (j *Job) RepoHostNameWithPort() string {
 	if j.RepoPort == 0 {
 		return j.RepoHostName


### PR DESCRIPTION
Closes #265

* Fix local storage metadata
* Show artifacts/cache uploading spinner
* Gracefully stop a job on the first Ctrl+C if confirmed
  * Detach on the first Ctrl+C
* Abort on the second Ctrl+C