### PR TITLE
Update gpuhunt to 0.0.7, which now supports cudo as an online provider

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ BASE_DEPS = [
     "docker>=6.0.0",
     "dnspython",
     "grpcio>=1.50",  # indirect
-    "gpuhunt==0.0.6",
+    "gpuhunt==0.0.7",
     "sentry-sdk[fastapi]",
     "httpx",
 ]


### PR DESCRIPTION
Fix #1016