### PR TITLE
Make `commands` optional in run configurations

### DIFF
--- a/runner/internal/executor/executor_test.go
+++ b/runner/internal/executor/executor_test.go
@@ -142,6 +142,7 @@ func TestExecutor_RemoteRepo(t *testing.T) {
 func makeTestExecutor(t *testing.T) *RunExecutor {
 	t.Helper()
 	baseDir, err := filepath.EvalSymlinks(t.TempDir())
+	workingDir := "."
 	require.NoError(t, err)
 
 	body := schemas.SubmitBody{
@@ -158,7 +159,7 @@ func makeTestExecutor(t *testing.T) *RunExecutor {
 			Commands:    []string{"/bin/bash", "-c"},
 			Env:         make(map[string]string),
 			MaxDuration: 0, // no timeout
-			WorkingDir:  ".",
+			WorkingDir:  &workingDir,
 		},
 		Secrets:         make(map[string]string),
 		RepoCredentials: &schemas.RepoCredentials{Protocol: "https"},

--- a/runner/internal/schemas/schemas.go
+++ b/runner/internal/schemas/schemas.go
@@ -46,7 +46,7 @@ type JobSpec struct {
 	Env            map[string]string `json:"env"`
 	Gateway        *Gateway          `json:"gateway"`
 	MaxDuration    int               `json:"max_duration"`
-	WorkingDir     string            `json:"working_dir"`
+	WorkingDir     *string           `json:"working_dir"`
 }
 
 type ClusterInfo struct {

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,8 @@ BASE_DEPS = [
     "python-multipart",
     "filelock",
     "docker>=6.0.0",
+    "python-dxf>=11.0.0",
+    "cachetools",
     "dnspython",
     "grpcio>=1.50",  # indirect
     "gpuhunt>=0.0.9rc1",

--- a/src/dstack/_internal/core/errors.py
+++ b/src/dstack/_internal/core/errors.py
@@ -120,3 +120,7 @@ class SSHKeyError(SSHError):
 
 class SSHPortInUseError(SSHError):
     pass
+
+
+class DockerRegistryError(DstackError):
+    pass

--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -175,7 +175,7 @@ class JobSpec(CoreModel):
     registry_auth: Optional[RegistryAuth]
     requirements: Requirements
     retry_policy: RetryPolicy
-    working_dir: str
+    working_dir: Optional[str]
 
 
 class JobProvisioningData(CoreModel):

--- a/src/dstack/_internal/server/background/tasks/process_runs.py
+++ b/src/dstack/_internal/server/background/tasks/process_runs.py
@@ -159,7 +159,7 @@ async def process_pending_run(session: AsyncSession, run_model: RunModel):
             session.add(new_job_model)
     # Create missing replicas
     for replica_num in range(scheduled_replicas, replicas):
-        jobs = get_jobs_from_run_spec(run.run_spec, replica_num=replica_num)
+        jobs = await get_jobs_from_run_spec(run.run_spec, replica_num=replica_num)
         for job in jobs:
             job_model = create_job_model_for_new_submission(
                 run_model=run_model,

--- a/src/dstack/_internal/server/services/docker.py
+++ b/src/dstack/_internal/server/services/docker.py
@@ -19,7 +19,7 @@ REGISTRY_REQUEST_TIMEOUT = 20
 
 
 @dataclass
-class DXFAuth:
+class DXFAuthAdapter:
     registry_auth: Optional[RegistryAuth]
 
     def __call__(self, dxf: DXF, response: requests.Response) -> None:
@@ -68,7 +68,7 @@ def get_image_config(image_name: str, registry_auth: Optional[RegistryAuth]) -> 
     registry_client = DXF(
         host=image.registry or DEFAULT_REGISTRY,
         repo=image.repo,
-        auth=DXFAuth(registry_auth),
+        auth=DXFAuthAdapter(registry_auth),
         timeout=REGISTRY_REQUEST_TIMEOUT,
     )
 

--- a/src/dstack/_internal/server/services/docker.py
+++ b/src/dstack/_internal/server/services/docker.py
@@ -1,16 +1,33 @@
-from enum import Enum
-from typing import Optional
+from dataclasses import dataclass
+from typing import List, Optional
 
 import requests
+from dxf import DXF
+from dxf.exceptions import DXFError
+from pydantic import Field, ValidationError, validator
+from typing_extensions import Annotated
 
+from dstack._internal.core.errors import DockerRegistryError
 from dstack._internal.core.models.common import CoreModel
+from dstack._internal.core.models.configurations import RegistryAuth
+from dstack._internal.server.utils.common import join_byte_stream_checked
 
-manifests_media_types = [
-    "application/vnd.oci.image.index.v1+json",
-    "application/vnd.oci.image.manifest.v1+json",
-    "application/vnd.docker.distribution.manifest.v2+json",
-    "application/vnd.docker.distribution.manifest.list.v2+json",
-]
+DEFAULT_PLATFORM = "linux/amd64"
+DEFAULT_REGISTRY = "index.docker.io"
+MAX_CONFIG_OBJECT_SIZE = 2**22  # 4 MiB
+REGISTRY_REQUEST_TIMEOUT = 20
+
+
+@dataclass
+class DXFAuth:
+    registry_auth: Optional[RegistryAuth]
+
+    def __call__(self, dxf: DXF, response: requests.Response) -> None:
+        dxf.authenticate(
+            username=self.registry_auth.username if self.registry_auth else None,
+            password=self.registry_auth.password if self.registry_auth else None,
+            response=response,
+        )
 
 
 class DockerImage(CoreModel):
@@ -24,66 +41,54 @@ class DockerImage(CoreModel):
     digest: Optional[str]
 
 
-class DockerPlatform(str, Enum):
-    x86 = "amd64"
-    arm = "arm64"
+class ImageConfig(CoreModel):
+    entrypoint: Annotated[Optional[List[str]], Field(alias="Entrypoint")] = None
+    cmd: Annotated[Optional[List[str]], Field(alias="Cmd")] = None
 
 
-class DockerRegistryClient:
-    def __init__(self):
-        self.registry: Optional[str] = None
-        self.repo: Optional[str] = None
-        self.s = requests.Session()
+class ImageConfigObject(CoreModel):
+    config: ImageConfig = ImageConfig()
 
-    def auth(self, repo: str, *, registry: Optional[str] = None, token: Optional[str] = None):
-        self.registry = registry
-        self.repo = repo
-
-        if not token:
-            auth_host = registry
-            params = {"scope": f"repository:{repo}:pull"}
-            if not registry:
-                auth_host = "auth.docker.io"
-                params["service"] = "registry.docker.io"
-
-            r = requests.get(f"https://{auth_host}/token", params=params)
-            r.raise_for_status()
-            token = r.json()["token"]
-        self.s.headers = {"Authorization": f"Bearer {token}"}
-
-    def manifests(self, tag: str = "latest", *, accept: Optional[str] = None) -> dict:
-        registry_host = self.registry or "registry-1.docker.io"
-        r = self.s.get(
-            f"https://{registry_host}/v2/{self.repo}/manifests/{tag}",
-            headers={"Accept": accept or ",".join(manifests_media_types)},
-        )
-        r.raise_for_status()
-        return r.json()
-
-    def blobs(self, digest: str) -> dict:
-        registry_host = self.registry or "registry-1.docker.io"
-        r = self.s.get(f"https://{registry_host}/v2/{self.repo}/blobs/{digest}")
-        r.raise_for_status()
-        return r.json()
+    @validator("config", pre=True)
+    def config_set_default_if_null(cls, value):
+        return ImageConfig() if value is None else value
 
 
-def get_image_config(
-    image: str, *, platform: DockerPlatform = DockerPlatform.x86, token: Optional[str] = None
-) -> dict:
-    image = parse_image_name(image)
-    client = DockerRegistryClient()
-    client.auth(image.repo, registry=image.registry, token=token)
+class ImageManifestConfigField(CoreModel):
+    digest: str
 
-    manifest = client.manifests(image.digest or image.tag)
-    if "config" not in manifest:  # manifest index/list, pick the right platform
-        for m in manifest["manifests"]:
-            if m["platform"]["architecture"] == platform.value:
-                manifest = client.manifests(m["digest"], accept=m["mediaType"])
-                break
-        else:
-            raise RuntimeError("No manifest for the specified platform")
 
-    return client.blobs(manifest["config"]["digest"])
+class ImageManifest(CoreModel):
+    config: ImageManifestConfigField
+
+
+def get_image_config(image_name: str, registry_auth: Optional[RegistryAuth]) -> ImageConfigObject:
+    image = parse_image_name(image_name)
+
+    registry_client = DXF(
+        host=image.registry or DEFAULT_REGISTRY,
+        repo=image.repo,
+        auth=DXFAuth(registry_auth),
+        timeout=REGISTRY_REQUEST_TIMEOUT,
+    )
+
+    with registry_client:
+        try:
+            manifest_resp = registry_client.get_manifest(
+                alias=image.digest or image.tag, platform=DEFAULT_PLATFORM
+            )
+            manifest = ImageManifest.__response__.parse_raw(manifest_resp)
+            config_stream = registry_client.pull_blob(manifest.config.digest)
+            config_resp = join_byte_stream_checked(config_stream, MAX_CONFIG_OBJECT_SIZE)
+            if config_resp is None:
+                raise DockerRegistryError(
+                    "Image config object exceeds the size limit of "
+                    f"{MAX_CONFIG_OBJECT_SIZE} bytes"
+                )
+            return ImageConfigObject.__response__.parse_raw(config_resp)
+
+        except (DXFError, requests.RequestException, ValidationError) as e:
+            raise DockerRegistryError(e)
 
 
 def parse_image_name(image: str) -> DockerImage:

--- a/src/dstack/_internal/server/services/jobs/__init__.py
+++ b/src/dstack/_internal/server/services/jobs/__init__.py
@@ -52,16 +52,16 @@ TERMINATING_PROCESSING_JOBS_LOCK = asyncio.Lock()
 TERMINATING_PROCESSING_JOBS_IDS = set()
 
 
-def get_jobs_from_run_spec(run_spec: RunSpec, replica_num: int) -> List[Job]:
+async def get_jobs_from_run_spec(run_spec: RunSpec, replica_num: int) -> List[Job]:
     return [
         Job(job_spec=s, job_submissions=[])
-        for s in get_job_specs_from_run_spec(run_spec, replica_num)
+        for s in await get_job_specs_from_run_spec(run_spec, replica_num)
     ]
 
 
-def get_job_specs_from_run_spec(run_spec: RunSpec, replica_num: int) -> List[JobSpec]:
+async def get_job_specs_from_run_spec(run_spec: RunSpec, replica_num: int) -> List[JobSpec]:
     job_configurator = _get_job_configurator(run_spec)
-    job_specs = job_configurator.get_job_specs(replica_num=replica_num)
+    job_specs = await job_configurator.get_job_specs(replica_num=replica_num)
     return job_specs
 
 

--- a/src/dstack/_internal/server/services/jobs/configurators/base.py
+++ b/src/dstack/_internal/server/services/jobs/configurators/base.py
@@ -159,7 +159,10 @@ class JobConfigurator(ABC):
             spot=None if spot_policy == SpotPolicy.AUTO else (spot_policy == SpotPolicy.SPOT),
         )
 
-    def _working_dir(self) -> str:
+    def _working_dir(self) -> Optional[str]:
+        """
+        None means default working directory
+        """
         return self.run_spec.working_dir
 
     def _python(self) -> str:

--- a/src/dstack/_internal/server/services/jobs/configurators/base.py
+++ b/src/dstack/_internal/server/services/jobs/configurators/base.py
@@ -3,7 +3,10 @@ import sys
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional
 
+from cachetools import TTLCache, cached
+
 import dstack.version as version
+from dstack._internal.core.errors import DockerRegistryError, ServerClientError
 from dstack._internal.core.models.configurations import (
     ConfigurationType,
     PortMapping,
@@ -19,6 +22,8 @@ from dstack._internal.core.models.runs import (
     RunSpec,
 )
 from dstack._internal.core.services.ssh.ports import filter_reserved_ports
+from dstack._internal.server.services.docker import ImageConfig, get_image_config
+from dstack._internal.server.utils.common import run_async
 
 
 def get_default_python_verison() -> str:
@@ -37,8 +42,8 @@ class JobConfigurator(ABC):
     def __init__(self, run_spec: RunSpec):
         self.run_spec = run_spec
 
-    def get_job_specs(self, replica_num: int) -> List[JobSpec]:
-        job_spec = self._get_job_spec(replica_num=replica_num, job_num=0, jobs_per_replica=1)
+    async def get_job_specs(self, replica_num: int) -> List[JobSpec]:
+        job_spec = await self._get_job_spec(replica_num=replica_num, job_num=0, jobs_per_replica=1)
         return [job_spec]
 
     @abstractmethod
@@ -61,7 +66,7 @@ class JobConfigurator(ABC):
     def _ports(self) -> List[PortMapping]:
         pass
 
-    def _get_job_spec(
+    async def _get_job_spec(
         self,
         replica_num: int,
         job_num: int,
@@ -73,7 +78,7 @@ class JobConfigurator(ABC):
             job_name=f"{self.run_spec.run_name}-{job_num}-{replica_num}",
             jobs_per_replica=jobs_per_replica,
             app_specs=self._app_specs(),
-            commands=self._commands(),
+            commands=await self._commands(),
             env=self._env(),
             home_dir=self._home_dir(),
             image_name=self._image_name(),
@@ -85,7 +90,7 @@ class JobConfigurator(ABC):
         )
         return job_spec
 
-    def _commands(self) -> List[str]:
+    async def _commands(self) -> List[str]:
         if self.run_spec.configuration.entrypoint is not None:  # docker-like format
             entrypoint = shlex.split(self.run_spec.configuration.entrypoint)
             commands = self.run_spec.configuration.commands
@@ -96,8 +101,22 @@ class JobConfigurator(ABC):
             entrypoint = ["/bin/sh", "-i", "-c"]
             commands = [_join_shell_commands(self._shell_commands())]
         else:  # custom docker image without commands
-            raise NotImplementedError()  # TODO read docker image manifest
-        return entrypoint + commands
+            image_config = await run_async(
+                _get_image_config,
+                self.run_spec.configuration.image,
+                self.run_spec.configuration.registry_auth,
+            )
+            entrypoint = image_config.entrypoint or []
+            commands = image_config.cmd or []
+
+        result = entrypoint + commands
+        if not result:
+            raise ServerClientError(
+                "Could not determine what command to run. "
+                "Please specify either `commands` or `entrypoint` in your run configuration"
+            )
+
+        return result
 
     def _app_specs(self) -> List[AppSpec]:
         specs = []
@@ -110,15 +129,6 @@ class JobConfigurator(ABC):
                 )
             )
         return specs
-
-    def _entrypoint(self) -> Optional[List[str]]:
-        if self.run_spec.configuration.entrypoint is not None:
-            return shlex.split(self.run_spec.configuration.entrypoint)
-        if self.run_spec.configuration.image is None:  # dstackai/base
-            return ["/bin/bash", "-i", "-c"]
-        if self._commands():  # custom docker image with commands
-            return ["/bin/sh", "-i", "-c"]
-        return None
 
     def _env(self) -> Dict[str, str]:
         return self.run_spec.configuration.env
@@ -168,3 +178,13 @@ def _join_shell_commands(commands: List[str], env: Optional[Dict[str, str]] = No
             cmd = "{ %s }" % cmd
         commands[i] = cmd
     return " && ".join(commands)
+
+
+@cached(TTLCache(maxsize=2048, ttl=80))
+def _get_image_config(image: str, registry_auth: Optional[RegistryAuth]) -> ImageConfig:
+    try:
+        return get_image_config(image, registry_auth).config
+    except DockerRegistryError as e:
+        raise ServerClientError(
+            f"Error pulling configuration for image {image!r} from the docker registry: {e}"
+        )

--- a/src/dstack/_internal/server/services/jobs/configurators/service.py
+++ b/src/dstack/_internal/server/services/jobs/configurators/service.py
@@ -24,3 +24,6 @@ class ServiceJobConfigurator(JobConfigurator):
 
     def _ports(self) -> List[PortMapping]:
         return []
+
+    def _working_dir(self) -> Optional[str]:
+        return None if not self._shell_commands() else super()._working_dir()

--- a/src/dstack/_internal/server/services/jobs/configurators/task.py
+++ b/src/dstack/_internal/server/services/jobs/configurators/task.py
@@ -11,10 +11,10 @@ DEFAULT_MAX_DURATION_SECONDS = 72 * 3600
 class TaskJobConfigurator(JobConfigurator):
     TYPE: ConfigurationType = ConfigurationType.TASK
 
-    def get_job_specs(self, replica_num: int) -> List[JobSpec]:
+    async def get_job_specs(self, replica_num: int) -> List[JobSpec]:
         job_specs = []
         for job_num in range(self.run_spec.configuration.nodes):
-            job_spec = self._get_job_spec(
+            job_spec = await self._get_job_spec(
                 replica_num=replica_num,
                 job_num=job_num,
                 jobs_per_replica=self.run_spec.configuration.nodes,

--- a/src/dstack/_internal/server/services/jobs/configurators/task.py
+++ b/src/dstack/_internal/server/services/jobs/configurators/task.py
@@ -37,3 +37,6 @@ class TaskJobConfigurator(JobConfigurator):
 
     def _ports(self) -> List[PortMapping]:
         return self.run_spec.configuration.ports
+
+    def _working_dir(self) -> Optional[str]:
+        return None if not self._shell_commands() else super()._working_dir()

--- a/src/dstack/_internal/server/services/runs.py
+++ b/src/dstack/_internal/server/services/runs.py
@@ -243,7 +243,7 @@ async def get_run_plan(
     creation_policy = profile.creation_policy or CreationPolicy.REUSE_OR_CREATE
 
     # TODO(egor-s): do we need to generate all replicas here?
-    jobs = get_jobs_from_run_spec(run_spec, replica_num=0)
+    jobs = await get_jobs_from_run_spec(run_spec, replica_num=0)
 
     pool = await get_or_create_pool_by_name(
         session=session, project=project, pool_name=profile.pool_name
@@ -390,7 +390,7 @@ async def submit_run(
         await gateways.register_service(session, run_model)
 
     for replica_num in range(replicas):
-        jobs = get_jobs_from_run_spec(run_spec, replica_num=replica_num)
+        jobs = await get_jobs_from_run_spec(run_spec, replica_num=replica_num)
         for job in jobs:
             job_model = create_job_model_for_new_submission(
                 run_model=run_model,
@@ -853,7 +853,7 @@ async def scale_run_replicas(session: AsyncSession, run_model: RunModel, replica
         for replica_num in range(
             len(active_replicas) + scheduled_replicas, len(active_replicas) + replicas_diff
         ):
-            jobs = get_jobs_from_run_spec(run_spec, replica_num=replica_num)
+            jobs = await get_jobs_from_run_spec(run_spec, replica_num=replica_num)
             for job in jobs:
                 job_model = create_job_model_for_new_submission(
                     run_model=run_model,

--- a/src/dstack/_internal/server/testing/common.py
+++ b/src/dstack/_internal/server/testing/common.py
@@ -220,7 +220,7 @@ async def create_job(
     replica_num: int = 0,
 ) -> JobModel:
     run_spec = RunSpec.parse_raw(run.run_spec)
-    job_spec = get_job_specs_from_run_spec(run_spec, replica_num=replica_num)[0]
+    job_spec = (await get_job_specs_from_run_spec(run_spec, replica_num=replica_num))[0]
     job = JobModel(
         project_id=run.project_id,
         run_id=run.id,

--- a/src/dstack/_internal/server/utils/common.py
+++ b/src/dstack/_internal/server/utils/common.py
@@ -1,6 +1,17 @@
 import asyncio
 from functools import partial
-from typing import Awaitable, Callable, Iterable, List, Sequence, Set, Tuple, TypeVar, Union
+from typing import (
+    Awaitable,
+    Callable,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 from typing_extensions import ParamSpec
 
@@ -73,3 +84,16 @@ async def wait_to_lock(lock: asyncio.Lock, locked: Set[KeyT], key: KeyT, *, dela
                 locked.add(key)
                 return
         await asyncio.sleep(delay)
+
+
+def join_byte_stream_checked(stream: Iterable[bytes], max_size: int) -> Optional[bytes]:
+    """
+    Join an iterable of `bytes` values into one `bytes` value,
+    unless its size exceeds `max_size`.
+    """
+    result = b""
+    for chunk in stream:
+        if len(result) + len(chunk) > max_size:
+            return None
+        result += chunk
+    return result

--- a/src/tests/_internal/cli/services/configurators/test_run.py
+++ b/src/tests/_internal/cli/services/configurators/test_run.py
@@ -14,13 +14,13 @@ from dstack._internal.core.models.configurations import (
 
 class TestRunConfigurator:
     def test_env(self):
-        conf = TaskConfiguration(commands=[])
+        conf = TaskConfiguration(commands=["whoami"])
         modified, args = apply_args(conf, ["-e", "A=1", "--env", "B=2"])
         conf.env = {"A": "1", "B": "2"}
         assert modified.dict() == conf.dict()
 
     def test_ports(self):
-        conf = TaskConfiguration(commands=[])
+        conf = TaskConfiguration(commands=["whoami"])
         modified, args = apply_args(conf, ["-p", "80", "--port", "8080"])
         conf.ports = [
             PortMapping(local_port=80, container_port=80),
@@ -29,18 +29,18 @@ class TestRunConfigurator:
         assert modified.dict() == conf.dict()
 
     def test_container_ports_conflict(self):
-        conf = TaskConfiguration(commands=[])
+        conf = TaskConfiguration(commands=["whoami"])
         with pytest.raises(ConfigurationError):
             apply_args(conf, ["-p", "8000:80", "--port", "8001:80"])
 
     def test_env_override(self):
-        conf = TaskConfiguration(commands=[], env={"A": "0"})
+        conf = TaskConfiguration(commands=["whoami"], env={"A": "0"})
         modified, args = apply_args(conf, ["-e", "A=1", "--env", "B=2"])
         conf.env = {"A": "1", "B": "2"}
         assert modified.dict() == conf.dict()
 
     def test_ports_override(self):
-        conf = TaskConfiguration(commands=[], ports=["80"])
+        conf = TaskConfiguration(commands=["whoami"], ports=["80"])
         modified, args = apply_args(conf, ["-p", "8000:80", "--port", "8001:8000"])
         conf.ports = [
             PortMapping(local_port=8000, container_port=80),
@@ -49,12 +49,12 @@ class TestRunConfigurator:
         assert modified.dict() == conf.dict()
 
     def test_local_ports_conflict(self):
-        conf = TaskConfiguration(commands=[], ports=["3000"])
+        conf = TaskConfiguration(commands=["whoami"], ports=["3000"])
         with pytest.raises(ConfigurationError):
             apply_args(conf, ["-p", "3000:4000"])
 
     def test_any_port(self):
-        conf = TaskConfiguration(commands=[], ports=["8000"])
+        conf = TaskConfiguration(commands=["whoami"], ports=["8000"])
         modified, args = apply_args(conf, ["-p", "*:8000"])
         conf.ports = [PortMapping(local_port=None, container_port=8000)]
         assert modified.dict() == conf.dict()

--- a/src/tests/_internal/core/models/test_configurations.py
+++ b/src/tests/_internal/core/models/test_configurations.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 import pytest
 
 from dstack._internal.core.errors import ConfigurationError
-from dstack._internal.core.models.configurations import parse
+from dstack._internal.core.models.configurations import RegistryAuth, parse
 from dstack._internal.core.models.resources import Range
 
 
@@ -50,3 +50,12 @@ class TestParseConfiguration:
                     },
                 )
             )
+
+
+def test_registry_auth_hashable():
+    """
+    RegistryAuth instances should be hashable
+    to be used as cache keys in _get_image_config
+    """
+    registry_auth = RegistryAuth(username="username", password="password")
+    hash(registry_auth)

--- a/src/tests/_internal/server/services/test_docker.py
+++ b/src/tests/_internal/server/services/test_docker.py
@@ -1,0 +1,104 @@
+import pytest
+
+from dstack._internal.server.services.docker import ImageConfigObject, ImageManifest
+
+
+@pytest.fixture
+def sample_image_manifest():
+    # Source: https://github.com/opencontainers/image-spec/blob/main/manifest.md
+    return {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": "sha256:b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7",
+            "size": 7023,
+        },
+        "layers": [
+            {
+                "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                "digest": "sha256:9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0",
+                "size": 32654,
+            },
+            {
+                "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                "digest": "sha256:3c3a4604a545cdc127456d94e421cd355bca5b528f4a9c1905b15da2eb4a4c6b",
+                "size": 16724,
+            },
+            {
+                "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                "digest": "sha256:ec4b8955958665577945c89419d1af06b5f7636b4ac3da7f12184802ad867736",
+                "size": 73109,
+            },
+        ],
+        "subject": {
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
+            "size": 7682,
+        },
+        "annotations": {"com.example.key1": "value1", "com.example.key2": "value2"},
+    }
+
+
+@pytest.fixture
+def sample_image_config_object():
+    # Source: https://github.com/opencontainers/image-spec/blob/main/config.md
+    return {
+        "created": "2015-10-31T22:22:56.015925234Z",
+        "author": "Alyssa P. Hacker <alyspdev@example.com>",
+        "architecture": "amd64",
+        "os": "linux",
+        "config": {
+            "User": "alice",
+            "ExposedPorts": {"8080/tcp": {}},
+            "Env": [
+                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                "FOO=oci_is_a",
+                "BAR=well_written_spec",
+            ],
+            "Entrypoint": ["/bin/my-app-binary"],
+            "Cmd": ["--foreground", "--config", "/etc/my-app.d/default.cfg"],
+            "Volumes": {"/var/job-result-data": {}, "/var/log/my-app-logs": {}},
+            "WorkingDir": "/home/alice",
+            "Labels": {
+                "com.example.project.git.url": "https://example.com/project.git",
+                "com.example.project.git.commit": "45a939b2999782a3f005621a8d0f29aa387e1d6b",
+            },
+        },
+        "rootfs": {
+            "diff_ids": [
+                "sha256:c6f988f4874bb0add23a778f753c65efe992244e148a1d2ec2a8b664fb66bbd1",
+                "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef",
+            ],
+            "type": "layers",
+        },
+        "history": [
+            {
+                "created": "2015-10-31T22:22:54.690851953Z",
+                "created_by": "/bin/sh -c #(nop) ADD file:a3bc1e842b69636f9df5256c49c5374fb4eef1e281fe3f282c65fb853ee171c5 in /",
+            },
+            {
+                "created": "2015-10-31T22:22:55.613815829Z",
+                "created_by": '/bin/sh -c #(nop) CMD ["sh"]',
+                "empty_layer": True,
+            },
+            {
+                "created": "2015-10-31T22:22:56.329850019Z",
+                "created_by": "/bin/sh -c apk add curl",
+            },
+        ],
+    }
+
+
+def test_parse_image_manifest(sample_image_manifest):
+    ImageManifest.__response__.parse_obj(sample_image_manifest)
+
+
+def test_parse_image_config_object(sample_image_config_object):
+    ImageConfigObject.__response__.parse_obj(sample_image_config_object)
+
+
+def test_parse_image_config_object_with_config_null(sample_image_config_object):
+    sample_image_config_object["config"] = None
+    config_object = ImageConfigObject.__response__.parse_obj(sample_image_config_object)
+    assert config_object.config is not None

--- a/src/tests/_internal/server/utils/test_common.py
+++ b/src/tests/_internal/server/utils/test_common.py
@@ -1,0 +1,33 @@
+import pytest
+
+from dstack._internal.server.utils.common import join_byte_stream_checked
+
+
+@pytest.mark.parametrize(
+    ["stream", "max_size", "result"],
+    [
+        [[b"12", b"34", b"56"], 7, b"123456"],
+        [[b"12", b"34", b"56"], 6, b"123456"],
+        [[b"12", b"34", b"56"], 5, None],
+        [[b"12", b"34", b"56"], 0, None],
+        [[], 0, b""],
+    ],
+)
+def test_join_byte_stream_checked(stream, max_size, result):
+    assert join_byte_stream_checked(iter(stream), max_size) == result
+
+
+@pytest.mark.parametrize(
+    ["stream", "max_size"],
+    [
+        [[b"12", b"34", b"56"], 5],
+        [[b"12", b"34", b"56"], 0],
+    ],
+)
+def test_join_byte_stream_checked_stops_iteration_when_limit_reached(stream, max_size):
+    def generator(stream):
+        for chunk in stream:
+            yield chunk
+        raise RuntimeError("Stream end reached, but next value was requested")
+
+    assert join_byte_stream_checked(generator(stream), max_size) is None


### PR DESCRIPTION
Now, if the user specifies a custom `image` in
their configuration, they can omit `commands` so
that the image's default entrypoint+cmd and 
default working directory are used.

We always override the image's entrypoint, so it
is necessary to find out what the default
entrypoint was and pass it to the runner. This is
done by the dstack server by requesting the
image's manifest from its container registry.

Closes #938