### PR TITLE
Hotfix: increase SSH in the container delay

### DIFF
--- a/cli/dstack/_internal/cli/commands/run/__init__.py
+++ b/cli/dstack/_internal/cli/commands/run/__init__.py
@@ -390,7 +390,8 @@ def _attach_to_container(hub_client: HubClient, run_name: str, ports_lock: Ports
     for run in _poll_run_head(hub_client, run_name, loop_statuses=[JobStatus.PREBUILDING]):
         pass
     app_ports = ports_lock.release()
-    for delay in range(0, 61, POLL_PROVISION_RATE_SECS):  # retry
+    # TODO replace long delay with starting ssh-server in the beginning
+    for delay in range(0, 60 * 10 + 1, POLL_PROVISION_RATE_SECS):  # retry
         time.sleep(POLL_PROVISION_RATE_SECS if delay else 0)  # skip first sleep
         if run_ssh_tunnel(run_name, app_ports):
             # console.print(f"To connect via SSH, use: `ssh {run_name}`")


### PR DESCRIPTION
Temporary fix for #471 

* Abort run if can't connect to SSH server in the container within 10 minutes