### PR TITLE
Simplify Configurator implementation

### DIFF
--- a/src/dstack/_internal/core/models/backends/__init__.py
+++ b/src/dstack/_internal/core/models/backends/__init__.py
@@ -73,6 +73,7 @@ from dstack._internal.core.models.backends.vastai import (
 )
 from dstack._internal.core.models.common import CoreModel
 
+# Backend config returned by the API
 AnyConfigInfoWithoutCreds = Union[
     AWSConfigInfo,
     AzureConfigInfo,
@@ -88,6 +89,10 @@ AnyConfigInfoWithoutCreds = Union[
     DstackConfigInfo,
     DstackBaseBackendConfigInfo,
 ]
+
+# Same as AnyConfigInfoWithoutCreds but also includes creds.
+# Used to create/update backend.
+# Also returned by the API to project admins so that they can see/update backend creds.
 AnyConfigInfoWithCreds = Union[
     AWSConfigInfoWithCreds,
     AzureConfigInfoWithCreds,
@@ -102,6 +107,12 @@ AnyConfigInfoWithCreds = Union[
     VastAIConfigInfoWithCreds,
     DstackConfigInfo,
 ]
+
+AnyConfigInfo = Union[AnyConfigInfoWithoutCreds, AnyConfigInfoWithCreds]
+
+# Same as AnyConfigInfoWithCreds but some fields may be optional.
+# Used for interactive setup with validation and suggestions (e.g. via UI).
+# If the backend does not need interactive setup, it's the same as AnyConfigInfoWithCreds.
 AnyConfigInfoWithCredsPartial = Union[
     AWSConfigInfoWithCredsPartial,
     AzureConfigInfoWithCredsPartial,
@@ -116,9 +127,8 @@ AnyConfigInfoWithCredsPartial = Union[
     VastAIConfigInfoWithCredsPartial,
     DstackConfigInfo,
 ]
-AnyConfigInfo = Union[AnyConfigInfoWithoutCreds, AnyConfigInfoWithCreds]
 
-
+# Suggestions for unfilled fields used in interactive setup.
 AnyConfigValues = Union[
     AWSConfigValues,
     AzureConfigValues,
@@ -135,6 +145,8 @@ AnyConfigValues = Union[
 ]
 
 
+# In case we'll support multiple backends of the same type,
+# this adds backend name to backend config.
 class BackendInfo(CoreModel):
     name: str
     config: AnyConfigInfoWithoutCreds

--- a/src/dstack/_internal/server/services/backends/__init__.py
+++ b/src/dstack/_internal/server/services/backends/__init__.py
@@ -166,7 +166,7 @@ async def create_backend(
     if backend is not None:
         raise ResourceExistsError()
     await run_async(configurator.get_config_values, config)
-    backend = configurator.create_backend(project=project, config=config)
+    backend = await run_async(configurator.create_backend, project=project, config=config)
     session.add(backend)
     await session.commit()
     clear_backend_cache(project.name)
@@ -188,7 +188,7 @@ async def update_backend(
     if config_info is None:
         raise ServerClientError("Backend does not exist")
     await run_async(configurator.get_config_values, config)
-    backend = configurator.create_backend(project=project, config=config)
+    backend = await run_async(configurator.create_backend, project=project, config=config)
     await session.execute(
         update(BackendModel)
         .where(

--- a/src/dstack/_internal/server/services/backends/configurators/base.py
+++ b/src/dstack/_internal/server/services/backends/configurators/base.py
@@ -16,13 +16,12 @@ from dstack._internal.server.models import BackendModel, ProjectModel
 class Configurator(ABC):
     TYPE: BackendType
 
-    @abstractmethod
     def get_default_configs(self) -> List[AnyConfigInfoWithCreds]:
         """
         Tries to detect backend creds on the machine and
         automatically construct backend configs from the creds.
         """
-        pass
+        return []
 
     @abstractmethod
     def get_config_values(self, config: AnyConfigInfoWithCredsPartial) -> AnyConfigValues:

--- a/src/dstack/_internal/server/services/backends/configurators/cudo.py
+++ b/src/dstack/_internal/server/services/backends/configurators/cudo.py
@@ -37,9 +37,6 @@ DEFAULT_REGION = "no-luster-1"
 class CudoConfigurator(Configurator):
     TYPE: BackendType = BackendType.CUDO
 
-    def get_default_configs(self) -> List[CudoConfigInfoWithCreds]:
-        return []
-
     def get_config_values(self, config: CudoConfigInfoWithCredsPartial) -> CudoConfigValues:
         config_values = CudoConfigValues()
         if config.creds is None:

--- a/src/dstack/_internal/server/services/backends/configurators/datacrunch.py
+++ b/src/dstack/_internal/server/services/backends/configurators/datacrunch.py
@@ -31,9 +31,6 @@ DEFAULT_REGION = "FIN-01"
 class DataCrunchConfigurator(Configurator):
     TYPE: BackendType = BackendType.DATACRUNCH
 
-    def get_default_configs(self) -> List[DataCrunchConfigInfoWithCreds]:
-        return []
-
     def get_config_values(
         self, config: DataCrunchConfigInfoWithCredsPartial
     ) -> DataCrunchConfigValues:

--- a/src/dstack/_internal/server/services/backends/configurators/lambdalabs.py
+++ b/src/dstack/_internal/server/services/backends/configurators/lambdalabs.py
@@ -44,9 +44,6 @@ DEFAULT_REGION = "us-east-1"
 class LambdaConfigurator(Configurator):
     TYPE: BackendType = BackendType.LAMBDA
 
-    def get_default_configs(self) -> List[LambdaConfigInfoWithCreds]:
-        return []
-
     def get_config_values(self, config: LambdaConfigInfoWithCredsPartial) -> LambdaConfigValues:
         config_values = LambdaConfigValues()
         if config.creds is None:

--- a/src/dstack/_internal/server/services/backends/configurators/nebius.py
+++ b/src/dstack/_internal/server/services/backends/configurators/nebius.py
@@ -32,9 +32,6 @@ REGIONS = ["eu-north1-c"]
 class NebiusConfigurator(Configurator):
     TYPE: BackendType = BackendType.NEBIUS
 
-    def get_default_configs(self) -> List[NebiusConfigInfoWithCreds]:
-        return []
-
     def get_config_values(self, config: NebiusConfigInfoWithCredsPartial) -> NebiusConfigValues:
         config_values = NebiusConfigValues()
         if config.creds is None:

--- a/src/dstack/_internal/server/services/backends/configurators/runpod.py
+++ b/src/dstack/_internal/server/services/backends/configurators/runpod.py
@@ -39,9 +39,6 @@ DEFAULT_REGION = "CA-MTL-1"
 class RunpodConfigurator(Configurator):
     TYPE: BackendType = BackendType.RUNPOD
 
-    def get_default_configs(self) -> List[RunpodConfigInfoWithCreds]:
-        return []
-
     def get_config_values(self, config: RunpodConfigInfoWithCredsPartial) -> RunpodConfigValues:
         config_values = RunpodConfigValues()
         if config.creds is None:

--- a/src/dstack/_internal/server/services/backends/configurators/tensordock.py
+++ b/src/dstack/_internal/server/services/backends/configurators/tensordock.py
@@ -30,9 +30,6 @@ REGIONS = []
 class TensorDockConfigurator(Configurator):
     TYPE: BackendType = BackendType.TENSORDOCK
 
-    def get_default_configs(self) -> List[TensorDockConfigInfoWithCreds]:
-        return []
-
     def get_config_values(
         self, config: TensorDockConfigInfoWithCredsPartial
     ) -> TensorDockConfigValues:

--- a/src/dstack/_internal/server/services/backends/configurators/vastai.py
+++ b/src/dstack/_internal/server/services/backends/configurators/vastai.py
@@ -30,9 +30,6 @@ REGIONS = []
 class VastAIConfigurator(Configurator):
     TYPE: BackendType = BackendType.VASTAI
 
-    def get_default_configs(self) -> List[VastAIConfigInfoWithCreds]:
-        return []
-
     def get_config_values(self, config: VastAIConfigInfoWithCredsPartial) -> VastAIConfigValues:
         config_values = VastAIConfigValues()
         if config.creds is None:


### PR DESCRIPTION
Closes #888 

The PR does not make Configurator.get_config_values() optional as described in the issue since we're not sure if we drop interactive configuration support.