### PR TITLE
Pass `backend_data` to `compute.terminate_instance`

### DIFF
--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -101,7 +101,9 @@ class AWSCompute(Compute):
             "stopped": InstanceState.STOPPED,
         }[state]
 
-    def terminate_instance(self, instance_id: str, region: str):
+    def terminate_instance(
+        self, instance_id: str, region: str, backend_data: Optional[str] = None
+    ):
         client = self.session.client("ec2", region_name=region)
         try:
             client.terminate_instances(InstanceIds=[instance_id])

--- a/src/dstack/_internal/core/backends/azure/compute.py
+++ b/src/dstack/_internal/core/backends/azure/compute.py
@@ -160,7 +160,9 @@ class AzureCompute(Compute):
         logger.info("Failed to request instance")
         raise NoCapacityError()
 
-    def terminate_instance(self, instance_id: str, region: str):
+    def terminate_instance(
+        self, instance_id: str, region: str, backend_data: Optional[str] = None
+    ):
         _terminate_instance(
             compute_client=self._compute_client,
             resource_group=self.config.resource_group,

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -34,7 +34,9 @@ class Compute(ABC):
         pass
 
     @abstractmethod
-    def terminate_instance(self, instance_id: str, region: str):
+    def terminate_instance(
+        self, instance_id: str, region: str, backend_data: Optional[str] = None
+    ):
         pass
 
     def get_instance_state(self, instance_id: str, region: str) -> InstanceState:

--- a/src/dstack/_internal/core/backends/gcp/compute.py
+++ b/src/dstack/_internal/core/backends/gcp/compute.py
@@ -67,7 +67,9 @@ class GCPCompute(Compute):
             offers_with_availability[key].region = region
         return list(offers_with_availability.values())
 
-    def terminate_instance(self, instance_id: str, region: str):
+    def terminate_instance(
+        self, instance_id: str, region: str, backend_data: Optional[str] = None
+    ):
         try:
             self.instances_client.delete(
                 project=self.config.project_id, zone=region, instance=instance_id

--- a/src/dstack/_internal/core/backends/lambdalabs/compute.py
+++ b/src/dstack/_internal/core/backends/lambdalabs/compute.py
@@ -74,7 +74,9 @@ class LambdaCompute(Compute):
             launch_command=launch_command,
         )
 
-    def terminate_instance(self, instance_id: str, region: str):
+    def terminate_instance(
+        self, instance_id: str, region: str, backend_data: Optional[str] = None
+    ):
         self.api_client.terminate_instances(instance_ids=[instance_id])
 
     def _get_offers_with_availability(

--- a/src/dstack/_internal/core/backends/local/compute.py
+++ b/src/dstack/_internal/core/backends/local/compute.py
@@ -35,7 +35,9 @@ class LocalCompute(Compute):
     def get_instance_state(self, instance_id: str, region: str) -> InstanceState:
         return InstanceState.RUNNING
 
-    def terminate_instance(self, instance_id: str, region: str):
+    def terminate_instance(
+        self, instance_id: str, region: str, backend_data: Optional[str] = None
+    ):
         pass
 
     def run_job(

--- a/src/dstack/_internal/core/backends/nebius/compute.py
+++ b/src/dstack/_internal/core/backends/nebius/compute.py
@@ -115,7 +115,9 @@ class NebiusCompute(Compute):
             dockerized=True,
         )
 
-    def terminate_instance(self, instance_id: str, region: str):
+    def terminate_instance(
+        self, instance_id: str, region: str, backend_data: Optional[str] = None
+    ):
         try:
             self.api_client.compute_instances_delete(instance_id)
         except NotFoundError:

--- a/src/dstack/_internal/core/backends/tensordock/compute.py
+++ b/src/dstack/_internal/core/backends/tensordock/compute.py
@@ -103,7 +103,9 @@ class TensorDockCompute(Compute):
             dockerized=True,
         )
 
-    def terminate_instance(self, instance_id: str, region: str):
+    def terminate_instance(
+        self, instance_id: str, region: str, backend_data: Optional[str] = None
+    ):
         try:
             self.api_client.delete_single(instance_id)
         except requests.HTTPError:

--- a/src/dstack/_internal/core/backends/vastai/api_client.py
+++ b/src/dstack/_internal/core/backends/vastai/api_client.py
@@ -21,7 +21,7 @@ class VastAIAPIClient:
         retries = Retry(
             total=5,
             backoff_factor=1,
-            status_forcelist=[429],
+            status_forcelist=[429, 504],
         )
         self.s.mount(prefix=self._url("/instances/"), adapter=HTTPAdapter(max_retries=retries))
         self.lock = threading.Lock()

--- a/src/dstack/_internal/core/backends/vastai/compute.py
+++ b/src/dstack/_internal/core/backends/vastai/compute.py
@@ -109,5 +109,7 @@ class VastAICompute(Compute):
             dockerized=False,
         )
 
-    def terminate_instance(self, instance_id: str, region: str):
+    def terminate_instance(
+        self, instance_id: str, region: str, backend_data: Optional[str] = None
+    ):
         self.api_client.destroy_instance(instance_id)

--- a/src/dstack/_internal/server/services/gateways.py
+++ b/src/dstack/_internal/server/services/gateways.py
@@ -128,7 +128,9 @@ async def delete_gateways(session: AsyncSession, project: ProjectModel, gateways
             continue
         backend = await get_project_backend_by_type(project, gateway.backend.type)
         tasks.append(
-            run_async(backend.compute().terminate_instance, gateway.instance_id, gateway.region)
+            run_async(
+                backend.compute().terminate_instance, gateway.instance_id, gateway.region, None
+            )
         )
         gateways.append(gateway)
     # terminate in parallel

--- a/src/dstack/_internal/server/services/jobs/__init__.py
+++ b/src/dstack/_internal/server/services/jobs/__init__.py
@@ -129,6 +129,7 @@ async def terminate_job_submission_instance(
         backend.compute().terminate_instance,
         job_submission.job_provisioning_data.instance_id,
         job_submission.job_provisioning_data.region,
+        job_submission.job_provisioning_data.backend_data,
     )
 
 


### PR DESCRIPTION
Closes #774

* Vast.AI: add retry on 504 status code