### PR TITLE
Support custom run names

### DIFF
--- a/cli/dstack/_internal/api/repos.py
+++ b/cli/dstack/_internal/api/repos.py
@@ -46,7 +46,7 @@ def get_local_repo_credentials(
 
     if identity_file is not None:  # must fail if key is invalid
         try:  # user provided ssh key
-            return test_remote_repo_credentials(
+            return check_remote_repo_credentials(
                 repo_data, RepoProtocol.SSH, identity_file=identity_file
             )
         except GitCommandError:
@@ -54,7 +54,7 @@ def get_local_repo_credentials(
 
     if oauth_token is not None:
         try:  # user provided oauth token
-            return test_remote_repo_credentials(
+            return check_remote_repo_credentials(
                 repo_data, RepoProtocol.HTTPS, oauth_token=oauth_token
             )
         except GitCommandError:
@@ -63,7 +63,7 @@ def get_local_repo_credentials(
     identities = get_host_config(original_hostname or repo_data.repo_host_name).get("identityfile")
     if identities:  # must fail if key is invalid
         try:  # key from ssh config
-            return test_remote_repo_credentials(
+            return check_remote_repo_credentials(
                 repo_data, RepoProtocol.SSH, identity_file=identities[0]
             )
         except GitCommandError:
@@ -75,7 +75,7 @@ def get_local_repo_credentials(
         oauth_token = gh_hosts.get(repo_data.repo_host_name, {}).get("oauth_token")
         if oauth_token is not None:
             try:  # token from gh config
-                return test_remote_repo_credentials(
+                return check_remote_repo_credentials(
                     repo_data, RepoProtocol.HTTPS, oauth_token=oauth_token
                 )
             except GitCommandError:
@@ -83,14 +83,14 @@ def get_local_repo_credentials(
 
     if os.path.exists(default_ssh_key):
         try:  # default user key
-            return test_remote_repo_credentials(
+            return check_remote_repo_credentials(
                 repo_data, RepoProtocol.SSH, identity_file=default_ssh_key
             )
         except GitCommandError:
             pass
 
 
-def test_remote_repo_credentials(
+def check_remote_repo_credentials(
     repo_data: RemoteRepoData,
     protocol: RepoProtocol,
     *,

--- a/cli/dstack/_internal/backend/base/__init__.py
+++ b/cli/dstack/_internal/backend/base/__init__.py
@@ -89,6 +89,10 @@ class Backend(ABC):
         pass
 
     @abstractmethod
+    def delete_run_jobs(self, repo_id: str, run_name: str):
+        pass
+
+    @abstractmethod
     def list_run_heads(
         self,
         repo_id: str,
@@ -262,8 +266,8 @@ class ComponentBasedBackend(Backend):
     def predict_instance_type(self, job: Job) -> Optional[InstanceType]:
         return base_jobs.predict_job_instance(self.compute(), job)
 
-    def create_run(self, repo_id: str) -> str:
-        return base_runs.create_run(self.storage())
+    def create_run(self, repo_id: str, run_name: Optional[str]) -> str:
+        return base_runs.create_run(self.storage(), run_name)
 
     def create_job(self, job: Job):
         base_jobs.create_job(self.storage(), job)
@@ -292,6 +296,9 @@ class ComponentBasedBackend(Backend):
 
     def delete_job_head(self, repo_id: str, job_id: str):
         base_jobs.delete_job_head(self.storage(), repo_id, job_id)
+
+    def delete_run_jobs(self, repo_id: str, run_name: str):
+        base_jobs.delete_jobs(self.storage(), repo_id, run_name)
 
     def list_run_heads(
         self,

--- a/cli/dstack/_internal/backend/base/runners.py
+++ b/cli/dstack/_internal/backend/base/runners.py
@@ -33,7 +33,7 @@ def delete_runner(storage: Storage, runner: Runner):
     storage.delete_object(_get_runner_filename(runner.runner_id))
 
 
-def stop_runner(compute: Compute, runner: Runner):
+def terminate_runner(compute: Compute, runner: Runner):
     if runner.request_id:
         if runner.resources.spot:
             compute.cancel_spot_request(runner)

--- a/cli/dstack/_internal/backend/local/compute.py
+++ b/cli/dstack/_internal/backend/local/compute.py
@@ -34,6 +34,7 @@ class LocalCompute(Compute):
 
     def terminate_instance(self, runner: Runner):
         runners.stop_process(runner.request_id)
+        runners.remove_container(runner.job.run_name)
 
     def cancel_spot_request(self, runner: Runner):
-        runners.stop_process(runner.request_id)
+        pass

--- a/cli/dstack/_internal/backend/local/compute.py
+++ b/cli/dstack/_internal/backend/local/compute.py
@@ -3,6 +3,7 @@ from typing import Optional
 from dstack._internal.backend.base.compute import Compute, choose_instance_type
 from dstack._internal.backend.local import runners
 from dstack._internal.backend.local.config import LocalConfig
+from dstack._internal.core.error import BackendValueError
 from dstack._internal.core.instance import InstanceType, LaunchedInstanceInfo
 from dstack._internal.core.job import Job
 from dstack._internal.core.request import RequestHead
@@ -29,6 +30,8 @@ class LocalCompute(Compute):
         return LaunchedInstanceInfo(request_id=pid, location=None)
 
     def restart_instance(self, job: Job):
+        if runners.get_container(job.run_name) is None:
+            raise BackendValueError("Container not found")
         pid = runners.start_runner_process(self.backend_config, job.runner_id)
         return LaunchedInstanceInfo(request_id=pid, location=None)
 

--- a/cli/dstack/_internal/backend/local/runners.py
+++ b/cli/dstack/_internal/backend/local/runners.py
@@ -11,6 +11,7 @@ import docker.errors
 import psutil
 import requests
 import yaml
+from docker.models.containers import Container
 from psutil import NoSuchProcess
 from tqdm import tqdm
 
@@ -217,10 +218,15 @@ def is_running(request_id: str) -> bool:
         return False
 
 
-def remove_container(container_name: str):
+def get_container(container_name: str) -> Optional[Container]:
     client = docker.from_env()
     try:
-        container = client.containers.get(container_name)
+        return client.containers.get(container_name)
     except docker.errors.NotFound:
-        return
-    container.remove()
+        return None
+
+
+def remove_container(container_name: str):
+    container = get_container(container_name)
+    if container is not None:
+        container.remove()

--- a/cli/dstack/_internal/backend/local/runners.py
+++ b/cli/dstack/_internal/backend/local/runners.py
@@ -7,11 +7,14 @@ from pathlib import Path
 from typing import Optional
 
 import cpuinfo
+import docker.errors
 import psutil
 import requests
 import yaml
 from psutil import NoSuchProcess
 from tqdm import tqdm
+
+import docker
 
 from dstack import version
 from dstack._internal.backend.base.config import BACKEND_CONFIG_FILENAME, RUNNER_CONFIG_FILENAME
@@ -212,3 +215,12 @@ def is_running(request_id: str) -> bool:
         return True
     except NoSuchProcess:
         return False
+
+
+def remove_container(container_name: str):
+    client = docker.from_env()
+    try:
+        container = client.containers.get(container_name)
+    except docker.errors.NotFound:
+        return
+    container.remove()

--- a/cli/dstack/_internal/cli/commands/build/__init__.py
+++ b/cli/dstack/_internal/cli/commands/build/__init__.py
@@ -39,13 +39,13 @@ class BuildCommand(BasicCommand):
             type=str,
             dest="file_name",
         )
-        add_project_argument(self._parser)
         self._parser.add_argument(
             "-y",
             "--yes",
             help="Do not ask for plan confirmation",
             action="store_true",
         )
+        add_project_argument(self._parser)
         self._parser.add_argument(
             "--profile",
             metavar="PROFILE",

--- a/cli/dstack/_internal/cli/commands/ls/__init__.py
+++ b/cli/dstack/_internal/cli/commands/ls/__init__.py
@@ -32,7 +32,6 @@ class LsCommand(BasicCommand):
             nargs="?",
             default="",
         )
-
         self._parser.add_argument(
             "-r", "--recursive", help="Show all files recursively", action="store_true"
         )

--- a/cli/dstack/_internal/cli/commands/rm/__init__.py
+++ b/cli/dstack/_internal/cli/commands/rm/__init__.py
@@ -37,22 +37,12 @@ class RMCommand(BasicCommand):
             and (args.yes or Confirm.ask(f"[red]Delete the run '{args.run_name}'?[/]"))
         ) or (args.all and (args.yes or Confirm.ask("[red]Delete all runs?[/]"))):
             hub_client = get_hub_client(project_name=args.project)
-            deleted_run = False
-            job_heads = hub_client.list_job_heads(args.run_name)
-            if job_heads:
-                finished_job_heads = []
-                for job_head in job_heads:
-                    if job_head.status.is_finished():
-                        finished_job_heads.append(job_head)
-                    elif args.run_name:
-                        console.print("The run is not finished yet. Stop the run first.")
-                        exit(1)
-                for job_head in finished_job_heads:
-                    hub_client.delete_job_head(job_head.job_id)
-                    deleted_run = True
-            if args.run_name and not deleted_run:
+            run_heads = hub_client.list_run_heads(args.run_name)
+            if len(run_heads) == 0 and args.run_name:
                 console.print(f"Cannot find the run '{args.run_name}'")
                 exit(1)
+            for run_head in run_heads:
+                hub_client.delete_run(run_head.run_name)
             console.print(f"[grey58]OK[/]")
         else:
             if not args.run_name and not args.all:

--- a/cli/dstack/_internal/cli/commands/run/__init__.py
+++ b/cli/dstack/_internal/cli/commands/run/__init__.py
@@ -84,9 +84,6 @@ class RunCommand(BasicCommand):
     @check_init
     def _command(self, args: Namespace):
         configurator = load_configuration(args.working_dir, args.file_name, args.profile_name)
-        if args.help:
-            configurator.get_parser(parser=copy.deepcopy(self._parser)).print_help()
-            exit(0)
 
         project_name = None
         if args.project:

--- a/cli/dstack/_internal/cli/main.py
+++ b/cli/dstack/_internal/cli/main.py
@@ -42,7 +42,6 @@ def main():
     subparsers = parser.add_subparsers(metavar="COMMAND")
 
     cli_initialize(parser=subparsers)
-
     if len(sys.argv) < 2:
         parser.print_help()
         exit(0)

--- a/cli/dstack/_internal/cli/utils/config.py
+++ b/cli/dstack/_internal/cli/utils/config.py
@@ -9,6 +9,7 @@ from dstack._internal.api.repos import load_repo
 from dstack._internal.cli.errors import CLIError
 from dstack._internal.cli.profiles import load_profiles
 from dstack._internal.core.error import RepoNotInitializedError
+from dstack._internal.core.repo.remote import RepoError
 from dstack._internal.core.userconfig import RepoUserConfig
 from dstack._internal.utils.common import get_dstack_dir
 from dstack.api.hub import HubClient, HubClientConfig
@@ -165,7 +166,10 @@ def get_hub_client(project_name: Optional[str] = None) -> HubClient:
                 f"No default project is configured. Call `dstack start` or `dstack config`."
             )
     repo_config = _read_repo_config_or_error_with_project_name(project_name)
-    repo = load_repo(repo_config)
+    try:
+        repo = load_repo(repo_config)
+    except RepoError as e:
+        raise CLIError(e.message)
     hub_client_config = HubClientConfig(url=project_config.url, token=project_config.token)
     hub_client = HubClient(config=hub_client_config, project=project_config.name, repo=repo)
     return hub_client

--- a/cli/dstack/_internal/hub/models/__init__.py
+++ b/cli/dstack/_internal/hub/models/__init__.py
@@ -6,6 +6,7 @@ from typing_extensions import Literal
 
 from dstack._internal.core.job import Job
 from dstack._internal.core.repo import RemoteRepoCredentials, RepoSpec
+from dstack._internal.core.repo.base import RepoRef
 from dstack._internal.core.repo.head import RepoHead
 from dstack._internal.core.run import RunHead
 from dstack._internal.core.secret import Secret
@@ -284,6 +285,11 @@ class ReposDelete(BaseModel):
 
 class RunsGetPlan(BaseModel):
     jobs: List[Job]
+
+
+class RunsCreate(BaseModel):
+    repo_ref: RepoRef
+    run_name: Optional[str]
 
 
 class RunsList(BaseModel):

--- a/cli/dstack/_internal/hub/routers/artifacts.py
+++ b/cli/dstack/_internal/hub/routers/artifacts.py
@@ -4,9 +4,8 @@ from fastapi import APIRouter, Depends
 
 from dstack._internal.core.artifact import Artifact
 from dstack._internal.hub.models import ArtifactsList
-from dstack._internal.hub.routers.util import get_backend, get_project
+from dstack._internal.hub.routers.util import call_backend, get_backend, get_project
 from dstack._internal.hub.security.permissions import ProjectMember
-from dstack._internal.hub.utils.common import run_async
 
 router = APIRouter(
     prefix="/api/project", tags=["artifacts"], dependencies=[Depends(ProjectMember())]
@@ -17,7 +16,7 @@ router = APIRouter(
 async def list_artifacts(project_name: str, body: ArtifactsList) -> List[Artifact]:
     project = await get_project(project_name=project_name)
     backend = await get_backend(project)
-    artifacts = await run_async(
+    artifacts = await call_backend(
         backend.list_run_artifact_files,
         body.repo_id,
         body.run_name,

--- a/cli/dstack/_internal/hub/routers/configurations.py
+++ b/cli/dstack/_internal/hub/routers/configurations.py
@@ -2,9 +2,8 @@ from fastapi import APIRouter, Depends
 
 from dstack._internal.core.repo import RepoRef
 from dstack._internal.hub.db.models import User
-from dstack._internal.hub.routers.util import get_backend, get_project
+from dstack._internal.hub.routers.util import call_backend, get_backend, get_project
 from dstack._internal.hub.security.permissions import Authenticated, ProjectMember
-from dstack._internal.hub.utils.common import run_async
 
 router = APIRouter(
     prefix="/api/project", tags=["configurations"], dependencies=[Depends(ProjectMember())]
@@ -20,6 +19,6 @@ async def delete_configuration_cache(
 ):
     project = await get_project(project_name=project_name)
     backend = await get_backend(project)
-    await run_async(
+    await call_backend(
         backend.delete_configuration_cache, repo_ref.repo_id, user.name, configuration_path
     )

--- a/cli/dstack/_internal/hub/routers/jobs.py
+++ b/cli/dstack/_internal/hub/routers/jobs.py
@@ -5,9 +5,8 @@ from fastapi import APIRouter, Depends
 from dstack._internal.core.job import Job, JobHead
 from dstack._internal.hub.db.models import User
 from dstack._internal.hub.models import JobHeadList, JobsGet, JobsList
-from dstack._internal.hub.routers.util import get_backend, get_project
+from dstack._internal.hub.routers.util import call_backend, get_backend, get_project
 from dstack._internal.hub.security.permissions import Authenticated, ProjectMember
-from dstack._internal.hub.utils.common import run_async
 
 router = APIRouter(prefix="/api/project", tags=["jobs"], dependencies=[Depends(ProjectMember())])
 
@@ -17,7 +16,7 @@ async def create_job(project_name: str, job: Job, user: User = Depends(Authentic
     project = await get_project(project_name=project_name)
     backend = await get_backend(project)
     job.hub_user_name = user.name
-    await run_async(backend.create_job, job)
+    await call_backend(backend.create_job, job)
     return job
 
 
@@ -25,7 +24,7 @@ async def create_job(project_name: str, job: Job, user: User = Depends(Authentic
 async def get_job(project_name: str, body: JobsGet) -> Job:
     project = await get_project(project_name=project_name)
     backend = await get_backend(project)
-    job = await run_async(backend.get_job, body.repo_id, body.job_id)
+    job = await call_backend(backend.get_job, body.repo_id, body.job_id)
     return job
 
 
@@ -33,7 +32,7 @@ async def get_job(project_name: str, body: JobsGet) -> Job:
 async def list_job(project_name: str, body: JobsList) -> List[Job]:
     project = await get_project(project_name=project_name)
     backend = await get_backend(project)
-    jobs = await run_async(backend.list_jobs, body.repo_id, body.run_name)
+    jobs = await call_backend(backend.list_jobs, body.repo_id, body.run_name)
     return jobs
 
 
@@ -41,7 +40,7 @@ async def list_job(project_name: str, body: JobsList) -> List[Job]:
 async def list_job_heads(project_name: str, body: JobHeadList) -> List[JobHead]:
     project = await get_project(project_name=project_name)
     backend = await get_backend(project)
-    job_heads = await run_async(backend.list_job_heads, body.repo_id, body.run_name)
+    job_heads = await call_backend(backend.list_job_heads, body.repo_id, body.run_name)
     return job_heads
 
 
@@ -49,4 +48,4 @@ async def list_job_heads(project_name: str, body: JobHeadList) -> List[JobHead]:
 async def delete_job(project_name: str, body: JobsGet):
     project = await get_project(project_name=project_name)
     backend = await get_backend(project)
-    await run_async(backend.delete_job_head, body.repo_id, body.job_id)
+    await call_backend(backend.delete_job_head, body.repo_id, body.job_id)

--- a/cli/dstack/_internal/hub/routers/link.py
+++ b/cli/dstack/_internal/hub/routers/link.py
@@ -4,9 +4,8 @@ from fastapi.security.http import HTTPAuthorizationCredentials, HTTPBearer
 
 from dstack._internal.backend.local import LocalBackend
 from dstack._internal.hub.models import StorageLink
-from dstack._internal.hub.routers.util import get_backend, get_project
+from dstack._internal.hub.routers.util import call_backend, get_backend, get_project
 from dstack._internal.hub.security.permissions import ProjectMember
-from dstack._internal.hub.utils.common import run_async
 
 router = APIRouter(prefix="/api/project", tags=["link"], dependencies=[Depends(ProjectMember())])
 
@@ -31,7 +30,7 @@ async def link_upload(
                 token=token.credentials,
             )
         )
-    url = await run_async(backend.get_signed_upload_url, body.object_key)
+    url = await call_backend(backend.get_signed_upload_url, body.object_key)
     return url
 
 
@@ -56,5 +55,5 @@ async def link_download(
                 token=token.credentials,
             )
         )
-    url = await run_async(backend.get_signed_download_url, body.object_key)
+    url = await call_backend(backend.get_signed_download_url, body.object_key)
     return url

--- a/cli/dstack/_internal/hub/routers/runs.py
+++ b/cli/dstack/_internal/hub/routers/runs.py
@@ -173,5 +173,5 @@ async def _get_run_head(backend: Backend, repo_id: str, run_name: str) -> RunHea
         return run_head
     raise HTTPException(
         status_code=status.HTTP_400_BAD_REQUEST,
-        detail=[error_detail(f"Run {run_name} not found", code="run_not_found")],
+        detail=[error_detail(f"Run {run_name} not found", code=BackendValueError.code)],
     )

--- a/cli/dstack/_internal/hub/routers/secrets.py
+++ b/cli/dstack/_internal/hub/routers/secrets.py
@@ -5,9 +5,8 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from dstack._internal.core.repo import RepoRef
 from dstack._internal.core.secret import Secret
 from dstack._internal.hub.models import SecretAddUpdate
-from dstack._internal.hub.routers.util import error_detail, get_backend, get_project
+from dstack._internal.hub.routers.util import call_backend, error_detail, get_backend, get_project
 from dstack._internal.hub.security.permissions import ProjectMember
-from dstack._internal.hub.utils.common import run_async
 
 router = APIRouter(
     prefix="/api/project", tags=["secrets"], dependencies=[Depends(ProjectMember())]
@@ -18,7 +17,7 @@ router = APIRouter(
 async def list_secrets(project_name: str, repo_ref: RepoRef) -> List[str]:
     project = await get_project(project_name=project_name)
     backend = await get_backend(project)
-    secrets_names = await run_async(backend.list_secret_names, repo_ref.repo_id)
+    secrets_names = await call_backend(backend.list_secret_names, repo_ref.repo_id)
     return secrets_names
 
 
@@ -26,21 +25,21 @@ async def list_secrets(project_name: str, repo_ref: RepoRef) -> List[str]:
 async def add_secret(project_name: str, body: SecretAddUpdate):
     project = await get_project(project_name=project_name)
     backend = await get_backend(project)
-    await run_async(backend.add_secret, body.repo_id, body.secret)
+    await call_backend(backend.add_secret, body.repo_id, body.secret)
 
 
 @router.post("/{project_name}/secrets/update")
 async def update_secret(project_name: str, body: SecretAddUpdate):
     project = await get_project(project_name=project_name)
     backend = await get_backend(project)
-    await run_async(backend.update_secret, body.repo_id, body.secret)
+    await call_backend(backend.update_secret, body.repo_id, body.secret)
 
 
 @router.post("/{project_name}/secrets/{secret_name}/get")
 async def get_secret(project_name: str, secret_name: str, repo_ref: RepoRef) -> Secret:
     project = await get_project(project_name=project_name)
     backend = await get_backend(project)
-    secret = await run_async(backend.get_secret, repo_ref.repo_id, secret_name)
+    secret = await call_backend(backend.get_secret, repo_ref.repo_id, secret_name)
     if secret is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=error_detail("Secret not found")
@@ -52,4 +51,4 @@ async def get_secret(project_name: str, secret_name: str, repo_ref: RepoRef) -> 
 async def delete_secret(project_name: str, secret_name: str, repo_ref: RepoRef):
     project = await get_project(project_name=project_name)
     backend = await get_backend(project)
-    await run_async(backend.delete_secret, repo_ref.repo_id, secret_name)
+    await call_backend(backend.delete_secret, repo_ref.repo_id, secret_name)

--- a/cli/dstack/_internal/hub/routers/tags.py
+++ b/cli/dstack/_internal/hub/routers/tags.py
@@ -5,9 +5,8 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from dstack._internal.core.repo import RepoRef
 from dstack._internal.core.tag import TagHead
 from dstack._internal.hub.models import AddTagPath, AddTagRun
-from dstack._internal.hub.routers.util import error_detail, get_backend, get_project
+from dstack._internal.hub.routers.util import call_backend, error_detail, get_backend, get_project
 from dstack._internal.hub.security.permissions import ProjectMember
-from dstack._internal.hub.utils.common import run_async
 
 router = APIRouter(prefix="/api/project", tags=["tags"], dependencies=[Depends(ProjectMember())])
 
@@ -18,7 +17,7 @@ router = APIRouter(prefix="/api/project", tags=["tags"], dependencies=[Depends(P
 async def list_heads_tags(project_name: str, repo_ref: RepoRef) -> List[TagHead]:
     project = await get_project(project_name=project_name)
     backend = await get_backend(project)
-    tags = await run_async(backend.list_tag_heads, repo_ref.repo_id)
+    tags = await call_backend(backend.list_tag_heads, repo_ref.repo_id)
     return tags
 
 
@@ -29,7 +28,7 @@ async def list_heads_tags(project_name: str, repo_ref: RepoRef) -> List[TagHead]
 async def get_tag(project_name: str, tag_name: str, repo_ref: RepoRef) -> TagHead:
     project = await get_project(project_name=project_name)
     backend = await get_backend(project)
-    tag = await run_async(backend.get_tag_head, repo_ref.repo_id, tag_name)
+    tag = await call_backend(backend.get_tag_head, repo_ref.repo_id, tag_name)
     if tag is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=error_detail("Tag not found")
@@ -41,8 +40,8 @@ async def get_tag(project_name: str, tag_name: str, repo_ref: RepoRef) -> TagHea
 async def delete_tag(project_name: str, tag_name: str, repo_ref: RepoRef):
     project = await get_project(project_name=project_name)
     backend = await get_backend(project)
-    tag = await run_async(backend.get_tag_head, repo_ref.repo_id, tag_name)
-    await run_async(backend.delete_tag_head, repo_ref.repo_id, tag)
+    tag = await call_backend(backend.get_tag_head, repo_ref.repo_id, tag_name)
+    await call_backend(backend.delete_tag_head, repo_ref.repo_id, tag)
 
 
 @router.post("/{project_name}/tags/add/run")
@@ -50,7 +49,7 @@ async def add_tag_from_run(project_name: str, body: AddTagRun):
     project = await get_project(project_name=project_name)
     backend = await get_backend(project)
     # todo pass error to CLI if tag already exists
-    await run_async(
+    await call_backend(
         backend.add_tag_from_run, body.repo_id, body.tag_name, body.run_name, body.run_jobs
     )
 

--- a/cli/dstack/api/hub/_api_client.py
+++ b/cli/dstack/api/hub/_api_client.py
@@ -718,6 +718,8 @@ def _make_hub_request(request_func, host, *args, **kwargs) -> requests.Response:
             body = resp.json()
             detail = body.get("detail")
             if detail is not None:
+                if isinstance(detail, list):
+                    detail = detail[0]
                 if detail.get("code") == BackendNotAvailableError.code:
                     raise HubClientError(detail["msg"])
                 elif detail.get("code") == BackendValueError.code:

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -28,6 +28,7 @@ psutil
 cryptography
 filelock
 watchfiles
+docker
 
 # AWS
 boto3

--- a/docs/docs/reference/cli/run.md
+++ b/docs/docs/reference/cli/run.md
@@ -8,18 +8,24 @@ This command runs a given configuration.
 
 ```shell
 $ dstack run --help
-Usage: dstack run [--project PROJECT] [--profile PROFILE] [-d] [--reload] WORKING_DIR [ARGS ...]
+Usage: dstack run [-h] [-f FILE] [-n NAME] [-y] [-d] [--project PROJECT] [--profile PROFILE]
+                  [--reload]
+                  WORKING_DIR [ARGS ...]
 
 Positional Arguments:
-  WORKING_DIR          The working directory of the run
-  ARGS                 Run arguments
+  WORKING_DIR           The working directory of the run
+  ARGS                  Run arguments
 
 Options:
-  --f FILE             The path to the run configuration file. Defaults to WORKING_DIR/.dstack.yml.
-  --project PROJECT    The name of the project
-  --profile PROFILE    The name of the profile
-  -d, --detach         Do not poll logs and run status
-  --reload             Enable auto-reload
+  -h, --help            Show this help message and exit
+  -f, --file FILE       The path to the run configuration file. Defaults to
+                        WORKING_DIR/.dstack.yml.
+  -n, --name NAME       The name of the run. If not specified, a random name is assigned.
+  -y, --yes             Do not ask for plan confirmation
+  -d, --detach          Do not poll logs and run status
+  --reload              Enable auto-reload
+  --project PROJECT     The name of the project
+  --profile PROFILE     The name of the profile
 ```
 
 </div>
@@ -35,11 +41,12 @@ The following arguments are required:
 The following arguments are optional:
 
 - `-f FILE`, `--f FILE` – (Optional) The path to the run configuration file. Defaults to `WORKING_DIR/.dstack.yml`.
+- `-n NAME`, `--name NAME` - (Optional) The name of the run. If not specified, a random name is assigned.
+- `-y`, `--yes` - (Optional) Do not ask for plan confirmation
+- `-d`, `--detach` – (Optional) Run in the detached mode to disable logs and run status polling. By default, the run is in the attached mode, so the logs are printed in real-time.
+- `--reload` – (Optional) Enable auto-reload 
 - `--project PROJECT` – (Optional) The name of the project
 - `--profile PROJECT` – (Optional) The name of the profile
-- `--reload` – (Optional) Enable auto-reload 
-- `-d`, `--detach` – (Optional) Run in the detached mode. Means, the command doesn't
-  poll logs and run status.
 
 [//]: # (- `-t TAG`, `--tag TAG` – &#40;Optional&#41; A tag name. Warning, if the tag exists, it will be overridden.)
 - `-p PORT [PORT ...]`, `--ports PORT [PORT ...]` – (Optional) Requests ports or define mappings for them (`LOCAL_PORT:CONTAINER_PORT`)
@@ -69,4 +76,4 @@ Build policies:
 [//]: # (Tags should be dropped)
 
 !!! info "NOTE:"
-    By default, it runs it in the attached mode, so you'll see the output in real-time.
+    By default, the run is in the attached mode, so you'll see the output in real-time.

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ BASE_DEPS = [
     "grpcio>=1.50",  # indirect
     "filelock",
     "watchfiles",
+    "docker>=6.0.0",
 ]
 
 AWS_DEPS = [


### PR DESCRIPTION
Closes #418

The PR adds `--name` argument to `dstack run` so it's possible to specify custom run name:

```
✗ dstack run . --name ml_dev_env

dstack will execute the following plan:

 CONFIGURATION  USER   PROJECT  INSTANCE  RESOURCES       SPOT POLICY  BUILD 
 .dstack.yml    admin  local    -         4xCPUs, 9951MB  on-demand    No    

Continue? [y/n]: y

Provisioning...

 RUN         USER   INSTANCE  SPOT  STATUS     SUBMITTED 
 ml_dev_env  admin  -         no    Submitted  now 
```