### PR TITLE
Properly escape artifact paths

### DIFF
--- a/cli/dstack/backend/base/jobs.py
+++ b/cli/dstack/backend/base/jobs.py
@@ -12,6 +12,7 @@ from dstack.core.repo import RepoRef
 from dstack.core.request import RequestStatus
 from dstack.core.runners import Runner
 from dstack.utils.common import get_milliseconds_since_epoch
+from dstack.utils.escape import escape_head, unescape_head
 
 
 def create_job(
@@ -226,7 +227,7 @@ def _get_job_head_filename(job: Job) -> str:
         f"{job.hub_user_name};"
         f"{job.submitted_at};"
         f"{job.status.value},{job.error_code.value if job.error_code else ''},{job.container_exit_code or ''};"
-        f"{','.join([a.artifact_path.replace('/', '_') for a in (job.artifact_specs or [])])};"
+        f"{','.join([escape_head(a.artifact_path) for a in (job.artifact_specs or [])])};"
         f"{','.join([a.app_name for a in (job.app_specs or [])])};"
         f"{job.tag_name or ''};"
         f"{job.instance_type or ''}"
@@ -262,7 +263,9 @@ def _parse_job_head_key(repo_id: str, full_key: str) -> JobHead:
         error_code=JobErrorCode(error_code) if error_code else None,
         container_exit_code=int(container_exit_code) if container_exit_code else None,
         submitted_at=int(submitted_at),
-        artifact_paths=artifacts.split(",") if artifacts else None,
+        artifact_paths=[unescape_head(path) for path in artifacts.split(",")]
+        if artifacts
+        else None,
         tag_name=tag_name or None,
         app_names=app_names.split(",") or None,
         instance_type=instance_type or None,

--- a/cli/dstack/backend/base/repos.py
+++ b/cli/dstack/backend/base/repos.py
@@ -12,7 +12,7 @@ from dstack.core.repo import (
     RepoProtocol,
     RepoSpec,
 )
-from dstack.utils.escape import Escaper
+from dstack.utils.escape import unescape_head
 
 # repo_id, last_run_at, tags_count, repo_type, repo_info
 repo_head_re = re.compile(r"([^;]+);(\d+);(\d+);(remote|local);(.*)")
@@ -41,11 +41,7 @@ def update_repo_last_run_at(storage: Storage, repo_spec: RepoSpec, last_run_at: 
                 repo_name=repo_spec.repo_data.repo_name,
             )
         elif repo_spec.repo_data.repo_type == "local":
-            repo_info = LocalRepoInfo(
-                repo_dir=Escaper({"/": "."}, escape_char="~").unescape(
-                    repo_spec.repo_data.repo_dir
-                ),
-            )
+            repo_info = LocalRepoInfo(repo_dir=unescape_head(repo_spec.repo_data.repo_dir))
         repo_head = RepoHead(
             repo_id=repo_spec.repo_ref.repo_id,
             repo_info=repo_info,
@@ -135,9 +131,7 @@ def _parse_repo_head_filename(repo_head_filepath: str) -> Optional[RepoHead]:
         )
     elif repo_type == "local":
         repo_dir = repo_info
-        repo_info = LocalRepoInfo(
-            repo_dir=Escaper({"/": "."}, escape_char="~").unescape(repo_dir),
-        )
+        repo_info = LocalRepoInfo(repo_dir=unescape_head(repo_dir))
     return RepoHead(
         repo_id=repo_id,
         repo_info=repo_info,

--- a/cli/dstack/backend/base/tags.py
+++ b/cli/dstack/backend/base/tags.py
@@ -10,6 +10,7 @@ from dstack.core.job import Job, JobStatus
 from dstack.core.repo import Repo
 from dstack.core.tag import TagHead
 from dstack.utils.common import get_milliseconds_since_epoch
+from dstack.utils.escape import unescape_head
 
 
 def get_tag_head(storage: Storage, repo_id: str, tag_name: str) -> Optional[TagHead]:
@@ -229,17 +230,9 @@ def _get_tag_heads_filenames_prefix(repo_id: str) -> str:
 def _unserialize_artifact_heads(artifact_heads):
     return (
         [
-            ArtifactHead(job_id=a.split("=")[0], artifact_path=a.split("=")[1])
+            ArtifactHead(job_id=a.split("=")[0], artifact_path=unescape_head(a.split("=")[1]))
             for a in artifact_heads.split(":")
         ]
         if artifact_heads
         else None
-    )
-
-
-def _serialize_artifact_heads(tag_head):
-    return (
-        ":".join([a.job_id + "=" + a.artifact_path for a in tag_head.artifact_heads])
-        if tag_head.artifact_heads
-        else ""
     )

--- a/cli/dstack/core/repo/local.py
+++ b/cli/dstack/core/repo/local.py
@@ -8,7 +8,7 @@ from typing_extensions import Literal
 
 from dstack.core.repo.base import Repo, RepoData, RepoInfo, RepoRef
 from dstack.utils.common import PathLike
-from dstack.utils.escape import Escaper
+from dstack.utils.escape import escape_head
 from dstack.utils.hash import get_sha256, slugify
 from dstack.utils.workflows import load_workflows
 
@@ -29,7 +29,7 @@ class LocalRepoInfo(RepoInfo):
 
     @property
     def head_key(self) -> str:
-        repo_dir = Escaper({"/": "."}, escape_char="~").escape(self.repo_dir)
+        repo_dir = escape_head(self.repo_dir)
         return f"{self.repo_type};{repo_dir}"
 
 

--- a/cli/dstack/core/tag.py
+++ b/cli/dstack/core/tag.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 from pydantic import BaseModel
 
 from dstack.core.artifact import ArtifactHead
+from dstack.utils.escape import escape_head
 
 
 class TagHead(BaseModel):
@@ -17,9 +18,7 @@ class TagHead(BaseModel):
 
     def serialize_artifact_heads(self):
         return (
-            ":".join(
-                [a.job_id + "=" + a.artifact_path.replace("/", "_") for a in self.artifact_heads]
-            )
+            ":".join([a.job_id + "=" + escape_head(a.artifact_path) for a in self.artifact_heads])
             if self.artifact_heads
             else ""
         )

--- a/cli/dstack/hub/routers/tags.py
+++ b/cli/dstack/hub/routers/tags.py
@@ -50,7 +50,7 @@ async def delete_tag(project_name: str, tag_name: str, repo_ref: RepoRef):
 async def add_tag_from_run(project_name: str, body: AddTagRun):
     project = await get_project(project_name=project_name)
     backend = get_backend(project)
-    backend.add_tag_from_run(
+    backend.add_tag_from_run(  # todo pass error to CLI if tag already exists
         body.repo_id, tag_name=body.tag_name, run_name=body.run_name, run_jobs=body.run_jobs
     )
 

--- a/cli/dstack/utils/escape.py
+++ b/cli/dstack/utils/escape.py
@@ -1,6 +1,10 @@
 from typing import Dict
 
 
+class UnescapeError(Exception):
+    pass
+
+
 class Escaper:
     """
     Generic escaping for strings.
@@ -10,9 +14,12 @@ class Escaper:
 
     >>> esc = Escaper({"/": "."}, escape_char="$")
     >>> esc.escape("foo/bar")
-    "foo$.bar"
+    'foo$.bar'
     >>> esc.escape("foo/$bar")
-    "foo$.$$bar"
+    'foo$.$$bar'
+    >>> esc.unescape("foo$/bar")
+    Traceback (most recent call last):
+    escape.UnescapeError: ('Unknown escape sequence', '$/')
     """
 
     def __init__(self, chars: Dict[str, str], escape_char: str):
@@ -40,10 +47,21 @@ class Escaper:
                 break
             parts.append(value[start:esc])
             if esc + 1 >= len(value):
-                raise ValueError("Unexpected EOL")
+                raise UnescapeError("Unexpected EOL")
             elif value[esc + 1] not in inv:
-                raise ValueError(f"Unknown escape sequence: {value[esc:esc + 2]}")
+                raise UnescapeError(f"Unknown escape sequence", value[esc : esc + 2])
             else:
                 parts.append(inv[value[esc + 1]])
             start = esc + 2
         return "".join(parts)
+
+
+_head_escaper = Escaper(chars={"/": "."}, escape_char="~")
+
+
+def escape_head(v: str) -> str:
+    return _head_escaper.escape(v)
+
+
+def unescape_head(v: str) -> str:
+    return _head_escaper.unescape(v)

--- a/runner/internal/backend/local/backend.go
+++ b/runner/internal/backend/local/backend.go
@@ -120,7 +120,7 @@ func (l Local) UpdateState(ctx context.Context) error {
 	if err != nil {
 		return gerrors.Wrap(err)
 	}
-	jobHeadFilepath := l.state.Job.JobHeadFilepathLocal()
+	jobHeadFilepath := l.state.Job.JobHeadFilepath()
 	for _, file := range files[:1] {
 		log.Trace(ctx, "Renaming file job", "From", file, "To", jobHeadFilepath)
 		err = l.storage.RenameFile(file, jobHeadFilepath)

--- a/runner/internal/common/string.go
+++ b/runner/internal/common/string.go
@@ -12,3 +12,11 @@ func AddTrailingSlash(value string) string {
 	}
 	return value + "/"
 }
+
+func IndexWithOffset(hay string, needle string, start int) int {
+	idx := strings.Index(hay[start:], needle)
+	if idx < 0 {
+		return -1
+	}
+	return start + idx
+}

--- a/runner/internal/executor/interpolator.go
+++ b/runner/internal/executor/interpolator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/dstackai/dstack/runner/internal/common"
 	"github.com/dstackai/dstack/runner/internal/log"
 	"strings"
 )
@@ -32,7 +33,7 @@ func (vi *VariablesInterpolator) Interpolate(ctx context.Context, s string) (str
 
 	start := 0
 	for start < len(s) {
-		dollar := IndexWithOffset(s, "$", start)
+		dollar := common.IndexWithOffset(s, "$", start)
 		if dollar == -1 || dollar == len(s)-1 {
 			sb.WriteString(s[start:])
 			break
@@ -43,13 +44,13 @@ func (vi *VariablesInterpolator) Interpolate(ctx context.Context, s string) (str
 			continue
 		}
 
-		opening := IndexWithOffset(s, PatternOpening, start)
+		opening := common.IndexWithOffset(s, PatternOpening, start)
 		if opening == -1 {
 			sb.WriteString(s[start:])
 			break
 		}
 		sb.WriteString(s[start:opening])
-		closing := IndexWithOffset(s, PatternClosing, opening)
+		closing := common.IndexWithOffset(s, PatternClosing, opening)
 		if closing == -1 {
 			return "", errors.New(fmt.Sprintf("no pattern closing: %s", s[opening:]))
 		}
@@ -64,12 +65,4 @@ func (vi *VariablesInterpolator) Interpolate(ctx context.Context, s string) (str
 		start = closing + len(PatternClosing)
 	}
 	return sb.String(), nil
-}
-
-func IndexWithOffset(hay string, needle string, start int) int {
-	idx := strings.Index(hay[start:], needle)
-	if idx < 0 {
-		return -1
-	}
-	return start + idx
 }

--- a/runner/internal/models/backend.go
+++ b/runner/internal/models/backend.go
@@ -143,32 +143,7 @@ func (j *Job) JobHeadFilepath() string {
 	}
 	artifactSlice := make([]string, len(j.Artifacts))
 	for _, art := range j.Artifacts {
-		artifactSlice = append(artifactSlice, art.Path)
-	}
-	return fmt.Sprintf(
-		"jobs/%s/l;%s;%s;%s;%d;%s;%s;%s;%s;%s",
-		j.RepoId,
-		j.JobID,
-		j.ProviderName,
-		j.HubUserName,
-		j.SubmittedAt,
-		strings.Join([]string{j.Status, j.ErrorCode, j.ContainerExitCode}, ","),
-		strings.Join(artifactSlice, ","),
-		strings.Join(appsSlice, ","),
-		j.TagName,
-		j.InstanceType,
-	)
-}
-
-func (j *Job) JobHeadFilepathLocal() string {
-	// TODO: we can get rid of this function once we stop putting artifact paths into job heads
-	appsSlice := make([]string, len(j.Apps))
-	for _, app := range j.Apps {
-		appsSlice = append(appsSlice, app.Name)
-	}
-	artifactSlice := make([]string, len(j.Artifacts))
-	for _, art := range j.Artifacts {
-		artifactSlice = append(artifactSlice, strings.ReplaceAll(art.Path, "/", "_"))
+		artifactSlice = append(artifactSlice, EscapeHead(art.Path))
 	}
 	return fmt.Sprintf(
 		"jobs/%s/l;%s;%s;%s;%d;%s;%s;%s;%s;%s",

--- a/runner/internal/models/escape.go
+++ b/runner/internal/models/escape.go
@@ -1,0 +1,35 @@
+package models
+
+import "strings"
+
+type Escaper struct {
+	chars      map[string]string
+	escapeChar string
+	encoder    *strings.Replacer
+}
+
+func NewEscaper(chars map[string]string, escapeChar string) *Escaper {
+	e := &Escaper{
+		chars:      chars,
+		escapeChar: escapeChar,
+	}
+	var tokens []string
+	tokens = append(tokens, escapeChar, escapeChar+escapeChar)
+	for from, to := range chars {
+		tokens = append(tokens, from, escapeChar+to)
+	}
+	e.encoder = strings.NewReplacer(tokens...)
+	return e
+}
+
+func (e *Escaper) Escape(v string) string {
+	return e.encoder.Replace(v)
+}
+
+//func (e *Escaper) Unescape(v string) (string, error) {}
+
+var headEscaper = NewEscaper(map[string]string{"/": "."}, "~")
+
+func EscapeHead(v string) string {
+	return headEscaper.Escape(v)
+}


### PR DESCRIPTION
Closes #314 

* Implement default `escape_head` and `unescape_head`
* Escape & unescape artifact paths in `JobHead` and `TagHead` filenames