### PR TITLE
Extend profile resources: GPU compute capability and total GPU memory

### DIFF
--- a/src/dstack/_internal/cli/utils/run.py
+++ b/src/dstack/_internal/cli/utils/run.py
@@ -1,11 +1,11 @@
-from typing import List, Optional
+from typing import List
 
 from rich.table import Table
 
 from dstack._internal.cli.utils.common import console
 from dstack._internal.core.models.instances import InstanceAvailability
 from dstack._internal.core.models.runs import RunPlan
-from dstack._internal.utils.common import pretty_date
+from dstack._internal.utils.common import pretty_date, pretty_resources
 from dstack.api import Run
 
 
@@ -17,16 +17,7 @@ def print_run_plan(run_plan: RunPlan, candidates_limit: int = 3):
     props.add_column()  # value
 
     req = job_plan.job_spec.requirements
-    if req.gpus:
-        resources = pretty_format_resources(
-            req.cpus,
-            req.memory_mib / 1024,
-            req.gpus.count,
-            req.gpus.name,
-            req.gpus.memory_mib / 1024 if req.gpus.memory_mib else None,
-        )
-    else:
-        resources = pretty_format_resources(req.cpus, req.memory_mib / 1024)
+    pretty_req = req.pretty_format(resources_only=True)
     max_price = f"${req.max_price:g}" if req.max_price else "-"
     max_duration = (
         f"{job_plan.job_spec.max_duration / 3600:g}h" if job_plan.job_spec.max_duration else "-"
@@ -38,9 +29,9 @@ def print_run_plan(run_plan: RunPlan, candidates_limit: int = 3):
         else "no"
     )
 
-    if job_plan.job_spec.requirements.spot is None:
+    if req.spot is None:
         spot_policy = "auto"
-    elif job_plan.job_spec.requirements.spot:
+    elif req.spot:
         spot_policy = "spot"
     else:
         spot_policy = "on-demand"
@@ -51,7 +42,7 @@ def print_run_plan(run_plan: RunPlan, candidates_limit: int = 3):
     props.add_row(th("Configuration"), run_plan.run_spec.configuration_path)
     props.add_row(th("Project"), run_plan.project_name)
     props.add_row(th("User"), run_plan.user)
-    props.add_row(th("Min resources"), resources)
+    props.add_row(th("Min resources"), pretty_req)
     props.add_row(th("Max price"), max_price)
     props.add_row(th("Max duration"), max_duration)
     props.add_row(th("Spot policy"), spot_policy)
@@ -71,16 +62,15 @@ def print_run_plan(run_plan: RunPlan, candidates_limit: int = 3):
 
     for i, c in enumerate(job_plan.candidates, start=1):
         r = c.instance.resources
+        resources = dict(cpus=r.cpus, memory=r.memory_mib)
         if r.gpus:
-            resources = pretty_format_resources(
-                r.cpus,
-                r.memory_mib / 1024,
-                len(r.gpus),
-                r.gpus[0].name,
-                r.gpus[0].memory_mib / 1024,
+            resources.update(
+                gpu_count=len(r.gpus),
+                gpu_name=r.gpus[0].name,
+                gpu_memory=r.gpus[0].memory_mib,
             )
-        else:
-            resources = pretty_format_resources(r.cpus, r.memory_mib / 1024)
+        resources = pretty_resources(**resources)
+
         availability = ""
         if c.availability in {InstanceAvailability.NOT_AVAILABLE, InstanceAvailability.NO_QUOTA}:
             availability = c.availability.value.replace("_", " ").title()
@@ -143,18 +133,3 @@ def generate_runs_table(
             renderables.append("TODO")  # TODO
         table.add_row(*renderables)
     return table
-
-
-def pretty_format_resources(
-    cpu: int,
-    memory: float,
-    gpu_count: Optional[int] = None,
-    gpu_name: Optional[str] = None,
-    gpu_memory: Optional[float] = None,
-) -> str:
-    s = f"{cpu}xCPUs, {memory:g}GB"
-    if gpu_count:
-        s += f", {gpu_count}x{gpu_name or 'GPU'}"
-        if gpu_memory:
-            s += f" ({gpu_memory:g}GB)"
-    return s

--- a/src/dstack/_internal/core/backends/base/offers.py
+++ b/src/dstack/_internal/core/backends/base/offers.py
@@ -28,6 +28,10 @@ def get_catalog_offers(
                 filters["min_gpu_memory"] = requirements.gpus.memory_mib / 1024
             if requirements.gpus.count is not None:
                 filters["min_gpu_count"] = requirements.gpus.count
+            if requirements.gpus.total_memory_mib is not None:
+                filters["min_total_gpu_memory"] = requirements.gpus.total_memory_mib / 1024
+            if requirements.gpus.compute_capability is not None:
+                filters["min_compute_capability"] = requirements.gpus.compute_capability
 
     offers = []
     for item in gpuhunt.query(**filters):

--- a/src/dstack/_internal/core/models/instances.py
+++ b/src/dstack/_internal/core/models/instances.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from pydantic import BaseModel
 
 from dstack._internal.core.models.backends.base import BackendType
+from dstack._internal.utils.common import pretty_resources
 
 
 class InstanceState(str, Enum):
@@ -25,6 +26,17 @@ class Resources(BaseModel):
     memory_mib: int
     gpus: List[Gpu]
     spot: bool
+
+    def pretty_format(self) -> str:
+        if not self.gpus:
+            return pretty_resources(cpus=self.cpus, memory=self.memory_mib)
+        return pretty_resources(
+            cpus=self.cpus,
+            memory=self.memory_mib,
+            gpu_count=len(self.gpus),
+            gpu_name=self.gpus[0].name,
+            gpu_memory=self.gpus[0].memory_mib,
+        )
 
 
 class InstanceType(BaseModel):

--- a/src/dstack/_internal/server/services/jobs/configurators/base.py
+++ b/src/dstack/_internal/server/services/jobs/configurators/base.py
@@ -142,6 +142,8 @@ class JobConfigurator(ABC):
                 count=self.run_spec.profile.resources.gpu.count,
                 memory_mib=self.run_spec.profile.resources.gpu.memory,
                 name=self.run_spec.profile.resources.gpu.name,
+                total_memory_mib=self.run_spec.profile.resources.gpu.total_memory,
+                compute_capability=self.run_spec.profile.resources.gpu.compute_capability,
             )
         return r
 

--- a/src/tests/_internal/cli/services/configurators/test_profile.py
+++ b/src/tests/_internal/cli/services/configurators/test_profile.py
@@ -17,6 +17,28 @@ from dstack._internal.core.models.profiles import (
 )
 
 
+class TestGPUComputeCapability:
+    def test_empty(self):
+        gpu = ProfileGPU()
+        assert gpu.compute_capability is None
+
+    def test_float(self):
+        gpu = ProfileGPU(compute_capability=7.5)
+        assert gpu.compute_capability == (7, 5)
+
+    def test_string(self):
+        gpu = ProfileGPU(compute_capability="8.1")
+        assert gpu.compute_capability == (8, 1)
+
+    def test_tuple(self):
+        gpu = ProfileGPU(compute_capability=(9, 0))
+        assert gpu.compute_capability == (9, 0)
+
+    def test_fail(self):
+        with pytest.raises(ValueError):
+            ProfileGPU(compute_capability="8.1.1")
+
+
 class TestGPUSpec:
     def test_name(self):
         assert gpu_spec("A100") == {"name": "A100"}


### PR DESCRIPTION
Closes #739 

* Add GPU compute capability as `profile.resources.gpu.compute_capability`
* Add total GPU memory as `profile.resources.gpu.total_memory`
* Set CPU and Memory to `None` by default
  * `gpuhunt` could set reasonable values based on requested GPU