### PR TITLE
Add ServerAliveInterval

### DIFF
--- a/runner/internal/gateway/ssh.go
+++ b/runner/internal/gateway/ssh.go
@@ -2,10 +2,11 @@ package gateway
 
 import (
 	"fmt"
-	"github.com/dstackai/dstack/runner/internal/gerrors"
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/dstackai/dstack/runner/internal/gerrors"
 )
 
 type SSHControl struct {
@@ -42,6 +43,7 @@ func (c *SSHControl) exec(args []string, command string) ([]byte, error) {
 		"-o", fmt.Sprintf("ControlPath=%s", c.controlPath),
 		"-o", "ControlMaster=auto",
 		"-o", "ControlPersist=yes",
+		"-o", "ServerAliveInterval=60",
 	}
 	if args != nil {
 		allArgs = append(allArgs, args...)

--- a/src/dstack/_internal/server/services/gateways.py
+++ b/src/dstack/_internal/server/services/gateways.py
@@ -254,7 +254,7 @@ async def register_service_jobs(
         raise ServerClientError("Gateway has no instance associated with it")
 
     domain = gateway.wildcard_domain.lstrip("*.") if gateway.wildcard_domain else None
-    private_bytes, public_bytes = generate_rsa_key_pair_bytes(comment=f"{project}/{run_name}")
+    private_bytes, public_bytes = generate_rsa_key_pair_bytes(comment=f"{project.name}/{run_name}")
 
     job.job_spec.gateway.gateway_name = gateway.name
     job.job_spec.gateway.ssh_key = private_bytes.decode()


### PR DESCRIPTION
This fix prevents an SSH tunnel between the service and gateway from going down because of inactivity.