### PR TITLE
Forward ports into the container, allowing listening localhost

### DIFF
--- a/cli/dstack/cli/commands/run/__init__.py
+++ b/cli/dstack/cli/commands/run/__init__.py
@@ -177,49 +177,14 @@ def _poll_run(
                     request_errors_printed = False
 
         jobs = [hub_client.get_job(job_head.job_id) for job_head in job_heads]
-        ports = {
-            app.port: app.map_to_port
-            for app in jobs[0].app_specs or []
-            if app.map_to_port is not None and app.port != app.map_to_port
-        }
-        backend_type = hub_client.get_project_backend_type()
-        if backend_type != "local":
-            include_ssh_config(config.ssh_config_path)
-            ssh_config_add_host(
-                config.ssh_config_path,
-                run_name,
-                {
-                    "HostName": jobs[0].host_name,
-                    # TODO: use non-root for all backends
-                    "User": "root" if backend_type != "azure" else "ubuntu",
-                    "IdentityFile": ssh_key,
-                    "StrictHostKeyChecking": "no",
-                    "UserKnownHostsFile": "/dev/null",
-                    "ControlPath": config.ssh_control_path(run_name),
-                    "ControlMaster": "auto",
-                    "ControlPersist": "10m",
-                },
-            )
-            console.print("Starting SSH tunnel...")
-            ports = allocate_local_ports(jobs)
-            # TODO: cleanup explicitly (stop tunnel)
-            if not run_ssh_tunnel(run_name, ports):
-                console.print("[warning]Warning: failed to start SSH tunnel[/warning] [red]✗[/]")
-        else:
-            console.print("Provisioning... It may take up to a minute. [green]✓[/]")
+        ports = attach(
+            hub_client.get_project_backend_type(),
+            jobs[0],
+            ssh_key,
+        )
         console.print()
         console.print("[grey58]To exit, press Ctrl+C.[/]")
         console.print()
-
-        for app_spec in jobs[0].app_specs or []:
-            if app_spec.app_name == "openssh-server":
-                ssh_port = app_spec.port
-                ssh_port = ports.get(ssh_port, ssh_port)
-                ssh_key_escaped = ssh_key.replace(" ", "\\ ")
-                console.print("To connect via SSH, use:")
-                console.print(f"  ssh -i {ssh_key_escaped} root@localhost -p {ssh_port}")
-                console.print()
-                break
 
         run = hub_client.list_run_heads(run_name)[0]
         if run.status.is_unfinished() or run.status == JobStatus.DONE:
@@ -247,6 +212,7 @@ def _poll_run(
                     status = run.status.name
                     break
         console.print(f"[grey58]{status.capitalize()}[/]")
+        ssh_config_remove_host(config.ssh_config_path, f"{run_name}-host")
         ssh_config_remove_host(config.ssh_config_path, run_name)
     except KeyboardInterrupt:
         global interrupt_count
@@ -324,5 +290,67 @@ def ask_on_interrupt(hub_client: HubClient, run_name: str):
         console.print("\n[grey58]Aborting...[/]")
         hub_client.stop_jobs(run_name, abort=True)
         console.print("[grey58]Aborted[/]")
+        ssh_config_remove_host(config.ssh_config_path, f"{run_name}-host")
         ssh_config_remove_host(config.ssh_config_path, run_name)
         exit(0)
+
+
+def attach(backend_type: str, job: Job, ssh_key_path: str) -> Dict[int, int]:
+    app_ports = {}
+    openssh_server_port = 0
+    for app in job.app_specs or []:
+        app_ports[app.port] = app.map_to_port or 0
+        if app.app_name == "openssh-server":
+            openssh_server_port = app.port
+    if not (backend_type != "local" or openssh_server_port != 0):
+        console.print("Provisioning... It may take up to a minute. [green]✓[/]")
+        return {k: v for k, v in app_ports.items() if v != 0}
+
+    console.print("Starting SSH tunnel...")
+    include_ssh_config(config.ssh_config_path)
+    host_ports = {int(job.env["WS_LOGS_PORT"]): 0}
+
+    if backend_type != "local":
+        ssh_config_add_host(
+            config.ssh_config_path,
+            f"{job.run_name}-host",
+            {
+                "HostName": job.host_name,
+                # TODO: use non-root for all backends
+                "User": "root" if backend_type != "azure" else "ubuntu",
+                "IdentityFile": ssh_key_path,
+                "StrictHostKeyChecking": "no",
+                "UserKnownHostsFile": "/dev/null",
+                "ControlPath": config.ssh_control_path(f"{job.run_name}-host"),
+                "ControlMaster": "auto",
+                "ControlPersist": "10m",
+            },
+        )
+        if openssh_server_port == 0:
+            host_ports.update(app_ports)
+            app_ports = {}
+        if not run_ssh_tunnel(f"{job.run_name}-host", allocate_local_ports(host_ports)):
+            console.print("[warning]Warning: failed to start SSH tunnel[/warning] [red]✗[/]")
+
+    if openssh_server_port != 0:
+        options = {
+            "HostName": "localhost",
+            "Port": app_ports[openssh_server_port] or openssh_server_port,
+            "User": "root",
+            "IdentityFile": ssh_key_path,
+            "StrictHostKeyChecking": "no",
+            "UserKnownHostsFile": "/dev/null",
+            "ControlPath": config.ssh_control_path(job.run_name),
+            "ControlMaster": "auto",
+            "ControlPersist": "10m",
+        }
+        if backend_type != "local":
+            options["ProxyJump"] = f"{job.run_name}-host"
+        ssh_config_add_host(config.ssh_config_path, job.run_name, options)
+        del app_ports[openssh_server_port]
+        if app_ports:
+            if not run_ssh_tunnel(job.run_name, allocate_local_ports(app_ports)):
+                console.print("[warning]Warning: failed to start SSH tunnel[/warning] [red]✗[/]")
+        console.print(f"To connect via SSH, use: `ssh {job.run_name}`")
+
+    return {**host_ports, **app_ports}

--- a/cli/dstack/cli/commands/run/ssh_tunnel.py
+++ b/cli/dstack/cli/commands/run/ssh_tunnel.py
@@ -4,9 +4,7 @@ import subprocess
 from contextlib import closing
 from typing import Dict, List
 
-from dstack.core.job import Job
 from dstack.providers.ports import PortUsedError
-from dstack.utils.common import PathLike
 
 
 def get_free_port() -> int:
@@ -28,14 +26,7 @@ def port_in_use(port: int) -> bool:
     return False
 
 
-def allocate_local_ports(jobs: List[Job]) -> Dict[int, int]:
-    ports = {}
-    for job in jobs[:1]:  # todo multiple jobs
-        if "WS_LOGS_PORT" in job.env:
-            ports[int(job.env["WS_LOGS_PORT"])] = None
-        for app_spec in job.app_specs or []:
-            ports[app_spec.port] = app_spec.map_to_port
-
+def allocate_local_ports(ports: Dict[int, int]) -> Dict[int, int]:
     map_to_ports = set()
     # mapped by user
     for port, map_to_port in ports.items():

--- a/cli/dstack/cli/commands/stop/__init__.py
+++ b/cli/dstack/cli/commands/stop/__init__.py
@@ -64,5 +64,6 @@ class StopCommand(BasicCommand):
             for job_head in job_heads:
                 if job_head.status.is_unfinished():
                     hub_client.stop_job(job_head.job_id, args.abort)
+            ssh_config_remove_host(config.ssh_config_path, f"{args.run_name}-host")
             ssh_config_remove_host(config.ssh_config_path, args.run_name)
             console.print(f"[grey58]OK[/]")

--- a/runner/internal/executor/executor.go
+++ b/runner/internal/executor/executor.go
@@ -567,7 +567,7 @@ func (ex *Executor) processJob(ctx context.Context, stoppedCh chan struct{}) err
 		Entrypoint:         job.Entrypoint,
 		Env:                ex.environment(ctx),
 		Mounts:             uniqueMount(bindings),
-		ExposedPorts:       ports.GetAppsExposedPorts(job.Apps),
+		ExposedPorts:       ports.GetAppsExposedPorts(ctx, job.Apps, isLocalBackend),
 		BindingPorts:       appsBindingPorts,
 		ShmSize:            resource.ShmSize,
 		AllowHostMode:      !isLocalBackend,


### PR DESCRIPTION
Closes #415

* If host mode is enabled (remote backends), run tunnel to the host
* If ssh-server is enabled, run tunnel to the container
  * For local runner docker exposes only the ssh-server port
* Add temporary Host entry in ssh config file to connect to the host `run-name-1-host`
* Add temporary Host entry in ssh config file to connect into the container `run-name-1`
  * Direct connection for local backend
  * Using ProxyJump `run-name-1-host` for remote backend

Remote host publically exposes only port 22