### PR TITLE
Add SSL support for services

### DIFF
--- a/cli/dstack/_internal/backend/aws/gateway.py
+++ b/cli/dstack/_internal/backend/aws/gateway.py
@@ -3,6 +3,8 @@ from typing import Optional
 
 from botocore.client import BaseClient
 
+from dstack._internal.backend.base.gateway import setup_nginx_certbot
+
 
 def create_gateway_instance(
     ec2_client: BaseClient,
@@ -149,14 +151,9 @@ def get_instance_id(ec2_client: BaseClient, instance_name: str) -> str:
 
 def gateway_user_data_script(ssh_key_pub: str) -> str:
     return f"""#!/bin/bash
-sudo apt-get update
-DEBIAN_FRONTEND=noninteractive sudo apt-get install -y -q nginx
+{setup_nginx_certbot()}
 UBUNTU_UID=$(id -u ubuntu)
 UBUNTU_GID=$(id -g ubuntu)
 install -m 700 -o $UBUNTU_UID -g $UBUNTU_GID -d /home/ubuntu/.ssh
 install -m 600 -o $UBUNTU_UID -g $UBUNTU_GID /dev/null /home/ubuntu/.ssh/authorized_keys
-echo "{ssh_key_pub}" > /home/ubuntu/.ssh/authorized_keys
-WWW_UID=$(id -u www-data)
-WWW_GID=$(id -g www-data)
-install -m 700 -o $WWW_UID -g $WWW_GID -d /var/www/.ssh
-install -m 600 -o $WWW_UID -g $WWW_GID /dev/null /var/www/.ssh/authorized_keys"""
+echo "{ssh_key_pub}" > /home/ubuntu/.ssh/authorized_keys"""

--- a/cli/dstack/_internal/backend/azure/gateway.py
+++ b/cli/dstack/_internal/backend/azure/gateway.py
@@ -34,6 +34,7 @@ from azure.mgmt.network.models import (
 )
 
 import dstack._internal.backend.azure.utils as azure_utils
+from dstack._internal.backend.base.gateway import setup_nginx_certbot
 
 
 def create_gateway(
@@ -187,9 +188,4 @@ def get_public_ip(
 
 def gateway_user_data_script() -> str:
     return f"""#!/bin/sh
-sudo apt-get update
-DEBIAN_FRONTEND=noninteractive sudo apt-get install -y -q nginx
-WWW_UID=$(id -u www-data)
-WWW_GID=$(id -g www-data)
-install -m 700 -o $WWW_UID -g $WWW_GID -d /var/www/.ssh
-install -m 600 -o $WWW_UID -g $WWW_GID /dev/null /var/www/.ssh/authorized_keys"""
+{setup_nginx_certbot()}"""

--- a/cli/dstack/_internal/backend/base/gateway.py
+++ b/cli/dstack/_internal/backend/base/gateway.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 from typing import List, Optional
 
@@ -13,8 +14,10 @@ from dstack._internal.backend.base.secrets import SecretsManager
 from dstack._internal.backend.base.storage import Storage
 from dstack._internal.core.error import SSHCommandError
 from dstack._internal.core.gateway import GatewayHead
+from dstack._internal.core.job import Job
 from dstack._internal.hub.utils.ssh import HUB_PRIVATE_KEY_PATH
 from dstack._internal.utils.common import PathLike, removeprefix
+from dstack._internal.utils.crypto import generate_rsa_key_pair_bytes
 from dstack._internal.utils.interpolator import VariablesInterpolator
 from dstack._internal.utils.random_names import generate_name
 
@@ -55,10 +58,13 @@ def publish(
     hostname: str,
     port: int,
     ssh_key: bytes,
+    secure: bool,
     user: str = "ubuntu",
     id_rsa: Optional[PathLike] = HUB_PRIVATE_KEY_PATH,
 ) -> str:
     command = ["sudo", "python3", "-", hostname, str(port), f'"{ssh_key.decode().strip()}"']
+    if secure:
+        command.append("--secure")
     with open(
         pkg_resources.resource_filename("dstack._internal", "scripts/gateway_publish.py"), "r"
     ) as f:
@@ -105,3 +111,22 @@ def setup_nginx_certbot() -> str:
         "install -m 600 -o $WWW_UID -g $WWW_GID /dev/null /var/www/.ssh/authorized_keys",
     ]
     return "\n".join(lines)
+
+
+def is_ip_address(hostname: str) -> bool:
+    return re.match(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$", hostname) is not None
+
+
+def setup_service_job(job: Job, secrets_manager: SecretsManager) -> Job:
+    job.gateway.hostname = resolve_hostname(
+        secrets_manager, job.repo_ref.repo_id, job.gateway.hostname
+    )
+    secure = not is_ip_address(job.gateway.hostname)
+    if secure and job.gateway.public_port == 80:
+        job.gateway.public_port = 443
+    private_bytes, public_bytes = generate_rsa_key_pair_bytes(comment=job.run_name)
+    job.gateway.sock_path = publish(
+        job.gateway.hostname, job.gateway.public_port, public_bytes, secure=secure
+    )
+    job.gateway.ssh_key = private_bytes.decode()
+    return job

--- a/cli/dstack/_internal/backend/base/gateway.py
+++ b/cli/dstack/_internal/backend/base/gateway.py
@@ -121,12 +121,12 @@ def setup_service_job(job: Job, secrets_manager: SecretsManager) -> Job:
     job.gateway.hostname = resolve_hostname(
         secrets_manager, job.repo_ref.repo_id, job.gateway.hostname
     )
-    secure = not is_ip_address(job.gateway.hostname)
-    if secure and job.gateway.public_port == 80:
+    job.gateway.secure = not is_ip_address(job.gateway.hostname)
+    if job.gateway.secure and job.gateway.public_port == 80:
         job.gateway.public_port = 443
     private_bytes, public_bytes = generate_rsa_key_pair_bytes(comment=job.run_name)
     job.gateway.sock_path = publish(
-        job.gateway.hostname, job.gateway.public_port, public_bytes, secure=secure
+        job.gateway.hostname, job.gateway.public_port, public_bytes, secure=job.gateway.secure
     )
     job.gateway.ssh_key = private_bytes.decode()
     return job

--- a/cli/dstack/_internal/backend/base/gateway.py
+++ b/cli/dstack/_internal/backend/base/gateway.py
@@ -91,3 +91,17 @@ def exec_ssh_command(
     if proc.returncode != 0:
         raise SSHCommandError(args, stderr.decode())
     return stdout
+
+
+def setup_nginx_certbot() -> str:
+    lines = [
+        "sudo apt-get update",
+        "DEBIAN_FRONTEND=noninteractive sudo apt-get install -y -q nginx",
+        "sudo snap install --classic certbot",
+        "sudo ln -s /snap/bin/certbot /usr/bin/certbot",
+        "WWW_UID=$(id -u www-data)",
+        "WWW_GID=$(id -g www-data)",
+        "install -m 700 -o $WWW_UID -g $WWW_GID -d /var/www/.ssh",
+        "install -m 600 -o $WWW_UID -g $WWW_GID /dev/null /var/www/.ssh/authorized_keys",
+    ]
+    return "\n".join(lines)

--- a/cli/dstack/_internal/backend/base/jobs.py
+++ b/cli/dstack/_internal/backend/base/jobs.py
@@ -22,7 +22,6 @@ from dstack._internal.core.job import (
 from dstack._internal.core.repo import RepoRef
 from dstack._internal.core.runners import Runner
 from dstack._internal.utils.common import get_milliseconds_since_epoch
-from dstack._internal.utils.crypto import generate_rsa_key_pair_bytes
 from dstack._internal.utils.escape import escape_head, unescape_head
 from dstack._internal.utils.logging import get_logger
 
@@ -128,14 +127,7 @@ def run_job(
         raise BackendError("Can't create a request for a job which status is not SUBMITTED")
     try:
         if job.configuration_type == ConfigurationType.SERVICE:
-            job.gateway.hostname = gateway.resolve_hostname(
-                secrets_manager, job.repo_ref.repo_id, job.gateway.hostname
-            )
-            private_bytes, public_bytes = generate_rsa_key_pair_bytes(comment=job.run_name)
-            job.gateway.sock_path = gateway.publish(
-                job.gateway.hostname, job.gateway.public_port, public_bytes
-            )
-            job.gateway.ssh_key = private_bytes.decode()
+            job = gateway.setup_service_job(job, secrets_manager)
             update_job(storage, job)
 
         _try_run_job(

--- a/cli/dstack/_internal/backend/gcp/gateway.py
+++ b/cli/dstack/_internal/backend/gcp/gateway.py
@@ -4,6 +4,7 @@ import google.api_core.exceptions
 from google.cloud import compute_v1
 
 import dstack._internal.backend.gcp.utils as gcp_utils
+from dstack._internal.backend.base.gateway import setup_nginx_certbot
 
 DSTACK_GATEWAY_TAG = "dstack-gateway"
 
@@ -113,9 +114,4 @@ def gateway_disks(zone: str) -> List[compute_v1.AttachedDisk]:
 
 def gateway_user_data_script() -> str:
     return f"""#!/bin/sh
-sudo apt-get update
-DEBIAN_FRONTEND=noninteractive sudo apt-get install -y -q nginx
-WWW_UID=$(id -u www-data)
-WWW_GID=$(id -g www-data)
-install -m 700 -o $WWW_UID -g $WWW_GID -d /var/www/.ssh
-install -m 600 -o $WWW_UID -g $WWW_GID /dev/null /var/www/.ssh/authorized_keys"""
+{setup_nginx_certbot()}"""

--- a/cli/dstack/_internal/cli/utils/run.py
+++ b/cli/dstack/_internal/cli/utils/run.py
@@ -346,12 +346,14 @@ def _run_container_ssh_tunnel(hub_client: HubClient, run_name: str, ports_lock: 
 
 def _poll_logs_ws(hub_client: HubClient, job: Job, ports: Dict[int, int]):
     hostname = "127.0.0.1"
+    secure = False
     if job.configuration_type == ConfigurationType.SERVICE:
         hostname = job.gateway.hostname
+        secure = job.gateway.secure
         ports = {**ports, job.gateway.service_port: job.gateway.public_port}
 
     def on_message(ws: WebSocketApp, message):
-        message = fix_urls(message, job, ports, hostname=hostname)
+        message = fix_urls(message, job, ports, hostname=hostname, secure=secure)
         sys.stdout.buffer.write(message)
         sys.stdout.buffer.flush()
 

--- a/cli/dstack/_internal/core/job.py
+++ b/cli/dstack/_internal/core/job.py
@@ -26,6 +26,7 @@ class Gateway(BaseModel):
     hostname: str
     service_port: int
     public_port: int = 80
+    secure: bool = False
     ssh_key: Optional[str]
     sock_path: Optional[str]
 

--- a/cli/dstack/_internal/hub/background/__init__.py
+++ b/cli/dstack/_internal/hub/background/__init__.py
@@ -7,7 +7,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 from dstack._internal.hub.background.tasks.resubmit_jobs import resubmit_jobs
 
 
-def start_background_tasks():
+def start_background_tasks() -> AsyncIOScheduler:
     def _error_listner(event: JobExecutionEvent):
         if isinstance(event.exception, asyncio.CancelledError):
             scheduler.shutdown()
@@ -16,3 +16,4 @@ def start_background_tasks():
     scheduler.add_job(resubmit_jobs, IntervalTrigger(seconds=60))
     scheduler.add_listener(_error_listner, EVENT_JOB_ERROR)
     scheduler.start()
+    return scheduler

--- a/cli/dstack/_internal/hub/background/__init__.py
+++ b/cli/dstack/_internal/hub/background/__init__.py
@@ -1,6 +1,3 @@
-import asyncio
-
-from apscheduler.events import EVENT_JOB_ERROR, JobExecutionEvent
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 

--- a/cli/dstack/_internal/hub/background/__init__.py
+++ b/cli/dstack/_internal/hub/background/__init__.py
@@ -8,12 +8,7 @@ from dstack._internal.hub.background.tasks.resubmit_jobs import resubmit_jobs
 
 
 def start_background_tasks() -> AsyncIOScheduler:
-    def _error_listner(event: JobExecutionEvent):
-        if isinstance(event.exception, asyncio.CancelledError):
-            scheduler.shutdown()
-
     scheduler = AsyncIOScheduler()
     scheduler.add_job(resubmit_jobs, IntervalTrigger(seconds=60))
-    scheduler.add_listener(_error_listner, EVENT_JOB_ERROR)
     scheduler.start()
     return scheduler

--- a/runner/internal/models/backend.go
+++ b/runner/internal/models/backend.go
@@ -149,9 +149,10 @@ type RepoData struct {
 
 type Gateway struct {
 	Hostname    string `yaml:"hostname"`
-	SSHKey      string `yaml:"ssh_key,omitempty"`
 	ServicePort int    `yaml:"service_port"`
 	PublicPort  int    `yaml:"public_port"`
+	Secure      bool   `yaml:"secure"`
+	SSHKey      string `yaml:"ssh_key,omitempty"`
 	SockPath    string `yaml:"sock_path,omitempty"`
 }
 


### PR DESCRIPTION
* Automatically issue Let's Encrypt certificate for domains
  * Custom domain required, `*.compute.amazonaws.com` domains are blacklisted by CA
  * Always use port 443 (+ redirect from 80)
* Still can choose a port for IP address hostname (except for 443)
* Put correct schema in logs
* Omit default port in logs