### PR TITLE
Warn user about long git diff

### DIFF
--- a/cli/dstack/_internal/core/repo/remote.py
+++ b/cli/dstack/_internal/core/repo/remote.py
@@ -175,8 +175,11 @@ class _DiffCollector:
     def timeout(self):
         now = time.monotonic()
         if not self.warned and now > self.start_time + self.warning_time:
-            print("Git diff takes longer than usual. Press Ctrl+C to abort git diff.")
-            print("Tip: exclude unnecessary files with .gitignore")
+            print(
+                "Provisioning is taking longer than usual, possibly because of having too many or large local "
+                "files that haven’t been pushed to Git. Tip: Exclude unnecessary files from provisioning "
+                "by using the `.gitignore` file."
+            )
             self.warned = True
         return (
             self.delay
@@ -219,5 +222,5 @@ def _repo_diff_verbose(repo: git.Repo, repo_hash: str, warning_time: float = 5) 
             )
         return collector.get()
     except KeyboardInterrupt:
-        print("\nGit diff aborted")
+        print("\nAborted")
         exit(1)


### PR DESCRIPTION
Closes #456 

* Warn user if git diff takes longer than 5 seconds
  * Suggest updating .gitignore
* Gracefully exit from git diff on Ctrl+C
* Do not serialize repo_diff
  * It accelerates get_run_plan for large diffs