### PR TITLE
Fix runner not terminating on max duration exceeded

### DIFF
--- a/runner/consts/consts.go
+++ b/runner/consts/consts.go
@@ -39,3 +39,8 @@ const DELAY_READ_STATUS = 5 * time.Second
 
 const REPO_HTTPS_URL = "https://%s/%s/%s.git"
 const REPO_GIT_URL = "git@%s:%s/%s.git"
+
+const (
+	TERMINATE_POLICY = "terminate"
+	STOP_POLICY      = "stop"
+)


### PR DESCRIPTION
Closes #632 

The behaviour was that the runner always stopped instead of respecting the termination policy. Since stopping is not supported for all backends, the instance may continue to run.