### PR TITLE
Make get_latest_runner_build robuster for editable installs

### DIFF
--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -241,6 +241,8 @@ def get_dstack_gateway_wheel(build: str) -> str:
 
 def get_dstack_gateway_commands() -> List[str]:
     build = get_dstack_runner_version()
+    if build == "latest":
+        raise ValueError("`latest` is not appropriate version for a gateway")
     return [
         "mkdir -p /home/ubuntu/dstack",
         "python3 -m venv /home/ubuntu/dstack/blue",

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -202,7 +202,7 @@ def get_latest_runner_build() -> Optional[str]:
     workflow_id = "build.yml"
     version_offset = 150
 
-    repo = git.Repo(search_parent_directories=True)
+    repo = git.Repo(os.path.abspath(os.path.dirname(__file__)), search_parent_directories=True)
     for remote in repo.remotes:
         if re.search(rf"[@/]github\.com[:/]{owner_repo}\.", remote.url):
             break


### PR DESCRIPTION
Use `__file__` instead of a current working directory to detect dstack repo