### PR TITLE
Auto-detect VS Code version for dev environment

### DIFF
--- a/cli/dstack/_internal/cli/commands/run/configurations.py
+++ b/cli/dstack/_internal/cli/commands/run/configurations.py
@@ -38,9 +38,9 @@ def _parse_dev_environment_configuration_data(
                 "ms-toolsai.jupyter",
             ],
         )
-        provider_data["setup"].append("pip install -q --no-cache-dir ipykernel")
     except NoVSCodeVersionError as e:
         console.print(f"[yellow]WARNING[/] {e.message}")
+    provider_data["setup"].append("pip install -q --no-cache-dir ipykernel")
     provider_data["setup"].extend(configuration_data.get("setup") or [])
     return provider_name, provider_data
 


### PR DESCRIPTION
* Rely on `code` in the PATH
* Do not install `vscode-server` if can't find `code` binary