### PR TITLE
Improve dstack run and dstack server output

### DIFF
--- a/cli/dstack/_internal/cli/commands/run/__init__.py
+++ b/cli/dstack/_internal/cli/commands/run/__init__.py
@@ -252,6 +252,10 @@ def _poll_run(
                     request_errors_printed = False
             # handle TERMINATED and DOWNLOADING
             run = next(_poll_run_head(hub_client, run_name))
+            if run.status == JobStatus.FAILED:
+                console.print()
+                _print_failed_run_message(run)
+                exit(1)
             if run.status == JobStatus.DOWNLOADING:
                 progress.update(task, description="Downloading deps... It may take a while.")
             elif run.has_request_status([RequestStatus.TERMINATED]):
@@ -322,9 +326,7 @@ def _poll_run(
 
 def _print_failed_run_message(run: RunHead):
     if run.job_heads[0].error_code is JobErrorCode.FAILED_TO_START_DUE_TO_NO_CAPACITY:
-        console.print(
-            "Provisioning failed due to no capacity. Set up retry policy to retry runs automatically.\n"
-        )
+        console.print("Provisioning failed due to no capacity\n")
     else:
         console.print("Provisioning failed\n")
 

--- a/cli/dstack/_internal/cli/commands/run/__init__.py
+++ b/cli/dstack/_internal/cli/commands/run/__init__.py
@@ -25,7 +25,7 @@ from dstack._internal.cli.common import add_project_argument, check_init, consol
 from dstack._internal.cli.config import config, get_hub_client
 from dstack._internal.core.error import RepoNotInitializedError
 from dstack._internal.core.instance import InstanceType
-from dstack._internal.core.job import Job, JobHead, JobStatus
+from dstack._internal.core.job import Job, JobErrorCode, JobHead, JobStatus
 from dstack._internal.core.plan import RunPlan
 from dstack._internal.core.request import RequestStatus
 from dstack._internal.core.run import RunHead
@@ -153,15 +153,10 @@ class RunCommand(BasicCommand):
             )
             runs = list_runs_hub(hub_client, run_name=run_name)
             run = runs[0]
-            if run.status == JobStatus.PENDING:
-                console.print("Cannot provision the instance due to no capacity. Retrying...\n")
-            print_runs(runs)
-            if run.status == JobStatus.FAILED:
-                console.print("\nProvisioning failed\n")
-                exit(1)
             if not args.detach:
                 _poll_run(
                     hub_client,
+                    run,
                     jobs,
                     ssh_key=config.repo_user_config.ssh_key_path,
                     watcher=watcher,
@@ -213,19 +208,34 @@ def _format_resources(instance_type: InstanceType) -> str:
 
 def _poll_run(
     hub_client: HubClient,
+    run: RunHead,
     job_heads: List[JobHead],
     ssh_key: Optional[str],
     watcher: Optional[Watcher],
 ):
-    run_name = job_heads[0].run_name
+    print_runs([run])
+    console.print()
+    if run.status == JobStatus.FAILED:
+        _print_failed_run_message(run)
+        exit(1)
+    run_name = run.run_name
+
     try:
-        console.print()
         with Progress(
             TextColumn("[progress.description]{task.description}"),
             SpinnerColumn(),
             transient=True,
         ) as progress:
-            task = progress.add_task("Provisioning... It may take up to a minute.", total=None)
+            task = None
+            for run in _poll_run_head(hub_client, run_name, loop_statuses=[JobStatus.PENDING]):
+                if task is None:
+                    task = progress.add_task(
+                        "Waiting for capacity... To exit, press Ctrl+C.", total=None
+                    )
+
+            if task is None:
+                task = progress.add_task("Provisioning... It may take up to a minute.", total=None)
+
             # idle PENDING and SUBMITTED
             request_errors_printed = False
             for run in _poll_run_head(
@@ -308,6 +318,15 @@ def _poll_run(
         global interrupt_count
         interrupt_count = 1
         _ask_on_interrupt(hub_client, run_name)
+
+
+def _print_failed_run_message(run: RunHead):
+    if run.job_heads[0].error_code is JobErrorCode.FAILED_TO_START_DUE_TO_NO_CAPACITY:
+        console.print(
+            "Provisioning failed due to no capacity. Set up retry policy to retry runs automatically.\n"
+        )
+    else:
+        console.print("Provisioning failed\n")
 
 
 def _attach(hub_client: HubClient, job: Job, ssh_key_path: str) -> Dict[int, int]:

--- a/cli/dstack/_internal/hub/background/__init__.py
+++ b/cli/dstack/_internal/hub/background/__init__.py
@@ -1,3 +1,6 @@
+import asyncio
+
+from apscheduler.events import EVENT_JOB_ERROR, JobExecutionEvent
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 
@@ -5,6 +8,11 @@ from dstack._internal.hub.background.tasks.resubmit_jobs import resubmit_jobs
 
 
 def start_background_tasks():
+    def _error_listner(event: JobExecutionEvent):
+        if isinstance(event.exception, asyncio.exceptions.CancelledError):
+            scheduler.shutdown()
+
     scheduler = AsyncIOScheduler()
     scheduler.add_job(resubmit_jobs, IntervalTrigger(seconds=60))
+    scheduler.add_listener(_error_listner, EVENT_JOB_ERROR)
     scheduler.start()

--- a/cli/dstack/_internal/hub/background/tasks/resubmit_jobs.py
+++ b/cli/dstack/_internal/hub/background/tasks/resubmit_jobs.py
@@ -44,7 +44,7 @@ def _resubmit_backend_jobs(backend: Backend):
                     if (
                         job.retry_policy is not None
                         and job.retry_policy.retry
-                        and curr_time - job.created_at < job.retry_policy.limit
+                        and curr_time - job.created_at < job.retry_policy.limit * 1000
                     ):
                         backend.resubmit_job(
                             job=job,

--- a/cli/dstack/_internal/hub/utils/logging.py
+++ b/cli/dstack/_internal/hub/utils/logging.py
@@ -1,11 +1,22 @@
+import asyncio
 import logging
 import os
 import sys
 
 
+class AsyncioCancelledErrorFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.exc_info is None:
+            return True
+        if isinstance(record.exc_info[1], asyncio.exceptions.CancelledError):
+            return False
+        return True
+
+
 def configure_root_logger():
     logger = logging.getLogger(None)
     handler = logging.StreamHandler(stream=sys.stdout)
+    handler.addFilter(AsyncioCancelledErrorFilter())
     formatter = logging.Formatter(
         fmt="%(levelname)s %(asctime)s.%(msecs)03d %(name)s %(message)s",
         datefmt="%Y-%m-%dT%H:%M:%S",

--- a/scripts/build_hub.sh
+++ b/scripts/build_hub.sh
@@ -3,7 +3,6 @@
 script_path="$(realpath $0)"
 root_dir="$(dirname $(dirname $script_path))"
 
-ls
 cd hub
 npm run build
 rm -rf ../cli/dstack/_internal/hub/statics


### PR DESCRIPTION
Fixes #492

Also, `dstack run` now prints `Waiting for capacity... To exit, press Ctrl+C.` instead of `Provisioning... It may take up to a minute.` in case of retrying on no capacity.