### PR TITLE
Create entry for each run in ssh config

### DIFF
--- a/cli/dstack/cli/commands/run/__init__.py
+++ b/cli/dstack/cli/commands/run/__init__.py
@@ -184,9 +184,9 @@ def _poll_run(
         }
         backend_type = hub_client.get_project_backend_type()
         if backend_type != "local":
-            include_ssh_config(config.ssh_config)
+            include_ssh_config(config.ssh_config_path)
             ssh_config_add_host(
-                config.ssh_config,
+                config.ssh_config_path,
                 run_name,
                 {
                     "HostName": jobs[0].host_name,
@@ -195,6 +195,9 @@ def _poll_run(
                     "IdentityFile": ssh_key,
                     "StrictHostKeyChecking": "no",
                     "UserKnownHostsFile": "/dev/null",
+                    "ControlPath": config.ssh_control_path(run_name),
+                    "ControlMaster": "auto",
+                    "ControlPersist": "10m",
                 },
             )
             console.print("Starting SSH tunnel...")
@@ -244,7 +247,7 @@ def _poll_run(
                     status = run.status.name
                     break
         console.print(f"[grey58]{status.capitalize()}[/]")
-        ssh_config_remove_host(config.ssh_config, run_name)
+        ssh_config_remove_host(config.ssh_config_path, run_name)
     except KeyboardInterrupt:
         global interrupt_count
         interrupt_count = 1
@@ -321,5 +324,5 @@ def ask_on_interrupt(hub_client: HubClient, run_name: str):
         console.print("\n[grey58]Aborting...[/]")
         hub_client.stop_jobs(run_name, abort=True)
         console.print("[grey58]Aborted[/]")
-        ssh_config_remove_host(config.ssh_config, run_name)
+        ssh_config_remove_host(config.ssh_config_path, run_name)
         exit(0)

--- a/cli/dstack/cli/commands/run/__init__.py
+++ b/cli/dstack/cli/commands/run/__init__.py
@@ -25,6 +25,7 @@ from dstack.core.error import NameNotFoundError, RepoNotInitializedError
 from dstack.core.job import Job, JobHead, JobStatus
 from dstack.core.request import RequestStatus
 from dstack.core.run import RunHead
+from dstack.utils.ssh import include_ssh_config, ssh_config_add_host, ssh_config_remove_host
 from dstack.utils.workflows import load_workflows
 
 POLL_PROVISION_RATE_SECS = 3
@@ -183,11 +184,23 @@ def _poll_run(
         }
         backend_type = hub_client.get_project_backend_type()
         if backend_type != "local":
+            include_ssh_config(config.ssh_config)
+            ssh_config_add_host(
+                config.ssh_config,
+                run_name,
+                {
+                    "HostName": jobs[0].host_name,
+                    # TODO: use non-root for all backends
+                    "User": "root" if backend_type != "azure" else "ubuntu",
+                    "IdentityFile": ssh_key,
+                    "StrictHostKeyChecking": "no",
+                    "UserKnownHostsFile": "/dev/null",
+                },
+            )
             console.print("Starting SSH tunnel...")
             ports = allocate_local_ports(jobs)
-            if not run_ssh_tunnel(
-                ssh_key, jobs[0].host_name, ports, backend_type
-            ):  # todo: cleanup explicitly (stop tunnel)
+            # TODO: cleanup explicitly (stop tunnel)
+            if not run_ssh_tunnel(run_name, ports):
                 console.print("[warning]Warning: failed to start SSH tunnel[/warning] [red]✗[/]")
         else:
             console.print("Provisioning... It may take up to a minute. [green]✓[/]")
@@ -231,6 +244,7 @@ def _poll_run(
                     status = run.status.name
                     break
         console.print(f"[grey58]{status.capitalize()}[/]")
+        ssh_config_remove_host(config.ssh_config, run_name)
     except KeyboardInterrupt:
         global interrupt_count
         interrupt_count = 1
@@ -307,4 +321,5 @@ def ask_on_interrupt(hub_client: HubClient, run_name: str):
         console.print("\n[grey58]Aborting...[/]")
         hub_client.stop_jobs(run_name, abort=True)
         console.print("[grey58]Aborted[/]")
+        ssh_config_remove_host(config.ssh_config, run_name)
         exit(0)

--- a/cli/dstack/cli/commands/run/ssh_tunnel.py
+++ b/cli/dstack/cli/commands/run/ssh_tunnel.py
@@ -56,23 +56,10 @@ def allocate_local_ports(jobs: List[Job]) -> Dict[int, int]:
     return ports
 
 
-def make_ssh_tunnel_args(
-    ssh_key: PathLike, hostname: str, ports: Dict[int, int], backend_type: str
-) -> List[str]:
-    username = "root"
-    if backend_type == "azure":
-        # root login is disabled on azure
-        # TODO: use non-root for all backends
-        username = "ubuntu"
+def make_ssh_tunnel_args(run_name: str, ports: Dict[int, int]) -> List[str]:
     args = [
         "ssh",
-        "-o",
-        "StrictHostKeyChecking=no",
-        "-o",
-        "UserKnownHostsFile=/dev/null",
-        "-i",
-        str(ssh_key),
-        f"{username}@{hostname}",
+        run_name,
         "-N",
         "-f",
     ]
@@ -81,10 +68,8 @@ def make_ssh_tunnel_args(
     return args
 
 
-def run_ssh_tunnel(
-    ssh_key: PathLike, hostname: str, ports: Dict[int, int], backend_type: str
-) -> bool:
-    args = make_ssh_tunnel_args(ssh_key, hostname, ports, backend_type)
+def run_ssh_tunnel(run_name: str, ports: Dict[int, int]) -> bool:
+    args = make_ssh_tunnel_args(run_name, ports)
     return (
         subprocess.run(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0
     )

--- a/cli/dstack/cli/commands/stop/__init__.py
+++ b/cli/dstack/cli/commands/stop/__init__.py
@@ -64,5 +64,5 @@ class StopCommand(BasicCommand):
             for job_head in job_heads:
                 if job_head.status.is_unfinished():
                     hub_client.stop_job(job_head.job_id, args.abort)
-            ssh_config_remove_host(config.ssh_config, args.run_name)
+            ssh_config_remove_host(config.ssh_config_path, args.run_name)
             console.print(f"[grey58]OK[/]")

--- a/cli/dstack/cli/commands/stop/__init__.py
+++ b/cli/dstack/cli/commands/stop/__init__.py
@@ -4,7 +4,8 @@ from rich.prompt import Confirm
 
 from dstack.cli.commands import BasicCommand
 from dstack.cli.common import add_project_argument, check_init, console
-from dstack.cli.config import get_hub_client
+from dstack.cli.config import config, get_hub_client
+from dstack.utils.ssh import ssh_config_remove_host
 
 
 def _verb(abort: bool):
@@ -63,4 +64,5 @@ class StopCommand(BasicCommand):
             for job_head in job_heads:
                 if job_head.status.is_unfinished():
                     hub_client.stop_job(job_head.job_id, args.abort)
+            ssh_config_remove_host(config.ssh_config, args.run_name)
             console.print(f"[grey58]OK[/]")

--- a/cli/dstack/cli/config.py
+++ b/cli/dstack/cli/config.py
@@ -21,6 +21,10 @@ class ConfigManager:
         self.home = Path(home).expanduser().resolve()
         self._cache: Dict[str, BaseModel] = {}
 
+    @property
+    def ssh_config(self) -> Path:
+        return self.home / "ssh_config"
+
     def dstack_key_path(self, repo_dir: Optional[PathLike] = None) -> Path:
         return self.home / "dstack_rsa"
 

--- a/cli/dstack/cli/config.py
+++ b/cli/dstack/cli/config.py
@@ -22,11 +22,14 @@ class ConfigManager:
         self._cache: Dict[str, BaseModel] = {}
 
     @property
-    def ssh_config(self) -> Path:
-        return self.home / "ssh_config"
+    def ssh_config_path(self) -> Path:
+        return _mkdir_parent(self.home / "ssh" / "config")
+
+    def ssh_control_path(self, run_name: str) -> Path:
+        return _mkdir_parent(self.home / "ssh" / "controls" / run_name)
 
     def dstack_key_path(self, repo_dir: Optional[PathLike] = None) -> Path:
-        return self.home / "dstack_rsa"
+        return _mkdir_parent(self.home / "ssh" / "id_rsa")
 
     @property
     def repos(self) -> Path:
@@ -171,3 +174,8 @@ def _read_repo_config_or_error_with_project_name(project_name: Optional[str]) ->
     except RepoNotInitializedError as e:
         e.project_name = project_name
         raise e
+
+
+def _mkdir_parent(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -26,6 +26,7 @@ typing-extensions
 file-read-backwards
 psutil
 cryptography
+filelock
 
 # AWS
 boto3

--- a/cli/tests/integration/test_commands.py
+++ b/cli/tests/integration/test_commands.py
@@ -43,7 +43,7 @@ class TestInit:
     def test_generate_default_ssh_key(
         self, capsys: CaptureFixture, dstack_dir: Path, tests_local_repo: Path
     ):
-        dstack_key_path = dstack_dir / "dstack_rsa"
+        dstack_key_path = dstack_dir / "ssh" / "id_rsa"
         with hub_process(dstack_dir):
             assert not dstack_key_path.exists()
             exit_code = run_dstack_cli(["init"], dstack_dir=dstack_dir, repo_dir=tests_local_repo)

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(
         "file-read-backwards>=3.0.0",
         "psutil>=5.0.0",
         "cryptography",
+        "filelock",
     ],
     extras_require={
         "aws": [


### PR DESCRIPTION
Closes #422 

* Add `Include ~/.dstack/ssh/config` in the default config
* Create an entry in `~/.dstack/ssh/config` for each attached remote run
* Delete the entry on the stop, abort, and exit
* Do not delete the entry on detach
* Create a control master to reuse the existing connection
* SSH provides auto-completion for entries
* Can connect to the instance with `ssh brave-ladybug-1`