### PR TITLE
Keep track of `instance_type`

### DIFF
--- a/cli/dstack/backend/base/jobs.py
+++ b/cli/dstack/backend/base/jobs.py
@@ -61,33 +61,7 @@ def list_job_head(storage: Storage, repo_id: str, job_id: str) -> Optional[JobHe
     job_head_key_prefix = _get_job_head_filename_prefix(repo_id, job_id)
     job_head_keys = storage.list_objects(job_head_key_prefix)
     for job_head_key in job_head_keys:
-        t = job_head_key[len(job_head_key_prefix) :].split(";")
-        (
-            provider_name,
-            hub_user_name,
-            submitted_at,
-            status_info,
-            artifacts,
-            app_names,
-            tag_name,
-        ) = tuple(t)
-        run_name, workflow_name, job_index = tuple(job_id.split(","))
-        status, error_code, container_exit_code = _parse_job_status_info(status_info)
-        return JobHead(
-            job_id=job_id,
-            repo_ref=RepoRef(repo_id=repo_id),
-            hub_user_name=hub_user_name,
-            run_name=run_name,
-            workflow_name=workflow_name or None,
-            provider_name=provider_name,
-            status=JobStatus(status),
-            error_code=JobErrorCode(error_code) if error_code else None,
-            container_exit_code=int(container_exit_code) if container_exit_code else None,
-            submitted_at=int(submitted_at),
-            artifact_paths=artifacts.split(",") if artifacts else None,
-            tag_name=tag_name or None,
-            app_names=app_names.split(",") or None,
-        )
+        return _parse_job_head_key(repo_id, job_head_key)
     return None
 
 
@@ -100,37 +74,7 @@ def list_job_heads(
     job_heads_keys = storage.list_objects(job_heads_keys_prefix)
     job_heads = []
     for job_head_key in job_heads_keys:
-        t = job_head_key[len(_get_jobs_dir(repo_id)) :].split(";")
-        (
-            _,
-            job_id,
-            provider_name,
-            hub_user_name,
-            submitted_at,
-            status_info,
-            artifacts,
-            app_names,
-            tag_name,
-        ) = tuple(t)
-        run_name, workflow_name, job_index = tuple(job_id.split(","))
-        status, error_code, container_exit_code = _parse_job_status_info(status_info)
-        job_heads.append(
-            JobHead(
-                job_id=job_id,
-                repo_ref=RepoRef(repo_id=repo_id),
-                hub_user_name=hub_user_name,
-                run_name=run_name,
-                workflow_name=workflow_name or None,
-                provider_name=provider_name,
-                status=JobStatus(status),
-                error_code=JobErrorCode(error_code) if error_code else None,
-                container_exit_code=int(container_exit_code) if container_exit_code else None,
-                submitted_at=int(submitted_at),
-                artifact_paths=artifacts.split(",") if artifacts else None,
-                tag_name=tag_name or None,
-                app_names=app_names.split(",") or None,
-            )
-        )
+        job_heads.append(_parse_job_head_key(repo_id, job_head_key))
     return job_heads
 
 
@@ -153,13 +97,14 @@ def run_job(
     runner = None
     try:
         job.runner_id = uuid.uuid4().hex
-        update_job(storage, job)
         instance_type = compute.get_instance_type(job)
         if instance_type is None:
             job.status = JobStatus.FAILED
             job.error_code = JobErrorCode.NO_INSTANCE_MATCHING_REQUIREMENTS
             update_job(storage, job)
             raise NoMatchingInstanceError("No instance type matching requirements")
+        job.instance_type = instance_type.instance_name
+        update_job(storage, job)
         runner = Runner(
             runner_id=job.runner_id, request_id=None, resources=instance_type.resources, job=job
         )
@@ -283,9 +228,45 @@ def _get_job_head_filename(job: Job) -> str:
         f"{job.status.value},{job.error_code.value if job.error_code else ''},{job.container_exit_code or ''};"
         f"{','.join([a.artifact_path.replace('/', '_') for a in (job.artifact_specs or [])])};"
         f"{','.join([a.app_name for a in (job.app_specs or [])])};"
-        f"{job.tag_name or ''}"
+        f"{job.tag_name or ''};"
+        f"{job.instance_type or ''}"
     )
     return key
+
+
+def _parse_job_head_key(repo_id: str, full_key: str) -> JobHead:
+    tokens = full_key[len(_get_jobs_dir(repo_id)) :].split(";")
+    tokens.extend([""] * (10 - len(tokens)))  # pad with empty tokens
+    (
+        _,
+        job_id,
+        provider_name,
+        hub_user_name,
+        submitted_at,
+        status_info,
+        artifacts,
+        app_names,
+        tag_name,
+        instance_type,
+    ) = tokens
+    run_name, workflow_name, job_index = tuple(job_id.split(","))
+    status, error_code, container_exit_code = _parse_job_status_info(status_info)
+    return JobHead(
+        job_id=job_id,
+        repo_ref=RepoRef(repo_id=repo_id),
+        hub_user_name=hub_user_name,
+        run_name=run_name,
+        workflow_name=workflow_name or None,
+        provider_name=provider_name,
+        status=JobStatus(status),
+        error_code=JobErrorCode(error_code) if error_code else None,
+        container_exit_code=int(container_exit_code) if container_exit_code else None,
+        submitted_at=int(submitted_at),
+        artifact_paths=artifacts.split(",") if artifacts else None,
+        tag_name=tag_name or None,
+        app_names=app_names.split(",") or None,
+        instance_type=instance_type or None,
+    )
 
 
 def _parse_job_status_info(status_info: str) -> Tuple[str, str, str]:

--- a/cli/dstack/cli/common.py
+++ b/cli/dstack/cli/common.py
@@ -25,10 +25,11 @@ def generate_runs_table(runs: List[RunHead], verbose: bool = False) -> Table:
     table.add_column("RUN", style="bold", no_wrap=True)
     table.add_column("WORKFLOW", style="grey58", max_width=16)
     table.add_column("SUBMITTED", style="grey58", no_wrap=True)
-    table.add_column("OWNER", style="grey58", no_wrap=True, max_width=16)
+    table.add_column("USER", style="grey58", no_wrap=True, max_width=16)
     table.add_column("STATUS", no_wrap=True)
-    table.add_column("TAG", style="bold yellow", no_wrap=True)
+    table.add_column("INSTANCE", no_wrap=True)
     if verbose:
+        table.add_column("TAG", style="bold yellow", no_wrap=True)
         table.add_column("ERROR", no_wrap=True)
 
     for run in runs:
@@ -39,10 +40,11 @@ def generate_runs_table(runs: List[RunHead], verbose: bool = False) -> Table:
             _status_color(run, submitted_at, False, False),
             _status_color(run, run.hub_user_name or "", False, False),
             _pretty_print_status(run),
-            _status_color(run, run.tag_name or "", False, False),
+            _pretty_print_instance_type(run),
         ]
         if verbose:
             row += [
+                _status_color(run, run.tag_name or "", False, False),
                 _pretty_print_error_code(run),
             ]
         table.add_row(*row)
@@ -96,6 +98,15 @@ def _pretty_print_error_code(run: RunHead) -> str:
             else:
                 return f"[red]{job_head.error_code.pretty_repr()}[/]"
     return ""
+
+
+def _pretty_print_instance_type(run: RunHead) -> str:
+    instances = [
+        _status_color(run, job.instance_type, False, False)
+        for job in run.job_heads
+        if job.instance_type
+    ]
+    return "\n".join(instances)
 
 
 def check_init(func):

--- a/cli/dstack/core/job.py
+++ b/cli/dstack/core/job.py
@@ -139,6 +139,7 @@ class JobHead(JobRef):
     artifact_paths: Optional[List[str]]
     tag_name: Optional[str]
     app_names: Optional[List[str]]
+    instance_type: Optional[str]
 
     def get_id(self) -> Optional[str]:
         return self.job_id
@@ -276,6 +277,7 @@ class Job(JobHead):
             "tag_name": self.tag_name or "",
             "ssh_key_pub": self.ssh_key_pub or "",
             "repo_code_filename": self.repo_code_filename,
+            "instance_type": self.instance_type,
         }
         if isinstance(self.repo_data, RemoteRepoData):
             job_data["repo_host_name"] = self.repo_data.repo_host_name
@@ -406,6 +408,7 @@ class Job(JobHead):
             request_id=job_data.get("request_id") or None,
             tag_name=job_data.get("tag_name") or None,
             ssh_key_pub=job_data.get("ssh_key_pub") or None,
+            instance_type=job_data.get("instance_type") or None,
         )
         return job
 

--- a/cli/dstack/hub/routers/runners.py
+++ b/cli/dstack/hub/routers/runners.py
@@ -18,6 +18,7 @@ async def run_runners(project_name: str, job: Job):
     backend = get_backend(project)
     try:
         backend.run_job(job=job, failed_to_start_job_new_status=JobStatus.PENDING)
+        print(job.instance_type)
     except NoMatchingInstanceError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/cli/dstack/hub/routers/runners.py
+++ b/cli/dstack/hub/routers/runners.py
@@ -18,7 +18,6 @@ async def run_runners(project_name: str, job: Job):
     backend = get_backend(project)
     try:
         backend.run_job(job=job, failed_to_start_job_new_status=JobStatus.PENDING)
-        print(job.instance_type)
     except NoMatchingInstanceError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/runner/internal/models/backend.go
+++ b/runner/internal/models/backend.go
@@ -52,6 +52,7 @@ type Job struct {
 	ContainerExitCode string       `yaml:"container_exit_code,omitempty"`
 	SubmittedAt       uint64       `yaml:"submitted_at"`
 	TagName           string       `yaml:"tag_name"`
+	InstanceType      string       `yaml:"instance_type"`
 	//Variables    map[string]interface{} `yaml:"variables"`
 	WorkflowName string `yaml:"workflow_name"`
 	WorkingDir   string `yaml:"working_dir"`
@@ -145,7 +146,7 @@ func (j *Job) JobHeadFilepath() string {
 		artifactSlice = append(artifactSlice, art.Path)
 	}
 	return fmt.Sprintf(
-		"jobs/%s/l;%s;%s;%s;%d;%s;%s;%s;%s",
+		"jobs/%s/l;%s;%s;%s;%d;%s;%s;%s;%s;%s",
 		j.RepoId,
 		j.JobID,
 		j.ProviderName,
@@ -155,6 +156,7 @@ func (j *Job) JobHeadFilepath() string {
 		strings.Join(artifactSlice, ","),
 		strings.Join(appsSlice, ","),
 		j.TagName,
+		j.InstanceType,
 	)
 }
 
@@ -169,7 +171,7 @@ func (j *Job) JobHeadFilepathLocal() string {
 		artifactSlice = append(artifactSlice, strings.ReplaceAll(art.Path, "/", "_"))
 	}
 	return fmt.Sprintf(
-		"jobs/%s/l;%s;%s;%s;%d;%s;%s;%s;%s",
+		"jobs/%s/l;%s;%s;%s;%d;%s;%s;%s;%s;%s",
 		j.RepoId,
 		j.JobID,
 		j.ProviderName,
@@ -179,6 +181,7 @@ func (j *Job) JobHeadFilepathLocal() string {
 		strings.Join(artifactSlice, ","),
 		strings.Join(appsSlice, ","),
 		j.TagName,
+		j.InstanceType,
 	)
 }
 


### PR DESCRIPTION
Closes #340

* Add `instance_type` to JobHead
  * Backward compatible: head files without `instace_type` would be parsed just fine
* Add `INSTANCE` column to runs table
* Rename `OWNER` column to `USER` (runs table)
* Show `TAG` column only in verbose mode (runs table)