### PR TITLE
[Feature]: Support Python 3.12

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [ "3.8", "3.9", "3.10", "3.11" ]
+        python: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
     steps:
      - name: Checkout repository
        uses: actions/checkout@v3

--- a/src/dstack/_internal/core/models/configurations.py
+++ b/src/dstack/_internal/core/models/configurations.py
@@ -27,6 +27,7 @@ class PythonVersion(str, Enum):
     PY39 = "3.9"
     PY310 = "3.10"
     PY311 = "3.11"
+    PY312 = "3.12"
 
 
 class RegistryAuth(ForbidExtra):


### PR DESCRIPTION
Fixes  #1029

> [!WARNING]
> Currently, when we build cloud AMIs, we pre-pull the base Docker images for all supported Python versions: 
see [docker-image-with-cuda.sh](https://github.com/dstackai/dstack/blob/master/packer/provisioners/docker-image-with-cuda.sh) and [docker-image-without-cuda.sh](https://github.com/dstackai/dstack/blob/master/packer/provisioners/docker-image-without-cuda.sh).
>
> I suggest that we stop doing it, and a) expect the base image to be always downloaded; b) split the image version into two versions: a) Docker image version; b) AMI version.

> [!NOTE]
> Currently, Python 3.12 image aren't pre-pulled to AWS/GCP/Azure AMIs. The idea is to see how it affects the startup and UX and get back to this question and either a) pre-pull them; or b) drop the pre-pulling logic entirely.