### PR TITLE
Updated `site_url` to fix social card links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 # Project information
 site_name: dstack
-site_url: https://docs.dstack.ai
+site_url: https://dstack.ai
 site_author: Andrey Cheptsov
 site_description: >-
   The easiest way to define ML workflows and run them on any cloud platform


### PR DESCRIPTION
Hi, 👋 
taking for example https://dstack.ai/docs/ the link to the social card image is https://docs.dstack.ai/assets/images/social/docs/index.png however https://docs.dstack.ai/ redirects to https://dstack.ai/docs/ which then results in https://dstack.ai/docs/assets/images/social/docs/index.png which doesn't exist and the social card can't load.
Modifying the `site_url` should fix the issue by linking to the social card https://dstack.ai/assets/images/social/docs/index.png  

I didn't consider this to be a big enough problem to warrant a separate Issue, and skipped this step from the contribution guidelines ✌️ 
I also noticed a slight disorganization of files inside the documentation directory, for example there is an `assets` directory with images inside, but apart of that there is a `images` / `javascripts` / `stylesheets` directories outside of the assets directory, I guess it's also a minor grievance, therefore no need to create any Issue for it, I'm just commenting as a side note.