### PR TITLE
Allow env variables interpolation

### DIFF
--- a/cli/dstack/_internal/backend/base/compute.py
+++ b/cli/dstack/_internal/backend/base/compute.py
@@ -129,7 +129,7 @@ def get_dstack_runner() -> str:
         build = version.__version__
     else:  # stgn
         bucket = "dstack-runner-downloads-stgn"
-        build = version.__version__ or os.environ.get("DSTACK_RUNNER_BUILD", None)
+        build = version.__version__ or os.environ.get("DSTACK_RUNNER_VERSION", "latest")
 
     commands = [
         f'sudo curl --output /usr/local/bin/dstack-runner "https://{bucket}.s3.eu-west-1.amazonaws.com/{build}/binaries/dstack-runner-linux-amd64"',

--- a/cli/dstack/version.py
+++ b/cli/dstack/version.py
@@ -1,4 +1,3 @@
 __version__ = None
 __is_release__ = False
 miniforge_image = "0.3"
-runner_build = "latest"

--- a/runner/internal/executor/executor.go
+++ b/runner/internal/executor/executor.go
@@ -515,7 +515,6 @@ func (ex *Executor) environment(ctx context.Context, includeRun bool) []string {
 		env.AddMapString(job.RunEnvironment)
 		env.AddMapString(cons)
 	}
-	env.AddMapString(job.Environment)
 	secrets, err := ex.backend.Secrets(ctx)
 	if err != nil {
 		log.Error(ctx, "Fail fetching secrets", "err", err)
@@ -629,7 +628,7 @@ func (ex *Executor) newSpec(ctx context.Context, credPath string) (*container.Sp
 		Image:              job.Image,
 		RegistryAuthBase64: makeRegistryAuthBase64(username, password),
 		WorkDir:            path.Join("/workflow", job.WorkingDir),
-		Commands:           container.ShellCommands(job.Commands),
+		Commands:           container.ShellCommands(container.InsertEnvs(job.Commands, job.Environment)),
 		Entrypoint:         job.Entrypoint,
 		Env:                ex.environment(ctx, true),
 		Mounts:             uniqueMount(bindings),


### PR DESCRIPTION
* Pass env variables as export commands to allow interpolation
* Rename DSTACK_RUNNER_BUILD to DSTACK_RUNNER_VERSION
* Set DSTACK_RUNNER_VERSION default to `latest`