### PR TITLE
Require `registry_auth.username` in configurations

### DIFF
--- a/src/dstack/_internal/core/models/configurations.py
+++ b/src/dstack/_internal/core/models/configurations.py
@@ -39,7 +39,7 @@ class RegistryAuth(ForbidExtra):
         password (str): The password or access token
     """
 
-    username: Annotated[Optional[str], Field(description="The username")]
+    username: Annotated[str, Field(description="The username")]
     password: Annotated[str, Field(description="The password or access token")]
 
 


### PR DESCRIPTION
Missing `username` is not actually supported and
causes exceptions when provisioning runs.

Maybe the idea behind making username optional was
to allow authentication with token only. Although
this seems to be possible according to the
standard, all major registries and tools,
including docker cli, do require a username.

Fixes #1071 