### PR TITLE
Elaborate error message on unmatched requirements for local backend

### DIFF
--- a/cli/dstack/_internal/core/job.py
+++ b/cli/dstack/_internal/core/job.py
@@ -54,6 +54,14 @@ class Requirements(BaseModel):
             req_data["local"] = self.local
         return req_data
 
+    def pretty_format(self):
+        res = ""
+        res += f"{self.cpus}xCPUs"
+        res += f", {self.memory_mib}MB"
+        if self.gpus:
+            res += f", {len(self.gpus)}x{self.gpus[0].name}"
+        return res
+
 
 class JobRef(BaseModel):
     @abstractmethod

--- a/cli/dstack/_internal/hub/routers/runs.py
+++ b/cli/dstack/_internal/hub/routers/runs.py
@@ -29,11 +29,12 @@ async def get_run_plan(
     for job in body.jobs:
         instance_type = await run_async(backend.predict_instance_type, job)
         if instance_type is None:
+            msg = f"No instance type matching requirements ({job.requirements.pretty_format()})."
+            if backend.name == "local":
+                msg += " Ensure that enough CPU and memory are available for Docker containers or lower the requirements."
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=error_detail(
-                    msg=NoMatchingInstanceError.message, code=NoMatchingInstanceError.code
-                ),
+                detail=error_detail(msg=msg, code=NoMatchingInstanceError.code),
             )
         try:
             build = backend.predict_build_plan(job)

--- a/runner/internal/container/engine.go
+++ b/runner/internal/container/engine.go
@@ -3,14 +3,15 @@ package container
 import (
 	"context"
 	"fmt"
-	"github.com/docker/docker/api/types/mount"
-	"github.com/docker/docker/pkg/jsonmessage"
-	"github.com/dstackai/dstack/runner/internal/environment"
-	"github.com/dstackai/dstack/runner/internal/models"
 	"io"
 	"os/exec"
 	"runtime"
 	"strings"
+
+	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/dstackai/dstack/runner/internal/environment"
+	"github.com/dstackai/dstack/runner/internal/models"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"


### PR DESCRIPTION
Fixes #559 

dstack now prints a more elaborate error message if local backend (Docker) doesn't have enough resources allocated to match the requirements, e.g.:

```
No instance type matching requirements (4xCPUs, 10240MB). Ensure that enough CPU and 
memory are available for Docker containers or lower the requirements.
```