### PR TITLE
Pools: fix failed instance status

### DIFF
--- a/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
@@ -178,7 +178,7 @@ async def _process_submitted_job(session: AsyncSession, job_model: JobModel):
             pool=pool,
             created_at=common_utils.get_current_datetime(),
             started_at=common_utils.get_current_datetime(),
-            status=InstanceStatus.BUSY,
+            status=InstanceStatus.STARTING,
             job_provisioning_data=job_provisioning_data.json(),
             offer=offer.json(),
             termination_policy=profile.termination_policy,

--- a/src/dstack/_internal/server/services/gateways/__init__.py
+++ b/src/dstack/_internal/server/services/gateways/__init__.py
@@ -314,6 +314,7 @@ async def init_gateways(session: AsyncSession):
     )
     gateway_computes = res.scalars().all()
 
+    logger.debug(f"Connecting to {len(gateway_computes)} gateways...")
     for gateway, error in await gather_map_async(
         gateway_computes,
         lambda g: gateway_connections_pool.add(g.ip_address, g.ssh_private_key),


### PR DESCRIPTION
* Register newly created instances as Starting, not Busy
* On the first successful health check set the status to Ready or Busy based on the assigned job field