### PR TITLE
Change build semantics

### DIFF
--- a/cli/dstack/_internal/cli/commands/build/__init__.py
+++ b/cli/dstack/_internal/cli/commands/build/__init__.py
@@ -19,9 +19,9 @@ from dstack._internal.core.error import RepoNotInitializedError
 from dstack._internal.core.job import JobStatus
 
 
-class PrebuildCommand(BasicCommand):
-    NAME = "prebuild"
-    DESCRIPTION = "Prebuild environment"
+class BuildCommand(BasicCommand):
+    NAME = "build"
+    DESCRIPTION = "Build environment"
 
     @check_init
     def _command(self, args: argparse.Namespace):
@@ -33,7 +33,7 @@ class PrebuildCommand(BasicCommand):
         ) = configurations.parse_configuration_file(
             args.working_dir, args.file_name, args.profile_name
         )
-        provider_data["prebuild"] = "prebuild-only"
+        provider_data["build_policy"] = "build-only"
 
         if args.project:
             project_name = args.project
@@ -75,6 +75,7 @@ class PrebuildCommand(BasicCommand):
                 exit(1)
             _poll_run(
                 hub_client,
+                run,
                 jobs,
                 ssh_key=config.repo_user_config.ssh_key_path,
                 watcher=None,

--- a/cli/dstack/_internal/cli/commands/build/__init__.py
+++ b/cli/dstack/_internal/cli/commands/build/__init__.py
@@ -68,7 +68,6 @@ class BuildCommand(BasicCommand):
                 args=args,
             )
             runs = list_runs_hub(hub_client, run_name=run_name)
-            print_runs(runs)
             run = runs[0]
             if run.status == JobStatus.FAILED:
                 console.print("\nProvisioning failed\n")

--- a/cli/dstack/_internal/cli/commands/run/__init__.py
+++ b/cli/dstack/_internal/cli/commands/run/__init__.py
@@ -409,8 +409,8 @@ def _attach(hub_client: HubClient, job: Job, ssh_key_path: str) -> Dict[int, int
 
 
 def _attach_to_container(hub_client: HubClient, run_name: str, ports_lock: PortsLock):
-    # idle PREBUILDING
-    for run in _poll_run_head(hub_client, run_name, loop_statuses=[JobStatus.PREBUILDING]):
+    # idle BUILDING
+    for run in _poll_run_head(hub_client, run_name, loop_statuses=[JobStatus.BUILDING]):
         pass
     app_ports = ports_lock.release()
     # TODO replace long delay with starting ssh-server in the beginning

--- a/cli/dstack/_internal/cli/commands/run/__init__.py
+++ b/cli/dstack/_internal/cli/commands/run/__init__.py
@@ -327,6 +327,8 @@ def _poll_run(
 def _print_failed_run_message(run: RunHead):
     if run.job_heads[0].error_code is JobErrorCode.FAILED_TO_START_DUE_TO_NO_CAPACITY:
         console.print("Provisioning failed due to no capacity\n")
+    elif run.job_heads[0].error_code is JobErrorCode.BUILD_NOT_FOUND:
+        console.print("Build not found. Run `dstack build` or add `--build` flag")
     else:
         console.print("Provisioning failed\n")
 

--- a/cli/dstack/_internal/cli/commands/run/configurations.py
+++ b/cli/dstack/_internal/cli/commands/run/configurations.py
@@ -46,6 +46,7 @@ def _parse_dev_environment_configuration_data(
         )
     provider_data["build"].append("pip install -q --no-cache-dir ipykernel")
     provider_data["build"].extend(configuration_data.get("build") or [])
+    provider_data["commands"] = configuration_data.get("init")
     return provider_name, provider_data
 
 

--- a/cli/dstack/_internal/cli/commands/run/configurations.py
+++ b/cli/dstack/_internal/cli/commands/run/configurations.py
@@ -29,10 +29,10 @@ def _parse_dev_environment_configuration_data(
     provider_name = "ssh"
     provider_data = {"configuration_type": "dev-environment"}
     _init_base_provider_data(configuration_data, provider_data)
-    provider_data["setup"] = []
+    provider_data["build"] = []
     try:
         VSCodeDesktopServer.patch_setup(
-            provider_data["setup"],
+            provider_data["build"],
             vscode_extensions=[
                 "ms-python.python",
                 "ms-toolsai.jupyter",
@@ -44,8 +44,8 @@ def _parse_dev_environment_configuration_data(
             "sea_green3]Command Palette[/sea_green3], executing [sea_green3]Shell Command: Install 'code' command in "
             "PATH[/sea_green3], and restarting terminal.[/]\n"
         )
-    provider_data["setup"].append("pip install -q --no-cache-dir ipykernel")
-    provider_data["setup"].extend(configuration_data.get("setup") or [])
+    provider_data["build"].append("pip install -q --no-cache-dir ipykernel")
+    provider_data["build"].extend(configuration_data.get("build") or [])
     return provider_name, provider_data
 
 
@@ -55,8 +55,8 @@ def _parse_task_configuration_data(
     # TODO: Support the `docker` provider
     provider_name = "bash"
     provider_data = {"configuration_type": "task", "commands": []}
-    if "setup" in configuration_data:
-        provider_data["setup"] = configuration_data["setup"] or []
+    if "build" in configuration_data:
+        provider_data["build"] = configuration_data["build"] or []
     provider_data["commands"].extend(configuration_data["commands"])
     _init_base_provider_data(configuration_data, provider_data)
     return provider_name, provider_data

--- a/cli/dstack/_internal/cli/commands/run/configurations.py
+++ b/cli/dstack/_internal/cli/commands/run/configurations.py
@@ -30,14 +30,11 @@ def _parse_dev_environment_configuration_data(
     provider_data = {"configuration_type": "dev-environment"}
     _init_base_provider_data(configuration_data, provider_data)
     provider_data["build"] = []
+    provider_data["commands"] = []
     try:
-        VSCodeDesktopServer.patch_setup(
-            provider_data["build"],
-            vscode_extensions=[
-                "ms-python.python",
-                "ms-toolsai.jupyter",
-            ],
-        )
+        extensions = ["ms-python.python", "ms-toolsai.jupyter"]
+        VSCodeDesktopServer.patch_setup(provider_data["build"], vscode_extensions=extensions)
+        VSCodeDesktopServer.patch_commands(provider_data["commands"], vscode_extensions=extensions)
     except NoVSCodeVersionError as e:
         console.print(
             "[grey58]Unable to detect the VS Code version and pre-install extensions. Fix by opening ["
@@ -46,7 +43,7 @@ def _parse_dev_environment_configuration_data(
         )
     provider_data["build"].append("pip install -q --no-cache-dir ipykernel")
     provider_data["build"].extend(configuration_data.get("build") or [])
-    provider_data["commands"] = configuration_data.get("init")
+    provider_data["commands"].extend(configuration_data.get("init") or [])
     return provider_name, provider_data
 
 

--- a/cli/dstack/_internal/cli/common.py
+++ b/cli/dstack/_internal/cli/common.py
@@ -63,7 +63,7 @@ _status_colors = {
     JobStatus.SUBMITTED: "yellow",
     JobStatus.PENDING: "yellow",
     JobStatus.DOWNLOADING: "yellow",
-    JobStatus.PREBUILDING: "yellow",
+    JobStatus.BUILDING: "yellow",
     JobStatus.RUNNING: "dark_sea_green4",
     JobStatus.UPLOADING: "dark_sea_green4",
     JobStatus.DONE: "grey74",

--- a/cli/dstack/_internal/cli/handlers.py
+++ b/cli/dstack/_internal/cli/handlers.py
@@ -1,9 +1,9 @@
+from dstack._internal.cli.commands.build import BuildCommand
 from dstack._internal.cli.commands.config import ConfigCommand
 from dstack._internal.cli.commands.cp import CpCommand
 from dstack._internal.cli.commands.init import InitCommand
 from dstack._internal.cli.commands.logs import LogCommand
 from dstack._internal.cli.commands.ls import LsCommand
-from dstack._internal.cli.commands.prebuild import PrebuildCommand
 from dstack._internal.cli.commands.prune import PruneCommand
 from dstack._internal.cli.commands.ps import PSCommand
 from dstack._internal.cli.commands.rm import RMCommand
@@ -19,7 +19,7 @@ commands_classes = [
     InitCommand,
     LogCommand,
     LsCommand,
-    PrebuildCommand,
+    BuildCommand,
     PruneCommand,
     PSCommand,
     RMCommand,

--- a/cli/dstack/_internal/core/job.py
+++ b/cli/dstack/_internal/core/job.py
@@ -18,7 +18,7 @@ from dstack._internal.core.repo import (
     RepoRef,
 )
 
-PrebuildPolicy = ["no-prebuild", "use-prebuild", "force-prebuild", "prebuild-only"]
+BuildPolicy = ["use-build", "build", "force-build", "build-only"]
 
 
 class GpusRequirements(BaseModel):
@@ -85,7 +85,7 @@ class JobStatus(str, Enum):
     PENDING = "pending"
     SUBMITTED = "submitted"
     DOWNLOADING = "downloading"
-    PREBUILDING = "prebuilding"
+    BUILDING = "building"
     RUNNING = "running"
     UPLOADING = "uploading"
     STOPPING = "stopping"
@@ -203,8 +203,8 @@ class Job(JobHead):
     request_id: Optional[str]
     tag_name: Optional[str]
     ssh_key_pub: Optional[str]
-    prebuild: Optional[str]
-    setup: Optional[List[str]]
+    build_policy: Optional[str]
+    build_commands: Optional[List[str]]
     run_env: Optional[Dict[str, str]]
 
     @root_validator(pre=True)
@@ -222,12 +222,12 @@ class Job(JobHead):
         )
         return data
 
-    @validator("prebuild")
-    def default_prebuild(cls, v: Optional[str]) -> str:
+    @validator("build_policy")
+    def default_build_policy(cls, v: Optional[str]) -> str:
         if not v:
-            return PrebuildPolicy[0]
-        if v not in PrebuildPolicy:
-            raise KeyError(f"Unknown prebuild policy: {v}")
+            return BuildPolicy[0]
+        if v not in BuildPolicy:
+            raise KeyError(f"Unknown build policy: {v}")
         return v
 
     def get_instance_spot_type(self) -> str:
@@ -304,8 +304,8 @@ class Job(JobHead):
             "ssh_key_pub": self.ssh_key_pub or "",
             "repo_code_filename": self.repo_code_filename,
             "instance_type": self.instance_type,
-            "prebuild": self.prebuild,
-            "setup": self.setup or [],
+            "build_policy": self.build_policy,
+            "build_commands": self.build_commands or [],
             "run_env": self.run_env or {},
         }
         if isinstance(self.repo_data, RemoteRepoData):
@@ -434,8 +434,8 @@ class Job(JobHead):
             tag_name=job_data.get("tag_name") or None,
             ssh_key_pub=job_data.get("ssh_key_pub") or None,
             instance_type=job_data.get("instance_type") or None,
-            prebuild=job_data.get("prebuild") or None,
-            setup=job_data.get("setup") or None,
+            build_policy=job_data.get("build_policy") or None,
+            build_commands=job_data.get("build_commands") or None,
             run_env=job_data.get("run_env") or None,
         )
         return job
@@ -461,7 +461,7 @@ class JobSpec(JobRef):
     requirements: Optional[Requirements] = None
     master_job: Optional[JobRef] = None
     app_specs: Optional[List[AppSpec]] = None
-    setup: Optional[List[str]] = None
+    build_commands: Optional[List[str]] = None
 
     def get_id(self) -> Optional[str]:
         return self.job_id

--- a/cli/dstack/_internal/core/job.py
+++ b/cli/dstack/_internal/core/job.py
@@ -120,6 +120,8 @@ class JobErrorCode(str, Enum):
     INTERRUPTED_BY_NO_CAPACITY = "interrupted_by_no_capacity"
     # Set by runner
     CONTAINER_EXITED_WITH_ERROR = "container_exited_with_error"
+    BUILD_NOT_FOUND = "build_not_found"
+    PORTS_BINDING_FAILED = "ports_binding_failed"
 
     def pretty_repr(self) -> str:
         return " ".join(self.value.split("_")).capitalize()

--- a/cli/dstack/_internal/providers/__init__.py
+++ b/cli/dstack/_internal/providers/__init__.py
@@ -14,13 +14,13 @@ from dstack._internal.core.cache import CacheSpec
 from dstack._internal.core.error import RepoNotInitializedError
 from dstack._internal.core.job import (
     ArtifactSpec,
+    BuildPolicy,
     ConfigurationType,
     DepSpec,
     GpusRequirements,
     Job,
     JobSpec,
     JobStatus,
-    PrebuildPolicy,
     Requirements,
     RetryPolicy,
     SpotPolicy,
@@ -51,8 +51,8 @@ class Provider:
         self.loaded = False
         self.home_dir: Optional[str] = None
         self.ports: Dict[int, PortMapping] = {}
-        self.prebuild: Optional[str] = None
-        self.setup: List[str] = []
+        self.build_policy: Optional[str] = None
+        self.build_commands: List[str] = []
 
     # TODO: This is a dirty hack
     def _safe_python_version(self, name: str):
@@ -124,8 +124,8 @@ class Provider:
         self.run_name = run_name
         self.ssh_key_pub = ssh_key_pub
         self.openssh_server = self.provider_data.get("ssh", self.openssh_server)
-        self.prebuild = self.provider_data.get("prebuild")
-        self.setup = self._get_list_data("setup")
+        self.build_policy = self.provider_data.get("build_policy")
+        self.build_commands = self._get_list_data("build") or []
 
         self.parse_args()
         self.ports = self.provider_data.get("ports") or {}
@@ -182,9 +182,11 @@ class Provider:
         parser.add_argument(
             "-p", "--port", metavar="PORTS", type=PortMapping, nargs=argparse.ONE_OR_MORE
         )
-        prebuild = parser.add_mutually_exclusive_group()
-        for value in PrebuildPolicy:
-            prebuild.add_argument(f"--{value}", action="store_const", dest="prebuild", const=value)
+        build_policy = parser.add_mutually_exclusive_group()
+        for value in BuildPolicy:
+            build_policy.add_argument(
+                f"--{value}", action="store_const", dest="build_policy", const=value
+            )
 
     def _parse_base_args(self, args: Namespace, unknown_args):
         if args.requirements:
@@ -242,8 +244,8 @@ class Provider:
         self.provider_data["ports"] = merge_ports(
             [PortMapping(i) for i in self.provider_data.get("ports") or []], args.port or []
         )
-        if args.prebuild:
-            self.prebuild = args.prebuild
+        if args.build_policy:
+            self.build_policy = args.build_policy
         if unknown_args:
             self.provider_data["run_args"] = unknown_args
 
@@ -297,8 +299,8 @@ class Provider:
                 tag_name=tag_name,
                 ssh_key_pub=self.ssh_key_pub,
                 repo_code_filename=repo_code_filename,
-                prebuild=self.prebuild,
-                setup=job_spec.setup,
+                build_policy=self.build_policy,
+                build_commands=job_spec.build_commands,
                 run_env=job_spec.run_env,
             )
             jobs.append(job)

--- a/cli/dstack/_internal/providers/__init__.py
+++ b/cli/dstack/_internal/providers/__init__.py
@@ -53,6 +53,7 @@ class Provider:
         self.ports: Dict[int, PortMapping] = {}
         self.build_policy: Optional[str] = None
         self.build_commands: List[str] = []
+        self.commands: List[str] = []
 
     # TODO: This is a dirty hack
     def _safe_python_version(self, name: str):
@@ -126,6 +127,7 @@ class Provider:
         self.openssh_server = self.provider_data.get("ssh", self.openssh_server)
         self.build_policy = self.provider_data.get("build_policy")
         self.build_commands = self._get_list_data("build") or []
+        self.commands = self._get_list_data("commands") or []
 
         self.parse_args()
         self.ports = self.provider_data.get("ports") or {}

--- a/cli/dstack/_internal/providers/bash/main.py
+++ b/cli/dstack/_internal/providers/bash/main.py
@@ -20,7 +20,6 @@ class BashProvider(Provider):
         self.artifact_specs = None
         self.working_dir = None
         self.resources = None
-        self.commands = None
         self.image_name = None
         self.home_dir = "/root"
         self.openssh_server = True
@@ -36,7 +35,6 @@ class BashProvider(Provider):
     ):
         super().load(hub_client, args, workflow_name, provider_data, run_name, ssh_key_pub)
         self.python = self._safe_python_version("python")
-        self.commands = self._get_list_data("commands")
         self.env = self._env()
         self.artifact_specs = self._artifact_specs()
         self.working_dir = self.provider_data.get("working_dir")

--- a/cli/dstack/_internal/providers/bash/main.py
+++ b/cli/dstack/_internal/providers/bash/main.py
@@ -86,7 +86,7 @@ class BashProvider(Provider):
                 artifact_specs=self.artifact_specs,
                 requirements=self.resources,
                 app_specs=apps,
-                setup=self.setup,
+                build_commands=self.build_commands,
             )
         ]
 

--- a/cli/dstack/_internal/providers/code/main.py
+++ b/cli/dstack/_internal/providers/code/main.py
@@ -100,7 +100,7 @@ class CodeProvider(Provider):
                 artifact_specs=self.artifact_specs,
                 requirements=self.resources,
                 app_specs=apps,
-                setup=self._setup(),
+                build_commands=self._setup(),
             )
         ]
 
@@ -122,8 +122,8 @@ class CodeProvider(Provider):
             f"/tmp/openvscode-server-v{self.version}-linux-$arch/bin/openvscode-server --install-extension ms-python.python --install-extension ms-toolsai.jupyter",
             "rm /usr/bin/python2*",
         ]
-        if self.setup:
-            commands.extend(self.setup)
+        if self.build_commands:
+            commands.extend(self.build_commands)
         return commands
 
     def _commands(self):

--- a/cli/dstack/_internal/providers/code/main.py
+++ b/cli/dstack/_internal/providers/code/main.py
@@ -140,6 +140,7 @@ class CodeProvider(Provider):
                     f"echo '  vscode-insiders://vscode-remote/ssh-remote+{self.run_name}/workflow'",
                 ]
             )
+        commands.extend(self.commands)
         commands.extend(
             [
                 'if [ $(uname -m) = "aarch64" ]; then arch="arm64"; else arch="x64"; fi',

--- a/cli/dstack/_internal/providers/docker/main.py
+++ b/cli/dstack/_internal/providers/docker/main.py
@@ -15,7 +15,6 @@ class DockerProvider(Provider):
         super().__init__("docker")
         self.image_name = None
         self.registry_auth = None
-        self.commands = None
         self.entrypoint = None
         self.artifact_specs = None
         self.env = None
@@ -34,7 +33,6 @@ class DockerProvider(Provider):
         super().load(hub_client, args, workflow_name, provider_data, run_name, ssh_key_pub)
         self.image_name = self.provider_data["image"]
         self.registry_auth = self.provider_data.get("registry_auth")
-        self.commands = self._get_list_data("commands")
         self.entrypoint = self._get_entrypoint()
         if self.commands and self.entrypoint is None:  # commands not empty
             self.entrypoint = ["/bin/sh", "-i", "-c"]

--- a/cli/dstack/_internal/providers/docker/main.py
+++ b/cli/dstack/_internal/providers/docker/main.py
@@ -90,7 +90,7 @@ class DockerProvider(Provider):
                 artifact_specs=self.artifact_specs,
                 requirements=self.resources,
                 app_specs=apps,
-                setup=self.setup,
+                build_commands=self.build_commands,
             )
         ]
 

--- a/cli/dstack/_internal/providers/lab/main.py
+++ b/cli/dstack/_internal/providers/lab/main.py
@@ -130,6 +130,7 @@ class LabProvider(Provider):
             self._extend_commands_with_env(commands, self.env)
         if self.openssh_server:
             OpenSSHExtension.patch_commands(commands, ssh_key_pub=self.ssh_key_pub)
+        commands.extend(self.commands)
         commands.extend(
             [
                 f'echo "c.ServerApp.port = {self.lab_port}" >> /root/.jupyter/jupyter_server_config.py',

--- a/cli/dstack/_internal/providers/lab/main.py
+++ b/cli/dstack/_internal/providers/lab/main.py
@@ -98,7 +98,7 @@ class LabProvider(Provider):
                 artifact_specs=self.artifact_specs,
                 requirements=self.resources,
                 app_specs=apps,
-                setup=self._setup(),
+                build_commands=self._setup(),
             )
         ]
 
@@ -120,8 +120,8 @@ class LabProvider(Provider):
             'echo "c.ServerApp.open_browser = False" >> /root/.jupyter/jupyter_server_config.py',
             "echo \"c.ServerApp.ip = '0.0.0.0'\" >> /root/.jupyter/jupyter_server_config.py",
         ]
-        if self.setup:
-            commands.extend(self.setup)
+        if self.build_commands:
+            commands.extend(self.build_commands)
         return commands
 
     def _commands(self):

--- a/cli/dstack/_internal/providers/notebook/main.py
+++ b/cli/dstack/_internal/providers/notebook/main.py
@@ -97,7 +97,7 @@ class NotebookProvider(Provider):
                 artifact_specs=self.artifact_specs,
                 requirements=self.resources,
                 app_specs=apps,
-                setup=self._setup(),
+                build_commands=self._setup(),
             )
         ]
 
@@ -117,8 +117,8 @@ class NotebookProvider(Provider):
             'echo "c.NotebookApp.open_browser = False" >> /root/.jupyter/jupyter_notebook_config.py',
             "echo \"c.NotebookApp.ip = '0.0.0.0'\" >> /root/.jupyter/jupyter_notebook_config.py",
         ]
-        if self.setup:
-            commands.extend(self.setup)
+        if self.build_commands:
+            commands.extend(self.build_commands)
         return commands
 
     def _commands(self):

--- a/cli/dstack/_internal/providers/notebook/main.py
+++ b/cli/dstack/_internal/providers/notebook/main.py
@@ -127,6 +127,7 @@ class NotebookProvider(Provider):
             self._extend_commands_with_env(commands, self.env)
         if self.openssh_server:
             OpenSSHExtension.patch_commands(commands, ssh_key_pub=self.ssh_key_pub)
+        commands.extend(self.commands)
         commands.extend(
             [
                 f'echo "c.NotebookApp.port = {self.notebook_port}" >> /root/.jupyter/jupyter_notebook_config.py',

--- a/cli/dstack/_internal/providers/ssh/main.py
+++ b/cli/dstack/_internal/providers/ssh/main.py
@@ -20,11 +20,9 @@ class SSHProvider(Provider):
         self.artifact_specs = None
         self.working_dir = None
         self.resources = None
-        self.setup = None
         self.image_name = None
         self.home_dir = "/root"
         self.code = True
-        self.setup = []
 
     def load(
         self,
@@ -37,7 +35,6 @@ class SSHProvider(Provider):
     ):
         super().load(hub_client, args, workflow_name, provider_data, run_name, ssh_key_pub)
         self.python = self._safe_python_version("python")
-        self.setup = self._get_list_data("setup") or []
         self.env = self._env()
         self.artifact_specs = self._artifact_specs()
         self.working_dir = self.provider_data.get("working_dir")
@@ -83,7 +80,7 @@ class SSHProvider(Provider):
                 artifact_specs=self.artifact_specs,
                 requirements=self.resources,
                 app_specs=apps,
-                setup=self.setup,
+                build_commands=self.build_commands,
             )
         ]
 

--- a/cli/dstack/_internal/providers/ssh/main.py
+++ b/cli/dstack/_internal/providers/ssh/main.py
@@ -95,7 +95,7 @@ class SSHProvider(Provider):
         if self.env:
             self._extend_commands_with_env(commands, self.env)
         OpenSSHExtension.patch_commands(commands, ssh_key_pub=self.ssh_key_pub)
-        # TODO: Pre-install ipykernel and other VS Code extensions
+        commands.extend(self.commands)
         if self.code:
             commands.extend(
                 [

--- a/cli/dstack/_internal/schemas/configuration.json
+++ b/cli/dstack/_internal/schemas/configuration.json
@@ -136,8 +136,12 @@
         "python": {
           "$ref": "#/definitions/python"
         },
-        "setup": {
-          "description": "The bash commands to pre-build the environment",
+        "build": {
+          "description": "The bash commands to build the environment",
+          "$ref": "#/definitions/_commands"
+        },
+        "init": {
+          "description": "The bash commands to execute on start",
           "$ref": "#/definitions/_commands"
         },
         "cache": {
@@ -175,8 +179,8 @@
         "python": {
           "$ref": "#/definitions/python"
         },
-        "setup": {
-          "description": "The bash commands to pre-build the environment",
+        "build": {
+          "description": "The bash commands to build the environment",
           "$ref": "#/definitions/_commands"
         },
         "commands": {

--- a/cli/dstack/_internal/schemas/workflows.json
+++ b/cli/dstack/_internal/schemas/workflows.json
@@ -209,14 +209,15 @@
       "type": "boolean",
       "default": false
     },
-    "prebuild": {
-      "description": "Prebuild image to accelerate start",
+    "build": {
+      "description": "Build image to accelerate start",
       "type": "string",
-      "default": "never",
+      "default": "use-build",
       "enum": [
-        "never",
-        "lazy",
-        "force"
+        "use-build",
+        "build",
+        "force-build",
+        "build-only"
       ]
     },
     "bash": {
@@ -266,8 +267,8 @@
         "cache": {
           "$ref": "#/definitions/cache"
         },
-        "prebuild": {
-          "$ref": "#/definitions/prebuild"
+        "build": {
+          "$ref": "#/definitions/build"
         },
         "setup": {
           "$ref": "#/definitions/setup"
@@ -330,8 +331,8 @@
         "cache": {
           "$ref": "#/definitions/cache"
         },
-        "prebuild": {
-          "$ref": "#/definitions/prebuild"
+        "build": {
+          "$ref": "#/definitions/build"
         },
         "setup": {
           "$ref": "#/definitions/setup"
@@ -394,8 +395,8 @@
         "cache": {
           "$ref": "#/definitions/cache"
         },
-        "prebuild": {
-          "$ref": "#/definitions/prebuild"
+        "build": {
+          "$ref": "#/definitions/build"
         }
       }
     },
@@ -443,8 +444,8 @@
         "cache": {
           "$ref": "#/definitions/cache"
         },
-        "prebuild": {
-          "$ref": "#/definitions/prebuild"
+        "build": {
+          "$ref": "#/definitions/build"
         }
       }
     },
@@ -492,8 +493,8 @@
         "cache": {
           "$ref": "#/definitions/cache"
         },
-        "prebuild": {
-          "$ref": "#/definitions/prebuild"
+        "build": {
+          "$ref": "#/definitions/build"
         }
       }
     },
@@ -543,8 +544,8 @@
           "type": "boolean",
           "default": false
         },
-        "prebuild": {
-          "$ref": "#/definitions/prebuild"
+        "build": {
+          "$ref": "#/definitions/build"
         }
       }
     }

--- a/cli/dstack/api/hub/_client.py
+++ b/cli/dstack/api/hub/_client.py
@@ -321,7 +321,7 @@ class HubClient:
         for job in jobs:
             self.submit_job(job)
         if tag_name:
-            self.add_tag_from_run(tag_name, self.run_name, jobs)
+            self.add_tag_from_run(tag_name, run_name, jobs)
         self.update_repo_last_run_at(last_run_at=int(round(time.time() * 1000)))
         return run_name, jobs  # todo return run_head
 

--- a/runner/consts/errorcodes/errorcodes.go
+++ b/runner/consts/errorcodes/errorcodes.go
@@ -2,4 +2,6 @@ package errorcodes
 
 const (
 	ContainerExitedWithError = "container_exited_with_error"
+	BuildNotFound            = "build_not_found"
+	PortsBindingFailed       = "ports_binding_failed"
 )

--- a/runner/consts/states/state.go
+++ b/runner/consts/states/state.go
@@ -6,7 +6,7 @@ const (
 	Failed      = "failed"
 	Stopped     = "stopped"
 	Downloading = "downloading"
-	Prebuilding = "prebuilding"
+	Building    = "building"
 	Uploading   = "uploading"
 	Stopping    = "stopping"
 )

--- a/runner/internal/backend/azure/backend.go
+++ b/runner/internal/backend/azure/backend.go
@@ -299,12 +299,12 @@ func (azbackend *AzureBackend) GetRepoArchive(ctx context.Context, path, dir str
 	return nil
 }
 
-func (azbackend *AzureBackend) GetPrebuildDiff(ctx context.Context, key, dst string) error {
+func (azbackend *AzureBackend) GetBuildDiff(ctx context.Context, key, dst string) error {
 	_ = azbackend.storage.DownloadFile(ctx, key, dst)
 	return nil
 }
 
-func (azbackend *AzureBackend) PutPrebuildDiff(ctx context.Context, src, key string) error {
+func (azbackend *AzureBackend) PutBuildDiff(ctx context.Context, src, key string) error {
 	if err := azbackend.storage.UploadFile(ctx, src, key); err != nil {
 		return gerrors.Wrap(err)
 	}

--- a/runner/internal/backend/backend.go
+++ b/runner/internal/backend/backend.go
@@ -39,8 +39,8 @@ type Backend interface {
 	GetJobByPath(ctx context.Context, path string) (*models.Job, error)
 	GetRepoDiff(ctx context.Context, path string) (string, error)
 	GetRepoArchive(ctx context.Context, path, dst string) error
-	GetPrebuildDiff(ctx context.Context, key, dst string) error
-	PutPrebuildDiff(ctx context.Context, src, key string) error
+	GetBuildDiff(ctx context.Context, key, dst string) error
+	PutBuildDiff(ctx context.Context, src, key string) error
 	GetTMPDir(ctx context.Context) string
 	GetDockerBindings(ctx context.Context) []mount.Mount
 }

--- a/runner/internal/backend/gcp/backend.go
+++ b/runner/internal/backend/gcp/backend.go
@@ -297,12 +297,12 @@ func (gbackend *GCPBackend) GetRepoArchive(ctx context.Context, path, dir string
 	return nil
 }
 
-func (gbackend *GCPBackend) GetPrebuildDiff(ctx context.Context, key, dst string) error {
+func (gbackend *GCPBackend) GetBuildDiff(ctx context.Context, key, dst string) error {
 	_ = gbackend.storage.downloadFile(ctx, key, dst)
 	return nil
 }
 
-func (gbackend *GCPBackend) PutPrebuildDiff(ctx context.Context, src, key string) error {
+func (gbackend *GCPBackend) PutBuildDiff(ctx context.Context, src, key string) error {
 	if err := gbackend.storage.uploadFile(ctx, src, key); err != nil {
 		return gerrors.Wrap(err)
 	}

--- a/runner/internal/backend/local/backend.go
+++ b/runner/internal/backend/local/backend.go
@@ -276,11 +276,11 @@ func (l *Local) GetRepoArchive(ctx context.Context, path, dir string) error {
 	return nil
 }
 
-func (l *Local) GetPrebuildDiff(ctx context.Context, key, dst string) error {
+func (l *Local) GetBuildDiff(ctx context.Context, key, dst string) error {
 	return errors.New("not implemented")
 }
 
-func (l *Local) PutPrebuildDiff(ctx context.Context, src, key string) error {
+func (l *Local) PutBuildDiff(ctx context.Context, src, key string) error {
 	return errors.New("not implemented")
 }
 

--- a/runner/internal/backend/s3/backend.go
+++ b/runner/internal/backend/s3/backend.go
@@ -418,7 +418,7 @@ func (s *S3) GetRepoArchive(ctx context.Context, path, dir string) error {
 	return nil
 }
 
-func (s *S3) GetPrebuildDiff(ctx context.Context, key, dst string) error {
+func (s *S3) GetBuildDiff(ctx context.Context, key, dst string) error {
 	out, err := s.cliS3.cli.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(key),
@@ -439,7 +439,7 @@ func (s *S3) GetPrebuildDiff(ctx context.Context, key, dst string) error {
 	return nil
 }
 
-func (s *S3) PutPrebuildDiff(ctx context.Context, src, key string) error {
+func (s *S3) PutBuildDiff(ctx context.Context, src, key string) error {
 	file, err := os.Open(src)
 	if err != nil {
 		return gerrors.Wrap(err)

--- a/runner/internal/container/engine.go
+++ b/runner/internal/container/engine.go
@@ -293,7 +293,7 @@ func (r *Engine) pullImageIfAbsent(ctx context.Context, image string, registryAu
 	return nil
 }
 
-func (r *Engine) GetPrebuildName(ctx context.Context, spec *PrebuildSpec) (string, error) {
+func (r *Engine) GetBuildDigest(ctx context.Context, spec *BuildSpec) (string, error) {
 	err := r.pullImageIfAbsent(ctx, spec.BaseImageName, spec.RegistryAuthBase64)
 	if err != nil {
 		return "", gerrors.Wrap(err)
@@ -306,8 +306,8 @@ func (r *Engine) GetPrebuildName(ctx context.Context, spec *PrebuildSpec) (strin
 	return spec.Hash(), nil
 }
 
-func (r *Engine) Prebuild(ctx context.Context, spec *PrebuildSpec, imageName string, stoppedCh chan struct{}, logs io.Writer) error {
-	if err := PrebuildImage(ctx, r.client, spec, imageName, stoppedCh, logs); err != nil {
+func (r *Engine) Build(ctx context.Context, spec *BuildSpec, imageName string, stoppedCh chan struct{}, logs io.Writer) error {
+	if err := BuildImage(ctx, r.client, spec, imageName, stoppedCh, logs); err != nil {
 		return gerrors.Wrap(err)
 	}
 	return nil

--- a/runner/internal/executor/executor.go
+++ b/runner/internal/executor/executor.go
@@ -246,7 +246,7 @@ func (ex *Executor) runJob(ctx context.Context, erCh chan error, stoppedCh chan 
 		log.Error(jctx, "Unknown RepoType", "RepoType", job.RepoType)
 	}
 
-	if job.Prebuild != models.PREBUILD_ONLY {
+	if job.BuildPolicy != models.BuildOnly {
 		log.Trace(jctx, "Dependency processing")
 		if err = ex.processCache(jctx); err != nil {
 			erCh <- gerrors.Wrap(err)
@@ -317,23 +317,21 @@ func (ex *Executor) runJob(ctx context.Context, erCh chan error, stoppedCh chan 
 		}
 	}
 
-	log.Trace(ctx, "Prebuilding container", "mode", job.Prebuild)
-	if job.Prebuild == models.NO_PREBUILD || len(job.Setup) == 0 {
-		mergeSetup(spec, job.Setup, job.Commands)
-	} else {
-		job.Status = states.Prebuilding
+	log.Trace(ctx, "Building container", "mode", job.BuildPolicy)
+	if len(job.BuildCommands) > 0 {
+		job.Status = states.Building
 		if err = ex.backend.UpdateState(jctx); err != nil {
 			erCh <- gerrors.Wrap(err)
 			return
 		}
-		if err = ex.prebuild(ctx, spec, stoppedCh, allLogs); err != nil {
+		if err = ex.build(ctx, spec, stoppedCh, allLogs); err != nil {
 			erCh <- gerrors.Wrap(err)
 			return
 		}
 	}
 
-	if job.Prebuild == models.PREBUILD_ONLY {
-		log.Trace(ctx, "Prebuild only, do not run the job")
+	if job.BuildPolicy == models.BuildOnly {
+		log.Trace(ctx, "Build only, do not run the job")
 		ex.streamLogs.Close()
 		erCh <- nil
 		return
@@ -708,36 +706,38 @@ func (ex *Executor) Shutdown(ctx context.Context) {
 	}
 }
 
-func (ex *Executor) prebuild(ctx context.Context, spec *container.Spec, stoppedCh chan struct{}, logs io.Writer) error {
+func (ex *Executor) build(ctx context.Context, spec *container.Spec, stoppedCh chan struct{}, logs io.Writer) error {
 	job := ex.backend.Job(ctx)
 	_, isLocalBackend := ex.backend.(*localbackend.Local)
 
-	prebuildSpec := &container.PrebuildSpec{
+	buildSpec := &container.BuildSpec{
 		BaseImageName:      spec.Image,
 		WorkDir:            spec.WorkDir,
-		Commands:           container.ShellCommands(job.Setup),
+		ConfigurationPath:  job.ConfigurationPath,
+		ConfigurationType:  job.ConfigurationType,
+		Commands:           container.ShellCommands(job.BuildCommands),
 		Entrypoint:         spec.Entrypoint,
 		Env:                ex.environment(ctx, false),
 		RegistryAuthBase64: spec.RegistryAuthBase64,
 		RepoPath:           path.Join(ex.backend.GetTMPDir(ctx), consts.RUNS_DIR, job.RunName, job.JobID),
 	}
-	prebuildName, err := ex.engine.GetPrebuildName(ctx, prebuildSpec)
+	buildName, err := ex.engine.GetBuildDigest(ctx, buildSpec)
 	if err != nil {
 		return gerrors.Wrap(err)
 	}
 
-	tempDir, err := os.MkdirTemp("", "prebuild")
+	tempDir, err := os.MkdirTemp("", "build")
 	if err != nil {
 		return gerrors.Wrap(err)
 	}
 	defer func() { _ = os.RemoveAll(tempDir) }()
 	diffPath := filepath.Join(tempDir, "layer.tar")
-	key := fmt.Sprintf("prebuilds/%s/%s.tar", job.RepoId, prebuildName)
-	imageName := fmt.Sprintf("dstackai/prebuild:%s", prebuildName)
+	key := fmt.Sprintf("builds/%s/%s.tar", job.RepoId, buildName)
+	imageName := fmt.Sprintf("dstackai/build:%s", buildName)
 
-	if job.Prebuild == models.USE_PREBUILD {
-		log.Trace(ctx, "Trying to fetch prebuild image diff", "key", key, "image", imageName)
-		if _, err := fmt.Fprintf(ex.streamLogs, "[PREBUILD] Looking for the image\n"); err != nil {
+	if job.BuildPolicy == models.UseBuild || job.BuildPolicy == models.Build {
+		log.Trace(ctx, "Trying to fetch build image diff", "key", key, "image", imageName)
+		if _, err := fmt.Fprintf(ex.streamLogs, "[BUILD] Looking for the image\n"); err != nil {
 			return gerrors.Wrap(err)
 		}
 		if isLocalBackend {
@@ -746,42 +746,46 @@ func (ex *Executor) prebuild(ctx context.Context, spec *container.Spec, stoppedC
 				return gerrors.Wrap(err)
 			}
 			if exists {
-				if _, err := fmt.Fprintf(ex.streamLogs, "[PREBUILD] Using image from the cache\n"); err != nil {
+				if _, err := fmt.Fprintf(ex.streamLogs, "[BUILD] Using image from the cache\n"); err != nil {
 					return gerrors.Wrap(err)
 				}
 				spec.Image = imageName
 				return nil
 			}
 		} else {
-			if err := ex.backend.GetPrebuildDiff(ctx, key, diffPath); err != nil {
+			if err := ex.backend.GetBuildDiff(ctx, key, diffPath); err != nil {
 				return gerrors.Wrap(err)
 			}
 			if stat, err := os.Stat(diffPath); err == nil {
-				if _, err = fmt.Fprintf(ex.streamLogs, "[PREBUILD] Loading image: %s\n", humanize.Bytes(uint64(stat.Size()))); err != nil {
+				if _, err = fmt.Fprintf(ex.streamLogs, "[BUILD] Loading image: %s\n", humanize.Bytes(uint64(stat.Size()))); err != nil {
 					return gerrors.Wrap(err)
 				}
 				if err := ex.engine.ImportImageDiff(ctx, diffPath); err != nil {
 					return gerrors.Wrap(err)
 				}
-				if _, err = fmt.Fprintf(ex.streamLogs, "[PREBUILD] Image loaded\n"); err != nil {
+				if _, err = fmt.Fprintf(ex.streamLogs, "[BUILD] Image loaded\n"); err != nil {
 					return gerrors.Wrap(err)
 				}
 				spec.Image = imageName
 				return nil
 			}
 		}
-		if _, err = fmt.Fprintf(ex.streamLogs, "[PREBUILD] No image found\n"); err != nil {
+		if _, err = fmt.Fprintf(ex.streamLogs, "[BUILD] No image found\n"); err != nil {
 			return gerrors.Wrap(err)
 		}
-		mergeSetup(spec, job.Setup, job.Commands)
-	} else if job.Prebuild == models.FORCE_PREBUILD || job.Prebuild == models.PREBUILD_ONLY {
-		err := ex.engine.Prebuild(ctx, prebuildSpec, imageName, stoppedCh, logs)
+		if job.BuildPolicy == models.UseBuild {
+			return gerrors.New("no build image found")
+		}
+	}
+
+	if job.BuildPolicy == models.Build || job.BuildPolicy == models.ForceBuild || job.BuildPolicy == models.BuildOnly {
+		err := ex.engine.Build(ctx, buildSpec, imageName, stoppedCh, logs)
 		if err != nil {
 			return gerrors.Wrap(err)
 		}
 		// local backend: store image in daemon cache
 		if !isLocalBackend {
-			if _, err := fmt.Fprintf(ex.streamLogs, "[PREBUILD] Saving image\n"); err != nil {
+			if _, err := fmt.Fprintf(ex.streamLogs, "[BUILD] Saving image\n"); err != nil {
 				return gerrors.Wrap(err)
 			}
 			if err := ex.engine.ExportImageDiff(ctx, imageName, diffPath); err != nil {
@@ -791,11 +795,11 @@ func (ex *Executor) prebuild(ctx context.Context, spec *container.Spec, stoppedC
 			if err != nil {
 				return gerrors.Wrap(err)
 			}
-			log.Trace(ctx, "Putting prebuild image diff", "key", key, "image", imageName, "size", stat.Size())
-			if _, err = fmt.Fprintf(ex.streamLogs, "[PREBUILD] Uploading image: %s\n", humanize.Bytes(uint64(stat.Size()))); err != nil {
+			log.Trace(ctx, "Putting build image diff", "key", key, "image", imageName, "size", stat.Size())
+			if _, err = fmt.Fprintf(ex.streamLogs, "[BUILD] Uploading image: %s\n", humanize.Bytes(uint64(stat.Size()))); err != nil {
 				return gerrors.Wrap(err)
 			}
-			if err = ex.backend.PutPrebuildDiff(ctx, diffPath, key); err != nil {
+			if err = ex.backend.PutBuildDiff(ctx, diffPath, key); err != nil {
 				return gerrors.Wrap(err)
 			}
 		}
@@ -803,12 +807,6 @@ func (ex *Executor) prebuild(ctx context.Context, spec *container.Spec, stoppedC
 	}
 
 	return nil
-}
-
-func mergeSetup(spec *container.Spec, setup []string, commands []string) {
-	merged := append([]string(nil), setup...)
-	merged = append(merged, commands...)
-	spec.Commands = container.ShellCommands(merged)
 }
 
 func uniqueMount(m []mount.Mount) []mount.Mount {

--- a/runner/internal/models/backend.go
+++ b/runner/internal/models/backend.go
@@ -18,9 +18,9 @@ type Job struct {
 	Apps           []App             `yaml:"apps"`
 	Artifacts      []Artifact        `yaml:"artifacts"`
 	Cache          []Cache           `yaml:"cache"`
-	Setup          []string          `yaml:"setup"`
+	BuildCommands  []string          `yaml:"build_commands"`
 	Commands       []string          `yaml:"commands"`
-	Prebuild       PrebuildPolicy    `yaml:"prebuild"`
+	BuildPolicy    BuildPolicy       `yaml:"build_policy"`
 	Entrypoint     []string          `yaml:"entrypoint"`
 	Environment    map[string]string `yaml:"env"`
 	RunEnvironment map[string]string `yaml:"run_env"`
@@ -134,13 +134,13 @@ type RunnerMetadata struct {
 	Status string `yaml:"status"`
 }
 
-type PrebuildPolicy string
+type BuildPolicy string
 
 const (
-	USE_PREBUILD   PrebuildPolicy = "use-prebuild"
-	NO_PREBUILD    PrebuildPolicy = "no-prebuild"
-	FORCE_PREBUILD PrebuildPolicy = "force-prebuild"
-	PREBUILD_ONLY  PrebuildPolicy = "prebuild-only"
+	UseBuild   BuildPolicy = "use-build"
+	Build      BuildPolicy = "build"
+	ForceBuild BuildPolicy = "force-build"
+	BuildOnly  BuildPolicy = "build-only"
 )
 
 func (j *Job) RepoHostNameWithPort() string {


### PR DESCRIPTION
Closes #499 

* Rename prebuild to build everywhere
* Introduce new build policies
  * `--use-build` (default) — fail if build commands are non-empty, but haven't been built yet
  * `--build` — lazily build before the run
  * `--force-build` — always build before the run
  * `--build-only` — do not run, only build
* Replace `setup` with `build` commands, which never would be executed as part of a run
* Add `init` commands to `dev-environment`, which would be executed every run before idling
* Install VS Code server in `init`, if the build version doesn't match the local one