### PR TITLE
Show run name in `dstack run --detach .`

### DIFF
--- a/src/dstack/_internal/cli/commands/run.py
+++ b/src/dstack/_internal/cli/commands/run.py
@@ -153,7 +153,7 @@ class RunCommand(APIBaseCommand):
             raise CLIError(e.msg)
 
         if args.detach:
-            console.print("Run submitted, detaching...")
+            console.print(f"Run [code]{run.name}[/] submitted, detaching...")
             return
 
         abort_at_exit = True


### PR DESCRIPTION
Closes #1111 