### PR TITLE
Fix the SSH issues related to the default SSH config and too many identity files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ dist/
 
 /runner/cmd/shim/shim
 /runner/cmd/runner/runner
+
+/build

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,3 @@ dist/
 
 /runner/cmd/shim/shim
 /runner/cmd/runner/runner
-
-/build

--- a/gateway/src/dstack/gateway/services/tunnel.py
+++ b/gateway/src/dstack/gateway/services/tunnel.py
@@ -8,12 +8,9 @@ from typing import List, Optional
 
 from pydantic import BaseModel
 
-from dstack._internal.core.services.configs import ConfigManager
 from dstack.gateway.errors import SSHError
 
 logger = logging.getLogger(__name__)
-
-config = ConfigManager()
 
 
 class SSHTunnel(BaseModel):
@@ -45,7 +42,7 @@ class SSHTunnel(BaseModel):
         cmd = [
             "ssh",
             "-F",
-            str(config.dstack_ssh_config_path),
+            "none",
             "-i",
             id_rsa_path,
             "-M",
@@ -61,7 +58,7 @@ class SSHTunnel(BaseModel):
             proxy = [
                 "ssh",
                 "-F",
-                str(config.dstack_ssh_config_path),
+                "none",
                 "-i",
                 id_rsa_path,
                 "-W",

--- a/gateway/src/dstack/gateway/services/tunnel.py
+++ b/gateway/src/dstack/gateway/services/tunnel.py
@@ -8,9 +8,12 @@ from typing import List, Optional
 
 from pydantic import BaseModel
 
+from dstack._internal.core.services.configs import ConfigManager
 from dstack.gateway.errors import SSHError
 
 logger = logging.getLogger(__name__)
+
+config = ConfigManager()
 
 
 class SSHTunnel(BaseModel):
@@ -39,14 +42,31 @@ class SSHTunnel(BaseModel):
         os.chmod(temp_dir, 0o755)  # grant any user read access
         control_path = f"{temp_dir}/control"
 
-        cmd = ["ssh", "-i", id_rsa_path, "-M", "-S", control_path]
+        cmd = [
+            "ssh",
+            "-F",
+            str(config.dstack_ssh_config_path),
+            "-i",
+            id_rsa_path,
+            "-M",
+            "-S",
+            control_path,
+        ]
         cmd += ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null"]
         cmd += ["-o", "StreamLocalBindMask=0111", "-o", "StreamLocalBindUnlink=yes"]
         cmd += ["-o", "ServerAliveInterval=60"]
         cmd += ["-f", "-N", "-L", f"{_sock_path(temp_dir)}:localhost:{app_port}"]
         if docker_host is not None:
             # use `host` as a jump host
-            proxy = ["ssh", "-i", id_rsa_path, "-W", "%h:%p"]
+            proxy = [
+                "ssh",
+                "-F",
+                str(config.dstack_ssh_config_path),
+                "-i",
+                id_rsa_path,
+                "-W",
+                "%h:%p",
+            ]
             proxy += ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null"]
             proxy += ["-p", str(port), host]
             cmd += ["-o", f"ProxyCommand={shlex.join(proxy)}"]

--- a/gateway/src/dstack/gateway/services/tunnel.py
+++ b/gateway/src/dstack/gateway/services/tunnel.py
@@ -39,31 +39,14 @@ class SSHTunnel(BaseModel):
         os.chmod(temp_dir, 0o755)  # grant any user read access
         control_path = f"{temp_dir}/control"
 
-        cmd = [
-            "ssh",
-            "-F",
-            "none",
-            "-i",
-            id_rsa_path,
-            "-M",
-            "-S",
-            control_path,
-        ]
+        cmd = ["ssh", "-F", "none", "-i", id_rsa_path, "-M", "-S", control_path]
         cmd += ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null"]
         cmd += ["-o", "StreamLocalBindMask=0111", "-o", "StreamLocalBindUnlink=yes"]
         cmd += ["-o", "ServerAliveInterval=60"]
         cmd += ["-f", "-N", "-L", f"{_sock_path(temp_dir)}:localhost:{app_port}"]
         if docker_host is not None:
             # use `host` as a jump host
-            proxy = [
-                "ssh",
-                "-F",
-                "none",
-                "-i",
-                id_rsa_path,
-                "-W",
-                "%h:%p",
-            ]
+            proxy = ["ssh", "-F", "none", "-i", id_rsa_path, "-W", "%h:%p"]
             proxy += ["-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null"]
             proxy += ["-p", str(port), host]
             cmd += ["-o", f"ProxyCommand={shlex.join(proxy)}"]

--- a/runner/internal/gateway/ssh.go
+++ b/runner/internal/gateway/ssh.go
@@ -87,6 +87,6 @@ func (c *SSHControl) Publish(localPort, sockPath string) error {
 
 func (c *SSHControl) Cleanup() {
 	// todo cleanup remote
-	_ = exec.Command("ssh", "-o", "ControlPath="+c.controlPath, "-O", "exit", c.hostname).Run()
+	_ = exec.Command("ssh", "-F", "none", "-o", "ControlPath="+c.controlPath, "-O", "exit", c.hostname).Run()
 	_ = os.RemoveAll(c.localTempDir)
 }

--- a/runner/internal/shim/docker_test.go
+++ b/runner/internal/shim/docker_test.go
@@ -68,6 +68,7 @@ func TestDocker_SSHServerConnect(t *testing.T) {
 
 	for i := 0; i < timeout; i++ {
 		cmd := exec.Command("ssh",
+			"-F", "none",
 			"-o", "StrictHostKeyChecking=no",
 			"-o", "UserKnownHostsFile=/dev/null",
 			"-i", tempDir+"/id_rsa",

--- a/src/dstack/_internal/cli/utils/common.py
+++ b/src/dstack/_internal/cli/utils/common.py
@@ -28,8 +28,8 @@ def cli_error(e: DstackError) -> CLIError:
 
 def configure_logging():
     dstack_logger = logging.getLogger("dstack")
-    dstack_logger.setLevel(os.getenv("DSTACK_CLI_LOG_LEVEL", "CRITICAL").upper())
-    handler = DstackRichHandler(console=console)
+    dstack_logger.setLevel(os.getenv("DSTACK_CLI_LOG_LEVEL", "WARNING").upper())
+    handler = DstackRichHandler(console=console, markup=True)
     handler.setFormatter(logging.Formatter(fmt="%(message)s", datefmt="[%X]"))
     dstack_logger.addHandler(handler)
 

--- a/src/dstack/_internal/cli/utils/common.py
+++ b/src/dstack/_internal/cli/utils/common.py
@@ -29,7 +29,7 @@ def cli_error(e: DstackError) -> CLIError:
 def configure_logging():
     dstack_logger = logging.getLogger("dstack")
     dstack_logger.setLevel(os.getenv("DSTACK_CLI_LOG_LEVEL", "WARNING").upper())
-    handler = DstackRichHandler(console=console, markup=True)
+    handler = DstackRichHandler(console=console)
     handler.setFormatter(logging.Formatter(fmt="%(message)s", datefmt="[%X]"))
     dstack_logger.addHandler(handler)
 

--- a/src/dstack/_internal/core/backends/kubernetes/compute.py
+++ b/src/dstack/_internal/core/backends/kubernetes/compute.py
@@ -35,13 +35,10 @@ from dstack._internal.core.models.instances import (
     SSHConnectionParams,
 )
 from dstack._internal.core.models.runs import Job, Requirements, Run
-from dstack._internal.core.services.configs import ConfigManager
 from dstack._internal.utils.common import parse_memory
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
-
-config = ConfigManager()
 
 RUNNER_SSH_PORT = 10022
 JUMP_POD_SSH_PORT = 22
@@ -543,7 +540,7 @@ def _run_ssh_command(hostname: str, port: int, ssh_private_key: str, command: st
             [
                 "ssh",
                 "-F",
-                str(config.dstack_ssh_config_path),
+                "none",
                 "-o",
                 "StrictHostKeyChecking=no",
                 "-i",

--- a/src/dstack/_internal/core/backends/kubernetes/compute.py
+++ b/src/dstack/_internal/core/backends/kubernetes/compute.py
@@ -35,10 +35,13 @@ from dstack._internal.core.models.instances import (
     SSHConnectionParams,
 )
 from dstack._internal.core.models.runs import Job, Requirements, Run
+from dstack._internal.core.services.configs import ConfigManager
 from dstack._internal.utils.common import parse_memory
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+config = ConfigManager()
 
 RUNNER_SSH_PORT = 10022
 JUMP_POD_SSH_PORT = 22
@@ -539,6 +542,8 @@ def _run_ssh_command(hostname: str, port: int, ssh_private_key: str, command: st
         subprocess.run(
             [
                 "ssh",
+                "-F",
+                str(config.dstack_ssh_config_path),
                 "-o",
                 "StrictHostKeyChecking=no",
                 "-i",

--- a/src/dstack/_internal/core/backends/lambdalabs/compute.py
+++ b/src/dstack/_internal/core/backends/lambdalabs/compute.py
@@ -23,8 +23,11 @@ from dstack._internal.core.models.instances import (
     LaunchedInstanceInfo,
 )
 from dstack._internal.core.models.runs import Job, Requirements, Run
+from dstack._internal.core.services.configs import ConfigManager
 
 _SHIM_CONFIG_FILEPATH = "/home/ubuntu/.dstack/config.json"
+
+config = ConfigManager()
 
 
 class _ShimConfig(BaseModel):
@@ -272,6 +275,8 @@ def _run_ssh_command(hostname: str, ssh_private_key: str, command: str):
         subprocess.run(
             [
                 "ssh",
+                "-F",
+                str(config.dstack_ssh_config_path),
                 "-o",
                 "StrictHostKeyChecking=no",
                 "-i",
@@ -291,6 +296,8 @@ def _run_scp_command(hostname: str, ssh_private_key: str, source: str, target: s
         subprocess.run(
             [
                 "scp",
+                "-F",
+                str(config.dstack_ssh_config_path),
                 "-o",
                 "StrictHostKeyChecking=no",
                 "-i",

--- a/src/dstack/_internal/core/backends/lambdalabs/compute.py
+++ b/src/dstack/_internal/core/backends/lambdalabs/compute.py
@@ -23,11 +23,8 @@ from dstack._internal.core.models.instances import (
     LaunchedInstanceInfo,
 )
 from dstack._internal.core.models.runs import Job, Requirements, Run
-from dstack._internal.core.services.configs import ConfigManager
 
 _SHIM_CONFIG_FILEPATH = "/home/ubuntu/.dstack/config.json"
-
-config = ConfigManager()
 
 
 class _ShimConfig(BaseModel):
@@ -276,7 +273,7 @@ def _run_ssh_command(hostname: str, ssh_private_key: str, command: str):
             [
                 "ssh",
                 "-F",
-                str(config.dstack_ssh_config_path),
+                "none",
                 "-o",
                 "StrictHostKeyChecking=no",
                 "-i",
@@ -297,7 +294,7 @@ def _run_scp_command(hostname: str, ssh_private_key: str, source: str, target: s
             [
                 "scp",
                 "-F",
-                str(config.dstack_ssh_config_path),
+                "none",
                 "-o",
                 "StrictHostKeyChecking=no",
                 "-i",

--- a/src/dstack/_internal/core/services/ssh/attach.py
+++ b/src/dstack/_internal/core/services/ssh/attach.py
@@ -59,6 +59,7 @@ class SSHAttach:
                 "Port": ssh_port,
                 "User": user,
                 "IdentityFile": id_rsa_path,
+                "IdentitiesOnly": "yes",
                 "StrictHostKeyChecking": "no",
                 "UserKnownHostsFile": "/dev/null",
             }
@@ -68,6 +69,7 @@ class SSHAttach:
                 "Port": ssh_proxy.port,
                 "User": ssh_proxy.username,
                 "IdentityFile": id_rsa_path,
+                "IdentitiesOnly": "yes",
                 "StrictHostKeyChecking": "no",
                 "UserKnownHostsFile": "/dev/null",
             }
@@ -77,6 +79,7 @@ class SSHAttach:
                 "Port": 10022,
                 "User": "root",
                 "IdentityFile": id_rsa_path,
+                "IdentitiesOnly": "yes",
                 "StrictHostKeyChecking": "no",
                 "UserKnownHostsFile": "/dev/null",
                 "ControlPath": self.tunnel.control_sock_path,
@@ -90,6 +93,7 @@ class SSHAttach:
                 "Port": ssh_port,
                 "User": user,
                 "IdentityFile": id_rsa_path,
+                "IdentitiesOnly": "yes",
                 "StrictHostKeyChecking": "no",
                 "UserKnownHostsFile": "/dev/null",
                 "ControlPath": self.tunnel.control_sock_path,

--- a/src/dstack/_internal/core/services/ssh/attach.py
+++ b/src/dstack/_internal/core/services/ssh/attach.py
@@ -49,8 +49,13 @@ class SSHAttach:
         self._ports_lock = ports_lock
         self.ports = ports_lock.dict()
         self.run_name = run_name
+        self.ssh_config_path = str(ConfigManager().dstack_ssh_config_path)
         self.tunnel = ClientTunnel(
-            run_name, self.ports, id_rsa_path=id_rsa_path, control_sock_path=control_sock_path
+            run_name,
+            self.ports,
+            id_rsa_path=id_rsa_path,
+            control_sock_path=control_sock_path,
+            ssh_config_path=self.ssh_config_path,
         )
         self.ssh_proxy = ssh_proxy
         if ssh_proxy is None:
@@ -103,7 +108,6 @@ class SSHAttach:
             }
         else:
             self.container_config = None
-        self.ssh_config_path = str(ConfigManager().dstack_ssh_config_path)
 
     def attach(self):
         include_ssh_config(self.ssh_config_path)

--- a/src/dstack/_internal/core/services/ssh/tunnel.py
+++ b/src/dstack/_internal/core/services/ssh/tunnel.py
@@ -32,7 +32,18 @@ class SSHTunnel:
 
     def open(self):
         # ControlMaster and ControlPath are always set
-        command = ["ssh", "-f", "-N", "-M", "-S", self.control_sock_path, "-i", self.id_rsa_path]
+        command = [
+            "ssh",
+            "-o",
+            "IdentitiesOnly=yes",
+            "-f",
+            "-N",
+            "-M",
+            "-S",
+            self.control_sock_path,
+            "-i",
+            self.id_rsa_path,
+        ]
         for k, v in self.options.items():
             command += ["-o", f"{k}={v}"]
         for port_remote, port_local in self.ports.items():

--- a/src/dstack/_internal/core/services/ssh/tunnel.py
+++ b/src/dstack/_internal/core/services/ssh/tunnel.py
@@ -5,11 +5,14 @@ import tempfile
 from typing import Dict, Optional
 
 from dstack._internal.core.models.instances import SSHConnectionParams
+from dstack._internal.core.services.configs import ConfigManager
 from dstack._internal.core.services.ssh import get_ssh_error
 from dstack._internal.utils.logging import get_logger
 from dstack._internal.utils.path import PathLike
 
 logger = get_logger(__name__)
+
+config = ConfigManager()
 
 
 class SSHTunnel:
@@ -34,8 +37,8 @@ class SSHTunnel:
         # ControlMaster and ControlPath are always set
         command = [
             "ssh",
-            "-o",
-            "IdentitiesOnly=yes",
+            "-F",
+            str(config.dstack_ssh_config_path),
             "-f",
             "-N",
             "-M",
@@ -100,7 +103,15 @@ class RunnerTunnel(SSHTunnel):
             control_sock_path = os.path.join(self.temp_dir.name, "control.sock")
         options = {}
         if ssh_proxy is not None:
-            proxy_command = ["ssh", "-i", id_rsa_path, "-W", "%h:%p"]
+            proxy_command = [
+                "ssh",
+                "-F",
+                str(config.dstack_ssh_config_path),
+                "-i",
+                id_rsa_path,
+                "-W",
+                "%h:%p",
+            ]
             proxy_command += [
                 "-o",
                 "StrictHostKeyChecking=no",

--- a/src/dstack/_internal/server/services/ssh/__init__.py
+++ b/src/dstack/_internal/server/services/ssh/__init__.py
@@ -5,10 +5,13 @@ import tempfile
 from typing import Any, Dict, List, Optional
 
 from dstack._internal.core.errors import SSHError
+from dstack._internal.core.services.configs import ConfigManager
 from dstack._internal.core.services.ssh import get_ssh_error
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+config = ConfigManager()
 
 
 class SSHAutoTunnel:
@@ -21,7 +24,15 @@ class SSHAutoTunnel:
         ) as f:
             f.write(id_rsa)
 
-        self._start_cmd = ["ssh", "-i", self.id_rsa, "-f", "-N"]
+        self._start_cmd = [
+            "ssh",
+            "-F",
+            str(config.dstack_ssh_config_path),
+            "-i",
+            self.id_rsa,
+            "-f",
+            "-N",
+        ]
         self._start_cmd += ["-M", "-S", self.control_sock_path]
         for key, value in options.items():
             self._start_cmd += ["-o", f"{key}={value}"]

--- a/src/dstack/_internal/server/services/ssh/__init__.py
+++ b/src/dstack/_internal/server/services/ssh/__init__.py
@@ -21,15 +21,7 @@ class SSHAutoTunnel:
         ) as f:
             f.write(id_rsa)
 
-        self._start_cmd = [
-            "ssh",
-            "-F",
-            "none",
-            "-i",
-            self.id_rsa,
-            "-f",
-            "-N",
-        ]
+        self._start_cmd = ["ssh", "-F", "none", "-i", self.id_rsa, "-f", "-N"]
         self._start_cmd += ["-M", "-S", self.control_sock_path]
         for key, value in options.items():
             self._start_cmd += ["-o", f"{key}={value}"]

--- a/src/dstack/_internal/server/services/ssh/__init__.py
+++ b/src/dstack/_internal/server/services/ssh/__init__.py
@@ -5,13 +5,10 @@ import tempfile
 from typing import Any, Dict, List, Optional
 
 from dstack._internal.core.errors import SSHError
-from dstack._internal.core.services.configs import ConfigManager
 from dstack._internal.core.services.ssh import get_ssh_error
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
-
-config = ConfigManager()
 
 
 class SSHAutoTunnel:
@@ -27,7 +24,7 @@ class SSHAutoTunnel:
         self._start_cmd = [
             "ssh",
             "-F",
-            str(config.dstack_ssh_config_path),
+            "none",
             "-i",
             self.id_rsa,
             "-f",

--- a/src/dstack/_internal/utils/ssh.py
+++ b/src/dstack/_internal/utils/ssh.py
@@ -9,9 +9,12 @@ from filelock import FileLock
 from paramiko.config import SSHConfig
 from paramiko.pkey import PKey, PublicBlob
 
+from dstack._internal.core.services.configs import ConfigManager
 from dstack._internal.utils.path import PathLike
 
 default_ssh_config_path = "~/.ssh/config"
+
+config = ConfigManager()
 
 
 def get_public_key_fingerprint(text: str) -> str:
@@ -29,7 +32,7 @@ def get_host_config(hostname: str, ssh_config_path: PathLike = default_ssh_confi
 
 
 def make_ssh_command_for_git(identity_file: PathLike) -> str:
-    return f"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -F /dev/null -o IdentityFile={identity_file}"
+    return f"ssh -F {config.dstack_ssh_config_path} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -F /dev/null -o IdentityFile={identity_file}"
 
 
 def try_ssh_key_passphrase(identity_file: PathLike, passphrase: str = "") -> bool:

--- a/src/dstack/_internal/utils/ssh.py
+++ b/src/dstack/_internal/utils/ssh.py
@@ -9,12 +9,9 @@ from filelock import FileLock
 from paramiko.config import SSHConfig
 from paramiko.pkey import PKey, PublicBlob
 
-from dstack._internal.core.services.configs import ConfigManager
 from dstack._internal.utils.path import PathLike
 
 default_ssh_config_path = "~/.ssh/config"
-
-config = ConfigManager()
 
 
 def get_public_key_fingerprint(text: str) -> str:
@@ -32,7 +29,7 @@ def get_host_config(hostname: str, ssh_config_path: PathLike = default_ssh_confi
 
 
 def make_ssh_command_for_git(identity_file: PathLike) -> str:
-    return f"ssh -F {config.dstack_ssh_config_path} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -F /dev/null -o IdentityFile={identity_file}"
+    return f"ssh -F none -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -F /dev/null -o IdentityFile={identity_file}"
 
 
 def try_ssh_key_passphrase(identity_file: PathLike, passphrase: str = "") -> bool:

--- a/src/dstack/_internal/utils/ssh.py
+++ b/src/dstack/_internal/utils/ssh.py
@@ -68,7 +68,8 @@ def include_ssh_config(path: PathLike, ssh_config_path: PathLike = default_ssh_c
                     f"The `[code]vscode://vscode-remote/ssh-remote+<run name>/workflow[/]` link and "
                     f"the `[code]ssh <run name>[/]` command won't work.\n\n"
                     f"To fix this, make sure `[code]{ssh_config_path}[/]` is writable, or add "
-                    f"`[code]Include {path}[/]` to the top of `[code]{ssh_config_path}[/]` manually."
+                    f"`[code]Include {path}[/]` to the top of `[code]{ssh_config_path}[/]` manually.",
+                    extra={"markup": True},
                 )
 
 

--- a/src/dstack/_internal/utils/ssh.py
+++ b/src/dstack/_internal/utils/ssh.py
@@ -9,7 +9,10 @@ from filelock import FileLock
 from paramiko.config import SSHConfig
 from paramiko.pkey import PKey, PublicBlob
 
+from dstack._internal.utils.logging import get_logger
 from dstack._internal.utils.path import PathLike
+
+logger = get_logger(__name__)
 
 default_ssh_config_path = "~/.ssh/config"
 
@@ -60,10 +63,12 @@ def include_ssh_config(path: PathLike, ssh_config_path: PathLike = default_ssh_c
                 with open(ssh_config_path, "w") as f:
                     f.write(include + content)
             except PermissionError:
-                print(f"Couldn't write to {ssh_config_path} due to a permissions problem")
-                print(f"Please include the following ssh config file manually: {path}")
-                print(
-                    f"You can do that by adding `Include {path}` to the top of {ssh_config_path}"
+                logger.warning(
+                    f"Couldn't update `[code]{ssh_config_path}[/]` due to a permissions problem.\n\n"
+                    f"The `[code]vscode://vscode-remote/ssh-remote+<run name>/workflow[/]` link and "
+                    f"the `[code]ssh <run name>[/]` command won't work.\n\n"
+                    f"To fix this, make sure `[code]{ssh_config_path}[/]` is writable, or add "
+                    f"`[code]Include {path}[/]` to the top of `[code]{ssh_config_path}[/]` manually."
                 )
 
 

--- a/src/dstack/_internal/utils/ssh.py
+++ b/src/dstack/_internal/utils/ssh.py
@@ -56,8 +56,15 @@ def include_ssh_config(path: PathLike, ssh_config_path: PathLike = default_ssh_c
             with open(ssh_config_path, "r") as f:
                 content = f.read()
         if include not in content:
-            with open(ssh_config_path, "w") as f:
-                f.write(include + content)
+            try:
+                with open(ssh_config_path, "w") as f:
+                    f.write(include + content)
+            except PermissionError:
+                print(f"Couldn't write to {ssh_config_path} due to a permissions problem")
+                print(f"Please include the following ssh config file manually: {path}")
+                print(
+                    f"You can do that by adding `Include {path}` to the top of {ssh_config_path}"
+                )
 
 
 def get_ssh_config(path: PathLike, host: str) -> Optional[Dict[str, str]]:


### PR DESCRIPTION
This PR addresses the following issues:

- #927
- #933
- #937

Implementation notes:

1. For issue 927, use `IdentitiesOnly` in the client SSH config
2. For issue 933, use `-F <client dstack SSH config path>` on the client, and `-F none` in other places when invoking the `ssh` command to exclude the default SSH config settings
3. For issue 937, display a clear error message