### PR TITLE
Implement spot policy and retry policy

### DIFF
--- a/cli/dstack/_internal/backend/aws/compute.py
+++ b/cli/dstack/_internal/backend/aws/compute.py
@@ -46,6 +46,7 @@ class AWSCompute(Compute):
             subnet_id=self.subnet_id,
             runner_id=job.runner_id,
             instance_type=instance_type,
+            spot=job.requirements.spot,
             repo_id=job.repo_ref.repo_id,
             hub_user_name=job.hub_user_name,
             ssh_key_pub=job.ssh_key_pub,

--- a/cli/dstack/_internal/backend/azure/compute.py
+++ b/cli/dstack/_internal/backend/azure/compute.py
@@ -103,7 +103,7 @@ class AzureCompute(Compute):
             instance_name=_get_instance_name(job),
             user_data=_get_user_data_script(self.azure_config, job, instance_type),
             ssh_pub_key=job.ssh_key_pub,
-            spot=instance_type.resources.interruptible,
+            spot=instance_type.resources.spot,
         )
         return vm.name
 
@@ -161,7 +161,7 @@ def _get_instance_types(client: ComputeManagementClient, location: str) -> List[
                     cpus=capabilities["vCPUs"],
                     memory_mib=int(float(capabilities["MemoryGB"]) * 1024),
                     gpus=gpus,
-                    interruptible=False,
+                    spot=True,
                     local=False,
                 ),
             )

--- a/cli/dstack/_internal/backend/base/compute.py
+++ b/cli/dstack/_internal/backend/base/compute.py
@@ -93,6 +93,8 @@ def _compare_instance_types(i1, i2):
 def _matches_requirements(resources: Resources, requirements: Optional[Requirements]) -> bool:
     if not requirements:
         return True
+    if requirements.spot and not resources.spot:
+        return False
     if requirements.cpus and requirements.cpus > resources.cpus:
         return False
     if requirements.memory_mib and requirements.memory_mib > resources.memory_mib:
@@ -113,7 +115,5 @@ def _matches_requirements(resources: Resources, requirements: Optional[Requireme
                 )
             )
         ):
-            return False
-        if requirements.spot and not resources.spot:
             return False
     return True

--- a/cli/dstack/_internal/backend/base/compute.py
+++ b/cli/dstack/_internal/backend/base/compute.py
@@ -53,16 +53,16 @@ def choose_instance_type(
     if len(eligible_instance_types) == 0:
         return None
     instance_type = eligible_instance_types[0]
-    interruptible = False
-    if requirements and requirements.interruptible:
-        interruptible = True
+    spot = False
+    if requirements and requirements.spot:
+        spot = True
     return InstanceType(
         instance_name=instance_type.instance_name,
         resources=Resources(
             cpus=instance_type.resources.cpus,
             memory_mib=instance_type.resources.memory_mib,
             gpus=instance_type.resources.gpus,
-            interruptible=interruptible,
+            spot=spot,
             local=False,
         ),
     )
@@ -114,6 +114,6 @@ def _matches_requirements(resources: Resources, requirements: Optional[Requireme
             )
         ):
             return False
-        if requirements.interruptible and not resources.interruptible:
+        if requirements.spot and not resources.spot:
             return False
     return True

--- a/cli/dstack/_internal/backend/base/jobs.py
+++ b/cli/dstack/_internal/backend/base/jobs.py
@@ -1,4 +1,3 @@
-import uuid
 from typing import List, Optional, Tuple
 
 import yaml
@@ -8,7 +7,7 @@ from dstack._internal.backend.base.compute import Compute, NoCapacityError
 from dstack._internal.backend.base.storage import Storage
 from dstack._internal.core.error import NoMatchingInstanceError
 from dstack._internal.core.instance import InstanceType
-from dstack._internal.core.job import Job, JobErrorCode, JobHead, JobStatus
+from dstack._internal.core.job import Job, JobErrorCode, JobHead, JobStatus, SpotPolicy
 from dstack._internal.core.repo import RepoRef
 from dstack._internal.core.request import RequestStatus
 from dstack._internal.core.runners import Runner
@@ -102,31 +101,15 @@ def run_job(
 ):
     if job.status != JobStatus.SUBMITTED:
         raise Exception("Can't create a request for a job which status is not SUBMITTED")
-
-    runner = None
     try:
-        instance_type = compute.get_instance_type(job)
-        if instance_type is None:
-            job.status = JobStatus.FAILED
-            job.error_code = JobErrorCode.NO_INSTANCE_MATCHING_REQUIREMENTS
-            update_job(storage, job)
-            raise NoMatchingInstanceError()
-        job.instance_type = instance_type.instance_name
-        update_job(storage, job)
-        runner = Runner(
-            runner_id=job.runner_id, request_id=None, resources=instance_type.resources, job=job
+        _try_run_job(
+            storage=storage,
+            compute=compute,
+            job=job,
+            failed_to_start_job_new_status=failed_to_start_job_new_status,
         )
-        runners.create_runner(storage, runner)
-        runner.request_id = compute.run_instance(job, instance_type)
-        runners.update_runner(storage, runner)
-    except NoCapacityError:
-        job.status = failed_to_start_job_new_status
-        job.error_code = JobErrorCode.FAILED_TO_START_DUE_TO_NO_CAPACITY
-        job.request_id = runner.request_id if runner else None
-        update_job(storage, job)
     except Exception as e:
         job.status = JobStatus.FAILED
-        job.request_id = runner.request_id if runner else None
         update_job(storage, job)
         raise e
 
@@ -201,6 +184,59 @@ def update_job_submission(job: Job):
     job.status = JobStatus.SUBMITTED
     job.submission_num += 1
     job.submitted_at = get_milliseconds_since_epoch()
+
+
+def _try_run_job(
+    storage: Storage,
+    compute: Compute,
+    job: Job,
+    failed_to_start_job_new_status: JobStatus,
+    attempt: int = 0,
+):
+    spot = (
+        job.spot_policy is SpotPolicy.SPOT or job.spot_policy is SpotPolicy.AUTO and attempt == 0
+    )
+    job.requirements.spot = spot
+    instance_type = compute.get_instance_type(job)
+    if instance_type is None:
+        if job.spot_policy == SpotPolicy.AUTO and attempt == 0:
+            _try_run_job(
+                storage=storage,
+                compute=compute,
+                job=job,
+                failed_to_start_job_new_status=failed_to_start_job_new_status,
+                attempt=attempt + 1,
+            )
+        else:
+            job.status = JobStatus.FAILED
+            job.error_code = JobErrorCode.NO_INSTANCE_MATCHING_REQUIREMENTS
+            update_job(storage, job)
+            raise NoMatchingInstanceError()
+    job.instance_type = instance_type.instance_name
+    update_job(storage, job)
+    runner = Runner(
+        runner_id=job.runner_id, request_id=None, resources=instance_type.resources, job=job
+    )
+    runners.create_runner(storage, runner)
+    try:
+        runner.request_id = compute.run_instance(job, instance_type)
+    except NoCapacityError:
+        if job.spot_policy == SpotPolicy.AUTO and attempt == 0:
+            _try_run_job(
+                storage=storage,
+                compute=compute,
+                job=job,
+                failed_to_start_job_new_status=failed_to_start_job_new_status,
+                attempt=attempt + 1,
+            )
+        else:
+            job.status = failed_to_start_job_new_status
+            job.error_code = JobErrorCode.FAILED_TO_START_DUE_TO_NO_CAPACITY
+            job.request_id = runner.request_id if runner else None
+            update_job(storage, job)
+    else:
+        runners.update_runner(storage, runner)
+        update_job(storage, job)
 
 
 def _get_jobs_dir(repo_id: str) -> str:

--- a/cli/dstack/_internal/backend/base/runners.py
+++ b/cli/dstack/_internal/backend/base/runners.py
@@ -36,7 +36,7 @@ def delete_runner(storage: Storage, runner: Runner):
 
 def stop_runner(storage: Storage, compute: Compute, runner: Runner):
     if runner.request_id:
-        if runner.resources.interruptible:
+        if runner.resources.spot:
             compute.cancel_spot_request(runner.request_id)
         else:
             compute.terminate_instance(runner.request_id)
@@ -59,8 +59,8 @@ def serialize_runner_yaml(
         s += "  gpus:\\n"
         for gpu in resources.gpus:
             s += f"    - name: {gpu.name}\\n      memory_mib: {gpu.memory_mib}\\n"
-    if resources.interruptible:
-        s += "  interruptible: true\\n"
+    if resources.spot:
+        s += "  spot: true\\n"
     if resources.local:
         s += "  local: true\\n"
     return s[:-2]

--- a/cli/dstack/_internal/backend/base/tags.py
+++ b/cli/dstack/_internal/backend/base/tags.py
@@ -157,6 +157,7 @@ def create_tag_from_local_dirs(
             raise DstackError(f"The '{local_path}' path doesn't refer to an existing directory")
 
     run_name = runs.create_run(storage)
+    created_at = get_milliseconds_since_epoch()
     job = Job(
         job_id=f"{run_name},,0",
         repo_ref=repo.repo_ref,
@@ -166,7 +167,8 @@ def create_tag_from_local_dirs(
         workflow_name=None,
         provider_name="bash",
         status=JobStatus.DONE,
-        submitted_at=get_milliseconds_since_epoch(),
+        created_at=created_at,
+        submitted_at=created_at,
         image_name="scratch",
         commands=None,
         env=None,

--- a/cli/dstack/_internal/backend/gcp/compute.py
+++ b/cli/dstack/_internal/backend/gcp/compute.py
@@ -108,7 +108,7 @@ class GCPCompute(Compute):
             instance_name=_get_instance_name(job),
             user_data_script=_get_user_data_script(self.gcp_config, job, instance_type),
             service_account=self.credentials.service_account_email,
-            interruptible=instance_type.resources.interruptible,
+            spot=instance_type.resources.spot,
             accelerators=_get_accelerator_configs(
                 project_id=self.gcp_config.project_id,
                 zone=self.gcp_config.zone,
@@ -234,7 +234,7 @@ def _get_gpu_instance_type(
             cpus=requirements.cpus,
             memory_mib=requirements.memory_mib,
             shm_size_mib=requirements.shm_size_mib,
-            interruptible=requirements.interruptible,
+            spot=requirements.spot,
             local=requirements.local,
             gpus=None,
         ),
@@ -308,7 +308,7 @@ def _machine_type_to_instance_type(machine_type: compute_v1.MachineType) -> Inst
             cpus=machine_type.guest_cpus,
             memory_mib=machine_type.memory_mb,
             gpus=gpus,
-            interruptible=True,
+            spot=True,
             local=False,
         ),
     )
@@ -349,7 +349,7 @@ def _add_gpus_to_instance_type(
                     resources=Resources(
                         cpus=instance_type.resources.cpus,
                         memory_mib=instance_type.resources.memory_mib,
-                        interruptible=instance_type.resources.interruptible,
+                        spot=instance_type.resources.spot,
                         local=instance_type.resources.local,
                         gpus=[
                             Gpu(
@@ -494,7 +494,7 @@ def _launch_instance(
     instance_name: str,
     user_data_script: str,
     service_account: str,
-    interruptible: bool,
+    spot: bool,
     accelerators: List[compute_v1.AcceleratorConfig],
     labels: Dict[str, str],
     ssh_key_pub: str,
@@ -526,7 +526,7 @@ def _launch_instance(
         user_data_script=user_data_script,
         service_account=service_account,
         external_access=True,
-        spot=interruptible,
+        spot=spot,
         accelerators=accelerators,
         labels=labels,
         ssh_key_pub=ssh_key_pub,

--- a/cli/dstack/_internal/backend/local/compute.py
+++ b/cli/dstack/_internal/backend/local/compute.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from dstack._internal.backend.base.compute import Compute
+from dstack._internal.backend.base.compute import Compute, choose_instance_type
 from dstack._internal.backend.local import runners
 from dstack._internal.backend.local.config import LocalConfig
 from dstack._internal.core.instance import InstanceType
@@ -17,7 +17,11 @@ class LocalCompute(Compute):
 
     def get_instance_type(self, job: Job) -> Optional[InstanceType]:
         resources = runners.check_runner_resources(self.backend_config, job.runner_id)
-        return InstanceType(instance_name="", resources=resources)
+        instance_type = choose_instance_type(
+            instance_types=[InstanceType(instance_name="", resources=resources)],
+            requirements=job.requirements,
+        )
+        return instance_type
 
     def run_instance(self, job: Job, instance_type: InstanceType) -> str:
         return runners.start_runner_process(self.backend_config, job.runner_id)

--- a/cli/dstack/_internal/backend/local/runners.py
+++ b/cli/dstack/_internal/backend/local/runners.py
@@ -67,7 +67,7 @@ def _unserialize_runner_resources(data: dict) -> Resources:
         gpus=[Gpu(name=g["name"], memory_mib=g["memory_mib"]) for g in data["gpus"]]
         if data.get("gpus")
         else [],
-        interruptible=False,
+        spot=False,
         local=True,
     )
 

--- a/cli/dstack/_internal/cli/commands/run/__init__.py
+++ b/cli/dstack/_internal/cli/commands/run/__init__.py
@@ -186,11 +186,11 @@ def _print_run_plan(configuration_file: str, run_plan: RunPlan):
     table.add_column("PROJECT", style="grey58", no_wrap=True, max_width=16)
     table.add_column("INSTANCE")
     table.add_column("RESOURCES")
-    table.add_column("SPOT")
+    table.add_column("SPOT POLICY")
     job_plan = run_plan.job_plans[0]
     instance = job_plan.instance_type.instance_name or "-"
     instance_info = _format_resources(job_plan.instance_type)
-    spot = "yes" if job_plan.instance_type.resources.interruptible else "no"
+    spot = job_plan.job.spot_policy.value
     table.add_row(
         configuration_file, run_plan.hub_user_name, run_plan.project, instance, instance_info, spot
     )

--- a/cli/dstack/_internal/cli/commands/run/__init__.py
+++ b/cli/dstack/_internal/cli/commands/run/__init__.py
@@ -152,8 +152,10 @@ class RunCommand(BasicCommand):
                 args=args,
             )
             runs = list_runs_hub(hub_client, run_name=run_name)
-            print_runs(runs)
             run = runs[0]
+            if run.status == JobStatus.PENDING:
+                console.print("Cannot provision the instance due to no capacity. Retrying...\n")
+            print_runs(runs)
             if run.status == JobStatus.FAILED:
                 console.print("\nProvisioning failed\n")
                 exit(1)

--- a/cli/dstack/_internal/cli/commands/run/configurations.py
+++ b/cli/dstack/_internal/cli/commands/run/configurations.py
@@ -95,12 +95,7 @@ def parse_configuration_file(
         profile = profiles.get("default")
     if profile and "resources" in profile:
         provider_data["resources"] = profile["resources"]
-        provider_data["resources"]["interruptible"] = True
-        if "instance-type" in profile["resources"]:
-            if profile["resources"]["instance-type"] == "on-demand":
-                del provider_data["resources"]["interruptible"]
-                # TODO: It doesn't support instance-type properly
-            del provider_data["resources"]["instance-type"]
+    provider_data["spot_policy"] = profile.get("spot_policy")
     project_name = profile.get("project") if profile else None
     if not Path(os.getcwd()).samefile(Path(working_dir)):
         provider_data["working_dir"] = str(Path(working_dir))

--- a/cli/dstack/_internal/cli/commands/run/configurations.py
+++ b/cli/dstack/_internal/cli/commands/run/configurations.py
@@ -27,7 +27,7 @@ def _parse_dev_environment_configuration_data(
     configuration_data: Dict[str, Any]
 ) -> Tuple[str, Dict[str, Any]]:
     provider_name = "ssh"
-    provider_data = {}
+    provider_data = {"configuration_type": "dev-environment"}
     _init_base_provider_data(configuration_data, provider_data)
     provider_data["setup"] = []
     try:
@@ -54,7 +54,7 @@ def _parse_task_configuration_data(
 ) -> Tuple[str, Dict[str, Any]]:
     # TODO: Support the `docker` provider
     provider_name = "bash"
-    provider_data = {"commands": []}
+    provider_data = {"configuration_type": "task", "commands": []}
     if "setup" in configuration_data:
         provider_data["setup"] = configuration_data["setup"] or []
     provider_data["commands"].extend(configuration_data["commands"])

--- a/cli/dstack/_internal/cli/commands/run/configurations.py
+++ b/cli/dstack/_internal/cli/commands/run/configurations.py
@@ -96,6 +96,7 @@ def parse_configuration_file(
     if profile and "resources" in profile:
         provider_data["resources"] = profile["resources"]
     provider_data["spot_policy"] = profile.get("spot_policy")
+    provider_data["retry_policy"] = profile.get("retry_policy")
     project_name = profile.get("project") if profile else None
     if not Path(os.getcwd()).samefile(Path(working_dir)):
         provider_data["working_dir"] = str(Path(working_dir))

--- a/cli/dstack/_internal/cli/common.py
+++ b/cli/dstack/_internal/cli/common.py
@@ -29,6 +29,7 @@ def generate_runs_table(
         table.add_column("CONFIGURATION", style="grey58")
     table.add_column("USER", style="grey58", no_wrap=True, max_width=16)
     table.add_column("INSTANCE", no_wrap=True)
+    table.add_column("SPOT", no_wrap=True)
     table.add_column("STATUS", no_wrap=True)
     table.add_column("SUBMITTED", style="grey58", no_wrap=True)
     if verbose:
@@ -44,6 +45,7 @@ def generate_runs_table(
             [
                 _status_color(run, run.hub_user_name or "", False, False),
                 _pretty_print_instance_type(run),
+                _pretty_print_spot(run),
                 _pretty_print_status(run),
                 _status_color(run, submitted_at, False, False),
             ]
@@ -105,6 +107,11 @@ def _pretty_print_error_code(run: RunHead) -> str:
             else:
                 return f"[red]{job_head.error_code.pretty_repr()}[/]"
     return ""
+
+
+def _pretty_print_spot(run: RunHead) -> str:
+    spot = "yes" if run.job_heads[0].instance_spot_type == "spot" else "no"
+    return _status_color(run, spot, False, False)
 
 
 def _pretty_print_instance_type(run: RunHead) -> str:

--- a/cli/dstack/_internal/core/instance.py
+++ b/cli/dstack/_internal/core/instance.py
@@ -6,6 +6,3 @@ from dstack._internal.core.runners import Resources
 class InstanceType(BaseModel):
     instance_name: str
     resources: Resources
-
-    def __str__(self) -> str:
-        return f'InstanceType(instance_name="{self.instance_name}", resources={self.resources})'

--- a/cli/dstack/_internal/hub/routers/runners.py
+++ b/cli/dstack/_internal/hub/routers/runners.py
@@ -17,8 +17,11 @@ router = APIRouter(
 async def run_runners(project_name: str, job: Job):
     project = await get_project(project_name=project_name)
     backend = get_backend(project)
+    failed_to_start_job_new_status = JobStatus.FAILED
+    if job.retry_policy.retry:
+        failed_to_start_job_new_status = JobStatus.PENDING
     try:
-        await run_async(backend.run_job, job, JobStatus.PENDING)
+        await run_async(backend.run_job, job, failed_to_start_job_new_status)
     except NoMatchingInstanceError:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/cli/dstack/_internal/schemas/profiles.json
+++ b/cli/dstack/_internal/schemas/profiles.json
@@ -70,6 +70,21 @@
         "on-demand",
         "auto"
       ]
+    },
+    "retry_policy": {
+      "description": "The policy for re-submitting runs",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "retry": {
+          "description": "Whether to retry runs on failure or not",
+          "type": "boolean"
+        },
+        "limit": {
+          "description": "The maximum period of re-submitting the run, e.g. 1d",
+          "type": "string"
+        }
+      }
     }
   },
   "properties": {
@@ -97,6 +112,9 @@
           },
           "spot_policy": {
             "$ref": "#/definitions/spot_policy"
+          },
+          "retry_policy": {
+            "$ref": "#/definitions/retry_policy"
           },
           "default": {
             "type": "boolean",

--- a/cli/dstack/_internal/schemas/profiles.json
+++ b/cli/dstack/_internal/schemas/profiles.json
@@ -59,17 +59,17 @@
           "enum": [
             true
           ]
-        },
-        "instance-type": {
-          "description": "The type of instance",
-          "type": "string",
-          "enum": [
-            "on-demand",
-            "auto",
-            "spot"
-          ]
         }
       }
+    },
+    "spot_policy": {
+      "description": "The policy for provisioning spot or on-demand instances",
+      "type": "string",
+      "enum": [
+        "spot",
+        "on-demand",
+        "auto"
+      ]
     }
   },
   "properties": {
@@ -94,6 +94,9 @@
           },
           "resources": {
             "$ref": "#/definitions/resources"
+          },
+          "spot_policy": {
+            "$ref": "#/definitions/spot_policy"
           },
           "default": {
             "type": "boolean",

--- a/cli/dstack/_internal/schemas/profiles.json
+++ b/cli/dstack/_internal/schemas/profiles.json
@@ -72,16 +72,16 @@
       ]
     },
     "retry_policy": {
-      "description": "The policy for re-submitting runs",
+      "description": "The policy for re-submitting the run",
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "retry": {
-          "description": "Whether to retry runs on failure or not",
+          "description": "Whether to retry the run on failure or not",
           "type": "boolean"
         },
         "limit": {
-          "description": "The maximum period of re-submitting the run, e.g. 1d",
+          "description": "The maximum period of retrying the run, e.g. 1d",
           "type": "string"
         }
       }

--- a/cli/tests/providers/docker/test_entrypoint.py
+++ b/cli/tests/providers/docker/test_entrypoint.py
@@ -10,7 +10,12 @@ from dstack._internal.providers.docker.main import DockerProvider
 def create_provider_data(
     commands: Optional[List[str]] = None, entrypoint: Optional[str] = None
 ) -> dict:
-    return {"image": "ubuntu:20.04", "commands": commands, "entrypoint": entrypoint}
+    return {
+        "image": "ubuntu:20.04",
+        "commands": commands,
+        "entrypoint": entrypoint,
+        "configuration_type": "task",
+    }
 
 
 args = Namespace(args=[], unknown=[], detach=True)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -181,12 +181,6 @@ profiles:
 
 </div>
 
-!!! info "Instance type"
-    By default, `dstack` will try to use spot instances if available and if they aren't available, it will
-    use on-demand instances. You can change this behavior by specifying the [`instance-type`](reference/profiles.yml.md) property.
-
-[//]: # (TODO: The `instance-type` property is not supported properly yet)
-
 Now, if you use the `dstack run` command, `dstack` will use the default profile.
 
 !!! info "Multiple profiles"

--- a/docs/docs/reference/cli/run.md
+++ b/docs/docs/reference/cli/run.md
@@ -45,6 +45,19 @@ The following arguments are optional:
 - `-t TAG`, `--tag TAG` – (Optional) A tag name. Warning, if the tag exists, it will be overridden.
 - `ARGS` – (Optional) Use `ARGS` to pass custom run arguments
 
+Spot policy (the arguments are mutually exclusive):
+
+- `--spot-policy` – The policy for provisioning spot or on-demand instances: `spot`, `on-demand`, or `auto`. 
+- `--spot` – A shorthand for `--spot-policy spot`
+- `--on-demand` – A shorthand for `--spot-policy on-demand`
+- `--spot-auto` – A shorthand for `--spot-policy auto`
+
+Retry policy (the arguments are mutually exclusive):
+
+- `--no-retry` – Do not retry the run on failure
+- `--retry` – Retry the run on failure. Use a default retry limit (1h). 
+- `--retry-limit` – Retry the run on failure with a custom retry limit, e.g. 4h or 1d
+
 Prebuild policies:
 
 - `--no-prebuild` – Run `setup` first, then `commands` if any

--- a/docs/docs/reference/profiles.yml.md
+++ b/docs/docs/reference/profiles.yml.md
@@ -16,10 +16,11 @@ Below is a full reference of all available properties.
             - `memory` (Optional) The minimum size of GPU memory (e.g., `"16GB"`)
         - `shm_size` (Optional) The size of shared memory (e.g., `"8GB"`). If you are using parallel communicating
           processes (e.g., dataloaders in PyTorch), you may need to configure this.
-    - `instance-type` - (Optional) The type of instance. Can be `auto`, `on-demand`, and `spot`. Defaults to `auto`.
+    - `spot_policy` - (Optional) The policy for provisioning spot or on-demand instances: `spot`, `on-demand`, or `auto`. `spot` provisions a spot instance. `on-demand` provisions a on-demand instance. `auto` first tries to provision a spot instance and then tries on-demand if spot is not available. Defaults to `on-demand` for dev environments and to `auto` for tasks.
+    - `retry_policy` - (Optional) The policy for re-submitting the run.
+        - `retry` - (Optional) Whether to retry the run on failure or not. Default to `false`
+        - `limit` - (Optional) The maximum period of retrying the run, e.g. 4h or 1d. Defaults to 1h if `retry` is `true`.
 
 [//]: # (TODO: Add examples)
-
-[//]: # (TODO: Explain how `instance-type` works)
 
 [//]: # (TODO: Add more explanations of how it works, incl. how to pass defined profiles to the CLI)

--- a/runner/internal/backend/gcp/backend.go
+++ b/runner/internal/backend/gcp/backend.go
@@ -162,7 +162,7 @@ func (gbackend *GCPBackend) CheckStop(ctx context.Context) (bool, error) {
 }
 
 func (gbackend *GCPBackend) IsInterrupted(ctx context.Context) (bool, error) {
-	if !gbackend.state.Resources.Interruptible {
+	if !gbackend.state.Resources.Spot {
 		return false, nil
 	}
 	return gbackend.compute.IsInterruptedSpot(ctx, gbackend.state.RequestID)

--- a/runner/internal/backend/s3/backend.go
+++ b/runner/internal/backend/s3/backend.go
@@ -189,7 +189,7 @@ func (s *S3) CheckStop(ctx context.Context) (bool, error) {
 }
 
 func (s *S3) IsInterrupted(ctx context.Context) (bool, error) {
-	if !s.state.Resources.Interruptible {
+	if !s.state.Resources.Spot {
 		return false, nil
 	}
 	return s.cliEC2.IsInterruptedSpot(ctx, s.state.RequestID)
@@ -203,7 +203,7 @@ func (s *S3) Shutdown(ctx context.Context) error {
 	if s.state.Resources.Local {
 		return nil
 	}
-	if s.state.Resources.Interruptible {
+	if s.state.Resources.Spot {
 		log.Trace(ctx, "Instance interruptible")
 		if err := s.cliEC2.CancelSpot(ctx, s.state.RequestID); err != nil {
 			return gerrors.Wrap(err)

--- a/runner/internal/models/backend.go
+++ b/runner/internal/models/backend.go
@@ -6,12 +6,12 @@ import (
 )
 
 type Resource struct {
-	CPUs          int    `yaml:"cpus,omitempty"`
-	Memory        uint64 `yaml:"memory_mib,omitempty"`
-	GPUs          []GPU  `yaml:"gpus,omitempty"`
-	Interruptible bool   `yaml:"interruptible,omitempty"`
-	ShmSize       int64  `yaml:"shm_size_mib,omitempty"`
-	Local         bool   `json:"local"`
+	CPUs    int    `yaml:"cpus,omitempty"`
+	Memory  uint64 `yaml:"memory_mib,omitempty"`
+	GPUs    []GPU  `yaml:"gpus,omitempty"`
+	Spot    bool   `yaml:"spot,omitempty"`
+	ShmSize int64  `yaml:"shm_size_mib,omitempty"`
+	Local   bool   `json:"local"`
 }
 
 type Job struct {
@@ -87,12 +87,12 @@ type App struct {
 }
 
 type Requirements struct {
-	GPUs          GPU   `yaml:"gpus,omitempty"`
-	CPUs          int   `yaml:"cpus,omitempty"`
-	Memory        int   `yaml:"memory_mib,omitempty"`
-	Interruptible bool  `yaml:"interruptible,omitempty"`
-	ShmSize       int64 `yaml:"shm_size_mib,omitempty"`
-	Local         bool  `json:"local"`
+	GPUs    GPU   `yaml:"gpus,omitempty"`
+	CPUs    int   `yaml:"cpus,omitempty"`
+	Memory  int   `yaml:"memory_mib,omitempty"`
+	Spot    bool  `yaml:"spot,omitempty"`
+	ShmSize int64 `yaml:"shm_size_mib,omitempty"`
+	Local   bool  `json:"local"`
 }
 
 type GPU struct {

--- a/runner/internal/models/backend.go
+++ b/runner/internal/models/backend.go
@@ -48,10 +48,14 @@ type Job struct {
 	Requirements      Requirements `yaml:"requirements"`
 	RunName           string       `yaml:"run_name"`
 	RunnerID          string       `yaml:"runner_id"`
+	SpotPolicy        string       `yaml:"spot_policy"`
+	RetryPolicy       RetryPolicy  `yaml:"retry_policy"`
 	Status            string       `yaml:"status"`
 	ErrorCode         string       `yaml:"error_code,omitempty"`
 	ContainerExitCode string       `yaml:"container_exit_code,omitempty"`
+	CreatedAt         uint64       `yaml:"created_at"`
 	SubmittedAt       uint64       `yaml:"submitted_at"`
+	SubmissionNum     int          `yaml:"submission_num"`
 	TagName           string       `yaml:"tag_name"`
 	InstanceType      string       `yaml:"instance_type"`
 	ConfigurationPath string       `yaml:"configuration_path"`
@@ -100,6 +104,11 @@ type GPU struct {
 	Count     int    `yaml:"count,omitempty"`
 	Name      string `yaml:"name,omitempty"`
 	MemoryMiB int    `yaml:"memory_mib,omitempty"`
+}
+
+type RetryPolicy struct {
+	Retry bool `yaml:"retry"`
+	Limit int  `yaml:"limit,omitempty"`
 }
 
 type State struct {

--- a/runner/internal/models/backend.go
+++ b/runner/internal/models/backend.go
@@ -55,6 +55,7 @@ type Job struct {
 	TagName           string       `yaml:"tag_name"`
 	InstanceType      string       `yaml:"instance_type"`
 	ConfigurationPath string       `yaml:"configuration_path"`
+	ConfigurationType string       `yaml:"configuration_type"`
 	WorkflowName      string       `yaml:"workflow_name"`
 	HomeDir           string       `yaml:"home_dir"`
 	WorkingDir        string       `yaml:"working_dir"`


### PR DESCRIPTION
Closes #449, #384, and #289.

1\. `interruptible` is renamed to `spot` everywhere.

2\. Local backend respects `resources`

3\. It's now possible to specify spot policy and retry policy in profiles.yaml:

- `profiles` (Required) - The root property (of an `array` type)
    - ...
    - `spot_policy` - (Optional) The policy for provisioning spot or on-demand instances: `spot`, `on-demand`, or `auto`. `spot` provisions a spot instance. `on-demand` provisions a on-demand instance. `auto` first tries to provision a spot instance and then tries on-demand if spot is not available. Defaults to `on-demand` for dev environments and to `auto` for tasks.
    - `retry_policy` - (Optional) The policy for re-submitting the run.
        - `retry` - (Optional) Whether to retry the run on failure or not. Default to `false`
        - `limit` - (Optional) The maximum period of retrying the run, e.g. 4h or 1d. Defaults to 1h if `retry` is `true`.
        
And as the CLI arguments:

Spot policy (the arguments are mutually exclusive):

- `--spot-policy` – The policy for provisioning spot or on-demand instances: `spot`, `on-demand`, or `auto`. 
- `--spot` – A shorthand for `--spot-policy spot`
- `--on-demand` – A shorthand for `--spot-policy on-demand`
- `--spot-auto` – A shorthand for `--spot-policy auto`

Retry policy (the arguments are mutually exclusive):

- `--no-retry` – Do not retry the run on failure
- `--retry` – Retry the run on failure. Use a default retry limit (1h). 
- `--retry-limit` – Retry the run on failure with a custom retry limit, e.g. 4h or 1d
