### PR TITLE
Migrate to Gen2 images for Azure, add A100 support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   build-docker:
-    if: ${{ inputs.build_docker == 'true' }}
+    if: inputs.build_docker
     defaults:
       run:
         working-directory: docker
@@ -63,7 +63,7 @@ jobs:
 
   build-aws-images:
     needs: build-docker
-    if: ${{ always() && inputs.build_aws == 'true' }}
+    if: ${{ always() && inputs.build_aws }}
     defaults:
       run:
         working-directory: runner
@@ -88,7 +88,7 @@ jobs:
 
   build-azure-images:
     needs: build-docker
-    if: ${{ always() && inputs.build_azure == 'true' }}
+    if: ${{ always() && inputs.build_azure }}
     defaults:
       run:
         working-directory: runner
@@ -125,7 +125,7 @@ jobs:
 
   build-gcp-images:
     needs: build-docker
-    if: ${{ always() && inputs.build_gcp == 'true' }}
+    if: ${{ always() && inputs.build_gcp }}
     defaults:
       run:
         working-directory: runner

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,15 +6,34 @@ on:
       image_version:
         description: "Docker image version"
         required: true
-      build_prefix:
-        description: "Cloud images prefix"
-        default: ""
+      staging:
+        description: "Staging build"
+        type: boolean
+        default: false
+      build_docker:
+        description: "Build docker images"
+        type: boolean
+        default: true
+      build_aws:
+        description: "Build AWS images"
+        type: boolean
+        default: true
+      build_azure:
+        description: "Build Azure images"
+        type: boolean
+        default: true
+      build_gcp:
+        description: "Build GCP images"
+        type: boolean
+        default: true
 
 env:
   PACKER_VERSION: "1.9.2"
+  BUILD_PREFIX: ${{ inputs.staging && format('stgn-{0}-', github.run_number) || '' }}
 
 jobs:
   build-docker:
+    if: ${{ inputs.build_docker == 'true' }}
     defaults:
       run:
         working-directory: docker
@@ -43,10 +62,11 @@ jobs:
          docker buildx build --platform linux/amd64 --build-arg PYTHON=${{ matrix.python }} --push --provenance=false --tag dstackai/base:py${{ matrix.python }}-${{ inputs.image_version }}-cuda-11.8 -f cuda/Dockerfile .
 
   build-aws-images:
+    needs: build-docker
+    if: ${{ always() && inputs.build_aws == 'true' }}
     defaults:
       run:
         working-directory: runner
-    needs: [ build-docker ]
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -64,13 +84,14 @@ jobs:
           cp -R ami/packer/* .
       - name: Run packer
         run: |
-          ./packer build -var-file=versions.json -var-file=aws-vars-prod.json -var image_version=${{ inputs.image_version }} -var build_prefix=${{ inputs.build_prefix }} aws-image${{ matrix.variant }}.json
+          ./packer build -var-file=versions.json -var-file=aws-vars-prod.json -var image_version=${{ inputs.image_version }} -var build_prefix=$BUILD_PREFIX aws-image${{ matrix.variant }}.json
 
   build-azure-images:
+    needs: build-docker
+    if: ${{ always() && inputs.build_azure == 'true' }}
     defaults:
       run:
         working-directory: runner
-    needs: [ build-docker ]
     runs-on: ubuntu-latest
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -95,18 +116,19 @@ jobs:
           cp -R ami/packer/* .
       - name: Run packer
         run: |
-          ./packer build -var-file=versions.json -var image_version=${{ inputs.image_version }} -var build_prefix=${{ inputs.build_prefix }} azure-image${{ matrix.variant }}.json
+          ./packer build -var-file=versions.json -var image_version=${{ inputs.image_version }} -var build_prefix=$BUILD_PREFIX azure-image${{ matrix.variant }}.json
       - name: Publish azure image
         run: |
-          IMAGE_DEFINITION=${{ inputs.build_prefix }}dstack${{ matrix.variant }}-${{ inputs.image_version }}
-          IMAGE_NAME=${{ inputs.build_prefix }}dstack${{ matrix.variant }}-${{ inputs.image_version }}
+          IMAGE_DEFINITION=$BUILD_PREFIXdstack${{ matrix.variant }}-${{ inputs.image_version }}
+          IMAGE_NAME=$BUILD_PREFIXdstack${{ matrix.variant }}-${{ inputs.image_version }}
           ../scripts/publish_azure_image.sh $IMAGE_DEFINITION $IMAGE_NAME
 
   build-gcp-images:
+    needs: build-docker
+    if: ${{ always() && inputs.build_gcp == 'true' }}
     defaults:
       run:
         working-directory: runner
-    needs: [ build-docker ]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -132,10 +154,10 @@ jobs:
           cp -R ami/packer/* .
       - name: Run packer
         run: |
-          ./packer build -var-file=versions.json -var image_version=${{ inputs.image_version }} -var build_prefix=${{ inputs.build_prefix }} gcp-image${{ matrix.variant }}.json
+          ./packer build -var-file=versions.json -var image_version=${{ inputs.image_version }} -var build_prefix=$BUILD_PREFIX gcp-image${{ matrix.variant }}.json
       - name: Publish images
         run: |
           IMAGE_VERSION=${IMAGE_VERSION//./-}
-          gcloud compute images add-iam-policy-binding ${{ inputs.build_prefix }}dstack${{ matrix.variant }}-$IMAGE_VERSION --member='allAuthenticatedUsers' --role='roles/compute.imageUser'
+          gcloud compute images add-iam-policy-binding $BUILD_PREFIXdstack${{ matrix.variant }}-$IMAGE_VERSION --member='allAuthenticatedUsers' --role='roles/compute.imageUser'
         env:
           IMAGE_VERSION: ${{ inputs.image_version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -84,7 +84,9 @@ jobs:
           cp -R ami/packer/* .
       - name: Run packer
         run: |
-          ./packer build -var-file=versions.json -var-file=aws-vars-prod.json -var image_version=${{ inputs.image_version }} -var build_prefix=$BUILD_PREFIX aws-image${{ matrix.variant }}.json
+          ./packer build -var-file=versions.json $PROD_VARS -var image_version=${{ inputs.image_version }} -var build_prefix=$BUILD_PREFIX aws-image${{ matrix.variant }}.json
+        env:
+          PROD_VARS: ${{ !inputs.staging && '-var-file=aws-vars-prod.json' || '' }}  # production ? var-file : ''
 
   build-azure-images:
     needs: build-docker
@@ -118,7 +120,7 @@ jobs:
         run: |
           ./packer build -var-file=versions.json -var image_version=${{ inputs.image_version }} -var build_prefix=$BUILD_PREFIX azure-image${{ matrix.variant }}.json
       - name: Publish azure image
-#        if: ${{ !inputs.staging }}
+        if: ${{ !inputs.staging }}
         run: |
           IMAGE_DEFINITION=${BUILD_PREFIX}dstack${{ matrix.variant }}-${{ inputs.image_version }}
           IMAGE_NAME=${BUILD_PREFIX}dstack${{ matrix.variant }}-${{ inputs.image_version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ on:
 
 env:
   PACKER_VERSION: "1.9.2"
-  BUILD_PREFIX: ${{ inputs.staging && format('stgn-{0}-', github.run_number) || '' }}
+  BUILD_PREFIX: ${{ inputs.staging && format('stgn-{0}-', github.run_number) || '' }}  # staging ? prefix : ''
 
 jobs:
   build-docker:
@@ -63,7 +63,7 @@ jobs:
 
   build-aws-images:
     needs: build-docker
-    if: ${{ always() && inputs.build_aws }}
+    if: always() && inputs.build_aws && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped')
     defaults:
       run:
         working-directory: runner
@@ -88,7 +88,7 @@ jobs:
 
   build-azure-images:
     needs: build-docker
-    if: ${{ always() && inputs.build_azure }}
+    if: always() && inputs.build_azure && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped')
     defaults:
       run:
         working-directory: runner
@@ -119,13 +119,13 @@ jobs:
           ./packer build -var-file=versions.json -var image_version=${{ inputs.image_version }} -var build_prefix=$BUILD_PREFIX azure-image${{ matrix.variant }}.json
       - name: Publish azure image
         run: |
-          IMAGE_DEFINITION=$BUILD_PREFIXdstack${{ matrix.variant }}-${{ inputs.image_version }}
-          IMAGE_NAME=$BUILD_PREFIXdstack${{ matrix.variant }}-${{ inputs.image_version }}
+          IMAGE_DEFINITION=${BUILD_PREFIX}dstack${{ matrix.variant }}-${{ inputs.image_version }}
+          IMAGE_NAME=${BUILD_PREFIX}dstack${{ matrix.variant }}-${{ inputs.image_version }}
           ../scripts/publish_azure_image.sh $IMAGE_DEFINITION $IMAGE_NAME
 
   build-gcp-images:
     needs: build-docker
-    if: ${{ always() && inputs.build_gcp }}
+    if: always() && inputs.build_gcp && (needs.build-docker.result == 'success' || needs.build-docker.result == 'skipped')
     defaults:
       run:
         working-directory: runner
@@ -158,6 +158,6 @@ jobs:
       - name: Publish images
         run: |
           IMAGE_VERSION=${IMAGE_VERSION//./-}
-          gcloud compute images add-iam-policy-binding $BUILD_PREFIXdstack${{ matrix.variant }}-$IMAGE_VERSION --member='allAuthenticatedUsers' --role='roles/compute.imageUser'
+          gcloud compute images add-iam-policy-binding ${BUILD_PREFIX}dstack${{ matrix.variant }}-$IMAGE_VERSION --member='allAuthenticatedUsers' --role='roles/compute.imageUser'
         env:
           IMAGE_VERSION: ${{ inputs.image_version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -118,6 +118,7 @@ jobs:
         run: |
           ./packer build -var-file=versions.json -var image_version=${{ inputs.image_version }} -var build_prefix=$BUILD_PREFIX azure-image${{ matrix.variant }}.json
       - name: Publish azure image
+#        if: ${{ !inputs.staging }}
         run: |
           IMAGE_DEFINITION=${BUILD_PREFIX}dstack${{ matrix.variant }}-${{ inputs.image_version }}
           IMAGE_NAME=${BUILD_PREFIX}dstack${{ matrix.variant }}-${{ inputs.image_version }}

--- a/cli/dstack/_internal/backend/azure/compute.py
+++ b/cli/dstack/_internal/backend/azure/compute.py
@@ -266,7 +266,7 @@ def _get_image_ref(
 
     image = compute_client.community_gallery_images.get(
         location=location,
-        public_gallery_name="dstack-d5e68bdc-cc66-484a-a485-b54e3683f151",
+        public_gallery_name="dstack-ebac134d-04b9-4c2b-8b6c-ad3e73904aa7",  # Gen2
         gallery_image_name=image_name,
     )
     return ImageReference(community_gallery_image_id=image.unique_id)

--- a/cli/dstack/version.py
+++ b/cli/dstack/version.py
@@ -1,3 +1,3 @@
 __version__ = None
 __is_release__ = False
-base_image = "0.4rc2"
+base_image = "0.4rc3"

--- a/runner/ami/packer/azure-image-cuda.json
+++ b/runner/ami/packer/azure-image-cuda.json
@@ -23,7 +23,7 @@
     "os_type": "Linux",
     "image_publisher": "canonical",
     "image_offer": "0001-com-ubuntu-server-jammy",
-    "image_sku": "22_04-lts",
+    "image_sku": "22_04-lts-gen2",
     "azure_tags": {
         "Name": "DSTACK-CUDA"
     },

--- a/runner/ami/packer/azure-image.json
+++ b/runner/ami/packer/azure-image.json
@@ -22,7 +22,7 @@
     "os_type": "Linux",
     "image_publisher": "canonical",
     "image_offer": "0001-com-ubuntu-server-jammy",
-    "image_sku": "22_04-lts",
+    "image_sku": "22_04-lts-gen2",
     "azure_tags": {
         "Name": "DSTACK"
     },

--- a/runner/ami/packer/provisioners/cuda.sh
+++ b/runner/ami/packer/provisioners/cuda.sh
@@ -14,9 +14,9 @@ wget https://developer.download.nvidia.com/compute/cuda/repos/$CUDA_DISTRO/$ARCH
 sudo dpkg -i cuda-keyring_1.0-1_all.deb
 rm cuda-keyring_1.0-1_all.deb
 
+CUDA_BRANCH=$(cut -d '.' -f 1 <<< "$CUDA_DRIVERS_VERSION")
 sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-	 cuda-drivers=$CUDA_DRIVERS_VERSION
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends cuda-drivers-$CUDA_BRANCH=$CUDA_DRIVERS_VERSION
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y curl
 NVDOCKER_DISTRO=$(. /etc/os-release;echo $ID$VERSION_ID)

--- a/runner/ami/packer/provisioners/kernel/apt-packages.sh
+++ b/runner/ami/packer/provisioners/kernel/apt-packages.sh
@@ -33,7 +33,7 @@ for dep in $DEPS; do
 done
 
 # Uninstall amazon-ssm-agent, which comes with Ubuntu AMI via snap.
-sudo snap remove amazon-ssm-agent
+sudo snap remove amazon-ssm-agent || true
 
 # Uninstall snapd, which is not used by us.
 sudo apt-get purge -y snapd

--- a/scripts/publish_azure_image.sh
+++ b/scripts/publish_azure_image.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 image_definition=$1
 image_name=$2
@@ -10,7 +10,7 @@ exit 1
 fi
 
 resource_group=dstack-resources-westeurope
-gallery_name=dstack_gallery_westeurope
+gallery_name=dstack_gallery_westeurope_gen2
 
 function get_image_definition {
     az sig image-definition show \

--- a/scripts/publish_azure_image.sh
+++ b/scripts/publish_azure_image.sh
@@ -32,7 +32,8 @@ function create_image_definition() {
         --offer dstack \
         --sku $image_definition \
         --os-type Linux \
-        --os-state generalized
+        --os-state generalized \
+        --hyper-v-generation V2
 }
 
 function create_image_version() {


### PR DESCRIPTION
Closes #424 

* Build Gen2 images
* Add A100 instances for Azure
* Fix cuda-drivers version pin
* Add more control to docker workflow