### PR TITLE
Use args in Vast AI

### DIFF
--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -165,7 +165,6 @@ def get_docker_commands(authorized_keys: List[str]) -> List[str]:
         "ssh-keygen -A > /dev/null",
         # start sshd
         "/usr/sbin/sshd -p 10022 -o PermitUserEnvironment=yes",
-        "touch ~/.no_auto_tmux",
     ]
     build = get_dstack_runner_version()
     runner = "/usr/local/bin/dstack-runner"

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -173,8 +173,8 @@ def get_docker_commands(authorized_keys: List[str]) -> List[str]:
     if version.__is_release__:
         bucket = "dstack-runner-downloads"
     commands += [
-        f'sudo curl --output {runner} "https://{bucket}.s3.eu-west-1.amazonaws.com/{build}/binaries/dstack-runner-linux-amd64"',
-        f"sudo chmod +x {runner}",
+        f'curl --output {runner} "https://{bucket}.s3.eu-west-1.amazonaws.com/{build}/binaries/dstack-runner-linux-amd64"',
+        f"chmod +x {runner}",
         f"{runner} --log-level 6 start --http-port 10999 --temp-dir /tmp/runner --home-dir /root --working-dir /workflow",
     ]
     return commands

--- a/src/dstack/_internal/core/backends/vastai/api_client.py
+++ b/src/dstack/_internal/core/backends/vastai/api_client.py
@@ -1,3 +1,4 @@
+import shlex
 import threading
 import time
 from typing import List, Optional, Union
@@ -68,8 +69,9 @@ class VastAIAPIClient:
             "env": {
                 "-p 10022:10022": "1",
             },
-            "onstart": onstart,
-            "runtype": "ssh_direc",
+            "onstart": "/bin/sh",
+            "args": ["-c", onstart],
+            "runtype": "args",
             "image_login": image_login,
             "python_utf8": False,
             "lang_utf8": False,

--- a/src/dstack/_internal/core/backends/vastai/compute.py
+++ b/src/dstack/_internal/core/backends/vastai/compute.py
@@ -89,6 +89,8 @@ class VastAICompute(Compute):
                     and ": OCI runtime create failed:" in resp["status_msg"]
                 ):
                     raise ComputeError(resp["status_msg"])
+                # if resp["actual_status"] == "exited":
+                #     raise ComputeError(resp["status_msg"])
                 logger.debug(
                     "Waiting %s: %s", instance_id, {k: v for k, v in resp.items() if "stat" in k}
                 )


### PR DESCRIPTION
Closes #763 

* Use `args` configuration type in vastai backend
  * No second SSH server
  * PATH is preserved
* Add 429 retry and caching for vastai