### PR TITLE
Costs estimation API

### DIFF
--- a/cli/dstack/_internal/backend/aws/__init__.py
+++ b/cli/dstack/_internal/backend/aws/__init__.py
@@ -7,11 +7,13 @@ from dstack._internal.backend.aws import utils as aws_utils
 from dstack._internal.backend.aws.compute import AWSCompute
 from dstack._internal.backend.aws.config import AWSConfig
 from dstack._internal.backend.aws.logs import AWSLogging
+from dstack._internal.backend.aws.pricing import AWSPricing
 from dstack._internal.backend.aws.secrets import AWSSecretsManager
 from dstack._internal.backend.aws.storage import AWSStorage
 from dstack._internal.backend.base import ComponentBasedBackend
 from dstack._internal.backend.base import runs as base_runs
 from dstack._internal.core.error import BackendAuthError
+from dstack._internal.core.instance import InstanceOffer
 from dstack._internal.core.job import Job, JobStatus
 
 
@@ -49,6 +51,7 @@ class AwsBackend(ComponentBasedBackend):
             logs_client=aws_utils.get_logs_client(self._session),
             bucket_name=self.backend_config.bucket_name,
         )
+        self._pricing = AWSPricing(session=self._session)
         self._check_credentials()
 
     @classmethod
@@ -72,13 +75,21 @@ class AwsBackend(ComponentBasedBackend):
     def logging(self) -> AWSLogging:
         return self._logging
 
-    def run_job(self, job: Job, failed_to_start_job_new_status: JobStatus):
+    def pricing(self) -> AWSPricing:
+        return self._pricing
+
+    def run_job(
+        self,
+        job: Job,
+        failed_to_start_job_new_status: JobStatus,
+        offer: Optional[InstanceOffer] = None,
+    ):
         self._logging.create_log_groups_if_not_exist(
             aws_utils.get_logs_client(self._session),
             self.backend_config.bucket_name,
             job.repo_ref.repo_id,
         )
-        super().run_job(job, failed_to_start_job_new_status)
+        super().run_job(job, failed_to_start_job_new_status, offer=offer)
 
     def create_run(self, repo_id: str, run_name: Optional[str]) -> str:
         self._logging.create_log_groups_if_not_exist(

--- a/cli/dstack/_internal/backend/aws/__init__.py
+++ b/cli/dstack/_internal/backend/aws/__init__.py
@@ -12,6 +12,7 @@ from dstack._internal.backend.aws.storage import AWSStorage
 from dstack._internal.backend.base import ComponentBasedBackend
 from dstack._internal.backend.base import runs as base_runs
 from dstack._internal.core.error import BackendAuthError
+from dstack._internal.core.job import Job, JobStatus
 
 
 class AwsBackend(ComponentBasedBackend):
@@ -70,6 +71,14 @@ class AwsBackend(ComponentBasedBackend):
 
     def logging(self) -> AWSLogging:
         return self._logging
+
+    def run_job(self, job: Job, failed_to_start_job_new_status: JobStatus):
+        self._logging.create_log_groups_if_not_exist(
+            aws_utils.get_logs_client(self._session),
+            self.backend_config.bucket_name,
+            job.repo_ref.repo_id,
+        )
+        super().run_job(job, failed_to_start_job_new_status)
 
     def create_run(self, repo_id: str, run_name: Optional[str]) -> str:
         self._logging.create_log_groups_if_not_exist(

--- a/cli/dstack/_internal/backend/aws/compute.py
+++ b/cli/dstack/_internal/backend/aws/compute.py
@@ -47,13 +47,14 @@ class AWSCompute(Compute):
                 instances[i.instance_name].available_regions.append(region)
         return list(instances.values())
 
-    def run_instance(self, job: Job, instance_type: InstanceType) -> LaunchedInstanceInfo:
+    def run_instance(
+        self, job: Job, instance_type: InstanceType, region: Optional[str] = None
+    ) -> LaunchedInstanceInfo:
         return runners.run_instance(
             session=self.session,
             iam_client=self.iam_client,
             bucket_name=self.backend_config.bucket_name,
-            region_name=self.backend_config.region_name,
-            extra_regions=self.backend_config.extra_regions,
+            region_name=region or self.backend_config.region_name,
             subnet_id=self.backend_config.subnet_id,
             runner_id=job.runner_id,
             instance_type=instance_type,

--- a/cli/dstack/_internal/backend/aws/pricing.py
+++ b/cli/dstack/_internal/backend/aws/pricing.py
@@ -1,0 +1,98 @@
+import datetime
+import json
+from typing import Dict, List, Optional
+
+import boto3
+from botocore.exceptions import ClientError, EndpointConnectionError
+
+import dstack._internal.backend.aws.utils as aws_utils
+from dstack._internal.backend.base.pricing import BasePricing
+from dstack._internal.core.instance import InstanceType
+
+
+class AWSPricing(BasePricing):
+    """
+    Required IAM policies:
+      * pricing:GetProducts
+      * ec2:DescribeSpotPriceHistory
+    """
+
+    def __init__(self, session: boto3.Session):
+        super().__init__()
+        self.session = session
+        self.pricing_client = self.session.client("pricing")
+        self.last_used: Dict[str, float] = {}
+
+    def _fetch_ondemand(self, attributes: Dict[str, str]):
+        def get_ondemand_price(terms: dict) -> Dict[str, str]:
+            for _, term in terms["OnDemand"].items():
+                for _, dim in term["priceDimensions"].items():
+                    return dim["pricePerUnit"]
+
+        # todo cache
+        pages = self.pricing_client.get_paginator("get_products").paginate(
+            ServiceCode="AmazonEC2",
+            Filters=[
+                {
+                    "Type": "TERM_MATCH",
+                    "Field": key,
+                    "Value": value,
+                }
+                for key, value in attributes.items()
+            ],
+        )
+        for page in pages:
+            for item in page["PriceList"]:
+                item = json.loads(item)
+                attrs = item["product"]["attributes"]
+                if "Usage" not in attrs["usagetype"] or attrs["tenancy"] == "Host":
+                    continue
+                price = get_ondemand_price(item["terms"])
+                if "USD" in price:
+                    self.cache[attrs["instanceType"]][(attrs["regionCode"], False)] = float(
+                        price["USD"]
+                    )
+
+    def _fetch_spot(self, instance_type: str, regions: List[str]):
+        for region in regions:
+            try:
+                client = aws_utils.get_ec2_client(self.session, region_name=region)
+                # todo cache
+                pages = client.get_paginator("describe_spot_price_history").paginate(
+                    Filters=[
+                        {
+                            "Name": "product-description",
+                            "Values": ["Linux/UNIX"],
+                        }
+                    ],
+                    # WARNING: using Filters["instance-type"] gives fewer results. Why?
+                    InstanceTypes=[instance_type],
+                    StartTime=datetime.datetime.utcnow(),
+                )
+                prices = []
+                for page in pages:
+                    for item in page["SpotPriceHistory"]:
+                        prices.append(float(item["SpotPrice"]))
+                if prices:
+                    # we drop AZ information
+                    self.cache[instance_type][(region, True)] = min(prices)
+            except (ClientError, EndpointConnectionError) as e:
+                pass
+
+    def fetch(self, instance: InstanceType, spot: Optional[bool]):
+        self._fetch_ondemand(
+            {
+                "instanceType": instance.instance_name,
+                "tenancy": "Shared",  # todo: is not valid for Dedicated VPC
+                "operatingSystem": "Linux",
+            }
+        )
+        if spot is not False:
+            regions = list(
+                set(
+                    region
+                    for region, _ in self.cache[instance.instance_name]
+                    if self.region_match(instance.available_regions, region)
+                )
+            )
+            self._fetch_spot(instance.instance_name, regions)

--- a/cli/dstack/_internal/backend/aws/pricing.py
+++ b/cli/dstack/_internal/backend/aws/pricing.py
@@ -1,16 +1,17 @@
 import datetime
 import json
+from collections import defaultdict
 from typing import Dict, List, Optional
 
 import boto3
 from botocore.exceptions import ClientError, EndpointConnectionError
 
 import dstack._internal.backend.aws.utils as aws_utils
-from dstack._internal.backend.base.pricing import BasePricing
+from dstack._internal.backend.base.pricing import Pricing
 from dstack._internal.core.instance import InstanceType
 
 
-class AWSPricing(BasePricing):
+class AWSPricing(Pricing):
     """
     Required IAM policies:
       * pricing:GetProducts
@@ -21,7 +22,6 @@ class AWSPricing(BasePricing):
         super().__init__()
         self.session = session
         self.pricing_client = self.session.client("pricing")
-        self.last_used: Dict[str, float] = {}
 
     def _fetch_ondemand(self, attributes: Dict[str, str]):
         def get_ondemand_price(terms: dict) -> Dict[str, str]:
@@ -29,7 +29,6 @@ class AWSPricing(BasePricing):
                 for _, dim in term["priceDimensions"].items():
                     return dim["pricePerUnit"]
 
-        # todo cache
         pages = self.pricing_client.get_paginator("get_products").paginate(
             ServiceCode="AmazonEC2",
             Filters=[
@@ -42,22 +41,33 @@ class AWSPricing(BasePricing):
             ],
         )
         for page in pages:
-            for item in page["PriceList"]:
-                item = json.loads(item)
+            for raw_item in page["PriceList"]:
+                item = json.loads(raw_item)
                 attrs = item["product"]["attributes"]
                 if "Usage" not in attrs["usagetype"] or attrs["tenancy"] == "Host":
                     continue
+                if "OnDemand" not in item["terms"]:
+                    continue
                 price = get_ondemand_price(item["terms"])
                 if "USD" in price:
-                    self.cache[attrs["instanceType"]][(attrs["regionCode"], False)] = float(
+                    self.registry[attrs["instanceType"]][(attrs["regionCode"], False)] = float(
                         price["USD"]
                     )
 
-    def _fetch_spot(self, instance_type: str, regions: List[str]):
+    def _fetch_spot(self, instances: List[InstanceType]):
+        regions = set(region for i in instances for region in i.available_regions)
         for region in regions:
+            instance_types = [
+                i.instance_name
+                for i in instances
+                if self._need_update(
+                    f"spot-{i.instance_name}-{region}", ttl=4 * 60 * 60
+                )  # 4 hours
+            ]
+            if not instance_types:
+                continue
             try:
                 client = aws_utils.get_ec2_client(self.session, region_name=region)
-                # todo cache
                 pages = client.get_paginator("describe_spot_price_history").paginate(
                     Filters=[
                         {
@@ -66,33 +76,28 @@ class AWSPricing(BasePricing):
                         }
                     ],
                     # WARNING: using Filters["instance-type"] gives fewer results. Why?
-                    InstanceTypes=[instance_type],
+                    InstanceTypes=instance_types,
                     StartTime=datetime.datetime.utcnow(),
                 )
-                prices = []
+                instance_prices = defaultdict(list)
                 for page in pages:
                     for item in page["SpotPriceHistory"]:
-                        prices.append(float(item["SpotPrice"]))
-                if prices:
+                        instance_prices[item["InstanceType"]].append(float(item["SpotPrice"]))
+                for instance_type, zone_prices in instance_prices.items():
                     # we drop AZ information
-                    self.cache[instance_type][(region, True)] = min(prices)
+                    self.registry[instance_type][(region, True)] = min(zone_prices)
             except (ClientError, EndpointConnectionError) as e:
                 pass
 
-    def fetch(self, instance: InstanceType, spot: Optional[bool]):
-        self._fetch_ondemand(
-            {
-                "instanceType": instance.instance_name,
-                "tenancy": "Shared",  # todo: is not valid for Dedicated VPC
-                "operatingSystem": "Linux",
-            }
-        )
-        if spot is not False:
-            regions = list(
-                set(
-                    region
-                    for region, _ in self.cache[instance.instance_name]
-                    if self.region_match(instance.available_regions, region)
+    def fetch(self, instances: List[InstanceType], spot: Optional[bool]):
+        for instance in instances:
+            if self._need_update(f"ondemand-{instance.instance_name}"):
+                self._fetch_ondemand(
+                    {
+                        "instanceType": instance.instance_name,
+                        "tenancy": "Shared",  # todo: is not valid for Dedicated VPC
+                        "operatingSystem": "Linux",
+                    }
                 )
-            )
-            self._fetch_spot(instance.instance_name, regions)
+        if spot is not False:
+            self._fetch_spot(instances)

--- a/cli/dstack/_internal/backend/aws/runners.py
+++ b/cli/dstack/_internal/backend/aws/runners.py
@@ -52,6 +52,7 @@ def run_instance(
 ) -> LaunchedInstanceInfo:
     regions = [region_name]
     if extra_regions:
+        # todo use single region, because hub handles multi-region & multi-cloud
         regions.extend(
             _get_instance_available_regions(
                 ec2_client=aws_utils.get_ec2_client(session),

--- a/cli/dstack/_internal/backend/azure/__init__.py
+++ b/cli/dstack/_internal/backend/azure/__init__.py
@@ -7,6 +7,7 @@ from azure.identity import ClientSecretCredential, DefaultAzureCredential
 from dstack._internal.backend.azure.compute import AzureCompute
 from dstack._internal.backend.azure.config import AzureConfig
 from dstack._internal.backend.azure.logs import AzureLogging
+from dstack._internal.backend.azure.pricing import AzurePricing
 from dstack._internal.backend.azure.secrets import AzureSecretsManager
 from dstack._internal.backend.azure.storage import AzureStorage
 from dstack._internal.backend.base import ComponentBasedBackend
@@ -46,6 +47,7 @@ class AzureBackend(ComponentBasedBackend):
                 resource_group=self.backend_config.resource_group,
                 storage_account=self.backend_config.storage_account,
             )
+            self._pricing = AzurePricing()
         except ClientAuthenticationError:
             raise BackendAuthError()
 
@@ -67,3 +69,6 @@ class AzureBackend(ComponentBasedBackend):
 
     def logging(self) -> AzureLogging:
         return self._logging
+
+    def pricing(self) -> AzurePricing:
+        return self._pricing

--- a/cli/dstack/_internal/backend/azure/compute.py
+++ b/cli/dstack/_internal/backend/azure/compute.py
@@ -108,6 +108,16 @@ class AzureCompute(Compute):
         )
         return choose_instance_type(instance_types=instance_types, requirements=job.requirements)
 
+    def get_supported_instances(self) -> List[InstanceType]:
+        instances = {}
+        for location in [self.azure_config.location]:
+            for i in _get_instance_types(client=self._compute_client, location=location):
+                if i.instance_name not in instances:
+                    instances[i.instance_name] = i
+                    i.available_regions = []
+                instances[i.instance_name].available_regions.append(location)
+        return list(instances.values())
+
     def run_instance(self, job: Job, instance_type: InstanceType) -> LaunchedInstanceInfo:
         return _run_instance(
             compute_client=self._compute_client,

--- a/cli/dstack/_internal/backend/azure/compute.py
+++ b/cli/dstack/_internal/backend/azure/compute.py
@@ -110,7 +110,7 @@ class AzureCompute(Compute):
 
     def get_supported_instances(self) -> List[InstanceType]:
         instances = {}
-        for location in [self.azure_config.location]:
+        for location in [self.azure_config.location] + self.azure_config.extra_locations:
             for i in _get_instance_types(client=self._compute_client, location=location):
                 if i.instance_name not in instances:
                     instances[i.instance_name] = i

--- a/cli/dstack/_internal/backend/azure/pricing.py
+++ b/cli/dstack/_internal/backend/azure/pricing.py
@@ -1,0 +1,70 @@
+import time
+from typing import Dict, Optional
+
+import requests
+
+from dstack._internal.backend.base.pricing import BasePricing, RegionSpot
+from dstack._internal.core.instance import InstanceType
+
+DEFAULT_TTL = 24 * 60 * 60  # 24 hours
+
+
+class AzurePricing(BasePricing):
+    def __init__(self):
+        self.endpoint = "https://prices.azure.com/api/retail/prices"
+        # instance -> { region_spot -> price }
+        self.cache: Dict[str, Dict[RegionSpot, float]] = {}
+        self.last_updated: Dict[str, float] = {}
+
+    def _put_instance(self, item: dict):
+        name = item["armSkuName"]
+        spot = "Spot" in item["meterName"]
+        region = item["armRegionName"]
+        if name not in self.cache:
+            self.cache[name] = {}
+        self.cache[name][(region, spot)] = item["retailPrice"]
+
+    def _fetch(self, query: str, ttl: int = DEFAULT_TTL):
+        now = time.time()
+        if now - self.last_updated.get(query, 0) < ttl:
+            return  # use cache
+        r = requests.get(
+            self.endpoint, params={"$filter": query, "api-version": "2021-10-01-preview"}
+        )
+        data = r.json()
+        while True:
+            for item in data["Items"]:
+                self._put_instance(item)
+            next_page = data["NextPageLink"]
+            if not next_page:
+                break
+            data = requests.get(next_page).json()
+        self.last_updated[query] = now
+
+    def estimate_instance(
+        self, instance: InstanceType, spot: Optional[bool] = None
+    ) -> Dict[RegionSpot, float]:
+        filters = [
+            "serviceName eq 'Virtual Machines'",
+            "priceType eq 'Consumption'",
+            f"armSkuName eq '{instance.instance_name}'",
+        ]
+        if spot is True:
+            filters.append("contains(meterName, 'Spot')")
+        elif spot is False:
+            filters.append("not contains(meterName, 'Spot')")
+        if instance.available_regions:
+            # TODO: split long lists in multiple fetches
+            filters.append(
+                "(%s)"
+                % " or ".join(
+                    f"armRegionName eq '{region}'" for region in sorted(instance.available_regions)
+                )
+            )
+        self._fetch(" and ".join(filters))
+        return {
+            (r, s): v
+            for (r, s), v in self.cache[instance.instance_name].items()
+            if (not instance.available_regions or r in instance.available_regions)
+            and (spot is None or spot is s)
+        }

--- a/cli/dstack/_internal/backend/azure/pricing.py
+++ b/cli/dstack/_internal/backend/azure/pricing.py
@@ -1,22 +1,17 @@
-import time
-from typing import Dict, Optional
+from typing import List, Optional
 
 import requests
 
-from dstack._internal.backend.base.pricing import DEFAULT_TTL, BasePricing
+from dstack._internal.backend.base.pricing import Pricing
 from dstack._internal.core.instance import InstanceType
 
 
-class AzurePricing(BasePricing):
+class AzurePricing(Pricing):
     def __init__(self):
         super().__init__()
         self.endpoint = "https://prices.azure.com/api/retail/prices"
-        self.last_updated: Dict[str, float] = {}
 
-    def _fetch(self, query: str, ttl: int = DEFAULT_TTL):
-        now = time.time()
-        if now - self.last_updated.get(query, 0) < ttl:
-            return  # use cache
+    def _fetch(self, query: str):
         r = requests.get(
             self.endpoint, params={"$filter": query, "api-version": "2021-10-01-preview"}
         )
@@ -24,29 +19,39 @@ class AzurePricing(BasePricing):
         while True:
             for item in data["Items"]:
                 region_spot = (item["armRegionName"], "Spot" in item["meterName"])
-                self.cache[item["armSkuName"]][region_spot] = item["retailPrice"]
+                self.registry[item["armSkuName"]][region_spot] = item["retailPrice"]
             next_page = data["NextPageLink"]
             if not next_page:
                 break
             data = requests.get(next_page).json()
-        self.last_updated[query] = now
 
-    def fetch(self, instance: InstanceType, spot: Optional[bool]):
-        filters = [
-            "serviceName eq 'Virtual Machines'",
-            "priceType eq 'Consumption'",
-            f"armSkuName eq '{instance.instance_name}'",
-        ]
-        if spot is True:
-            filters.append("contains(meterName, 'Spot')")
-        elif spot is False:
-            filters.append("not contains(meterName, 'Spot')")
-        if instance.available_regions:
-            # TODO: split long lists in multiple fetches
-            filters.append(
-                "(%s)"
-                % " or ".join(
-                    f"armRegionName eq '{region}'" for region in sorted(instance.available_regions)
+    def fetch(self, instances: List[InstanceType], spot: Optional[bool]):
+        regions = set()
+        instance_types = []
+        for i in instances:
+            if not i.available_regions:
+                if self._need_update(i.instance_name):
+                    instance_types.append(i.instance_name)
+                continue
+            for region in i.available_regions:
+                if self._need_update(f"{i.instance_name}-{region}"):
+                    instance_types.append(i.instance_name)
+                    regions.add(region)
+        if not instance_types:
+            return
+
+        regions = list(regions)
+        for t in range(0, len(instance_types), 10):
+            filters = [
+                "serviceName eq 'Virtual Machines'",
+                "priceType eq 'Consumption'",
+                "(%s)" % " or ".join(f"armSkuName eq '{i}'" for i in instance_types[t : t + 10]),
+            ]
+            if not regions:
+                self._fetch(" and ".join(filters))
+                continue
+            for r in range(0, len(regions), 5):
+                regions_filter = "(%s)" % " or ".join(
+                    f"armRegionName eq '{region}'" for region in regions[r : r + 5]
                 )
-            )
-        self._fetch(" and ".join(filters))
+                self._fetch(" and ".join(filters + [regions_filter]))

--- a/cli/dstack/_internal/backend/base/compute.py
+++ b/cli/dstack/_internal/backend/base/compute.py
@@ -40,7 +40,9 @@ class Compute(ABC):
         pass
 
     @abstractmethod
-    def run_instance(self, job: Job, instance_type: InstanceType) -> LaunchedInstanceInfo:
+    def run_instance(
+        self, job: Job, instance_type: InstanceType, region: Optional[str] = None
+    ) -> LaunchedInstanceInfo:
         pass
 
     def restart_instance(self, job: Job) -> LaunchedInstanceInfo:

--- a/cli/dstack/_internal/backend/base/compute.py
+++ b/cli/dstack/_internal/backend/base/compute.py
@@ -36,6 +36,10 @@ class Compute(ABC):
         pass
 
     @abstractmethod
+    def get_supported_instances(self) -> List[InstanceType]:
+        pass
+
+    @abstractmethod
     def run_instance(self, job: Job, instance_type: InstanceType) -> LaunchedInstanceInfo:
         pass
 

--- a/cli/dstack/_internal/backend/base/jobs.py
+++ b/cli/dstack/_internal/backend/base/jobs.py
@@ -227,9 +227,9 @@ def _try_run_job(
         job.requirements.spot = spot
         instance_type = compute.get_instance_type(job)
     else:
-        job.requirements.spot = offer.spot
+        job.requirements.spot = offer.instance_type.resources.spot
         instance_type = offer.instance_type
-        # todo set price in job
+        job.price = offer.price
     if instance_type is None:
         if job.spot_policy == SpotPolicy.AUTO and attempt == 0:
             return _try_run_job(

--- a/cli/dstack/_internal/backend/base/jobs.py
+++ b/cli/dstack/_internal/backend/base/jobs.py
@@ -248,8 +248,7 @@ def _try_run_job(
     )
     runners.create_runner(storage, runner)
     try:
-        # todo use offer.region
-        launched_instance_info = compute.run_instance(job, instance_type)
+        launched_instance_info = compute.run_instance(job, instance_type, region=offer.region)
         runner.request_id = job.request_id = launched_instance_info.request_id
         job.location = launched_instance_info.location
     except NoCapacityError:
@@ -339,8 +338,9 @@ def _get_job_head_filename_from_job_head(job_head: JobHead) -> str:
 
 
 def _parse_job_head_key(repo_id: str, full_key: str) -> JobHead:
-    tokens = full_key[len(_get_jobs_dir(repo_id)) :].split(";")
-    tokens.extend([""] * (13 - len(tokens)))  # pad with empty tokens
+    head_size = 13
+    tokens = full_key[len(_get_jobs_dir(repo_id)) :].split(";")[:head_size]  # strip extra tokens
+    tokens.extend([""] * (head_size - len(tokens)))  # pad with empty tokens
     (
         _,
         job_id,

--- a/cli/dstack/_internal/backend/base/jobs.py
+++ b/cli/dstack/_internal/backend/base/jobs.py
@@ -312,7 +312,8 @@ def _get_job_head_filename_from_job(job: Job) -> str:
         f"{job.tag_name or ''};"
         f"{job.instance_type or ''};"
         f"{escape_head(job.configuration_path)};"
-        f"{job.get_instance_spot_type()}"
+        f"{job.get_instance_spot_type()};"
+        f"{job.price or ''}"
     )
     return key
 
@@ -331,14 +332,15 @@ def _get_job_head_filename_from_job_head(job_head: JobHead) -> str:
         f"{job_head.tag_name or ''};"
         f"{job_head.instance_type or ''};"
         f"{escape_head(job_head.configuration_path)};"
-        f"{job_head.instance_spot_type}"
+        f"{job_head.instance_spot_type};"
+        f"{job_head.price or ''}"
     )
     return key
 
 
 def _parse_job_head_key(repo_id: str, full_key: str) -> JobHead:
     tokens = full_key[len(_get_jobs_dir(repo_id)) :].split(";")
-    tokens.extend([""] * (12 - len(tokens)))  # pad with empty tokens
+    tokens.extend([""] * (13 - len(tokens)))  # pad with empty tokens
     (
         _,
         job_id,
@@ -352,6 +354,7 @@ def _parse_job_head_key(repo_id: str, full_key: str) -> JobHead:
         instance_type,
         configuration_path,
         instance_spot_type,
+        price,
     ) = tokens
     run_name, workflow_name, job_index = tuple(job_id.split(","))
     status, error_code, container_exit_code = _parse_job_status_info(status_info)
@@ -374,6 +377,7 @@ def _parse_job_head_key(repo_id: str, full_key: str) -> JobHead:
         instance_type=instance_type or None,
         configuration_path=unescape_head(configuration_path),
         instance_spot_type=instance_spot_type or None,
+        price=float(price) if price else None,
     )
 
 

--- a/cli/dstack/_internal/backend/base/pricing.py
+++ b/cli/dstack/_internal/backend/base/pricing.py
@@ -1,15 +1,37 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Optional, Tuple
+from collections import defaultdict
+from typing import Dict, List, Optional, Tuple
 
 from dstack._internal.core.instance import InstanceType
 
 RegionSpot = Tuple[str, bool]
+DEFAULT_TTL = 24 * 60 * 60  # 24 hours
 
 
 class BasePricing(ABC):
+    def __init__(self):
+        # instance -> { region_spot -> price }
+        self.cache: Dict[str, Dict[RegionSpot, float]] = defaultdict(dict)
+
     @abstractmethod
+    def fetch(self, instance: InstanceType, spot: Optional[bool]):
+        pass
+
     def estimate_instance(
         self, instance: InstanceType, spot: Optional[bool] = None
     ) -> Dict[RegionSpot, float]:
         """Estimate the cost in USD of running the specified instance for 1 hour in specified regions"""
-        pass
+        self.fetch(instance, spot)
+        return {
+            (r, s): v
+            for (r, s), v in self.cache[instance.instance_name].items()
+            if self.region_match(instance.available_regions, r) and self.spot_match(spot, s)
+        }
+
+    @classmethod
+    def region_match(cls, regions: Optional[List[str]], region: str) -> bool:
+        return not regions or region in regions
+
+    @classmethod
+    def spot_match(cls, requested: Optional[bool], spot: bool) -> bool:
+        return requested is None or spot == requested

--- a/cli/dstack/_internal/backend/base/pricing.py
+++ b/cli/dstack/_internal/backend/base/pricing.py
@@ -24,6 +24,7 @@ class Pricing(ABC):
 
     @abstractmethod
     def fetch(self, instances: List[InstanceType], spot: Optional[bool]):
+        # ignores instances[i].resources.spot
         pass
 
     def get_prices(
@@ -38,7 +39,9 @@ class Pricing(ABC):
                     continue
                 if not self.spot_match(spot, is_spot):
                     continue
-                offers.append(InstanceOffer(instance, region, spot, price))
+                i = instance.copy(deep=True)
+                i.resources.spot = is_spot
+                offers.append(InstanceOffer(i, region, price))
         return offers
 
     @classmethod

--- a/cli/dstack/_internal/backend/base/pricing.py
+++ b/cli/dstack/_internal/backend/base/pricing.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+from typing import Dict, Optional, Tuple
+
+from dstack._internal.core.instance import InstanceType
+
+RegionSpot = Tuple[str, bool]
+
+
+class BasePricing(ABC):
+    @abstractmethod
+    def estimate_instance(
+        self, instance: InstanceType, spot: Optional[bool] = None
+    ) -> Dict[RegionSpot, float]:
+        """Estimate the cost in USD of running the specified instance for 1 hour in specified regions"""
+        pass

--- a/cli/dstack/_internal/backend/base/pricing.py
+++ b/cli/dstack/_internal/backend/base/pricing.py
@@ -1,37 +1,54 @@
+import time
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from typing import Dict, List, Optional, Tuple
 
-from dstack._internal.core.instance import InstanceType
+from dstack._internal.core.instance import InstanceOffer, InstanceType
 
 RegionSpot = Tuple[str, bool]
 DEFAULT_TTL = 24 * 60 * 60  # 24 hours
 
 
-class BasePricing(ABC):
+class Pricing(ABC):
     def __init__(self):
-        # instance -> { region_spot -> price }
-        self.cache: Dict[str, Dict[RegionSpot, float]] = defaultdict(dict)
+        # instance_key -> { (region, spot) -> price }
+        self.registry: Dict[str, Dict[RegionSpot, float]] = defaultdict(dict)
+        self._last_updated: Dict[str, float] = {}
+
+    def _need_update(self, key: str, ttl: int = DEFAULT_TTL):
+        now = time.monotonic()
+        if key not in self._last_updated or now - self._last_updated[key] > ttl:
+            self._last_updated[key] = now
+            return True
+        return False
 
     @abstractmethod
-    def fetch(self, instance: InstanceType, spot: Optional[bool]):
+    def fetch(self, instances: List[InstanceType], spot: Optional[bool]):
         pass
 
-    def estimate_instance(
-        self, instance: InstanceType, spot: Optional[bool] = None
-    ) -> Dict[RegionSpot, float]:
+    def get_prices(
+        self, instances: List[InstanceType], spot: Optional[bool] = None
+    ) -> List[InstanceOffer]:
         """Estimate the cost in USD of running the specified instance for 1 hour in specified regions"""
-        self.fetch(instance, spot)
-        return {
-            (r, s): v
-            for (r, s), v in self.cache[instance.instance_name].items()
-            if self.region_match(instance.available_regions, r) and self.spot_match(spot, s)
-        }
+        self.fetch(instances, spot)
+        offers = []
+        for instance in instances:
+            for (region, is_spot), price in self.registry[self.instance_key(instance)].items():
+                if not self.region_match(instance.available_regions, region):
+                    continue
+                if not self.spot_match(spot, is_spot):
+                    continue
+                offers.append(InstanceOffer(instance, region, spot, price))
+        return offers
 
     @classmethod
-    def region_match(cls, regions: Optional[List[str]], region: str) -> bool:
-        return not regions or region in regions
+    def region_match(cls, available_regions: Optional[List[str]], region: str) -> bool:
+        return not available_regions or region in available_regions
 
     @classmethod
     def spot_match(cls, requested: Optional[bool], spot: bool) -> bool:
         return requested is None or spot == requested
+
+    @classmethod
+    def instance_key(cls, instance: InstanceType) -> str:
+        return instance.instance_name

--- a/cli/dstack/_internal/backend/gcp/__init__.py
+++ b/cli/dstack/_internal/backend/gcp/__init__.py
@@ -10,6 +10,7 @@ from dstack._internal.backend.gcp.auth import authenticate
 from dstack._internal.backend.gcp.compute import GCPCompute
 from dstack._internal.backend.gcp.config import GCPConfig
 from dstack._internal.backend.gcp.logs import GCPLogging
+from dstack._internal.backend.gcp.pricing import GCPPricing
 from dstack._internal.backend.gcp.secrets import GCPSecretsManager
 from dstack._internal.backend.gcp.storage import GCPStorage
 
@@ -43,6 +44,7 @@ class GCPBackend(ComponentBasedBackend):
             bucket_name=self.backend_config.bucket_name,
             credentials=credentials,
         )
+        self._pricing = GCPPricing(credentials=credentials)
 
     def storage(self) -> GCPStorage:
         return self._storage
@@ -55,6 +57,9 @@ class GCPBackend(ComponentBasedBackend):
 
     def logging(self) -> GCPLogging:
         return self._logging
+
+    def pricing(self) -> GCPPricing:
+        return self._pricing
 
     @classmethod
     def load(cls) -> Optional["GCPBackend"]:

--- a/cli/dstack/_internal/backend/gcp/compute.py
+++ b/cli/dstack/_internal/backend/gcp/compute.py
@@ -37,26 +37,27 @@ _supported_accelerators = [
     {"accelerator_name": "nvidia-a100-80gb", "gpu_name": "A100", "memory_mb": 1024 * 80},
     {"accelerator_name": "nvidia-tesla-a100", "gpu_name": "A100", "memory_mb": 1024 * 40},
     {"accelerator_name": "nvidia-l4", "gpu_name": "L4", "memory_mb": 1024 * 24},
+    # Limits from https://cloud.google.com/compute/docs/gpus
     {
         "accelerator_name": "nvidia-tesla-t4",
         "gpu_name": "T4",
         "memory_mb": 1024 * 16,
-        "max_vcpu": 48,
-        "max_ram_mb": 1024 * 312,
+        "max_vcpu": {1: 48, 2: 48, 4: 96},
+        "max_ram_mb": {1: 312 * 1024, 2: 312 * 1024, 4: 624 * 1024},
     },
     {
         "accelerator_name": "nvidia-tesla-v100",
         "gpu_name": "V100",
         "memory_mb": 1024 * 16,
-        "max_vcpu": 12,
-        "max_ram_mb": 1024 * 78,
+        "max_vcpu": {1: 12, 2: 24, 4: 48, 8: 96},
+        "max_ram_mb": {1: 78 * 1024, 2: 156 * 1024, 4: 312 * 1024, 8: 624 * 1024},
     },
     {
         "accelerator_name": "nvidia-tesla-p100",
         "gpu_name": "P100",
         "memory_mb": 1024 * 16,
-        "max_vcpu": 16,
-        "max_ram_mb": 1024 * 104,
+        "max_vcpu": {1: 16, 2: 32, 4: 64},  # 4: 96
+        "max_ram_mb": {1: 104 * 1024, 2: 208 * 1024, 4: 208 * 1024},  # 4: 624
     },
 ]
 
@@ -107,6 +108,53 @@ class GCPCompute(Compute):
             zone=self.gcp_config.zone,
             requirements=job.requirements,
         )
+
+    def get_supported_instances(self) -> List[InstanceType]:
+        vm_families = ["e2-medium", "e2-standard-*", "e2-highmem-*", "e2-highcpu-*", "m1-*"] + [
+            "a2-*",
+            "g2-*",
+        ]
+        instances = {}
+        for zone in [self.gcp_config.zone]:
+            region = zone[:-2]
+            instance_types = _list_instance_types(
+                machine_types_client=self.machine_types_client,
+                project_id=self.gcp_config.project_id,
+                zone=zone,
+                machine_families=vm_families,
+            )
+            for i in instance_types:
+                if i.instance_name not in instances:
+                    instances[i.instance_name] = i
+                    i.available_regions = []
+                instances[i.instance_name].available_regions.append(region)
+
+            n1_instance_types = _list_instance_types(
+                machine_types_client=self.machine_types_client,
+                project_id=self.gcp_config.project_id,
+                zone=zone,
+                machine_families=["n1-*"],
+            )
+            n1_instance_types = [
+                # skip shared-core instances
+                i
+                for i in n1_instance_types
+                if i.instance_name not in ("n1-standard-1", "n1-highcpu-2")
+            ]
+            accelerator_types = _list_accelerator_types(
+                accelerator_types_client=self.accelerator_types_client,
+                project_id=self.gcp_config.project_id,
+                zone=zone,
+                accelerator_families=["nvidia-tesla-t4", "nvidia-tesla-v100", "nvidia-tesla-p100"],
+            )
+            for i in _instances_x_accelerators(n1_instance_types, accelerator_types):
+                gpu = i.resources.gpus[0]
+                name = f"{i.instance_name}-{len(i.resources.gpus)}x{gpu.name}-{gpu.memory_mib}"
+                if name not in instances:
+                    instances[name] = i
+                    i.available_regions = []
+                instances[name].available_regions.append(region)
+        return list(instances.values())
 
     def run_instance(self, job: Job, instance_type: InstanceType) -> LaunchedInstanceInfo:
         return _run_instance(
@@ -366,7 +414,6 @@ def _add_gpus_to_instance_type(
     instance_type: InstanceType,
     requirements: Requirements,
 ) -> List[InstanceType]:
-    instance_types = []
     accelerator_types = _list_accelerator_types(
         accelerator_types_client=accelerator_types_client,
         project_id=project_id,
@@ -377,34 +424,42 @@ def _add_gpus_to_instance_type(
             "nvidia-tesla-p100",
         ],
     )
-    for at in accelerator_types:
-        for gpu_count in range(1, at.maximum_cards_per_instance):
-            max_vcpu = _get_max_vcpu_per_accelerator(at.name) * gpu_count
-            max_ram_mb = _get_max_ram_per_accelerator(at.name) * gpu_count
-            if (
-                max_vcpu < instance_type.resources.cpus
-                or max_ram_mb < instance_type.resources.memory_mib
-            ):
+    return _instances_x_accelerators([instance_type], accelerator_types)
+
+
+def _instances_x_accelerators(
+    instances: List[InstanceType], accelerators: List[compute_v1.AcceleratorType]
+) -> List[InstanceType]:
+    pow2 = [2**i for i in range(4)]
+    combined = []
+    for accelerator in accelerators:
+        for count in pow2:
+            if count > accelerator.maximum_cards_per_instance:
                 continue
-            instance_types.append(
-                InstanceType(
-                    instance_name=instance_type.instance_name,
-                    resources=Resources(
-                        cpus=instance_type.resources.cpus,
-                        memory_mib=instance_type.resources.memory_mib,
-                        spot=instance_type.resources.spot,
-                        local=instance_type.resources.local,
-                        gpus=[
-                            Gpu(
-                                name=_accelerator_name_to_gpu_name(at.name),
-                                memory_mib=_get_gpu_memory(at.name),
-                            )
-                            for _ in range(gpu_count)
-                        ],
-                    ),
-                )
-            )
-    return instance_types
+            max_vcpu = _get_max_vcpu_per_accelerator(accelerator.name, count)
+            max_ram_mb = _get_max_ram_per_accelerator(accelerator.name, count)
+            for instance in instances:
+                if (
+                    max_vcpu < instance.resources.cpus
+                    or max_ram_mb < instance.resources.memory_mib
+                ):
+                    continue
+                combined.append(_attach_accelerator(instance, accelerator, count))
+    return combined
+
+
+def _attach_accelerator(
+    instance: InstanceType, accelerator: compute_v1.AcceleratorType, count: int
+) -> InstanceType:
+    data = instance.dict()
+    data["resources"]["gpus"] = [
+        Gpu(
+            name=_accelerator_name_to_gpu_name(accelerator.name),
+            memory_mib=_get_gpu_memory(accelerator.name),
+        )
+        for _ in range(count)
+    ]
+    return InstanceType.parse_obj(data)
 
 
 def _list_accelerator_types(
@@ -435,16 +490,16 @@ def _gpu_to_accelerator_name(gpu: Gpu) -> str:
             return acc["accelerator_name"]
 
 
-def _get_max_vcpu_per_accelerator(accelerator_name: str) -> int:
+def _get_max_vcpu_per_accelerator(accelerator_name: str, count: int) -> int:
     for acc in _supported_accelerators:
         if acc["accelerator_name"] == accelerator_name:
-            return acc["max_vcpu"]
+            return acc["max_vcpu"][count]
 
 
-def _get_max_ram_per_accelerator(accelerator_name: str) -> int:
+def _get_max_ram_per_accelerator(accelerator_name: str, count: int) -> int:
     for acc in _supported_accelerators:
         if acc["accelerator_name"] == accelerator_name:
-            return acc["max_ram_mb"]
+            return acc["max_ram_mb"][count]
 
 
 def _get_image_name(

--- a/cli/dstack/_internal/backend/gcp/compute.py
+++ b/cli/dstack/_internal/backend/gcp/compute.py
@@ -115,7 +115,14 @@ class GCPCompute(Compute):
             "g2-*",
         ]
         instances = {}
-        for zone in [self.gcp_config.zone]:
+        zones = _get_zones(
+            regions_client=self.regions_client,
+            project_id=self.gcp_config.project_id,
+            primary_region=self.gcp_config.region,
+            primary_zone=self.gcp_config.zone,
+            extra_regions=self.gcp_config.extra_regions,
+        )
+        for zone in zones:
             region = zone[:-2]
             instance_types = _list_instance_types(
                 machine_types_client=self.machine_types_client,

--- a/cli/dstack/_internal/backend/gcp/compute.py
+++ b/cli/dstack/_internal/backend/gcp/compute.py
@@ -123,7 +123,6 @@ class GCPCompute(Compute):
             extra_regions=self.gcp_config.extra_regions,
         )
         for zone in zones:
-            region = zone[:-2]
             instance_types = _list_instance_types(
                 machine_types_client=self.machine_types_client,
                 project_id=self.gcp_config.project_id,
@@ -134,7 +133,7 @@ class GCPCompute(Compute):
                 if i.instance_name not in instances:
                     instances[i.instance_name] = i
                     i.available_regions = []
-                instances[i.instance_name].available_regions.append(region)
+                instances[i.instance_name].available_regions.append(zone)
 
             n1_instance_types = _list_instance_types(
                 machine_types_client=self.machine_types_client,
@@ -160,7 +159,7 @@ class GCPCompute(Compute):
                 if name not in instances:
                     instances[name] = i
                     i.available_regions = []
-                instances[name].available_regions.append(region)
+                instances[name].available_regions.append(zone)
         return list(instances.values())
 
     def run_instance(self, job: Job, instance_type: InstanceType) -> LaunchedInstanceInfo:

--- a/cli/dstack/_internal/backend/gcp/pricing.py
+++ b/cli/dstack/_internal/backend/gcp/pricing.py
@@ -1,0 +1,88 @@
+import re
+from collections import defaultdict
+from typing import Dict, Optional
+
+import google.cloud.billing_v1 as billing_v1
+from google.oauth2 import service_account
+
+from dstack._internal.backend.base.pricing import BasePricing, RegionSpot
+from dstack._internal.core.instance import InstanceType
+
+COMPUTE_SERVICE = "services/6F81-5844-456A"
+VM_FAMILIES = {
+    "A2 Instance": "a2",
+    "E2 Instance": "e2",
+    "G2 Instance": "g2",
+    "Memory-optimized Instance": "m1",
+    "N1 Predefined Instance": "n1",
+}
+GPU_FAMILIES = {
+    "Nvidia Tesla A100": "A100",
+    "Nvidia L4": "L4",
+    "Nvidia Tesla P100": "P100",
+    "Nvidia Tesla T4": "T4",
+    "Nvidia Tesla V100": "V100",
+}
+
+
+class GCPPricing(BasePricing):
+    def __init__(self, credentials: Optional[service_account.Credentials] = None):
+        super().__init__()
+        self.client = billing_v1.CloudCatalogClient(credentials=credentials)
+        self.family_cache: Dict[str, Dict[str, Dict[RegionSpot, float]]] = {
+            "ram": defaultdict(dict),
+            "core": defaultdict(dict),
+            "gpu": defaultdict(dict),
+        }
+
+    def _fetch_families(self):
+        skus = self.client.list_skus(parent=COMPUTE_SERVICE)
+        for sku in skus:
+            if sku.category.resource_family != "Compute":
+                continue
+            if sku.category.usage_type not in ["OnDemand", "Preemptible"]:
+                continue
+
+            r = re.match(
+                r"^(?:spot preemptible )?(.+) (gpu|ram|core)", sku.description, flags=re.IGNORECASE
+            )
+            if not r:
+                continue
+            family, resource = r.groups()
+            if family in VM_FAMILIES:
+                family = VM_FAMILIES[family]
+            elif family in GPU_FAMILIES:
+                family = GPU_FAMILIES[family]
+            else:
+                continue
+
+            for region in sku.service_regions:
+                region_spot = (region, sku.category.usage_type == "Preemptible")
+                self.family_cache[resource.lower()][family][region_spot] = (
+                    sku.pricing_info[0].pricing_expression.tiered_rates[0].unit_price.nanos / 1e9
+                )
+
+    def fetch(self, instance: InstanceType, spot: Optional[bool]):
+        # todo cache
+        self._fetch_families()
+
+        vm_family = instance.instance_name.split("-")[0]
+        gpu_family = None if not instance.resources.gpus else instance.resources.gpus[0].name
+        region_spots = self.family_cache["core"].get(vm_family, {}).keys()
+        region_spots &= self.family_cache["ram"].get(vm_family, {}).keys()
+        if gpu_family:
+            region_spots &= self.family_cache["gpu"].get(gpu_family, {}).keys()
+
+        for region_spot in region_spots:
+            cost = instance.resources.cpus * self.family_cache["core"][vm_family][region_spot]
+            cost += (
+                instance.resources.memory_mib
+                / 1024
+                * self.family_cache["ram"][vm_family][region_spot]
+            )
+            if gpu_family:
+                cost += (
+                    len(instance.resources.gpus)
+                    * self.family_cache["gpu"][gpu_family][region_spot]
+                )
+            self.cache[instance.instance_name][region_spot] = cost

--- a/cli/dstack/_internal/backend/gcp/pricing.py
+++ b/cli/dstack/_internal/backend/gcp/pricing.py
@@ -68,8 +68,9 @@ class GCPPricing(Pricing):
             self._fetch_families()
 
         for instance in instances:
-            if not self._need_update(self.instance_key(instance)):
-                return
+            region_zones = defaultdict(list)
+            for zone in instance.available_regions:
+                region_zones[zone[:-2]].append(zone)
 
             vm_family = instance.instance_name.split("-")[0]
             gpu_family = None if not instance.resources.gpus else instance.resources.gpus[0].name
@@ -90,7 +91,9 @@ class GCPPricing(Pricing):
                         len(instance.resources.gpus)
                         * self.family_cache["gpu"][gpu_family][region_spot]
                     )
-                self.registry[self.instance_key(instance)][region_spot] = cost
+                region, is_spot = region_spot
+                for zone in region_zones[region]:
+                    self.registry[self.instance_key(instance)][(zone, is_spot)] = cost
 
     @classmethod
     def instance_key(cls, instance: InstanceType) -> str:

--- a/cli/dstack/_internal/backend/lambdalabs/__init__.py
+++ b/cli/dstack/_internal/backend/lambdalabs/__init__.py
@@ -10,6 +10,7 @@ from dstack._internal.backend.base import ComponentBasedBackend
 from dstack._internal.backend.base import runs as base_runs
 from dstack._internal.backend.lambdalabs.compute import LambdaCompute
 from dstack._internal.backend.lambdalabs.config import LambdaConfig
+from dstack._internal.core.job import Job, JobStatus
 
 
 class LambdaBackend(ComponentBasedBackend):
@@ -59,6 +60,14 @@ class LambdaBackend(ComponentBasedBackend):
 
     def logging(self) -> AWSLogging:
         return self._logging
+
+    def run_job(self, job: Job, failed_to_start_job_new_status: JobStatus):
+        self._logging.create_log_groups_if_not_exist(
+            aws_utils.get_logs_client(self._session),
+            self.backend_config.storage_config.bucket,
+            job.repo_ref.repo_id,
+        )
+        super().run_job(job, failed_to_start_job_new_status)
 
     def create_run(self, repo_id: str, run_name: Optional[str]) -> str:
         self._logging.create_log_groups_if_not_exist(

--- a/cli/dstack/_internal/backend/lambdalabs/__init__.py
+++ b/cli/dstack/_internal/backend/lambdalabs/__init__.py
@@ -10,6 +10,8 @@ from dstack._internal.backend.base import ComponentBasedBackend
 from dstack._internal.backend.base import runs as base_runs
 from dstack._internal.backend.lambdalabs.compute import LambdaCompute
 from dstack._internal.backend.lambdalabs.config import LambdaConfig
+from dstack._internal.backend.lambdalabs.pricing import LambdaPricing
+from dstack._internal.core.instance import InstanceOffer
 from dstack._internal.core.job import Job, JobStatus
 
 
@@ -41,6 +43,7 @@ class LambdaBackend(ComponentBasedBackend):
             logs_client=aws_utils.get_logs_client(self._session),
             bucket_name=self.backend_config.storage_config.bucket,
         )
+        self._pricing = LambdaPricing()
 
     @classmethod
     def load(cls) -> Optional["LambdaBackend"]:
@@ -61,13 +64,21 @@ class LambdaBackend(ComponentBasedBackend):
     def logging(self) -> AWSLogging:
         return self._logging
 
-    def run_job(self, job: Job, failed_to_start_job_new_status: JobStatus):
+    def pricing(self) -> LambdaPricing:
+        return self._pricing
+
+    def run_job(
+        self,
+        job: Job,
+        failed_to_start_job_new_status: JobStatus,
+        offer: Optional[InstanceOffer] = None,
+    ):
         self._logging.create_log_groups_if_not_exist(
             aws_utils.get_logs_client(self._session),
             self.backend_config.storage_config.bucket,
             job.repo_ref.repo_id,
         )
-        super().run_job(job, failed_to_start_job_new_status)
+        super().run_job(job, failed_to_start_job_new_status, offer=offer)
 
     def create_run(self, repo_id: str, run_name: Optional[str]) -> str:
         self._logging.create_log_groups_if_not_exist(

--- a/cli/dstack/_internal/backend/lambdalabs/compute.py
+++ b/cli/dstack/_internal/backend/lambdalabs/compute.py
@@ -118,8 +118,9 @@ class LambdaCompute:
     def get_supported_instances(self) -> List[InstanceType]:
         return _list_instance_types(self.api_client, self.lambda_config.regions)
 
-    def run_instance(self, job: Job, instance_type: InstanceType) -> LaunchedInstanceInfo:
-        region = _get_instance_region(instance_type, self.lambda_config.regions)
+    def run_instance(
+        self, job: Job, instance_type: InstanceType, region: Optional[str] = None
+    ) -> LaunchedInstanceInfo:
         instance_id = _run_instance(
             api_client=self.api_client,
             region_name=region,

--- a/cli/dstack/_internal/backend/lambdalabs/compute.py
+++ b/cli/dstack/_internal/backend/lambdalabs/compute.py
@@ -115,6 +115,9 @@ class LambdaCompute:
             requirements=job.requirements,
         )
 
+    def get_supported_instances(self) -> List[InstanceType]:
+        return _list_instance_types(self.api_client, self.lambda_config.regions)
+
     def run_instance(self, job: Job, instance_type: InstanceType) -> LaunchedInstanceInfo:
         region = _get_instance_region(instance_type, self.lambda_config.regions)
         instance_id = _run_instance(

--- a/cli/dstack/_internal/backend/lambdalabs/pricing.py
+++ b/cli/dstack/_internal/backend/lambdalabs/pricing.py
@@ -1,6 +1,6 @@
-from typing import Optional
+from typing import List, Optional
 
-from dstack._internal.backend.base.pricing import BasePricing
+from dstack._internal.backend.base.pricing import Pricing
 from dstack._internal.core.instance import InstanceType
 
 """
@@ -32,7 +32,10 @@ PRICES = {
 }
 
 
-class LambdaPricing(BasePricing):
-    def fetch(self, instance: InstanceType, spot: Optional[bool]):
-        for region in instance.available_regions:
-            self.cache[instance.instance_name][(region, False)] = PRICES[instance.instance_name]
+class LambdaPricing(Pricing):
+    def fetch(self, instances: List[InstanceType], spot: Optional[bool]):
+        for instance in instances:
+            for region in instance.available_regions:
+                self.registry[instance.instance_name][(region, False)] = PRICES[
+                    instance.instance_name
+                ]

--- a/cli/dstack/_internal/backend/lambdalabs/pricing.py
+++ b/cli/dstack/_internal/backend/lambdalabs/pricing.py
@@ -1,0 +1,38 @@
+from typing import Optional
+
+from dstack._internal.backend.base.pricing import BasePricing
+from dstack._internal.core.instance import InstanceType
+
+"""
+Dumped on 2023-08-10 at https://cloud.lambdalabs.com/instances
+```js
+const selector = document.querySelector("[class^=_select-instance-type-step]")
+const instances = selector.querySelectorAll("[class^=_instance-type-item]")
+const prices = [...instances].map((i) => ({
+    price: parseFloat(i.querySelector("[class^=_price]").textContent),
+    name: i.querySelector("[class^=_request-button]")?.id || i.querySelector("[class^=_instance-type-title]").textContent,
+}))
+```
+"""
+PRICES = {
+    "gpu_8x_h100_sxm5": 20.72,
+    "gpu_1x_h100_pcie": 1.99,
+    "gpu_8x_a100_80gb_sxm4": 12.0,
+    "gpu_1x_a10": 0.6,
+    "gpu_1x_rtx6000": 0.5,
+    "gpu_1x_a100": 1.1,
+    "gpu_1x_a100_sxm4": 1.1,
+    "gpu_2x_a100": 2.2,
+    "gpu_4x_a100": 4.4,
+    "gpu_8x_a100": 8.8,
+    "gpu_1x_a6000": 0.8,
+    "gpu_2x_a6000": 1.6,
+    "gpu_4x_a6000": 3.2,
+    "gpu_8x_v100": 4.4,
+}
+
+
+class LambdaPricing(BasePricing):
+    def fetch(self, instance: InstanceType, spot: Optional[bool]):
+        for region in instance.available_regions:
+            self.cache[instance.instance_name][(region, False)] = PRICES[instance.instance_name]

--- a/cli/dstack/_internal/backend/local/__init__.py
+++ b/cli/dstack/_internal/backend/local/__init__.py
@@ -5,6 +5,7 @@ from dstack._internal.backend.base import build as base_build
 from dstack._internal.backend.local.compute import LocalCompute
 from dstack._internal.backend.local.config import LocalConfig
 from dstack._internal.backend.local.logs import LocalLogging
+from dstack._internal.backend.local.pricing import LocalPricing
 from dstack._internal.backend.local.secrets import LocalSecretsManager
 from dstack._internal.backend.local.storage import LocalStorage
 from dstack._internal.core.build import BuildPlan
@@ -23,6 +24,7 @@ class LocalBackend(ComponentBasedBackend):
         self._compute = LocalCompute(self.backend_config)
         self._secrets_manager = LocalSecretsManager(self.backend_config.backend_dir)
         self._logging = LocalLogging(self.backend_config)
+        self._pricing = LocalPricing()
 
     @classmethod
     def load(cls) -> Optional["LocalBackend"]:
@@ -42,6 +44,9 @@ class LocalBackend(ComponentBasedBackend):
 
     def logging(self) -> LocalLogging:
         return self._logging
+
+    def pricing(self) -> LocalPricing:
+        return self._pricing
 
     def predict_build_plan(self, job: Job) -> BuildPlan:
         # guess platform from uname

--- a/cli/dstack/_internal/backend/local/compute.py
+++ b/cli/dstack/_internal/backend/local/compute.py
@@ -32,7 +32,9 @@ class LocalCompute(Compute):
         resources = runners.check_runner_resources(self.backend_config, uuid.uuid4().hex)
         return [InstanceType(instance_name="", resources=resources, available_regions=[""])]
 
-    def run_instance(self, job: Job, instance_type: InstanceType) -> LaunchedInstanceInfo:
+    def run_instance(
+        self, job: Job, instance_type: InstanceType, region: Optional[str] = None
+    ) -> LaunchedInstanceInfo:
         pid = runners.start_runner_process(self.backend_config, job.runner_id)
         return LaunchedInstanceInfo(request_id=pid, location=None)
 

--- a/cli/dstack/_internal/backend/local/compute.py
+++ b/cli/dstack/_internal/backend/local/compute.py
@@ -1,4 +1,6 @@
-from typing import Optional
+import functools
+import uuid
+from typing import List, Optional
 
 from dstack._internal.backend.base.compute import Compute, choose_instance_type
 from dstack._internal.backend.local import runners
@@ -24,6 +26,11 @@ class LocalCompute(Compute):
             requirements=job.requirements,
         )
         return instance_type
+
+    @functools.lru_cache()
+    def get_supported_instances(self) -> List[InstanceType]:
+        resources = runners.check_runner_resources(self.backend_config, uuid.uuid4().hex)
+        return [InstanceType(instance_name="", resources=resources, available_regions=[""])]
 
     def run_instance(self, job: Job, instance_type: InstanceType) -> LaunchedInstanceInfo:
         pid = runners.start_runner_process(self.backend_config, job.runner_id)

--- a/cli/dstack/_internal/backend/local/pricing.py
+++ b/cli/dstack/_internal/backend/local/pricing.py
@@ -1,0 +1,10 @@
+from typing import List, Optional
+
+from dstack._internal.backend.base.pricing import Pricing
+from dstack._internal.core.instance import InstanceType
+
+
+class LocalPricing(Pricing):
+    def fetch(self, instances: List[InstanceType], spot: Optional[bool]):
+        # empty instance_name and region
+        self.registry[""][("", False)] = 0.0

--- a/cli/dstack/_internal/cli/commands/start/__init__.py
+++ b/cli/dstack/_internal/cli/commands/start/__init__.py
@@ -25,7 +25,7 @@ class StartCommand(BasicCommand):
             host=args.host,
             port=args.port,
             reload=version.__version__ is None,
-            log_level="error",
+            log_level="info" if version.__version__ is None else "error",
         )
 
     def register(self):

--- a/cli/dstack/_internal/cli/utils/common.py
+++ b/cli/dstack/_internal/cli/utils/common.py
@@ -32,6 +32,7 @@ def generate_runs_table(
     table.add_column("BACKEND", style="grey58", no_wrap=True, max_width=16)
     table.add_column("INSTANCE", no_wrap=True)
     table.add_column("SPOT", no_wrap=True)
+    table.add_column("PRICE", no_wrap=True)
     table.add_column("STATUS", no_wrap=True)
     table.add_column("SUBMITTED", style="grey58", no_wrap=True)
     if verbose:
@@ -50,6 +51,7 @@ def generate_runs_table(
                 run_info.backend,
                 _pretty_print_instance_type(run),
                 _pretty_print_spot(run),
+                _pretty_print_price(run),
                 _pretty_print_status(run),
                 _status_color(run, submitted_at, False, False),
             ]
@@ -128,6 +130,15 @@ def _pretty_print_instance_type(run: RunHead) -> str:
         if job.instance_type
     ] or [_status_color(run, "-", False, False)]
     return "\n".join(instances)
+
+
+def _pretty_print_price(run: RunHead) -> str:
+    prices = [
+        _status_color(run, f"{job.price:.4g} $/h", False, False)
+        for job in run.job_heads
+        if job.price is not None
+    ] or [_status_color(run, "-", False, False)]
+    return "\n".join(prices)
 
 
 def check_init(func):

--- a/cli/dstack/_internal/core/instance.py
+++ b/cli/dstack/_internal/core/instance.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import List, Optional
 
 from pydantic import BaseModel
@@ -14,3 +15,11 @@ class InstanceType(BaseModel):
 class LaunchedInstanceInfo(BaseModel):
     request_id: str
     location: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class InstanceOffer:
+    instance_type: InstanceType
+    region: str
+    spot: bool
+    price: float

--- a/cli/dstack/_internal/core/instance.py
+++ b/cli/dstack/_internal/core/instance.py
@@ -21,5 +21,4 @@ class LaunchedInstanceInfo(BaseModel):
 class InstanceOffer:
     instance_type: InstanceType
     region: str
-    spot: bool
     price: float

--- a/cli/dstack/_internal/core/job.py
+++ b/cli/dstack/_internal/core/job.py
@@ -157,6 +157,7 @@ class JobHead(JobRef):
     app_names: Optional[List[str]]
     instance_type: Optional[str]
     instance_spot_type: Optional[str]
+    price: Optional[float]
 
     def get_id(self) -> Optional[str]:
         return self.job_id

--- a/cli/dstack/_internal/core/job.py
+++ b/cli/dstack/_internal/core/job.py
@@ -198,6 +198,7 @@ class Job(JobHead):
     location: Optional[str]
     master_job: Optional[str]  # not implemented
     max_duration: Optional[int]
+    price: Optional[float]
     provider_name: Optional[str] = ""  # deprecated
     registry_auth: Optional[RegistryAuth]
     repo_code_filename: Optional[str]

--- a/cli/dstack/_internal/hub/routers/runners.py
+++ b/cli/dstack/_internal/hub/routers/runners.py
@@ -41,7 +41,6 @@ async def run(project_name: str, body: RunRunners):
         body.job,
     )
     candidates.sort(key=lambda i: i[1].price)
-    print(*candidates[:5], sep="\n")
 
     for backend, offer in candidates:
         logger.info(

--- a/cli/dstack/_internal/hub/routers/runners.py
+++ b/cli/dstack/_internal/hub/routers/runners.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from dstack._internal.core.build import BuildNotFoundError
@@ -7,13 +9,16 @@ from dstack._internal.hub.routers.util import (
     call_backend,
     error_detail,
     get_backends,
+    get_instance_candidates,
     get_job_backend,
     get_project,
     get_run_backend,
 )
 from dstack._internal.hub.schemas import RunRunners, StopRunners
 from dstack._internal.hub.security.permissions import ProjectMember
+from dstack._internal.utils.logging import get_logger
 
+logger = get_logger(__name__)
 router = APIRouter(
     prefix="/api/project", tags=["runners"], dependencies=[Depends(ProjectMember())]
 )
@@ -26,11 +31,24 @@ async def run(project_name: str, body: RunRunners):
     failed_to_start_job_new_status = JobStatus.FAILED
     if body.job.retry_policy.retry:
         failed_to_start_job_new_status = JobStatus.PENDING
-    for db_backend, backend in backends:
-        if body.backends is not None and db_backend.type not in body.backends:
-            continue
+
+    candidates = await get_instance_candidates(
+        [
+            backend
+            for db_backend, backend in backends
+            if not body.backends or db_backend.type in body.backends
+        ],
+        body.job,
+    )
+    candidates.sort(key=lambda i: i[1].price)
+    print(*candidates[:5], sep="\n")
+
+    for backend, offer in candidates:
+        logger.info(
+            f"Trying {offer.instance_type.instance_name} in {backend.name} for ${offer.price:.4} per hour"
+        )
         try:
-            await call_backend(backend.run_job, body.job, failed_to_start_job_new_status)
+            await call_backend(backend.run_job, body.job, failed_to_start_job_new_status, offer)
             return
         except NoMatchingInstanceError:
             continue

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -56,4 +56,5 @@ google-cloud-storage
 google-cloud-compute
 google-cloud-secret-manager
 google-cloud-logging
+google-cloud-billing
 google-api-python-client

--- a/runner/internal/models/backend.go
+++ b/runner/internal/models/backend.go
@@ -44,7 +44,7 @@ type Job struct {
 	Location          string            `yaml:"location,omitempty"`
 	MasterJobID       string            `yaml:"master_job,omitempty"`
 	MaxDuration       uint64            `yaml:"max_duration,omitempty"`
-	Price             float64           `yaml:"price,omitempty"`
+	Price             float64           `yaml:"price,omitempty"`         // head
 	ProviderName      string            `yaml:"provider_name,omitempty"` // deprecated, head
 	RegistryAuth      RegistryAuth      `yaml:"registry_auth,omitempty"`
 	RepoCodeFilename  string            `yaml:"repo_code_filename,omitempty"`
@@ -200,8 +200,12 @@ func (j *Job) JobHeadFilepath() string {
 	for i, art := range j.Artifacts {
 		artifactSlice[i] = EscapeHead(art.Path)
 	}
+	price := ""
+	if j.Price > 0 {
+		price = fmt.Sprintf("%f", j.Price)
+	}
 	return fmt.Sprintf(
-		"jobs/%s/l;%s;%s;%s;%d;%s;%s;%s;%s;%s;%s;%s",
+		"jobs/%s/l;%s;%s;%s;%d;%s;%s;%s;%s;%s;%s;%s;%s",
 		j.RepoRef.RepoId,
 		j.JobID,
 		"", // ProviderName
@@ -214,6 +218,7 @@ func (j *Job) JobHeadFilepath() string {
 		j.InstanceType,
 		EscapeHead(j.ConfigurationPath),
 		j.GetInstanceType(),
+		price,
 	)
 }
 

--- a/runner/internal/models/backend.go
+++ b/runner/internal/models/backend.go
@@ -44,6 +44,7 @@ type Job struct {
 	Location          string            `yaml:"location,omitempty"`
 	MasterJobID       string            `yaml:"master_job,omitempty"`
 	MaxDuration       uint64            `yaml:"max_duration,omitempty"`
+	Price             float64           `yaml:"price,omitempty"`
 	ProviderName      string            `yaml:"provider_name,omitempty"` // deprecated, head
 	RegistryAuth      RegistryAuth      `yaml:"registry_auth,omitempty"`
 	RepoCodeFilename  string            `yaml:"repo_code_filename,omitempty"`

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ GCP_DEPS = [
     "google-cloud-secret-manager>=2.0.0",
     "google-cloud-logging>=2.0.0",
     "google-api-python-client>=2.80.0",
+    "google-cloud-billing>=1.11.0",
 ]
 
 LAMBDA_DEPS = AWS_DEPS


### PR DESCRIPTION
Closes #629

* Collect prices on instances from cloud providers
* Cache prices in memory
* Collect prices from many backends in parallel
* Try backends and instances in price ascending order
* Fix AWS log group creation
* Fix GCP attachable GPU count issues
* Show prices in runs table

New required permissions for AWS:
* `pricing:GetProducts`
* `ec2:DescribeSpotPriceHistory`