### PR TITLE
Fixed the YAML schema validation for `replicas`

### DIFF
--- a/src/dstack/_internal/core/models/configurations.py
+++ b/src/dstack/_internal/core/models/configurations.py
@@ -1,6 +1,6 @@
 import re
 from enum import Enum
-from typing import Dict, List, Mapping, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 from pydantic import BaseModel, Field, ValidationError, conint, constr, root_validator, validator
 from typing_extensions import Annotated, Literal
@@ -233,7 +233,10 @@ class ServiceConfiguration(BaseConfiguration):
         Field(description="Mapping of the model for the OpenAI-compatible endpoint"),
     ] = None
     auth: Annotated[bool, Field(description="Enable the authorization")] = True
-    replicas: Annotated[Range[int], Field(description="The range ")] = Range[int](min=1, max=1)
+    replicas: Annotated[
+        Union[conint(ge=1), constr(regex=r"^[0-9]+..[1-9][0-9]*$"), Range[int]],
+        Field(description="The range "),
+    ] = Range[int](min=1, max=1)
     scaling: Annotated[
         Optional[ScalingSpec], Field(description="The auto-scaling configuration")
     ] = None
@@ -247,15 +250,20 @@ class ServiceConfiguration(BaseConfiguration):
         return v
 
     @validator("replicas")
-    def convert_replicas(cls, v: Range[int]) -> Range[int]:
+    def convert_replicas(cls, v: Any) -> Range[int]:
+        if isinstance(v, str) and ".." in v:
+            min, max = v.replace(" ", "").split("..")
+            v = Range(min=min or 0, max=max or None)
+        elif isinstance(v, (int, float)):
+            v = Range(min=v, max=v)
         if v.max is None:
-            raise ValueError("The maximum number of replicas must be set")
-        if v.max < 1:
-            raise ValueError("The maximum number of replicas must be greater than 0")
-        if v.min is None:
-            v.min = 0
-        elif v.min < 0:
-            raise ValueError("The minimum number of replicas must be greater or equal than 0")
+            raise ValueError("The maximum number of replicas is required")
+        if v.min < 0:
+            raise ValueError("The minimum number of replicas must be greater than or equal to 0")
+        if v.max < v.min:
+            raise ValueError(
+                "The maximum number of replicas must be greater than the minium number of replicas"
+            )
         return v
 
     @root_validator()
@@ -263,9 +271,9 @@ class ServiceConfiguration(BaseConfiguration):
         scaling = values.get("scaling")
         replicas = values.get("replicas")
         if replicas.min != replicas.max and not scaling:
-            raise ValueError("Auto-scaling must be defined for a range of replicas")
+            raise ValueError("When you set `replicas` to a range, ensure to specify `scaling`.")
         if replicas.min == replicas.max and scaling:
-            raise ValueError("Can't perform auto-scaling for a fixed number of replicas")
+            raise ValueError("To use `scaling`, `replicas` must be set to a range.")
         return values
 
 

--- a/src/dstack/_internal/core/models/configurations.py
+++ b/src/dstack/_internal/core/models/configurations.py
@@ -262,7 +262,7 @@ class ServiceConfiguration(BaseConfiguration):
             raise ValueError("The minimum number of replicas must be greater than or equal to 0")
         if v.max < v.min:
             raise ValueError(
-                "The maximum number of replicas must be greater than the minium number of replicas"
+                "The maximum number of replicas must be greater than or equal to the minium number of replicas"
             )
         return v
 

--- a/src/tests/_internal/core/models/test_configurations.py
+++ b/src/tests/_internal/core/models/test_configurations.py
@@ -1,0 +1,52 @@
+from typing import Any, Optional
+
+import pytest
+
+from dstack._internal.core.errors import ConfigurationError
+from dstack._internal.core.models.configurations import parse
+from dstack._internal.core.models.resources import Range
+
+
+class TestParseConfiguration:
+    def test_services_replicas_and_scaling(self):
+        def test_conf(replicas: Any, scaling: Optional[Any] = None):
+            conf = {
+                "type": "service",
+                "commands": ["python3 -m http.server"],
+                "port": 8000,
+                "replicas": replicas,
+            }
+            if scaling:
+                conf["scaling"] = scaling
+            return conf
+
+        assert parse(test_conf(1)).replicas == Range(min=1, max=1)
+        assert parse(test_conf("2")).replicas == Range(min=2, max=2)
+        assert parse(test_conf("3..3")).replicas == Range(min=3, max=3)
+        with pytest.raises(
+            ConfigurationError,
+            match="When you set `replicas` to a range, ensure to specify `scaling`",
+        ):
+            parse(test_conf("0..10"))
+        assert parse(
+            test_conf(
+                "0..10",
+                {
+                    "metric": "rps",
+                    "target": 10,
+                },
+            )
+        ).replicas == Range(min=0, max=10)
+        with pytest.raises(
+            ConfigurationError,
+            match="When you set `replicas` to a range, ensure to specify `scaling`",
+        ):
+            parse(
+                test_conf(
+                    "0..10",
+                    {
+                        "metric": "rpc",
+                        "target": 10,
+                    },
+                )
+            )


### PR DESCRIPTION
Previously, the YAML schema showed errors if `replicas` was set to a `str` or `int`

<img width="600" src="https://github.com/dstackai/dstack/assets/54148038/9d707e7a-95d2-46e5-9d52-0baeb730e451">
