### PR TITLE
error in documentation: use --url instead of --server

### DIFF
--- a/docs/docs/installation/index.md
+++ b/docs/docs/installation/index.md
@@ -423,7 +423,7 @@ To configure the client on a different machine or for other projects, use [`dsta
 <div class="termy">
 
 ```shell
-$ dstack config --server &lt;your server adddress&gt; --project &lt;your project name&gt; --token &lt;your user token&gt;
+$ dstack config --url &lt;your server adddress&gt; --project &lt;your project name&gt; --token &lt;your user token&gt;
     
 Configurated is updated at ~/.dstack/config.yml
 ```


### PR DESCRIPTION
There must be error in documentation: no such option `--server`
```
$dstack --version
0.14.0

$dstack config --help
Usage: dstack config [-h] [--project PROJECT] [--url URL] [--token TOKEN]
                     [--default] [--remove] [--no-default]

Options:
  -h, --help         Show this help message and exit
  --project PROJECT  The name of the project to configure
  --url URL          Server url
  --token TOKEN      User token
  --default          Set the project as default. It will be used when
                     --project is omitted in commands.
  --remove           Delete project configuration
  --no-default       Do not prompt to set the project as default
```