### PR TITLE
Add PATH to .profile

### DIFF
--- a/cli/dstack/_internal/configurators/extensions/ssh.py
+++ b/cli/dstack/_internal/configurators/extensions/ssh.py
@@ -26,6 +26,7 @@ class SSHd:
             [
                 f'echo "{self.key_pub}" >> ~/.ssh/authorized_keys',
                 f"env >> ~/.ssh/environment",
+                f'echo "export PATH=$PATH" >> ~/.profile',
                 f"ssh-keygen -A > /dev/null",
                 f"/usr/sbin/sshd -p {self.port} -o PermitUserEnvironment=yes",
             ]


### PR DESCRIPTION
This PR allows passing PATH from custom docker image to SSH session and VS Code. Other variables are passed via .ssh/environment