### PR TITLE
Generate default SSH keypair

### DIFF
--- a/cli/dstack/cli/commands/init/__init__.py
+++ b/cli/dstack/cli/commands/init/__init__.py
@@ -62,9 +62,6 @@ class InitCommand(BasicCommand):
             except InvalidRepoCredentialsError as e:
                 raise CLIError(e.message)
         except InvalidGitRepositoryError:
-            console.print(
-                f"[gray58]No git remote is used, it could affect efficiency of source code transfer[/]"
-            )
             repo = LocalRepo(repo_dir=Path.cwd())
             repo_credentials = None
 

--- a/cli/dstack/cli/commands/init/__init__.py
+++ b/cli/dstack/cli/commands/init/__init__.py
@@ -1,8 +1,12 @@
+import os
 from argparse import Namespace
 from pathlib import Path
 from typing import Optional
 
 import giturlparse
+from cryptography.hazmat.backends import default_backend as crypto_default_backend
+from cryptography.hazmat.primitives import serialization as crypto_serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 from git.exc import InvalidGitRepositoryError
 
 from dstack.api.repos import InvalidRepoCredentialsError, get_local_repo_credentials
@@ -42,7 +46,7 @@ class InitCommand(BasicCommand):
             "--ssh-identity",
             metavar="SSH_PRIVATE_KEY",
             help="A path to the private SSH key file for SSH tunneling",
-            type=str,
+            type=Path,
             dest="ssh_identity_file",
         )
         self._parser.add_argument("--local", action="store_true", help="Do not use git")
@@ -69,30 +73,61 @@ class InitCommand(BasicCommand):
             RepoUserConfig(
                 repo_id=repo.repo_ref.repo_id,
                 repo_type=repo.repo_data.repo_type,
-                ssh_key_path=get_ssh_keypair(args.ssh_identity_file),
+                ssh_key_path=get_ssh_keypair(
+                    args.ssh_identity_file,
+                    dstack_key_path=config.dstack_key_path(Path.cwd()),
+                ),
             )
         )
         hub_client = get_hub_client(project_name=args.project)
         if repo_credentials is not None:
             hub_client.save_repo_credentials(repo_credentials)
-        status = (
-            "[yellow]WARNING[/]"
-            if config.repo_user_config.ssh_key_path is None
-            else "[green]OK[/]"
-        )
-        console.print(f"{status}")
-        if config.repo_user_config.ssh_key_path is None:
-            console.print(
-                f"[red]SSH is not enabled. To enable it, make sure `{args.ssh_identity_file or '~/.ssh/id_rsa'}` exists or call `dstack init --ssh-identity PATH`[/]"
-            )
+        console.print(f"[green]OK[/]")
 
 
-def get_ssh_keypair(key_path: Optional[str], default: str = "~/.ssh/id_rsa") -> Optional[str]:
+def get_ssh_keypair(
+    key_path: Optional[Path], dstack_key_path: Optional[Path] = None
+) -> Optional[str]:
     """Returns path to the private key if keypair exists"""
-    key_path = Path(key_path or default).expanduser().resolve()
-    pub_key = (
-        key_path if key_path.suffix == ".pub" else key_path.with_suffix(key_path.suffix + ".pub")
-    )
-    private_key = pub_key.with_suffix("")
-    if pub_key.exists() and private_key.exists():
-        return str(private_key)
+    if key_path is not None:
+        key_path = key_path.expanduser().resolve()
+        pub_key = (
+            key_path
+            if key_path.suffix == ".pub"
+            else key_path.with_suffix(key_path.suffix + ".pub")
+        )
+        private_key = pub_key.with_suffix("")
+        if pub_key.exists() and private_key.exists():
+            return str(private_key)
+        raise CLIError(
+            f"Make sure valid keypair exists: {private_key}(.pub) and rerun `dstack init`"
+        )
+
+    if dstack_key_path is None:
+        return None
+    if not dstack_key_path.exists():
+        key = rsa.generate_private_key(
+            backend=crypto_default_backend(), public_exponent=65537, key_size=2048
+        )
+
+        def key_opener(path, flags):
+            return os.open(path, flags, 0o600)
+
+        with open(dstack_key_path, "wb", opener=key_opener) as f:
+            f.write(
+                key.private_bytes(
+                    crypto_serialization.Encoding.PEM,
+                    crypto_serialization.PrivateFormat.PKCS8,
+                    crypto_serialization.NoEncryption(),
+                )
+            )
+        with open(
+            dstack_key_path.with_suffix(dstack_key_path.suffix + ".pub"), "wb", opener=key_opener
+        ) as f:
+            f.write(
+                key.public_key().public_bytes(
+                    crypto_serialization.Encoding.OpenSSH,
+                    crypto_serialization.PublicFormat.OpenSSH,
+                )
+            )
+    return str(dstack_key_path)

--- a/cli/dstack/cli/config.py
+++ b/cli/dstack/cli/config.py
@@ -21,6 +21,9 @@ class ConfigManager:
         self.home = Path(home).expanduser().resolve()
         self._cache: Dict[str, BaseModel] = {}
 
+    def dstack_key_path(self, repo_dir: Optional[PathLike] = None) -> Path:
+        return self.home / "dstack_rsa"
+
     @property
     def repos(self) -> Path:
         return self.home / "repos"

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -33,3 +33,4 @@ alembic
 typing-extensions
 file-read-backwards
 psutil
+cryptography

--- a/cli/tests/integration/test_commands.py
+++ b/cli/tests/integration/test_commands.py
@@ -40,14 +40,16 @@ class TestConfig:
 
 
 class TestInit:
-    def test_warns_if_no_ssh_key(
+    def test_generate_default_ssh_key(
         self, capsys: CaptureFixture, dstack_dir: Path, tests_local_repo: Path
     ):
+        dstack_key_path = dstack_dir / "dstack_rsa"
         with hub_process(dstack_dir):
+            assert not dstack_key_path.exists()
             exit_code = run_dstack_cli(["init"], dstack_dir=dstack_dir, repo_dir=tests_local_repo)
             assert exit_code == 0
-            stdout = capsys.readouterr().out
-            assert "WARNING" in stdout and "SSH is not enabled" in stdout
+            print(list(dstack_dir.iterdir()))
+            assert dstack_key_path.exists()
 
 
 class TestRun:
@@ -74,6 +76,8 @@ class TestRun:
         self, capsys: CaptureFixture, dstack_dir: Path, tests_local_repo: Path
     ):
         with hub_process(dstack_dir):
+            exit_code = run_dstack_cli(["init"], dstack_dir=dstack_dir, repo_dir=tests_local_repo)
+            assert exit_code == 0
             exit_code = run_dstack_cli(
                 ["run", "bash", "-c", "echo 'Hello, world!'"],
                 dstack_dir=dstack_dir,
@@ -83,7 +87,7 @@ class TestRun:
             assert "Hello, world!" in capsys.readouterr().out
 
     def test_runs_workflow_from_yaml_file(
-        self, capsys: CaptureFixture, dstack_dir: Path, tests_public_repo: Path, ssh_key
+        self, capsys: CaptureFixture, dstack_dir: Path, tests_public_repo: Path
     ):
         with hub_process(dstack_dir):
             exit_code = run_dstack_cli(["init"], dstack_dir=dstack_dir, repo_dir=tests_public_repo)
@@ -97,7 +101,7 @@ class TestRun:
 
 class TestArtifacts:
     def test_lists_artifacts(
-        self, capsys: CaptureFixture, dstack_dir: Path, tests_public_repo: Path, ssh_key
+        self, capsys: CaptureFixture, dstack_dir: Path, tests_public_repo: Path
     ):
         with hub_process(dstack_dir):
             exit_code = run_dstack_cli(["init"], dstack_dir=dstack_dir, repo_dir=tests_public_repo)
@@ -135,7 +139,7 @@ class TestArtifacts:
 
 class TestDeps:
     def test_reads_artifacts_from_dep_workflow(
-        self, capsys: CaptureFixture, dstack_dir: Path, tests_public_repo: Path, ssh_key
+        self, capsys: CaptureFixture, dstack_dir: Path, tests_public_repo: Path
     ):
         with hub_process(dstack_dir):
             exit_code = run_dstack_cli(["init"], dstack_dir=dstack_dir, repo_dir=tests_public_repo)
@@ -156,6 +160,8 @@ class TestSecrets:
         self, capsys: CaptureFixture, dstack_dir: Path, tests_local_repo: Path
     ):
         with hub_process(dstack_dir):
+            exit_code = run_dstack_cli(["init"], dstack_dir=dstack_dir, repo_dir=tests_local_repo)
+            assert exit_code == 0
             exit_code = run_dstack_cli(
                 ["secrets", "add", "MY_SECRET", "my_secret_value"],
                 dstack_dir=dstack_dir,

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ setup(
         "typing-extensions>=4.0.0",
         "file-read-backwards>=3.0.0",
         "psutil>=5.0.0",
+        "cryptography",
     ],
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
Closes #406 

* Remove warning for local repo
* `dstack init`: generate ssh keypair (`~/.dstack/dstack_rsa`) if `--ssh-identity` is not specified
* Adjust tests for new `--ssh-identity` behaviour
* Patch `dstack.cli.config.config.home` in integration tests