### PR TITLE
Use python3.11 in generate-json-schema

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,6 +160,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
       - name: Install AWS
         run: pip install awscli
       - name: Install dstack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
       - name: Install AWS
         run: pip install awscli
       - name: Install dstack


### PR DESCRIPTION
Fixes #858 .

The CI was broken due to the behavior introduced by the new urllib3==2.2.0 release on Jan 30, 2024. The awscli pins urllib3<=2.1, but installing dstack on Python3.10 alongside caused the usage of urllib3==2.2.0. The problem does not occur on Python 3.11 (as opposed to Python 3.10 used in this CI step before).

If the problem happens again, consider pinning urllib3 in dstack deps.