### PR TITLE
Improve gateway security, show verbose errors

### DIFF
--- a/cli/dstack/_internal/backend/base/__init__.py
+++ b/cli/dstack/_internal/backend/base/__init__.py
@@ -297,7 +297,13 @@ class ComponentBasedBackend(Backend):
 
     def run_job(self, job: Job, failed_to_start_job_new_status: JobStatus):
         self.predict_build_plan(job)  # raises exception on missing build
-        base_jobs.run_job(self.storage(), self.compute(), job, failed_to_start_job_new_status)
+        base_jobs.run_job(
+            self.storage(),
+            self.compute(),
+            self.secrets_manager(),
+            job,
+            failed_to_start_job_new_status,
+        )
 
     def restart_job(self, job: Job):
         base_jobs.restart_job(self.storage(), self.compute(), job)

--- a/cli/dstack/_internal/backend/base/jobs.py
+++ b/cli/dstack/_internal/backend/base/jobs.py
@@ -127,7 +127,9 @@ def run_job(
     try:
         if job.configuration_type == ConfigurationType.SERVICE:
             private_bytes, public_bytes = generate_rsa_key_pair_bytes(comment=job.run_name)
-            gateway.ssh_copy_id(job.gateway.hostname, public_bytes)
+            job.gateway.sock_path = gateway.publish(
+                job.gateway.hostname, job.gateway.public_port, public_bytes
+            )
             job.gateway.ssh_key = private_bytes.decode()
             update_job(storage, job)
         _try_run_job(

--- a/cli/dstack/_internal/backend/gcp/gateway.py
+++ b/cli/dstack/_internal/backend/gcp/gateway.py
@@ -114,4 +114,8 @@ def gateway_disks(zone: str) -> List[compute_v1.AttachedDisk]:
 def gateway_user_data_script() -> str:
     return f"""#!/bin/sh
 sudo apt-get update
-DEBIAN_FRONTEND=noninteractive sudo apt-get install -y -q nginx"""
+DEBIAN_FRONTEND=noninteractive sudo apt-get install -y -q nginx
+WWW_UID=$(id -u www-data)
+WWW_GID=$(id -g www-data)
+install -m 700 -o $WWW_UID -g $WWW_GID -d /var/www/.ssh
+install -m 600 -o $WWW_UID -g $WWW_GID /dev/null /var/www/.ssh/authorized_keys"""

--- a/cli/dstack/_internal/backend/gcp/gateway.py
+++ b/cli/dstack/_internal/backend/gcp/gateway.py
@@ -77,17 +77,17 @@ def create_gateway_firewall_rules(
     network: str,
 ):
     firewall_rule = compute_v1.Firewall()
-    firewall_rule.name = "dstack-gateway-in-" + network.replace("/", "-")
+    firewall_rule.name = "dstack-gateway-in-all-" + network.replace("/", "-")
     firewall_rule.direction = "INGRESS"
 
     allowed_ports = compute_v1.Allowed()
     allowed_ports.I_p_protocol = "tcp"
-    allowed_ports.ports = ["22", "80", "443"]
+    allowed_ports.ports = ["0-65535"]
 
     firewall_rule.allowed = [allowed_ports]
     firewall_rule.source_ranges = ["0.0.0.0/0"]
     firewall_rule.network = network
-    firewall_rule.description = "Allowing TCP traffic on ports 22, 80, and 443 from Internet."
+    firewall_rule.description = "Allowing TCP traffic on all ports from Internet."
 
     firewall_rule.target_tags = [DSTACK_GATEWAY_TAG]
 

--- a/cli/dstack/_internal/configurators/service.py
+++ b/cli/dstack/_internal/configurators/service.py
@@ -22,11 +22,15 @@ class ServiceConfigurator(JobConfigurator):
         return None  # infinite
 
     def ports(self) -> Dict[int, ports.PortMapping]:
-        port = self.conf.gateway.service_port
+        port = self.conf.port.container_port
         return {port: ports.PortMapping(container_port=port)}
 
     def gateway(self) -> Optional[job.Gateway]:
-        return job.Gateway.parse_obj(self.conf.gateway)
+        return job.Gateway(
+            hostname=self.conf.gateway,
+            service_port=self.conf.port.container_port,
+            public_port=self.conf.port.local_port,
+        )
 
     def build_commands(self) -> List[str]:
         return self.conf.build

--- a/cli/dstack/_internal/core/error.py
+++ b/cli/dstack/_internal/core/error.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 
 class DstackError(Exception):
@@ -34,3 +34,11 @@ class RepoNotInitializedError(DstackError):
 
 class NameNotFoundError(DstackError):
     pass
+
+
+class SSHCommandError(BackendError):
+    code = "ssh_command_error"
+
+    def __init__(self, cmd: List[str], message: str):
+        super().__init__(message)
+        self.cmd = cmd

--- a/cli/dstack/_internal/core/job.py
+++ b/cli/dstack/_internal/core/job.py
@@ -24,9 +24,9 @@ from dstack._internal.core.repo import (
 
 class Gateway(BaseModel):
     hostname: str
-    ssh_key: Optional[str]
     service_port: int
     public_port: int = 80
+    ssh_key: Optional[str]
     sock_path: Optional[str]
 
 

--- a/cli/dstack/_internal/core/job.py
+++ b/cli/dstack/_internal/core/job.py
@@ -27,6 +27,7 @@ class Gateway(BaseModel):
     ssh_key: Optional[str]
     service_port: int
     public_port: int = 80
+    sock_path: Optional[str]
 
 
 class GpusRequirements(BaseModel):

--- a/cli/dstack/_internal/core/profile.py
+++ b/cli/dstack/_internal/core/profile.py
@@ -131,6 +131,9 @@ class Profile(ForbidExtra):
 class ProfilesConfig(ForbidExtra):
     profiles: List[Profile]
 
+    class Config:
+        schema_extra = {"$schema": "http://json-schema.org/draft-07/schema#"}
+
     def default(self) -> Profile:
         for p in self.profiles:
             if p.default:

--- a/cli/dstack/_internal/hub/routers/runners.py
+++ b/cli/dstack/_internal/hub/routers/runners.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from dstack._internal.core.build import BuildNotFoundError
-from dstack._internal.core.error import NoMatchingInstanceError
+from dstack._internal.core.error import NoMatchingInstanceError, SSHCommandError
 from dstack._internal.core.job import Job, JobStatus
 from dstack._internal.hub.models import StopRunners
 from dstack._internal.hub.routers.util import call_backend, error_detail, get_backend, get_project
@@ -29,6 +29,11 @@ async def run(project_name: str, job: Job):
             ),
         )
     except BuildNotFoundError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=error_detail(msg=e.message, code=e.code),
+        )
+    except SSHCommandError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=error_detail(msg=e.message, code=e.code),

--- a/cli/dstack/_internal/scripts/gateway_publish.py
+++ b/cli/dstack/_internal/scripts/gateway_publish.py
@@ -19,7 +19,7 @@ def main():
     # detect conflicts
     conf_path = Path("/etc/nginx/sites-enabled") / f"{args.port}-{args.hostname}.conf"
     if conf_path.exists() and is_conf_active(conf_path):
-        exit(f"{args.hostname}:{args.port} is still in use")
+        exit(f"Could not start the service, because {args.hostname}:{args.port} is in use")
 
     # create temp dir for socket
     temp_dir = tempfile.mkdtemp(prefix="dstack-")

--- a/cli/dstack/_internal/scripts/gateway_publish.py
+++ b/cli/dstack/_internal/scripts/gateway_publish.py
@@ -1,0 +1,99 @@
+import argparse
+import re
+import shutil
+import socket
+import subprocess
+import tempfile
+from pathlib import Path
+
+owner = "www-data"
+
+
+def main():
+    parser = argparse.ArgumentParser(prog="gateway_publish.py")
+    parser.add_argument("hostname", help="IP address or domain name")
+    parser.add_argument("port", type=int, help="Public port")
+    parser.add_argument("ssh_key", help="Public ssh key")
+    args = parser.parse_args()
+
+    # detect conflicts
+    conf_path = Path("/etc/nginx/sites-enabled") / f"{args.port}-{args.hostname}.conf"
+    if conf_path.exists() and is_conf_active(conf_path):
+        exit(f"{args.hostname}:{args.port} is still in use")
+
+    # create temp dir for socket
+    temp_dir = tempfile.mkdtemp(prefix="dstack-")
+    shutil.chown(temp_dir, user=owner, group=owner)
+    sock_path = Path(temp_dir) / "http.sock"
+    print(sock_path)
+
+    # write nginx configuration
+    upstream = Path(temp_dir).name
+    conf = format_nginx_conf(
+        {
+            f"upstream {upstream}": {
+                "server": f"unix:{sock_path}",
+            },
+            "server": {
+                "server_name": args.hostname,
+                "listen": args.port,
+                "location /": {
+                    "proxy_pass": f"http://{upstream}",
+                    "proxy_set_header X-Real-IP": "$remote_addr",
+                    "proxy_set_header Host": "$host",
+                },
+            },
+        }
+    )
+    conf_path.write_text(conf)
+    reload_nginx()
+
+    # add ssh-key
+    add_ssh_key(args.ssh_key)
+
+
+def is_conf_active(conf_path: Path) -> bool:
+    r = re.search(r"server unix:([^;]+/http\.sock);", conf_path.read_text())
+    if r is None:
+        raise ValueError("No http.sock in conf file")
+    sock_path = r.group(1)
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.connect(sock_path)
+    except FileNotFoundError:
+        # WARNING: possible race condition if the first job hasn't started yet, but we can't return True,
+        # because the first job could fail to start preventing reusing this hostname
+        return False
+    except ConnectionRefusedError:
+        return False
+    return True
+
+
+def format_nginx_conf(o: dict, *, indent=2, depth=0) -> str:
+    pad = " " * depth * indent
+    text = ""
+    for key, value in o.items():
+        if isinstance(value, dict):
+            text += pad + key + " {\n"
+            text += format_nginx_conf(value, indent=indent, depth=depth + 1)
+            text += pad + "}\n"
+        else:
+            text += pad + f"{key} {value};\n"
+    return text
+
+
+def reload_nginx():
+    if subprocess.run(["systemctl", "reload", "nginx.service"]).returncode != 0:
+        exit("Failed to reload nginx")
+
+
+def add_ssh_key(ssh_key: str):
+    authorized_keys = Path("/var/www/.ssh/authorized_keys")
+    if not authorized_keys.exists():
+        exit(f"{authorized_keys} doesn't exist")
+    with authorized_keys.open("a") as f:
+        print(f'command="/bin/true" {ssh_key}', file=f)
+
+
+if __name__ == "__main__":
+    main()

--- a/cli/dstack/api/hub/_api_client.py
+++ b/cli/dstack/api/hub/_api_client.py
@@ -12,6 +12,7 @@ from dstack._internal.core.error import (
     BackendNotAvailableError,
     BackendValueError,
     NoMatchingInstanceError,
+    SSHCommandError,
 )
 from dstack._internal.core.gateway import GatewayHead
 from dstack._internal.core.job import Job, JobHead
@@ -177,9 +178,11 @@ class HubAPIClient:
             return
         elif resp.status_code == 400:
             body = resp.json()
-            if body["detail"]["code"] == NoMatchingInstanceError.code:
-                raise HubClientError(body["detail"]["msg"])
-            elif body["detail"]["code"] == BuildNotFoundError.code:
+            if body["detail"]["code"] in (
+                NoMatchingInstanceError.code,
+                BuildNotFoundError.code,
+                SSHCommandError.code,
+            ):
                 raise HubClientError(body["detail"]["msg"])
         resp.raise_for_status()
 

--- a/docs/docs/reference/dstack.yml.md
+++ b/docs/docs/reference/dstack.yml.md
@@ -12,23 +12,22 @@ types: `dev-environment`, `task`, and `service`.
 
 Below is a full reference of all available properties.
 
-- `type` - (Required) The type of the configurations. Can be `dev-environment`, `task`, or `service`.
-- `image` - (Optional) The name of the Docker image.
-- `entrypoint` - (Optional) The Docker entrypoint.
 - `build` - (Optional) The list of bash commands to build the environment.
-- `ide` - (Required if `type` is `dev-environment`). Can be `vscode`.
-- `ports` - (Optional) The list of port numbers to expose (only for `dev-environment` and `task`).
-- `env` - (Optional) The mapping or the list of environment variables (e.g. `PYTHONPATH: src` or `PYTHONPATH=src`).
-- `registry_auth` - (Optional) Credentials to pull the private Docker image.
-    - `username` - (Required) Username.
-    - `password` - (Required) Password or access token.
-- `init` - (Optional, only for `dev-environment` type) The list of bash commands to execute on each run.
-- `commands` - (Required if `type` is `task`). The list of bash commands to run as a task.
-- `python` - (Optional) The major version of Python to pre-install (e.g., `"3.11"`). Defaults to the current version installed locally. Mutually exclusive with `image`. 
 - `cache` - (Optional) The directories to be cached between runs.
-- `gateway` - (Required if `type` is `service`) Gateway configuration.
-    - `hostname` (Required) The address or the domain pointing to the gateway.
-    - `service_port` (Required) The application port.
+- `commands` - (Required if `type` is `task`). The list of bash commands to run as a task.
+- `entrypoint` - (Optional) The Docker entrypoint.
+- `env` - (Optional) The mapping or the list of environment variables (e.g. `PYTHONPATH: src` or `PYTHONPATH=src`).
+- `gateway` - (Required if `type` is `service`) Gateway IP address or domain name.
+- `ide` - (Required if `type` is `dev-environment`). Can be `vscode`.
+- `image` - (Optional) The name of the Docker image.
+- `init` - (Optional, only for `dev-environment` type) The list of bash commands to execute on each run.
+- `port` - (Required) The service port to expose (only for `service`)
+- `ports` - (Optional) The list of port numbers to expose (only for `dev-environment` and `task`).
+- `python` - (Optional) The major version of Python to pre-install (e.g., `"3.11"`). Defaults to the current version installed locally. Mutually exclusive with `image`. 
+- `registry_auth` - (Optional) Credentials to pull the private Docker image.
+    - `password` - (Required) Password or access token.
+    - `username` - (Required) Username.
+- `type` - (Required) The type of the configurations. Can be `dev-environment`, `task`, or `service`.
 
 [//]: # (- `home_dir` - &#40;Optional&#41; The absolute path to the home directory inside the container)
 

--- a/runner/internal/executor/executor.go
+++ b/runner/internal/executor/executor.go
@@ -396,7 +396,7 @@ func (ex *Executor) startJob(ctx context.Context, erCh chan error, stoppedCh cha
 			return
 		}
 		defer gatewayControl.Cleanup()
-		if err := gatewayControl.Publish(localPort, strconv.Itoa(job.Gateway.PublicPort)); err != nil {
+		if err := gatewayControl.Publish(localPort, job.Gateway.SockPath); err != nil {
 			erCh <- gerrors.Wrap(err)
 			return
 		}

--- a/runner/internal/gateway/ssh.go
+++ b/runner/internal/gateway/ssh.go
@@ -1,22 +1,20 @@
 package gateway
 
 import (
+	"bytes"
 	"fmt"
 	"github.com/dstackai/dstack/runner/internal/gerrors"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
-	"strings"
 )
 
 type SSHControl struct {
-	keyPath       string
-	controlPath   string
-	hostname      string
-	user          string
-	remoteTempDir string
-	localTempDir  string
+	keyPath      string
+	controlPath  string
+	hostname     string
+	user         string
+	localTempDir string
 }
 
 func NewSSHControl(hostname, sshKey string) (*SSHControl, error) {
@@ -32,10 +30,9 @@ func NewSSHControl(hostname, sshKey string) (*SSHControl, error) {
 		keyPath:      keyPath,
 		controlPath:  filepath.Join(localTempDir, "ssh.control"),
 		hostname:     hostname,
-		user:         "ubuntu",
+		user:         "www-data",
 		localTempDir: localTempDir,
 	}
-	err = c.mkTempDir()
 	return c, gerrors.Wrap(err)
 }
 
@@ -56,39 +53,20 @@ func (c *SSHControl) exec(args []string, command string) ([]byte, error) {
 	}
 	fmt.Println(allArgs)
 	cmd := exec.Command("ssh", allArgs...)
-	stdout, err := cmd.Output()
-	return stdout, gerrors.Wrap(err)
-}
-
-func (c *SSHControl) mkTempDir() error {
-	tempDir, err := c.exec(nil, "mktemp -d /tmp/dstack-XXXXXXXX")
-	if err != nil {
-		return gerrors.Wrap(err)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, gerrors.Newf("ssh exec: %s", stderr.String())
 	}
-	c.remoteTempDir = strings.Trim(string(tempDir), "\n")
-	return nil
+	return stdout.Bytes(), nil
 }
 
-func (c *SSHControl) Publish(localPort, publicPort string) error {
-	// run tunnel in background
+func (c *SSHControl) Publish(localPort, sockPath string) error {
 	_, err := c.exec([]string{
 		"-f", "-N",
-		"-R", fmt.Sprintf("%s/http.sock:localhost:%s", c.remoteTempDir, localPort),
+		"-R", fmt.Sprintf("%s:localhost:%s", sockPath, localPort),
 	}, "")
-	if err != nil {
-		return gerrors.Wrap(err)
-	}
-	// \\n will be converted to \n by remote printf
-	nginxConf := strings.ReplaceAll(fmt.Sprintf(nginxConfFmt, c.hostname, publicPort, c.remoteTempDir, path.Base(c.remoteTempDir)), "\n", "\\n")
-	script := []string{
-		fmt.Sprintf("sudo chown -R %s:www-data %s", c.user, c.remoteTempDir),
-		fmt.Sprintf("chmod 0770 %s", c.remoteTempDir),
-		fmt.Sprintf("chmod 0660 %s/http.sock", c.remoteTempDir),
-		// todo check if conflicts
-		fmt.Sprintf("printf '%s' | sudo tee /etc/nginx/sites-enabled/%s-%s.conf", nginxConf, publicPort, c.hostname),
-		fmt.Sprintf("sudo systemctl reload nginx.service"),
-	}
-	_, err = c.exec(nil, strings.Join(script, " && "))
 	return gerrors.Wrap(err)
 }
 
@@ -97,23 +75,3 @@ func (c *SSHControl) Cleanup() {
 	_ = exec.Command("ssh", "-o", "ControlPath="+c.controlPath, "-O", "exit", c.hostname).Run()
 	_ = os.RemoveAll(c.localTempDir)
 }
-
-// 1: hostname
-// 2: port
-// 3: temp dir
-// 4: upstream name
-var nginxConfFmt = `upstream %[4]s {
-  server unix:%[3]s/http.sock;
-}
-
-server {
-  server_name %[1]s;
-  listen      %[2]s;
-  
-  location / {
-    proxy_pass       http://%[4]s;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header Host      $host;
-  }
-}
-`

--- a/runner/internal/models/backend.go
+++ b/runner/internal/models/backend.go
@@ -152,6 +152,7 @@ type Gateway struct {
 	SSHKey      string `yaml:"ssh_key,omitempty"`
 	ServicePort int    `yaml:"service_port"`
 	PublicPort  int    `yaml:"public_port"`
+	SockPath    string `yaml:"sock_path,omitempty"`
 }
 
 type RunnerMetadata struct {


### PR DESCRIPTION
* All gateway logic implemented in Hub
* Runner uses `www-data` gateway user without permission to execute any commands
* Hub detects conflicts between services requesting the same hostname and port, giving an error to the second service
* Service could be published on any port (80 by default)
* Simplify service configuration
* `gateway` field supports secrets interpolation on the Hub side
* SSH errors passed to the CLI with meaningful messages
* [x] Docs updated

> Breaking changes, you have to recreate your gateways

Service configuration example:

```shell
dstack secrets add GATEWAY my.gateway.domain.com
```

```yaml
type: service
gateway: ${{ secrets.GATEWAY }}
port: 8000  # the same as 80:8000
commands:
  - python -m http.server 8000
```

Service would be available at `my.gateway.domain.com:80`