### PR TITLE
Make pool-related CLI arguments respect profile

### DIFF
--- a/src/dstack/_internal/cli/commands/run.py
+++ b/src/dstack/_internal/cli/commands/run.py
@@ -17,12 +17,6 @@ from dstack._internal.cli.utils.common import confirm_ask, console
 from dstack._internal.cli.utils.run import print_run_plan
 from dstack._internal.core.errors import CLIError, ConfigurationError, ServerClientError
 from dstack._internal.core.models.configurations import ConfigurationType
-from dstack._internal.core.models.profiles import (
-    DEFAULT_RUN_TERMINATION_IDLE_TIME,
-    CreationPolicy,
-    TerminationPolicy,
-    parse_max_duration,
-)
 from dstack._internal.core.models.runs import JobErrorCode
 from dstack._internal.core.services.configs import ConfigManager
 from dstack._internal.utils.logging import get_logger
@@ -84,29 +78,6 @@ class RunCommand(APIBaseCommand):
             type=int,
             default=3,
         )
-        self._parser.add_argument(
-            "--pool",
-            dest="pool_name",
-            help="The name of the pool. If not set, the default pool will be used",
-        )
-        self._parser.add_argument(
-            "--reuse",
-            dest="creation_policy_reuse",
-            action="store_true",
-            help="Reuse instance from pool",
-        )
-        self._parser.add_argument(
-            "--idle-duration",
-            dest="idle_duration",
-            type=str,
-            help="Idle time before instance termination",
-        )
-        self._parser.add_argument(
-            "--instance",
-            dest="instance_name",
-            metavar="NAME",
-            help="Reuse instance from pool with name [code]NAME[/]",
-        )
         register_profile_args(self._parser)
 
     def _command(self, args: argparse.Namespace):
@@ -117,31 +88,6 @@ class RunCommand(APIBaseCommand):
                 BaseRunConfigurator.register(self._parser)
             self._parser.print_help()
             return
-
-        termination_policy_idle = DEFAULT_RUN_TERMINATION_IDLE_TIME
-        termination_policy = TerminationPolicy.DESTROY_AFTER_IDLE
-
-        if args.idle_duration is not None:
-            try:
-                termination_policy_idle = int(args.idle_duration)
-            except ValueError:
-                termination_policy_idle = parse_max_duration(args.idle_duration)
-
-        creation_policy = (
-            CreationPolicy.REUSE if args.creation_policy_reuse else CreationPolicy.REUSE_OR_CREATE
-        )
-
-        if creation_policy == CreationPolicy.REUSE and termination_policy_idle is not None:
-            console.print(
-                "[warning]If the flag --reuse is set, the argument --idle-duration will be skipped[/]"
-            )
-            termination_policy = TerminationPolicy.DONT_DESTROY
-
-        if args.instance_name is not None and termination_policy_idle is not None:
-            console.print(
-                f"[warning]--idle-duration won't be applied to the instance {args.instance_name!r}[/]"
-            )
-            termination_policy = TerminationPolicy.DONT_DESTROY
 
         super()._command(args)
         try:
@@ -176,11 +122,11 @@ class RunCommand(APIBaseCommand):
                     max_price=profile.max_price,
                     working_dir=args.working_dir,
                     run_name=args.run_name,
-                    pool_name=args.pool_name,
-                    instance_name=args.instance_name,
-                    creation_policy=creation_policy,
-                    termination_policy=termination_policy,
-                    termination_policy_idle=termination_policy_idle,
+                    pool_name=profile.pool_name,
+                    instance_name=profile.instance_name,
+                    creation_policy=profile.creation_policy,
+                    termination_policy=profile.termination_policy,
+                    termination_policy_idle=profile.termination_idle_time,
                 )
         except ConfigurationError as e:
             raise CLIError(str(e))

--- a/src/dstack/_internal/cli/utils/run.py
+++ b/src/dstack/_internal/cli/utils/run.py
@@ -4,6 +4,7 @@ from rich.table import Table
 
 from dstack._internal.cli.utils.common import console
 from dstack._internal.core.models.instances import InstanceAvailability, InstanceType
+from dstack._internal.core.models.profiles import TerminationPolicy
 from dstack._internal.core.models.runs import RunPlan
 from dstack._internal.utils.common import pretty_date
 from dstack.api import Run
@@ -28,6 +29,11 @@ def print_run_plan(run_plan: RunPlan, offers_limit: int = 3):
         if retry_policy.retry
         else "no"
     )
+    creation_policy = run_plan.run_spec.profile.creation_policy
+    termination_policy = run_plan.run_spec.profile.termination_policy
+    termination_idle_time = f"{run_plan.run_spec.profile.termination_idle_time}s"
+    if termination_policy == TerminationPolicy.DONT_DESTROY:
+        termination_idle_time = "-"
 
     if req.spot is None:
         spot_policy = "auto"
@@ -48,6 +54,9 @@ def print_run_plan(run_plan: RunPlan, offers_limit: int = 3):
     props.add_row(th("Max duration"), max_duration)
     props.add_row(th("Spot policy"), spot_policy)
     props.add_row(th("Retry policy"), retry_policy)
+    props.add_row(th("Creation policy"), creation_policy)
+    props.add_row(th("Termination policy"), termination_policy)
+    props.add_row(th("Termination idle time"), termination_idle_time)
 
     offers = Table(box=None)
     offers.add_column("#")

--- a/src/dstack/_internal/core/models/profiles.py
+++ b/src/dstack/_internal/core/models/profiles.py
@@ -121,18 +121,21 @@ class Profile(ForbidExtra):
     instance_name: Annotated[Optional[str], Field(description="The name of the instance")]
     creation_policy: Annotated[
         Optional[CreationPolicy], Field(description="The policy for using instances from the pool")
-    ]
+    ] = CreationPolicy.REUSE_OR_CREATE
     termination_policy: Annotated[
         Optional[TerminationPolicy], Field(description="The policy for termination instances")
-    ]
+    ] = TerminationPolicy.DESTROY_AFTER_IDLE
     termination_idle_time: Annotated[
-        int,
-        Field(description="Seconds to wait before destroying the instance"),
+        Optional[Union[str, int]],
+        Field(description="Time to wait before destroying the idle instance"),
     ] = DEFAULT_RUN_TERMINATION_IDLE_TIME
 
     _validate_max_duration = validator("max_duration", pre=True, allow_reuse=True)(
         parse_max_duration
     )
+    _validate_termination_idle_time = validator(
+        "termination_idle_time", pre=True, allow_reuse=True
+    )(parse_duration)
 
 
 class ProfilesConfig(ForbidExtra):

--- a/src/dstack/_internal/server/services/runs.py
+++ b/src/dstack/_internal/server/services/runs.py
@@ -172,7 +172,7 @@ async def get_run_plan(
         _validate_run_name(run_spec.run_name)
 
     profile = run_spec.profile
-    creation_policy = profile.creation_policy
+    creation_policy = profile.creation_policy or CreationPolicy.REUSE_OR_CREATE
 
     pool = await get_or_create_pool_by_name(
         session=session, project=project, pool_name=profile.pool_name
@@ -199,7 +199,7 @@ async def get_run_plan(
         job_offers: List[InstanceOfferWithAvailability] = []
         job_offers.extend(pool_offers)
 
-        if creation_policy is None or creation_policy == CreationPolicy.REUSE_OR_CREATE:
+        if creation_policy == CreationPolicy.REUSE_OR_CREATE:
             offers = await get_offers_by_requirements(
                 project=project,
                 profile=profile,

--- a/src/dstack/api/server/__init__.py
+++ b/src/dstack/api/server/__init__.py
@@ -1,4 +1,5 @@
 import os
+import pprint
 import time
 from typing import Dict, List, Optional, Type
 
@@ -121,7 +122,8 @@ class APIClient:
                     code = kwargs.pop("code")
                     raise _server_client_errors[code](**kwargs)
             if resp.status_code == 422:
-                logger.debug("Server validation error: %s", resp.text)
+                formatted_error = pprint.pformat(resp.json())
+                raise ClientError(f"Server validation error: \n{formatted_error}")
             resp.raise_for_status()
         return resp
 


### PR DESCRIPTION
Closes #949

* Make `dstack run` respect pool-related `profiles.yml` settings.
* Refactor `dstack run` and `dstack pool add` to share `profiles.yml` CLI arguments.
* Remove redundant CLI arguments/parsing and reuse `profiles.yml` validation.
* Remove `dstack run`-specific arguments from `dstack pool add`, e.g. `--max-duration`.
* Extend run plan table with pool-related policies.