### PR TITLE
Use `instance_name` as `instance_id` for GCP and Azure

### DIFF
--- a/cli/dstack/_internal/backend/azure/compute.py
+++ b/cli/dstack/_internal/backend/azure/compute.py
@@ -275,7 +275,7 @@ def _run_instance(
                     cuda=len(instance_type.resources.gpus) > 0,
                 ),
                 vm_size=instance_type.instance_name,
-                instance_name=_get_instance_name(job),
+                instance_name=job.instance_name,
                 user_data=_get_user_data_script(
                     azure_config=_config_with_location(azure_config, location),
                     job=job,
@@ -290,11 +290,6 @@ def _run_instance(
             logger.info("Failed to request instance in %s", location)
     logger.info("Failed to request instance")
     raise NoCapacityError()
-
-
-def _get_instance_name(job: Job) -> str:
-    # TODO support multiple jobs per run
-    return f"dstack-{job.run_name}"
 
 
 def _get_image_ref(

--- a/cli/dstack/_internal/backend/gcp/compute.py
+++ b/cli/dstack/_internal/backend/gcp/compute.py
@@ -467,11 +467,6 @@ def _get_image_name(
     return None
 
 
-def _get_instance_name(job: Job) -> str:
-    # TODO support multiple jobs per run
-    return f"dstack-{job.run_name}"
-
-
 def _get_user_data_script(gcp_config: GCPConfig, job: Job, instance_type: InstanceType) -> str:
     config_content = gcp_config.serialize_yaml().replace("\n", "\\n")
     runner_content = serialize_runner_yaml(job.runner_id, instance_type.resources, 3000, 4000)
@@ -567,7 +562,7 @@ def _run_instance(
                     images_client=images_client,
                     instance_type=instance_type,
                 ),
-                instance_name=_get_instance_name(job),
+                instance_name=job.instance_name,
                 user_data_script=_get_user_data_script(
                     gcp_config=_config_with_zone(gcp_config, zone),
                     job=job,

--- a/cli/dstack/_internal/backend/local/compute.py
+++ b/cli/dstack/_internal/backend/local/compute.py
@@ -37,7 +37,8 @@ class LocalCompute(Compute):
 
     def terminate_instance(self, runner: Runner):
         runners.stop_process(runner.request_id)
-        runners.remove_container(runner.job.run_name)
+        container_name = runner.job.instance_name or runner.job.run_name
+        runners.remove_container(container_name)
 
     def cancel_spot_request(self, runner: Runner):
         pass

--- a/cli/dstack/_internal/cli/utils/run.py
+++ b/cli/dstack/_internal/cli/utils/run.py
@@ -196,7 +196,9 @@ def _print_failed_run_message(run: RunHead):
     elif run.job_heads[0].error_code is JobErrorCode.BUILD_NOT_FOUND:
         console.print("Build not found. Run `dstack build` or add `--build` flag")
     else:
-        console.print("Provisioning failed\n")
+        console.print(
+            f"Provisioning failed.\nTo see runner logs, run `dstack logs --diagnose {run.run_name}`.\n"
+        )
 
 
 def reserve_ports(apps: List[AppSpec], local_backend: bool) -> Tuple[PortsLock, PortsLock]:

--- a/cli/dstack/_internal/configurators/__init__.py
+++ b/cli/dstack/_internal/configurators/__init__.py
@@ -166,6 +166,7 @@ class JobConfigurator(ABC):
             gateway=self.gateway(),
             home_dir=self.home_dir(),
             image_name=self.image_name(run_plan),
+            instance_name=f"dstack-{run_name}",
             job_id=f"{run_name},,0",
             max_duration=self.max_duration(),
             registry_auth=self.registry_auth(),

--- a/cli/dstack/_internal/core/job.py
+++ b/cli/dstack/_internal/core/job.py
@@ -192,6 +192,7 @@ class Job(JobHead):
     host_name: Optional[str]
     hub_user_name: str = ""
     image_name: str
+    instance_name: Optional[str]
     instance_spot_type: Optional[str]
     instance_type: Optional[str]
     job_id: str

--- a/runner/internal/backend/azure/backend.go
+++ b/runner/internal/backend/azure/backend.go
@@ -92,7 +92,7 @@ func (azbackend *AzureBackend) Init(ctx context.Context, ID string) error {
 	if err := base.LoadRunnerState(ctx, azbackend.storage, ID, &azbackend.state); err != nil {
 		return gerrors.Wrap(err)
 	}
-	ip, err := azbackend.compute.GetInstancePublicIP(ctx, azbackend.state.RequestID)
+	ip, err := azbackend.compute.GetInstancePublicIP(ctx, azbackend.state.Job.InstanceName)
 	if err != nil {
 		return gerrors.Wrap(err)
 	}
@@ -137,7 +137,7 @@ func (azbackend *AzureBackend) Stop(ctx context.Context) error {
 
 func (azbackend *AzureBackend) Shutdown(ctx context.Context) error {
 	log.Trace(ctx, "Starting shutdown")
-	err := azbackend.compute.TerminateInstance(ctx, azbackend.state.RequestID)
+	err := azbackend.compute.TerminateInstance(ctx, azbackend.state.Job.InstanceName)
 	if err != nil {
 		return gerrors.Wrap(err)
 	}

--- a/runner/internal/backend/gcp/backend.go
+++ b/runner/internal/backend/gcp/backend.go
@@ -86,7 +86,7 @@ func (gbackend *GCPBackend) Init(ctx context.Context, ID string) error {
 	if err := base.LoadRunnerState(ctx, gbackend.storage, ID, &gbackend.state); err != nil {
 		return gerrors.Wrap(err)
 	}
-	ip, err := gbackend.compute.GetInstancePublicIP(ctx, gbackend.state.RequestID)
+	ip, err := gbackend.compute.GetInstancePublicIP(ctx, gbackend.state.Job.InstanceName)
 	if err != nil {
 		return gerrors.Wrap(err)
 	}
@@ -116,11 +116,11 @@ func (gbackend *GCPBackend) IsInterrupted(ctx context.Context) (bool, error) {
 	if !gbackend.state.Resources.Spot {
 		return false, nil
 	}
-	return gbackend.compute.IsInterruptedSpot(ctx, gbackend.state.RequestID)
+	return gbackend.compute.IsInterruptedSpot(ctx, gbackend.state.Job.InstanceName)
 }
 
 func (gbackend *GCPBackend) Stop(ctx context.Context) error {
-	err := gbackend.compute.StopInstance(ctx, gbackend.state.RequestID)
+	err := gbackend.compute.StopInstance(ctx, gbackend.state.Job.InstanceName)
 	if err != nil {
 		return gerrors.Wrap(err)
 	}
@@ -128,7 +128,7 @@ func (gbackend *GCPBackend) Stop(ctx context.Context) error {
 }
 
 func (gbackend *GCPBackend) Shutdown(ctx context.Context) error {
-	err := gbackend.compute.TerminateInstance(ctx, gbackend.state.RequestID)
+	err := gbackend.compute.TerminateInstance(ctx, gbackend.state.Job.InstanceName)
 	if err != nil {
 		return gerrors.Wrap(err)
 	}

--- a/runner/internal/executor/executor.go
+++ b/runner/internal/executor/executor.go
@@ -402,7 +402,7 @@ func (ex *Executor) startJob(ctx context.Context, erCh chan error, stoppedCh cha
 		}
 	}
 
-	container, err := ex.engine.CreateNamed(ctx, spec, job.RunName, allLogs)
+	container, err := ex.engine.CreateNamed(ctx, spec, job.InstanceName, allLogs)
 	if err != nil {
 		erCh <- gerrors.Wrap(err)
 		return

--- a/runner/internal/models/backend.go
+++ b/runner/internal/models/backend.go
@@ -38,6 +38,7 @@ type Job struct {
 	HostName          string            `yaml:"host_name,omitempty"`
 	HubUserName       string            `yaml:"hub_user_name"` // head
 	Image             string            `yaml:"image_name"`
+	InstanceName      string            `yaml:"instance_name"`
 	InstanceSpotType  string            `yaml:"instance_spot_type,omitempty"` // head
 	InstanceType      string            `yaml:"instance_type,omitempty"`      // head
 	JobID             string            `yaml:"job_id"`                       // head


### PR DESCRIPTION
Fixes #638 
