### PR TITLE
Refactor pools

### DIFF
--- a/docs/docs/reference/cli/index.md
+++ b/docs/docs/reference/cli/index.md
@@ -164,7 +164,7 @@ $ dstack pool create --help
 
 ##### dstack pool list
 
-The `dstack pool delete` lists all existing pools.
+The `dstack pool list` lists all existing pools.
 
 <div class="termy">
 
@@ -182,7 +182,7 @@ The `dstack pool delete` command deletes a specified pool.
 <div class="termy">
 
 ```shell
-$ dstack gateway update --help
+$ dstack pool delete --help
 #GENERATE#
 ```
 

--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -219,6 +219,11 @@ class RunPlan(BaseModel):
     job_plans: List[JobPlan]
 
 
+class PoolInstanceOffers(BaseModel):
+    pool_name: str
+    instances: List[InstanceOfferWithAvailability]
+
+
 class InstanceStatus(str, Enum):
     PENDING = "pending"
     CREATING = "creating"

--- a/src/dstack/_internal/server/models.py
+++ b/src/dstack/_internal/server/models.py
@@ -87,7 +87,7 @@ class ProjectModel(BaseModel):
     default_pool_id: Mapped[Optional[UUIDType]] = mapped_column(
         ForeignKey("pools.id", use_alter=True, ondelete="SET NULL"), nullable=True
     )
-    default_pool: Mapped["PoolModel"] = relationship(
+    default_pool: Mapped[Optional["PoolModel"]] = relationship(
         foreign_keys=[default_pool_id], lazy="selectin"
     )
 

--- a/src/dstack/_internal/server/routers/pools.py
+++ b/src/dstack/_internal/server/routers/pools.py
@@ -6,16 +6,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import dstack._internal.core.models.pools as models
 import dstack._internal.server.schemas.pools as schemas
 import dstack._internal.server.services.pools as pools
-from dstack._internal.core.errors import ResourceNotExistsError
 from dstack._internal.server.db import get_session
 from dstack._internal.server.models import ProjectModel, UserModel
 from dstack._internal.server.schemas.runs import AddRemoteInstanceRequest
 from dstack._internal.server.security.permissions import ProjectMember
-from dstack._internal.server.services.runs import (
-    abort_runs_of_pool,
-    list_project_runs,
-    run_model_to_run,
-)
 
 router = APIRouter(prefix="/api/project/{project_name}/pool", tags=["pool"])
 
@@ -26,7 +20,47 @@ async def list_pool(
     user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectMember()),
 ) -> List[models.Pool]:
     _, project = user_project
-    return await pools.list_project_pool(session=session, project=project)
+    return await pools.list_project_pools(session=session, project=project)
+
+
+@router.post("/create")
+async def create_pool(
+    body: schemas.CreatePoolRequest,
+    session: AsyncSession = Depends(get_session),
+    user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectMember()),
+) -> None:
+    _, project = user_project
+    await pools.create_pool(session=session, project=project, name=body.name)
+
+
+@router.post("/set_default")
+async def set_default_pool(
+    body: schemas.SetDefaultPoolRequest,
+    session: AsyncSession = Depends(get_session),
+    user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectMember()),
+):
+    _, project_model = user_project
+    await pools.set_default_pool(session, project_model, body.pool_name)
+
+
+@router.post("/delete")
+async def delete_pool(
+    body: schemas.DeletePoolRequest,
+    session: AsyncSession = Depends(get_session),
+    user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectMember()),
+) -> None:
+    _, project = user_project
+    await pools.delete_pool(session, project, body.name)
+
+
+@router.post("/show")
+async def show_pool(
+    body: schemas.ShowPoolRequest,
+    session: AsyncSession = Depends(get_session),
+    user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectMember()),
+) -> models.PoolInstances:
+    _, project = user_project
+    return await pools.show_pool_instances(session, project, pool_name=body.name)
 
 
 @router.post("/remove")
@@ -39,71 +73,6 @@ async def remove_instance(
     await pools.remove_instance(
         session, project_model, body.pool_name, body.instance_name, body.force
     )
-
-
-@router.post("/set_default")
-async def set_default_pool(
-    body: schemas.SetDefaultPoolRequest,
-    session: AsyncSession = Depends(get_session),
-    user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectMember()),
-) -> bool:
-    _, project_model = user_project
-    return await pools.set_default_pool(session, project_model, body.pool_name)
-
-
-@router.post("/delete")
-async def delete_pool(
-    body: schemas.DeletePoolRequest,
-    session: AsyncSession = Depends(get_session),
-    user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectMember()),
-) -> None:
-    pool_name = body.name
-    _, project_model = user_project
-
-    if body.force:
-        await abort_runs_of_pool(session, project_model, pool_name)
-        await pools.delete_pool(session, project_model, pool_name)
-        return
-
-    # check active runs
-    runs = await list_project_runs(session, project_model, repo_id=None)
-    active_runs = []
-    for run_model in runs:
-        if run_model.status.is_finished():
-            continue
-        run = run_model_to_run(run_model)
-        run_pool_name = run.run_spec.profile.pool_name
-        if run_pool_name == pool_name:
-            active_runs.append(run)
-    if active_runs:
-        return
-
-    # TODO: check active instances
-
-    await pools.delete_pool(session, project_model, pool_name)
-
-
-@router.post("/create")
-async def create_pool(
-    body: schemas.CreatePoolRequest,
-    session: AsyncSession = Depends(get_session),
-    user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectMember()),
-) -> None:
-    _, project = user_project
-    await pools.create_pool_model(session=session, project=project, name=body.name)
-
-
-@router.post("/show")
-async def show_pool(
-    body: schemas.ShowPoolRequest,
-    session: AsyncSession = Depends(get_session),
-    user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectMember()),
-) -> models.PoolInstances:
-    _, project = user_project
-    instances = await pools.show_pool(session, project, pool_name=body.name)
-    if instances is None:
-        raise ResourceNotExistsError("Pool is not found")
-    return instances
 
 
 @router.post("/add_remote")

--- a/src/dstack/_internal/server/schemas/runs.py
+++ b/src/dstack/_internal/server/schemas/runs.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 from pydantic import BaseModel
 
-from dstack._internal.core.models.instances import InstanceOfferWithAvailability, SSHKey
+from dstack._internal.core.models.instances import SSHKey
 from dstack._internal.core.models.profiles import Profile
 from dstack._internal.core.models.resources import ResourcesSpec
 from dstack._internal.core.models.runs import Requirements, RunSpec
@@ -24,11 +24,6 @@ class GetRunPlanRequest(BaseModel):
 class GetOffersRequest(BaseModel):
     profile: Profile
     requirements: Requirements
-
-
-class GetOffersResponse(BaseModel):
-    pool_name: str
-    instances: List[InstanceOfferWithAvailability]
 
 
 class CreateInstanceRequest(BaseModel):

--- a/src/dstack/api/_public/runs.py
+++ b/src/dstack/api/_public/runs.py
@@ -7,7 +7,7 @@ from abc import ABC
 from copy import copy
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Tuple, Union
+from typing import Dict, Iterable, List, Optional, Union
 
 from websocket import WebSocketApp
 
@@ -15,7 +15,7 @@ import dstack.api as api
 from dstack._internal.core.errors import ConfigurationError, ResourceNotExistsError
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.configurations import AnyRunConfiguration
-from dstack._internal.core.models.instances import InstanceOfferWithAvailability, SSHKey
+from dstack._internal.core.models.instances import SSHKey
 from dstack._internal.core.models.pools import Instance
 from dstack._internal.core.models.profiles import (
     DEFAULT_RUN_TERMINATION_IDLE_TIME,
@@ -27,7 +27,13 @@ from dstack._internal.core.models.profiles import (
 )
 from dstack._internal.core.models.repos.base import Repo
 from dstack._internal.core.models.resources import ResourcesSpec
-from dstack._internal.core.models.runs import JobSpec, Requirements, RunPlan, RunSpec
+from dstack._internal.core.models.runs import (
+    JobSpec,
+    PoolInstanceOffers,
+    Requirements,
+    RunPlan,
+    RunSpec,
+)
 from dstack._internal.core.models.runs import JobStatus as RunStatus
 from dstack._internal.core.models.runs import Run as RunModel
 from dstack._internal.core.services.logs import URLReplacer
@@ -365,9 +371,7 @@ class RunCollection:
         )
         return self.exec_plan(run_plan, repo, reserve_ports=reserve_ports)
 
-    def get_offers(
-        self, profile: Profile, requirements: Requirements
-    ) -> Tuple[str, List[InstanceOfferWithAvailability]]:
+    def get_offers(self, profile: Profile, requirements: Requirements) -> PoolInstanceOffers:
         return self._api_client.runs.get_offers(self._project, profile, requirements)
 
     def create_instance(

--- a/src/dstack/api/server/_pools.py
+++ b/src/dstack/api/server/_pools.py
@@ -36,10 +36,9 @@ class PoolAPIClient(APIClientGroup):
         )
         self._request(f"/api/project/{project_name}/pool/remove", body=body.json())
 
-    def set_default(self, project_name: str, pool_name: str) -> bool:
+    def set_default(self, project_name: str, pool_name: str) -> None:
         body = schemas_pools.SetDefaultPoolRequest(pool_name=pool_name)
-        result = self._request(f"/api/project/{project_name}/pool/set_default", body=body.json())
-        return bool(result.json())
+        self._request(f"/api/project/{project_name}/pool/set_default", body=body.json())
 
     def add_remote(
         self,

--- a/src/dstack/api/server/_runs.py
+++ b/src/dstack/api/server/_runs.py
@@ -1,16 +1,21 @@
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from pydantic import parse_obj_as
 
-from dstack._internal.core.models.instances import InstanceOfferWithAvailability, SSHKey
+from dstack._internal.core.models.instances import SSHKey
 from dstack._internal.core.models.pools import Instance
 from dstack._internal.core.models.profiles import Profile
-from dstack._internal.core.models.runs import Requirements, Run, RunPlan, RunSpec
+from dstack._internal.core.models.runs import (
+    PoolInstanceOffers,
+    Requirements,
+    Run,
+    RunPlan,
+    RunSpec,
+)
 from dstack._internal.server.schemas.runs import (
     CreateInstanceRequest,
     DeleteRunsRequest,
     GetOffersRequest,
-    GetOffersResponse,
     GetRunPlanRequest,
     GetRunRequest,
     ListRunsRequest,
@@ -33,11 +38,10 @@ class RunsAPIClient(APIClientGroup):
 
     def get_offers(
         self, project_name: str, profile: Profile, requirements: Requirements
-    ) -> Tuple[str, List[InstanceOfferWithAvailability]]:
+    ) -> PoolInstanceOffers:
         body = GetOffersRequest(profile=profile, requirements=requirements)
         resp = self._request(f"/api/project/{project_name}/runs/get_offers", body=body.json())
-        response = parse_obj_as(GetOffersResponse, resp.json())
-        return response.pool_name, response.instances
+        return parse_obj_as(PoolInstanceOffers, resp.json())
 
     def create_instance(
         self,

--- a/src/tests/_internal/server/background/tasks/test_process_submitted_jobs.py
+++ b/src/tests/_internal/server/background/tasks/test_process_submitted_jobs.py
@@ -19,7 +19,7 @@ from dstack._internal.core.models.runs import InstanceStatus, JobStatus
 from dstack._internal.server.background.tasks.process_submitted_jobs import process_submitted_jobs
 from dstack._internal.server.models import JobModel
 from dstack._internal.server.services.pools import (
-    get_or_create_default_pool_by_name,
+    get_or_create_pool_by_name,
 )
 from dstack._internal.server.testing.common import (
     create_instance,
@@ -207,7 +207,7 @@ class TestProcessSubmittedJobs:
             session=session,
             project_id=project.id,
         )
-        pool = await get_or_create_default_pool_by_name(session, project, pool_name=None)
+        pool = await get_or_create_pool_by_name(session, project, pool_name=None)
         instance = await create_instance(
             session=session,
             project=project,

--- a/src/tests/_internal/server/services/test_pools.py
+++ b/src/tests/_internal/server/services/test_pools.py
@@ -1,156 +1,27 @@
-import datetime as dt
 import uuid
-from unittest.mock import patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import dstack._internal.server.services.pools as services_pools
-import dstack._internal.server.services.projects as services_projects
-import dstack._internal.server.services.runs as runs
-import dstack._internal.server.services.users as services_users
-from dstack._internal.core.models import resources
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.instances import (
-    InstanceAvailability,
-    InstanceOfferWithAvailability,
     InstanceType,
-    LaunchedInstanceInfo,
     Resources,
-    SSHKey,
 )
-from dstack._internal.core.models.pools import Instance, Pool
-from dstack._internal.core.models.profiles import Profile
-from dstack._internal.core.models.runs import InstanceStatus, Requirements
-from dstack._internal.core.models.users import GlobalRole
+from dstack._internal.core.models.pools import Instance
+from dstack._internal.core.models.runs import InstanceStatus
 from dstack._internal.server.models import InstanceModel
 from dstack._internal.server.testing.common import create_project, create_user
 from dstack._internal.utils.common import get_current_datetime
 
 
-class TestPoolService:
+class TestGenerateInstanceName:
     @pytest.mark.asyncio
-    async def test_pool_smoke(self, session: AsyncSession, test_db):
+    async def test_generates_instance_name(self, session: AsyncSession, test_db):
         user = await create_user(session=session)
         project = await create_project(session=session, owner=user)
-        pool = await services_pools.create_pool_model(
-            session=session, project=project, name="test_pool"
-        )
-        im = InstanceModel(
-            name="test_instnce",
-            project=project,
-            pool=pool,
-            status=InstanceStatus.PENDING,
-            job_provisioning_data="",
-            offer="",
-            region="",
-            price=1,
-            backend=BackendType.LOCAL,
-        )
-        session.add(im)
-        await session.commit()
-        await session.refresh(pool)
-
-        core_model_pool = services_pools.pool_model_to_pool(pool)
-        assert core_model_pool == Pool(
-            name="test_pool",
-            default=True,
-            created_at=pool.created_at.replace(tzinfo=dt.timezone.utc),  # ???
-            total_instances=1,
-            available_instances=0,
-        )
-
-        list_pools = await services_pools.list_project_pool(session=session, project=project)
-        assert list_pools == [services_pools.pool_model_to_pool(pool)]
-
-        list_pool_models = await services_pools.list_project_pool_models(
-            session=session, project=project
-        )
-        assert len(list_pool_models) == 1
-
-        pool_intances = await services_pools.get_pool_instances(session, project, "test_pool")
-        assert pool_intances == [im]
-
-    @pytest.mark.asyncio
-    async def test_delete_pool(self, session: AsyncSession, test_db):
-        POOL_NAME = "test_pool"
-        user = await services_users.create_user(session, "test_user", global_role=GlobalRole.ADMIN)
-        project = await services_projects.create_project(session, user, "test_project")
-        project_model = await services_projects.get_project_model_by_name_or_error(
-            session, project.project_name
-        )
-        pool = await services_pools.create_pool_model(session, project_model, POOL_NAME)
-
-        await services_pools.delete_pool(session, project_model, POOL_NAME)
-
-        deleted_pools = await services_pools.list_deleted_pools(session, project_model)
-        assert len(deleted_pools) == 1
-        assert pool.name == deleted_pools[0].name
-
-    @pytest.mark.asyncio
-    async def test_show_pool(self, session: AsyncSession, test_db):
-        POOL_NAME = "test_pool"
-        user = await create_user(session=session)
-        project = await create_project(session=session, owner=user)
-        pool = await services_pools.create_pool_model(
-            session=session, project=project, name=POOL_NAME
-        )
-        im = InstanceModel(
-            name="test_instnce",
-            project=project,
-            pool=pool,
-            status=InstanceStatus.PENDING,
-            job_provisioning_data='{"ssh_proxy":null, "backend":"local","hostname":"hostname_test","region":"eu-west","price":1.0,"username":"user1","ssh_port":12345,"dockerized":false,"instance_id":"test_instance","instance_type": {"name": "instance", "resources": {"cpus": 1, "memory_mib": 512, "gpus": [], "spot": false, "disk": {"size_mib": 102400}, "description":""}}}',
-            offer='{"price":"LOCAL", "price":1.0, "backend":"local", "region":"eu-west-1", "availability":"available","instance": {"name": "instance", "resources": {"cpus": 1, "memory_mib": 512, "gpus": [], "spot": false, "disk": {"size_mib": 102400}, "description":""}}}',
-            region="eu-west",
-            price=1,
-            backend=BackendType.LOCAL,
-        )
-        session.add(im)
-        await session.commit()
-
-        pool_instances = await services_pools.show_pool(session, project, POOL_NAME)
-        assert len(pool_instances.instances) == 1
-
-    @pytest.mark.asyncio
-    async def test_get_pool_instances(self, session: AsyncSession, test_db):
-        POOL_NAME = "test_pool"
-        user = await create_user(session=session)
-        project = await create_project(session=session, owner=user)
-        pool = await services_pools.create_pool_model(
-            session=session, project=project, name=POOL_NAME
-        )
-        im = InstanceModel(
-            name="test_instnce",
-            project=project,
-            pool=pool,
-            status=InstanceStatus.PENDING,
-            job_provisioning_data='{"backend":"local","hostname":"hostname_test","region":"eu-west","price":1.0,"username":"user1","ssh_port":12345,"dockerized":false,"instance_id":"test_instance","instance_type": {"name": "instance", "resources": {"cpus": 1, "memory_mib": 512, "gpus": [], "spot": false, "disk": {"size_mib": 102400}, "description":""}}}',
-            offer='{"price":"LOCAL", "price":1.0, "backend":"local", "region":"eu-west-1", "availability":"available","instance": {"name": "instance", "resources": {"cpus": 1, "memory_mib": 512, "gpus": [], "spot": false, "disk": {"size_mib": 102400}, "description":""}}}',
-            region="eu-west",
-            price=1,
-            backend=BackendType.LOCAL,
-        )
-        session.add(im)
-        await session.commit()
-
-        instances = await services_pools.get_pool_instances(session, project, POOL_NAME)
-        assert len(instances) == 1
-
-        empty_instances = await services_pools.get_pool_instances(
-            session, project, f"{POOL_NAME}-0"
-        )
-        assert len(empty_instances) == 0
-
-
-class TestPoolUtils:
-    @pytest.mark.asyncio
-    async def test_generate_instance_name(self, session: AsyncSession, test_db):
-        user = await create_user(session=session)
-        project = await create_project(session=session, owner=user)
-        pool = await services_pools.create_pool_model(
-            session=session, project=project, name="test_pool"
-        )
+        pool = await services_pools.create_pool(session=session, project=project, name="test_pool")
         im = InstanceModel(
             name="test_instnce",
             project=project,
@@ -172,7 +43,9 @@ class TestPoolUtils:
         assert len(car) > 0
         assert len(cdr) > 0
 
-    def test_convert_instance(self):
+
+class TestInstanceModelToInstance:
+    def test_converts_instance(self):
         created = get_current_datetime()
         expected_instance = Instance(
             backend=BackendType.LOCAL,
@@ -186,7 +59,6 @@ class TestPoolUtils:
             region="eu-west-1",
             price=1.0,
         )
-
         im = InstanceModel(
             id=str(uuid.uuid4()),
             created_at=created,
@@ -197,89 +69,5 @@ class TestPoolUtils:
             job_provisioning_data='{"ssh_proxy":null, "backend":"local","hostname":"hostname_test","region":"eu-west","price":1.0,"username":"user1","ssh_port":12345,"dockerized":false,"instance_id":"test_instance","instance_type": {"name": "instance", "resources": {"cpus": 1, "memory_mib": 512, "gpus": [], "spot": false, "disk": {"size_mib": 102400}, "description":""}}}',
             offer='{"price":"LOCAL", "price":1.0, "backend":"local", "region":"eu-west-1", "availability":"available","instance": {"name": "instance", "resources": {"cpus": 1, "memory_mib": 512, "gpus": [], "spot": false, "disk": {"size_mib": 102400}, "description":""}}}',
         )
-
         instance = services_pools.instance_model_to_instance(im)
         assert instance == expected_instance
-
-
-class TestCreatePool:
-    @pytest.mark.asyncio
-    async def test_pool_double_name(self, session: AsyncSession, test_db):
-        user = await create_user(session=session)
-        project = await create_project(session=session, owner=user)
-        await services_pools.create_pool_model(session=session, project=project, name="test_pool")
-        with pytest.raises(ValueError):
-            await services_pools.create_pool_model(
-                session=session, project=project, name="test_pool"
-            )
-
-    @pytest.mark.asyncio
-    async def test_create_cloud_instance(self, session: AsyncSession, test_db):
-        user = await create_user(session)
-        project = await create_project(session, user)
-
-        profile = Profile(name="test_profile")
-
-        requirements = Requirements(resources=resources.ResourcesSpec(cpu=1), spot=True)
-
-        offer = InstanceOfferWithAvailability(
-            backend=BackendType.DATACRUNCH,
-            instance=InstanceType(
-                name="instance", resources=Resources(cpus=1, memory_mib=512, spot=False, gpus=[])
-            ),
-            region="en",
-            price=0.1,
-            availability=InstanceAvailability.AVAILABLE,
-        )
-
-        launched_instance = LaunchedInstanceInfo(
-            instance_id="running_instance.id",
-            ip_address="running_instance.ip",
-            region="running_instance.location",
-            ssh_port=22,
-            username="root",
-            dockerized=True,
-            backend_data=None,
-        )
-
-        class DummyBackend:
-            TYPE = BackendType.DATACRUNCH
-
-            def compute(self):
-                return self
-
-            def create_instance(self, *args, **kwargs):
-                return launched_instance
-
-        offers = [(DummyBackend(), offer)]
-
-        with patch("dstack._internal.server.services.runs.get_run_plan_by_requirements") as reqs:
-            reqs.return_value = offers
-            await runs.create_instance(
-                session,
-                project,
-                user,
-                profile=profile,
-                pool_name="test_pool",
-                instance_name="test_instance",
-                requirements=requirements,
-                ssh_key=SSHKey(public=""),
-            )
-
-        pool = await services_pools.get_pool(session, project, "test_pool")
-        assert pool is not None
-        instance = pool.instances[0]
-
-        assert instance.name == "test_instance"
-        assert instance.deleted == False
-        assert instance.deleted_at is None
-
-        # assert instance.job_provisioning_data == '{"backend": "datacrunch", "instance_type": {"name": "instance", "resources": {"cpus": 1, "memory_mib": 512, "gpus": [], "spot": false, "disk": {"size_mib": 102400}, "description": ""}}, "instance_id": "running_instance.id", "ssh_proxy": null, "hostname": "running_instance.ip", "region": "running_instance.location", "price": 0.1, "username": "root", "ssh_port": 22, "dockerized": true, "backend_data": null}'
-
-        excepted_offer = (
-            '{"backend": "datacrunch", "instance": {"name": "instance", "resources": '
-            '{"cpus": 1, "memory_mib": 512, "gpus": [], "spot": false, "disk": '
-            '{"size_mib": 102400}, "description": ""}}, "region": "en", "price": 0.1, '
-            '"availability": "available", "instance_runtime": "shim"}'
-        )
-        assert instance.offer == excepted_offer


### PR DESCRIPTION
Fixes #935.
Fixes #936.
Fixes #939.
Fixes #940.

This PR fixes a bunch of pool-related bugs and weird behavior. It also involves major refactoring including:

1. Moving business logic out of views.
2. Removing code duplication.
3. Making add_instance/run_job/get_offers/get_run_plan all reuse the same logic.
4. Removing redundant tests.