### PR TITLE
Virtual repo support

### DIFF
--- a/runner/internal/executor/repo.go
+++ b/runner/internal/executor/repo.go
@@ -24,7 +24,7 @@ func (ex *RunExecutor) setupRepo(ctx context.Context) error {
 		if err := ex.prepareGit(ctx); err != nil {
 			return gerrors.Wrap(err)
 		}
-	case "local":
+	case "local", "virtual":
 		log.Trace(ctx, "Extracting tar archive")
 		if err := ex.prepareArchive(ctx); err != nil {
 			return gerrors.Wrap(err)

--- a/src/dstack/_internal/core/models/configurations.py
+++ b/src/dstack/_internal/core/models/configurations.py
@@ -8,6 +8,7 @@ from typing_extensions import Annotated, Literal
 from dstack._internal.core.errors import ConfigurationError
 from dstack._internal.core.models.common import ForbidExtra
 from dstack._internal.core.models.repos.base import Repo
+from dstack._internal.core.models.repos.virtual import VirtualRepo
 
 CommandsList = List[str]
 ValidPort = conint(gt=0, le=65536)
@@ -114,8 +115,8 @@ class BaseConfiguration(ForbidExtra):
             return dict(pair.split(sep="=", maxsplit=1) for pair in v)
         return v
 
-    def get_repo(self) -> Optional[Repo]:
-        return None
+    def get_repo(self) -> Repo:
+        return VirtualRepo(repo_id="none")
 
 
 class BaseConfigurationWithPorts(BaseConfiguration):

--- a/src/dstack/_internal/core/models/repos/__init__.py
+++ b/src/dstack/_internal/core/models/repos/__init__.py
@@ -9,10 +9,11 @@ from dstack._internal.core.models.repos.remote import (
     RemoteRepoInfo,
     RemoteRunRepoData,
 )
+from dstack._internal.core.models.repos.virtual import VirtualRepoInfo, VirtualRunRepoData
 
-AnyRunRepoData = Union[RemoteRunRepoData, LocalRunRepoData]
+AnyRunRepoData = Union[RemoteRunRepoData, LocalRunRepoData, VirtualRunRepoData]
 
-AnyRepoInfo = Union[RemoteRepoInfo, LocalRepoInfo]
+AnyRepoInfo = Union[RemoteRepoInfo, LocalRepoInfo, VirtualRepoInfo]
 
 
 class RepoHead(BaseModel):

--- a/src/dstack/_internal/core/models/repos/base.py
+++ b/src/dstack/_internal/core/models/repos/base.py
@@ -4,6 +4,8 @@ from typing import BinaryIO, Optional
 
 from pydantic import BaseModel
 
+import dstack._internal.core.models.repos as repos
+
 
 class RepoType(str, Enum):
     REMOTE = "remote"
@@ -23,7 +25,7 @@ class BaseRepoInfo(BaseModel):
 class Repo(ABC):
     repo_id: str
     repo_dir: Optional[str]
-    run_repo_data: BaseRepoInfo
+    run_repo_data: "repos.AnyRunRepoData"
 
     @abstractmethod
     def write_code_file(self, fp: BinaryIO) -> str:

--- a/src/dstack/api/__init__.py
+++ b/src/dstack/api/__init__.py
@@ -1,8 +1,13 @@
 from dstack._internal.core.errors import ClientError
+from dstack._internal.core.models.backends.base import BackendType
+from dstack._internal.core.models.configurations import (
+    DevEnvironmentConfiguration as DevEnvironment,
+)
 from dstack._internal.core.models.configurations import ServiceConfiguration as Service
 from dstack._internal.core.models.configurations import TaskConfiguration as Task
 from dstack._internal.core.models.profiles import ProfileGPU as GPU
 from dstack._internal.core.models.profiles import ProfileResources as Resources
+from dstack._internal.core.models.repos.virtual import VirtualRepo
 from dstack._internal.core.services.ssh.ports import PortUsedError
 from dstack.api._public import BackendCollection, Client, RepoCollection, RunCollection
 from dstack.api._public.backends import Backend

--- a/src/dstack/api/_public/runs.py
+++ b/src/dstack/api/_public/runs.py
@@ -16,14 +16,10 @@ import dstack.api as api
 from dstack._internal.core.errors import ConfigurationError
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.configurations import AnyRunConfiguration
-from dstack._internal.core.models.configurations import ServiceConfiguration as Service
-from dstack._internal.core.models.configurations import TaskConfiguration as Task
-from dstack._internal.core.models.logs import LogEvent
 from dstack._internal.core.models.profiles import Profile
 from dstack._internal.core.models.profiles import ProfileResources as Resources
 from dstack._internal.core.models.profiles import ProfileRetryPolicy as RetryPolicy
 from dstack._internal.core.models.profiles import SpotPolicy
-from dstack._internal.core.models.repos import LocalRepo, RemoteRepo
 from dstack._internal.core.models.repos.base import Repo
 from dstack._internal.core.models.runs import JobSpec
 from dstack._internal.core.models.runs import JobStatus as RunStatus


### PR DESCRIPTION
* Add virtual repo support to the runner
* Add default empty virtual repo for all configurations
  * Now you can run a task without any files `Client.runs.submit(configuration=Task(...), repo=None)`