### PR TITLE
Add `run` CLI options: env, port, gpu

### DIFF
--- a/cli/dstack/_internal/configurators/cli.py
+++ b/cli/dstack/_internal/configurators/cli.py
@@ -1,0 +1,35 @@
+import re
+from typing import Dict, Tuple
+
+import dstack._internal.configurators.ports as ports
+
+
+def port_mapping(v: str) -> ports.PortMapping:
+    # argparse uses __name__ for handling ValueError
+    return ports.PortMapping.parse(v)
+
+
+def env_var(v: str) -> Tuple[str, str]:
+    r = re.match(r"^([a-zA-Z_][a-zA-Z0-9_]*)=(.*)$", v)
+    if r is None:
+        raise ValueError(v)
+    key, value = r.groups()
+    return key, value
+
+
+def gpu_resource(v: str) -> Dict[str, str]:
+    patterns = {
+        "name": r"^[a-z].+$",  # GPU name starts with a letter
+        "count": r"^\d+$",  # Count contains digits only
+        "memory": r"^\d+(mb|gb)$",  # Memory has a suffix
+    }
+    data = {}
+    for part in v.split(":"):
+        for key, pattern in patterns.items():
+            if re.match(pattern, part.lower()) is not None:
+                data[key] = part
+                patterns.pop(key)  # every field could be used at most once
+                break
+        else:
+            raise ValueError(part)
+    return data

--- a/cli/dstack/_internal/core/job.py
+++ b/cli/dstack/_internal/core/job.py
@@ -49,7 +49,9 @@ class Requirements(BaseModel):
         res += f"{self.cpus}xCPUs"
         res += f", {self.memory_mib}MB"
         if self.gpus:
-            res += f", {self.gpus.count}x{self.gpus.name}"
+            res += f", {self.gpus.count}x{self.gpus.name or 'GPU'}"
+            if self.gpus.memory_mib:
+                res += f" {self.gpus.memory_mib / 1024:g}GB"
         return res
 
 

--- a/cli/dstack/_internal/core/profile.py
+++ b/cli/dstack/_internal/core/profile.py
@@ -64,7 +64,7 @@ class ProfileGPU(ForbidExtra):
     _validate_mem = validator("memory", pre=True, allow_reuse=True)(parse_memory)
 
     @validator("name")
-    def _validate_name(name: str):
+    def _validate_name(cls, name: str):
         return name.upper()
 
 

--- a/docs/docs/reference/cli/run.md
+++ b/docs/docs/reference/cli/run.md
@@ -49,7 +49,9 @@ The following arguments are optional:
 - `--profile PROJECT` – (Optional) The name of the profile
 
 [//]: # (- `-t TAG`, `--tag TAG` – &#40;Optional&#41; A tag name. Warning, if the tag exists, it will be overridden.)
-- `-p PORT [PORT ...]`, `--ports PORT [PORT ...]` – (Optional) Requests ports or define mappings for them (`LOCAL_PORT:CONTAINER_PORT`)
+- `-p PORT`, `--port PORT` – (Optional) Requests port or define mapping (`LOCAL_PORT:CONTAINER_PORT`)
+- `-e ENV`, `--env ENV` – (Optional) Set environment variable (`NAME=value`)
+- `--gpu` – (Optional) Request a GPU for the run. Specify any: name, count, memory (`NAME:COUNT:MEMORY` or `NAME` or `COUNT:MEMORY`, etc...)
 - `ARGS` – (Optional) Use `ARGS` to pass custom run arguments
 
 Spot policy (the arguments are mutually exclusive):


### PR DESCRIPTION
Closes #625 

* Replace single `--ports PORT PORT` with multiple `--port PORT --port PORT`
* Add `--env` to set run environment variable (can override configuration file)
* Add `--gpu` to request GPU for the run (merges with configuration file)
  * `--gpu A100`
  * `--gpu A100:2`
  * `--gpu 1`
  * `--gpu 16GB`
  * `--gpu 4:16GB`
* Improve "No instance type matching requirements" error formatting
* Update `run` docs