### PR TITLE
Multiple attachment improvements #747

### DIFF
--- a/src/dstack/_internal/cli/commands/logs.py
+++ b/src/dstack/_internal/cli/commands/logs.py
@@ -38,10 +38,7 @@ class LogsCommand(APIBaseCommand):
             if run.status.is_finished():
                 raise CLIError(f"Run {args.run_name} is finished")
             else:
-                try:
-                    run.attach(args.ssh_identity_file)
-                except PortUsedError:
-                    pass
+                run.attach(args.ssh_identity_file)
         logs = run.logs(diagnose=args.diagnose)
         try:
             for log in logs:

--- a/src/dstack/_internal/core/services/ssh/ports.py
+++ b/src/dstack/_internal/core/services/ssh/ports.py
@@ -58,7 +58,13 @@ class PortsLock:
         return mapping
 
     def dict(self) -> Dict[int, int]:
-        return {remote_port: sock.getsockname()[1] for remote_port, sock in self.sockets.items()}
+        d = {}
+        for remote_port, local_port in self.restrictions.items():
+            if local_port:
+                d[remote_port] = local_port
+            else:
+                d[remote_port] = self.sockets[remote_port].getsockname()[1]
+        return d
 
     @staticmethod
     def _listen(port: int) -> Optional[socket.socket]:

--- a/src/dstack/_internal/core/services/ssh/tunnel.py
+++ b/src/dstack/_internal/core/services/ssh/tunnel.py
@@ -134,12 +134,20 @@ class ClientTunnel(SSHTunnel):
     CLITunnel connects to the host from ssh config
     """
 
-    def __init__(self, host: str, ports: Dict[int, int], id_rsa_path: PathLike):
-        self.temp_dir = tempfile.TemporaryDirectory()
+    def __init__(
+        self,
+        host: str,
+        ports: Dict[int, int],
+        id_rsa_path: PathLike,
+        control_sock_path: Optional[str] = None,
+    ):
+        self.temp_dir = tempfile.TemporaryDirectory() if not control_sock_path else None
         super().__init__(
             host=host,
             id_rsa_path=id_rsa_path,
             ports=ports,
-            control_sock_path=os.path.join(self.temp_dir.name, "control.sock"),
+            control_sock_path=os.path.join(self.temp_dir.name, "control.sock")
+            if not control_sock_path
+            else control_sock_path,
             options={},
         )

--- a/src/dstack/_internal/utils/ssh.py
+++ b/src/dstack/_internal/utils/ssh.py
@@ -3,7 +3,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 
 from filelock import FileLock
 from paramiko.config import SSHConfig
@@ -51,6 +51,29 @@ def include_ssh_config(path: PathLike, ssh_config_path: PathLike = default_ssh_c
         if include not in content:
             with open(ssh_config_path, "w") as f:
                 f.write(include + content)
+
+
+def get_ssh_config(path: PathLike, host: str) -> Optional[Dict[str, str]]:
+    if os.path.exists(path):
+        config = {}
+        current_host = None
+
+        with open(path, "r") as f:
+            for line in f:
+                line = line.strip()
+
+                if not line or line.startswith("#"):
+                    continue
+
+                if line.startswith("Host "):
+                    current_host = line.split(" ")[1]
+                    config[current_host] = {}
+                else:
+                    key, value = line.split(maxsplit=1)
+                    config[current_host][key] = value
+        return config.get(host)
+    else:
+        return None
 
 
 def update_ssh_config(path: PathLike, host: str, options: Dict[str, str]):


### PR DESCRIPTION
- Allow to invoke `run.attach` without errors when the tunnel is already established by another process
- Allow to invoke `run.attach` on a run obtained via `client.runs.get` and have attached logs
- Support `-a` (`--attach`) in `dstack logs`
- Automatically detach from the run on the program's exit