### PR TITLE
Separate Repo and api.Client

### DIFF
--- a/src/dstack/_internal/cli/commands/__init__.py
+++ b/src/dstack/_internal/cli/commands/__init__.py
@@ -66,6 +66,6 @@ class APIBaseCommand(BaseCommand):
     def _command(self, args: argparse.Namespace):
         configure_logging()
         try:
-            self.api = Client.from_config(Path.cwd(), args.project, init=False)
+            self.api = Client.from_config(project_name=args.project)
         except ConfigurationError as e:
             raise CLIError(str(e))

--- a/src/dstack/_internal/cli/commands/run.py
+++ b/src/dstack/_internal/cli/commands/run.py
@@ -14,13 +14,9 @@ from dstack._internal.cli.services.configurators.run import (
 )
 from dstack._internal.cli.utils.common import confirm_ask, console
 from dstack._internal.cli.utils.run import print_run_plan
-from dstack._internal.core.errors import (
-    CLIError,
-    ConfigurationError,
-    ResourceExistsError,
-    ServerClientError,
-)
+from dstack._internal.core.errors import CLIError, ConfigurationError, ServerClientError
 from dstack._internal.core.models.configurations import ConfigurationType
+from dstack._internal.core.services.configs import ConfigManager
 from dstack._internal.utils.logging import get_logger
 from dstack.api import RunStatus
 from dstack.api.utils import load_configuration, load_profile
@@ -86,6 +82,11 @@ class RunCommand(APIBaseCommand):
 
         super()._command(args)
         try:
+            repo = self.api.repos.load(Path.cwd())
+            self.api.ssh_identity_file = (
+                ConfigManager().get_repo_config(repo.repo_dir).ssh_key_path
+            )
+
             profile = load_profile(Path.cwd(), args.profile)
             apply_profile_args(args, profile)
 
@@ -101,6 +102,7 @@ class RunCommand(APIBaseCommand):
             with console.status("Getting run plan..."):
                 run_plan = self.api.runs.get_plan(
                     configuration=conf,
+                    repo=repo,
                     configuration_path=configuration_path,
                     backends=profile.backends,
                     resources=profile.resources,  # pass profile piece by piece
@@ -121,7 +123,7 @@ class RunCommand(APIBaseCommand):
 
         try:
             with console.status("Submitting run..."):
-                run = self.api.runs.exec_plan(run_plan, reserve_ports=not args.detach)
+                run = self.api.runs.exec_plan(run_plan, repo, reserve_ports=not args.detach)
         except ServerClientError as e:
             raise CLIError(e.msg)
 

--- a/src/dstack/_internal/core/models/configurations.py
+++ b/src/dstack/_internal/core/models/configurations.py
@@ -7,6 +7,7 @@ from typing_extensions import Annotated, Literal
 
 from dstack._internal.core.errors import ConfigurationError
 from dstack._internal.core.models.common import ForbidExtra
+from dstack._internal.core.models.repos.base import Repo
 
 CommandsList = List[str]
 ValidPort = conint(gt=0, le=65536)
@@ -112,6 +113,9 @@ class BaseConfiguration(ForbidExtra):
         if isinstance(v, list):
             return dict(pair.split(sep="=", maxsplit=1) for pair in v)
         return v
+
+    def get_repo(self) -> Optional[Repo]:
+        return None
 
 
 class BaseConfigurationWithPorts(BaseConfiguration):

--- a/src/dstack/_internal/core/models/repos/base.py
+++ b/src/dstack/_internal/core/models/repos/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import BinaryIO
+from typing import BinaryIO, Optional
 
 from pydantic import BaseModel
 
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 class RepoType(str, Enum):
     REMOTE = "remote"
     LOCAL = "local"
+    VIRTUAL = "virtual"
 
 
 class RepoProtocol(str, Enum):
@@ -15,9 +16,14 @@ class RepoProtocol(str, Enum):
     HTTPS = "https"
 
 
+class BaseRepoInfo(BaseModel):
+    repo_type: str
+
+
 class Repo(ABC):
     repo_id: str
-    run_repo_data: BaseModel  # TODO make it more specific
+    repo_dir: Optional[str]
+    run_repo_data: BaseRepoInfo
 
     @abstractmethod
     def write_code_file(self, fp: BinaryIO) -> str:

--- a/src/dstack/_internal/core/models/repos/local.py
+++ b/src/dstack/_internal/core/models/repos/local.py
@@ -5,13 +5,13 @@ from typing import BinaryIO, Optional
 from pydantic import BaseModel
 from typing_extensions import Literal
 
-from dstack._internal.core.models.repos.base import Repo
+from dstack._internal.core.models.repos.base import BaseRepoInfo, Repo
 from dstack._internal.utils.hash import get_sha256, slugify
 from dstack._internal.utils.ignore import GitIgnore
 from dstack._internal.utils.path import PathLike
 
 
-class LocalRepoInfo(BaseModel):
+class LocalRepoInfo(BaseRepoInfo):
     repo_type: Literal["local"] = "local"
     repo_dir: str
 
@@ -32,6 +32,8 @@ class LocalRepo(Repo):
         repo_dir: Optional[PathLike] = None,
         repo_data: Optional[LocalRunRepoData] = None,
     ):
+        self.repo_dir = repo_dir
+
         if repo_dir is not None:
             repo_data = LocalRunRepoData(repo_dir=str(repo_dir))
         elif repo_data is None:

--- a/src/dstack/_internal/core/models/repos/remote.py
+++ b/src/dstack/_internal/core/models/repos/remote.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 from typing_extensions import Literal
 
 from dstack._internal.core.errors import DstackError
-from dstack._internal.core.models.repos.base import Repo, RepoProtocol
+from dstack._internal.core.models.repos.base import BaseRepoInfo, Repo, RepoProtocol
 from dstack._internal.utils.hash import get_sha256, slugify
 from dstack._internal.utils.path import PathLike
 from dstack._internal.utils.ssh import get_host_config
@@ -25,7 +25,7 @@ class RemoteRepoCreds(BaseModel):
     oauth_token: Optional[str]
 
 
-class RemoteRepoInfo(BaseModel):
+class RemoteRepoInfo(BaseRepoInfo):
     repo_type: Literal["remote"] = "remote"
     repo_host_name: str
     repo_port: Optional[int]
@@ -89,16 +89,11 @@ class RemoteRepo(Repo):
         repo_url: Optional[str] = None,
         repo_data: Optional[RemoteRunRepoData] = None,
     ):
-        """
-        >>> RemoteRepo(local_repo_dir=os.getcwd())
-        >>> RemoteRepo(repo_id="playground", repo_url="https://github.com/dstackai/dstack-playground.git")
-        """
-
-        self.local_repo_dir = local_repo_dir
+        self.repo_dir = local_repo_dir
         self.repo_url = repo_url
 
-        if self.local_repo_dir is not None:
-            repo = git.Repo(self.local_repo_dir)
+        if self.repo_dir is not None:
+            repo = git.Repo(self.repo_dir)
             tracking_branch = repo.active_branch.tracking_branch()
             if tracking_branch is None:
                 raise RepoError("No remote branch is configured")

--- a/src/dstack/_internal/core/models/repos/virtual.py
+++ b/src/dstack/_internal/core/models/repos/virtual.py
@@ -1,0 +1,38 @@
+import io
+import tarfile
+from typing import BinaryIO, Dict, Literal
+
+from dstack._internal.core.models.repos.base import BaseRepoInfo, Repo
+from dstack._internal.utils.hash import get_sha256
+from dstack._internal.utils.path import resolve_relative_path
+
+
+class VirtualRepoInfo(BaseRepoInfo):
+    repo_type: Literal["virtual"] = "virtual"
+
+
+class VirtualRunRepoData(VirtualRepoInfo):
+    pass
+
+
+class VirtualRepo(Repo):
+    """Represents in-memory repo, transferred as a tar ball"""
+
+    run_repo_data: VirtualRunRepoData
+
+    def __init__(self, repo_id: str):
+        self.repo_id = repo_id
+        self.repo_dir = None
+        self.files: Dict[str, bytes] = {}
+        self.run_repo_data = VirtualRunRepoData()
+
+    def add_file(self, path: str, content: bytes):
+        self.files[resolve_relative_path(path).as_posix()] = content
+
+    def write_code_file(self, fp: BinaryIO) -> str:
+        with tarfile.TarFile(mode="w", fileobj=fp) as t:
+            for path, content in sorted(self.files.items()):
+                info = tarfile.TarInfo(path)
+                info.size = len(content)
+                t.addfile(info, fileobj=io.BytesIO(initial_bytes=content))
+        return get_sha256(fp)

--- a/src/dstack/_internal/utils/path.py
+++ b/src/dstack/_internal/utils/path.py
@@ -1,5 +1,5 @@
 import os
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Union
 
 PathLike = Union[str, os.PathLike]
@@ -11,3 +11,18 @@ def path_in_dir(path: PathLike, directory: PathLike) -> bool:
         return True
     except ValueError:
         return False
+
+
+def resolve_relative_path(path: str) -> PurePath:
+    path = PurePath(path)
+    if path.is_absolute():
+        raise ValueError("Path should be relative")
+    stack = []
+    for part in path.parts:
+        if part == "..":
+            if not stack:
+                raise ValueError("Path is outside of the repo")
+            stack.pop()
+        else:
+            stack.append(part)
+    return PurePath(*stack)

--- a/src/dstack/api/_public/__init__.py
+++ b/src/dstack/api/_public/__init__.py
@@ -1,19 +1,12 @@
-from pathlib import Path
-from typing import Optional, Union
-
-from git import InvalidGitRepositoryError
+from typing import Optional
 
 import dstack._internal.core.services.api_client as api_client_service
 from dstack._internal.core.errors import ConfigurationError
-from dstack._internal.core.models.repos import LocalRepo, RemoteRepo
-from dstack._internal.core.models.repos.base import RepoType
 from dstack._internal.core.services.configs import ConfigManager
-from dstack._internal.core.services.repos import load_repo
-from dstack._internal.utils.crypto import generate_rsa_key_pair
 from dstack._internal.utils.logging import get_logger
 from dstack._internal.utils.path import PathLike
 from dstack.api._public.backends import BackendCollection
-from dstack.api._public.repos import RepoCollection
+from dstack.api._public.repos import RepoCollection, get_ssh_keypair
 from dstack.api._public.runs import RunCollection
 from dstack.api.server import APIClient
 
@@ -36,86 +29,43 @@ class Client:
         self,
         api_client: APIClient,
         project_name: str,
-        repo_dir: PathLike,
-        repo: Union[RemoteRepo, LocalRepo],
-        git_identity_file: Optional[PathLike] = None,
-        oauth_token: Optional[str] = None,
         ssh_identity_file: Optional[PathLike] = None,
-        init: bool = True,
     ):
         """
         Args:
             api_client: low-level server API client
             project_name: project name used for runs
-            repo_dir: path to the repo
-            repo: repo used for runs
-            git_identity_file: private SSH key to access remote repo, used only if `init` is True
-            oauth_token: GitHub OAuth token to access remote repo, used only if `init` is True
             ssh_identity_file: SSH keypair to access instances
-            init: initialize the repo first
         """
         self._client = api_client
         self._project = project_name
-        self._repos = RepoCollection(api_client, project_name, repo)
+        self._repos = RepoCollection(api_client, project_name)
         self._backends = BackendCollection(api_client, project_name)
-        self._runs = RunCollection(api_client, project_name, repo_dir, repo, ssh_identity_file)
-
-        if init:
-            self.repos.init(git_identity_file, oauth_token)
+        self._runs = RunCollection(api_client, project_name, self)
+        if ssh_identity_file:
+            self.ssh_identity_file = str(ssh_identity_file)
         else:
-            if not self.repos.is_initialized():
-                raise ConfigurationError(f"The repo is not initialized")
+            self.ssh_identity_file = get_ssh_keypair(None, ConfigManager().dstack_key_path)
 
     @staticmethod
     def from_config(
-        repo_dir: PathLike,
         project_name: Optional[str] = None,
         server_url: Optional[str] = None,
         user_token: Optional[str] = None,
-        git_identity_file: Optional[PathLike] = None,
-        oauth_token: Optional[str] = None,
         ssh_identity_file: Optional[PathLike] = None,
-        local_repo: bool = False,
-        init: bool = True,
     ) -> "Client":
         """
         Creates a Client using global config `~/.dstack/config.yml`
 
         Args:
-            repo_dir: path to the repo
             project_name: name of the project, required if `server_url` and `user_token` are specified
             server_url: dstack server url, e.g. `http://localhost:3000/`
             user_token: dstack user token
-            git_identity_file: path to a private SSH key to access remote repo
-            oauth_token: GitHub OAuth token to access remote repo
             ssh_identity_file: SSH keypair to access instances
-            local_repo: load repo as local, has an effect only if `init` is True
-            init: initialize the repo first
 
         Returns:
             dstack Client
         """
-        config = ConfigManager()
-        if not init:
-            logger.debug("Loading repo config")
-            repo_config = config.get_repo_config(repo_dir)
-            if repo_config is None:
-                raise ConfigurationError(f"The repo is not initialized")
-            repo = load_repo(repo_config)
-            if ssh_identity_file is None:
-                ssh_identity_file = repo_config.ssh_key_path
-        else:
-            logger.debug("Initializing repo")
-            repo = LocalRepo(repo_dir=repo_dir)  # default
-            if not local_repo:
-                try:
-                    repo = RemoteRepo(local_repo_dir=repo_dir)
-                except InvalidGitRepositoryError:
-                    pass  # use default
-            ssh_identity_file = get_ssh_keypair(ssh_identity_file, config.dstack_key_path)
-            config.save_repo_config(
-                repo_dir, repo.repo_id, RepoType(repo.run_repo_data.repo_type), ssh_identity_file
-            )
         if server_url is not None and user_token is not None:
             if project_name is None:
                 raise ConfigurationError(f"The project name is not specified")
@@ -123,14 +73,9 @@ class Client:
         else:
             api_client, project_name = api_client_service.get_api_client(project_name=project_name)
         return Client(
-            api_client,
-            project_name,
-            repo_dir,
-            repo,
-            git_identity_file,
-            oauth_token,
-            ssh_identity_file,
-            init,
+            api_client=api_client,
+            project_name=project_name,
+            ssh_identity_file=ssh_identity_file,
         )
 
     @property
@@ -152,22 +97,3 @@ class Client:
     @property
     def project(self) -> str:
         return self._project
-
-
-def get_ssh_keypair(key_path: Optional[PathLike], dstack_key_path: Path) -> str:
-    """Returns a path to the private key"""
-    if key_path is not None:
-        key_path = Path(key_path).expanduser().resolve()
-        pub_key = (
-            key_path
-            if key_path.suffix == ".pub"
-            else key_path.with_suffix(key_path.suffix + ".pub")
-        )
-        private_key = pub_key.with_suffix("")
-        if pub_key.exists() and private_key.exists():
-            return str(private_key)
-        raise ConfigurationError(f"Make sure valid keypair exists: {private_key}(.pub)")
-
-    if not dstack_key_path.exists():
-        generate_rsa_key_pair(private_key_path=dstack_key_path)
-    return str(dstack_key_path)

--- a/src/dstack/api/_public/repos.py
+++ b/src/dstack/api/_public/repos.py
@@ -1,16 +1,25 @@
+from pathlib import Path
 from typing import Optional, Union
 
 import giturlparse
 import requests
+from git import InvalidGitRepositoryError
 
 from dstack._internal.core.errors import ConfigurationError
 from dstack._internal.core.models.repos import LocalRepo, RemoteRepo
+from dstack._internal.core.models.repos.base import Repo, RepoType
+from dstack._internal.core.services.configs import ConfigManager
 from dstack._internal.core.services.repos import (
     InvalidRepoCredentialsError,
     get_local_repo_credentials,
+    load_repo,
 )
+from dstack._internal.utils.crypto import generate_rsa_key_pair
+from dstack._internal.utils.logging import get_logger
 from dstack._internal.utils.path import PathLike
 from dstack.api.server import APIClient
+
+logger = get_logger(__name__)
 
 
 class RepoCollection:
@@ -18,49 +27,121 @@ class RepoCollection:
     Operations with repos
     """
 
-    def __init__(self, api_client: APIClient, project: str, repo: Union[RemoteRepo, LocalRepo]):
+    def __init__(self, api_client: APIClient, project: str):
         self._api_client = api_client
         self._project = project
-        self._repo = repo
 
     def init(
         self,
+        repo: Repo,
         git_identity_file: Optional[PathLike] = None,
         oauth_token: Optional[str] = None,
     ):
         """
-        Upload credentials and initializes the remote repo in the project
+        Upload credentials and initializes the repo in the project
 
         Args:
+            repo: repo to initialize
             git_identity_file: SSH private key to access the remote repo
             oauth_token: GitHub OAuth token to access the remote repo
         """
         creds = None
-        if isinstance(self._repo, RemoteRepo):
+        if isinstance(repo, RemoteRepo):
             try:
                 creds = get_local_repo_credentials(
-                    repo_data=self._repo.run_repo_data,
+                    repo_data=repo.run_repo_data,
                     identity_file=git_identity_file,
                     oauth_token=oauth_token,
-                    original_hostname=giturlparse.parse(self._repo.repo_url).resource,
+                    original_hostname=giturlparse.parse(repo.repo_url).resource,
                 )
             except InvalidRepoCredentialsError as e:
                 raise ConfigurationError(*e.args)
-        self._api_client.repos.init(
-            self._project, self._repo.repo_id, self._repo.run_repo_data, creds
-        )
+        self._api_client.repos.init(self._project, repo.repo_id, repo.run_repo_data, creds)
 
-    def is_initialized(self) -> bool:
+    def is_initialized(
+        self,
+        repo: Repo,
+    ) -> bool:
         """
         Checks if the remote repo is initialized in the project
+
+        Args:
+            repo: repo to check
 
         Returns:
             repo is initialized
         """
         try:
-            self._api_client.repos.get(self._project, self._repo.repo_id, include_creds=False)
+            self._api_client.repos.get(self._project, repo.repo_id, include_creds=False)
             return True
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 404:
                 return False
             raise
+
+    def load(
+        self,
+        repo_dir: PathLike,
+        local: bool = False,
+        init: bool = False,
+        git_identity_file: Optional[PathLike] = None,
+        oauth_token: Optional[str] = None,
+    ) -> Union[RemoteRepo, LocalRepo]:
+        """
+        Loads the repo from the local directory using global config
+
+        Args:
+            repo_dir: repo root directory
+            local: do not try to load `RemoteRepo` first
+            init: initialize the repo if it's not initialized
+            git_identity_file: path to an SSH private key to access the remote repo
+            oauth_token: GitHub OAuth token to access the remote repo
+
+        Raises:
+            ConfigurationError: if the repo is not initialized and `init` is `False`
+
+        Returns:
+            repo: initialized repo
+        """
+        config = ConfigManager()
+        if not init:
+            logger.debug("Loading repo config")
+            repo_config = config.get_repo_config(repo_dir)
+            if repo_config is None:
+                raise ConfigurationError(f"The repo is not initialized")
+            repo = load_repo(repo_config)
+        else:
+            logger.debug("Initializing repo")
+            repo = LocalRepo(repo_dir=repo_dir)  # default
+            if not local:
+                try:
+                    repo = RemoteRepo(local_repo_dir=repo_dir)
+                except InvalidGitRepositoryError:
+                    pass  # use default
+            self.init(repo, git_identity_file, oauth_token)
+            config.save_repo_config(
+                repo.repo_dir,
+                repo.repo_id,
+                RepoType(repo.run_repo_data.repo_type),
+                get_ssh_keypair(None, config.dstack_key_path),
+            )
+        return repo
+
+
+def get_ssh_keypair(key_path: Optional[PathLike], dstack_key_path: Path) -> str:
+    """Returns a path to the private key"""
+    if key_path is not None:
+        key_path = Path(key_path).expanduser().resolve()
+        pub_key = (
+            key_path
+            if key_path.suffix == ".pub"
+            else key_path.with_suffix(key_path.suffix + ".pub")
+        )
+        private_key = pub_key.with_suffix("")
+        if pub_key.exists() and private_key.exists():
+            return str(private_key)
+        raise ConfigurationError(f"Make sure valid keypair exists: {private_key}(.pub)")
+
+    if not dstack_key_path.exists():
+        generate_rsa_key_pair(private_key_path=dstack_key_path)
+    return str(dstack_key_path)

--- a/src/tests/_internal/utils/test_path.py
+++ b/src/tests/_internal/utils/test_path.py
@@ -1,0 +1,18 @@
+from pathlib import PurePath
+
+import pytest
+
+from dstack._internal.utils.path import resolve_relative_path
+
+
+class TestResolveRelativePath:
+    def test_abs_path(self):
+        with pytest.raises(ValueError):
+            resolve_relative_path("/tmp")
+
+    def test_escape_repo(self):
+        with pytest.raises(ValueError):
+            resolve_relative_path("repo/../..")
+
+    def test_normalize(self):
+        assert resolve_relative_path("repo/./../repo2") == PurePath("repo2")


### PR DESCRIPTION
* Remove repo-related parameters from `dstack.api.Client.from_config`
* Add method `Client.repos.load`
* Pass repo as a parameter to `Client.runs.submit`
* Add method `BaseConfiguration.get_repo` which returns `None` by default
