### PR TITLE
Tune job log levels

### DIFF
--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -52,6 +52,7 @@ class JobErrorCode(str, Enum):
     FAILED_TO_START_DUE_TO_NO_CAPACITY = "failed_to_start_due_to_no_capacity"
     INTERRUPTED_BY_NO_CAPACITY = "interrupted_by_no_capacity"
     WAITING_RUNNER_LIMIT_EXCEEDED = "waiting_runner_limit_exceeded"
+    TERMINATED_BY_USER = "terminated_by_user"
     # Set by the runner
     CONTAINER_EXITED_WITH_ERROR = "container_exited_with_error"
     PORTS_BINDING_FAILED = "ports_binding_failed"

--- a/src/dstack/_internal/server/background/tasks/process_finished_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_finished_jobs.py
@@ -10,6 +10,7 @@ from dstack._internal.server.services.jobs import (
     job_model_to_job_submission,
     terminate_job_submission_instance,
 )
+from dstack._internal.server.services.logging import job_log
 from dstack._internal.utils.common import get_current_datetime
 from dstack._internal.utils.logging import get_logger
 
@@ -54,9 +55,9 @@ async def _process_job(job_id):
                     job_submission=job_submission,
                 )
             job_model.removed = True
-            logger.debug("Job %s is marked as removed", job_model.job_name)
+            logger.info(*job_log("marked as removed", job_model))
         except Exception as e:
             job_model.removed = False
-            logger.error("Failed to terminate job instance %s: %s", job_model.job_name, e)
+            logger.error(*job_log("failed to terminate job instance: %s", job_model, e))
         job_model.last_processed_at = get_current_datetime()
         await session.commit()

--- a/src/dstack/_internal/server/services/backends/__init__.py
+++ b/src/dstack/_internal/server/services/backends/__init__.py
@@ -1,5 +1,6 @@
 import asyncio
 import heapq
+import time
 from typing import List, Optional, Tuple, Type, Union
 
 from sqlalchemy import delete, update

--- a/src/dstack/_internal/server/services/logging.py
+++ b/src/dstack/_internal/server/services/logging.py
@@ -1,0 +1,18 @@
+from typing import Any, List
+
+from dstack._internal.server.models import JobModel
+
+
+def job_log(message: str, job_model: JobModel, *args: Any) -> List[Any]:
+    """Build args for `logger.info` or similar.
+
+    Args:
+        message: c-style format string for `args`
+        job_model: job to log
+        *args: substituted into `message`
+
+    Returns:
+        final format string and args
+    """
+    # job_name is not unique across projects, so we add job_id prefix
+    return [f"(%s)%s: {message}", job_model.id.hex[:6], job_model.job_name, *args]


### PR DESCRIPTION
Closes #788 

* Use warning level for abnormal situations
* Use info level for status change
* Use debug level for everything else
* Add a uniform prefix to all job-related logs. Prefix includes job name and job_id prefix to distinguish collisions across projects
* Add JobErrorCode.TERMINATED_BY_USER

Sample logs for INFO level

```
INFO 2023-11-22T16:59:47.503 dstack._internal.server.background.tasks.process_submitted_jobs (01fbe8)angry-dragonfly-1-0: now is provisioning
INFO 2023-11-22T17:00:18.696 dstack._internal.server.background.tasks.process_running_jobs (01fbe8)angry-dragonfly-1-0: now is pulling
INFO 2023-11-22T17:00:56.844 dstack._internal.server.background.tasks.process_running_jobs (01fbe8)angry-dragonfly-1-0: now is running
INFO 2023-11-22T17:01:03.681 dstack._internal.server.services.jobs (01fbe8)angry-dragonfly-1-0: terminated by user
INFO 2023-11-22T17:01:21.888 dstack._internal.server.background.tasks.process_finished_jobs (01fbe8)angry-dragonfly-1-0: marked as removed
```