### PR TITLE
Fix isinstance check for core models

### DIFF
--- a/src/dstack/_internal/cli/services/configurators/run.py
+++ b/src/dstack/_internal/cli/services/configurators/run.py
@@ -7,6 +7,7 @@ import dstack._internal.core.models.resources as resources
 from dstack._internal.cli.services.args import disk_spec, env_var, gpu_spec, port_mapping
 from dstack._internal.cli.utils.common import console
 from dstack._internal.core.errors import ConfigurationError
+from dstack._internal.core.models.common import is_core_model_instance
 from dstack._internal.core.models.configurations import (
     BaseConfiguration,
     BaseConfigurationWithPorts,
@@ -63,7 +64,7 @@ class BaseRunConfigurator:
             conf.resources.disk = args.disk_spec
 
         for k, v in conf.env.items():
-            if isinstance(v, EnvSentinel):
+            if is_core_model_instance(v, EnvSentinel):
                 try:
                     conf.env[k] = v.from_env(os.environ)
                 except ValueError as e:

--- a/src/dstack/_internal/core/backends/aws/auth.py
+++ b/src/dstack/_internal/core/backends/aws/auth.py
@@ -4,6 +4,7 @@ from boto3.session import Session
 
 from dstack._internal.core.errors import BackendAuthError
 from dstack._internal.core.models.backends.aws import AnyAWSCreds, AWSAccessKeyCreds
+from dstack._internal.core.models.common import is_core_model_instance
 
 
 def authenticate(creds: AnyAWSCreds, region: str) -> Session:
@@ -13,7 +14,7 @@ def authenticate(creds: AnyAWSCreds, region: str) -> Session:
 
 
 def get_session(creds: AnyAWSCreds, region: str) -> Session:
-    if isinstance(creds, AWSAccessKeyCreds):
+    if is_core_model_instance(creds, AWSAccessKeyCreds):
         return boto3.session.Session(
             region_name=region,
             aws_access_key_id=creds.access_key,

--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -18,6 +18,7 @@ from dstack._internal.core.backends.base.offers import get_catalog_offers
 from dstack._internal.core.errors import ComputeError, NoCapacityError
 from dstack._internal.core.models.backends.aws import AWSAccessKeyCreds
 from dstack._internal.core.models.backends.base import BackendType
+from dstack._internal.core.models.common import is_core_model_instance
 from dstack._internal.core.models.instances import (
     InstanceAvailability,
     InstanceConfiguration,
@@ -36,7 +37,7 @@ logger = get_logger(__name__)
 class AWSCompute(Compute):
     def __init__(self, config: AWSConfig):
         self.config = config
-        if isinstance(config.creds, AWSAccessKeyCreds):
+        if is_core_model_instance(config.creds, AWSAccessKeyCreds):
             self.session = boto3.Session(
                 aws_access_key_id=config.creds.access_key,
                 aws_secret_access_key=config.creds.secret_key,

--- a/src/dstack/_internal/core/backends/azure/auth.py
+++ b/src/dstack/_internal/core/backends/azure/auth.py
@@ -10,6 +10,7 @@ from dstack._internal.core.models.backends.azure import (
     AzureClientCreds,
     AzureDefaultCreds,
 )
+from dstack._internal.core.models.common import is_core_model_instance
 
 AzureCredential = Union[ClientSecretCredential, DefaultAzureCredential]
 
@@ -21,7 +22,7 @@ def authenticate(creds: AnyAzureCreds) -> Tuple[AzureCredential, str]:
 
 
 def get_credential(creds: AnyAzureCreds) -> Tuple[AzureCredential, str]:
-    if isinstance(creds, AzureClientCreds):
+    if is_core_model_instance(creds, AzureClientCreds):
         credential = ClientSecretCredential(
             tenant_id=creds.tenant_id,
             client_id=creds.client_id,

--- a/src/dstack/_internal/core/backends/gcp/auth.py
+++ b/src/dstack/_internal/core/backends/gcp/auth.py
@@ -13,6 +13,7 @@ from dstack._internal.core.models.backends.gcp import (
     GCPDefaultCreds,
     GCPServiceAccountCreds,
 )
+from dstack._internal.core.models.common import is_core_model_instance
 
 
 def authenticate(creds: AnyGCPCreds) -> Tuple[Credentials, Optional[str]]:
@@ -26,7 +27,7 @@ def authenticate(creds: AnyGCPCreds) -> Tuple[Credentials, Optional[str]]:
 
 
 def get_credentials(creds: AnyGCPCreds) -> Tuple[Credentials, Optional[str]]:
-    if isinstance(creds, GCPServiceAccountCreds):
+    if is_core_model_instance(creds, GCPServiceAccountCreds):
         try:
             service_account_info = json.loads(creds.data)
             credentials = service_account.Credentials.from_service_account_info(

--- a/src/dstack/_internal/core/models/common.py
+++ b/src/dstack/_internal/core/models/common.py
@@ -20,7 +20,7 @@ class CoreModelMeta(DualBaseModelMeta):
         return (
             type.__subclasscheck__(cls, subclass)
             or issubclass(subclass, cls.__request__)
-            or issubclass(subclass, cls.__request__)
+            or issubclass(subclass, cls.__response__)
         )
 
 

--- a/src/dstack/_internal/core/models/common.py
+++ b/src/dstack/_internal/core/models/common.py
@@ -49,7 +49,7 @@ class Duration(int):
 
 def is_core_model_instance(instance: CoreModel, class_: Type[CoreModel]) -> bool:
     """
-    Implements isintance check for CoreModel such that
+    Implements isinstance check for CoreModel such that
     models parsed with MyModel.__response__ pass the check against MyModel.
     See https://github.com/dstackai/dstack/issues/1124
     """

--- a/src/dstack/_internal/core/models/common.py
+++ b/src/dstack/_internal/core/models/common.py
@@ -1,7 +1,27 @@
 import re
 from typing import Union
 
-from pydantic_duality import DualBaseModel
+from pydantic_duality import DualBaseModel, DualBaseModelMeta
+
+
+# Change DualBaseModelMeta so that model parsed with MyModel.__response__
+# would pass the check for isinstance(instance, MyModel).
+class CoreModelMeta(DualBaseModelMeta):
+    """Metaclass used for custom types."""
+
+    def __instancecheck__(cls, instance) -> bool:
+        return (
+            type.__instancecheck__(cls, instance)
+            or isinstance(instance, cls.__request__)
+            or isinstance(instance, cls.__response__)
+        )
+
+    def __subclasscheck__(cls, subclass: type):
+        return (
+            type.__subclasscheck__(cls, subclass)
+            or issubclass(subclass, cls.__request__)
+            or issubclass(subclass, cls.__request__)
+        )
 
 
 # DualBaseModel creates two classes for the model:
@@ -9,7 +29,9 @@ from pydantic_duality import DualBaseModel
 # and another with extra = "ignore" (CoreModel.__response__).
 # This allows to use the same model both for a strict parsing of the user input and
 # for a permissive parsing of the server responses.
-class CoreModel(DualBaseModel):
+
+
+class CoreModel(DualBaseModel, metaclass=CoreModelMeta):
     pass
 
 

--- a/src/dstack/_internal/core/models/common.py
+++ b/src/dstack/_internal/core/models/common.py
@@ -1,5 +1,5 @@
 import re
-from typing import Type, Union
+from typing import Any, Type, Union
 
 from pydantic_duality import DualBaseModel
 
@@ -47,7 +47,7 @@ class Duration(int):
         raise ValueError(f"Cannot parse the duration {v}")
 
 
-def is_core_model_instance(instance: CoreModel, class_: Type[CoreModel]) -> bool:
+def is_core_model_instance(instance: Any, class_: Type[CoreModel]) -> bool:
     """
     Implements isinstance check for CoreModel such that
     models parsed with MyModel.__response__ pass the check against MyModel.

--- a/src/dstack/_internal/server/services/backends/configurators/aws.py
+++ b/src/dstack/_internal/server/services/backends/configurators/aws.py
@@ -20,6 +20,7 @@ from dstack._internal.core.models.backends.base import (
     ConfigElementValue,
     ConfigMultiElement,
 )
+from dstack._internal.core.models.common import is_core_model_instance
 from dstack._internal.server import settings
 from dstack._internal.server.models import BackendModel, ProjectModel
 from dstack._internal.server.services.backends.configurators.base import (
@@ -69,12 +70,15 @@ class AWSConfigurator(Configurator):
         )
         if config.creds is None:
             return config_values
-        if isinstance(config.creds, AWSDefaultCreds) and not settings.DEFAULT_CREDS_ENABLED:
+        if (
+            is_core_model_instance(config.creds, AWSDefaultCreds)
+            and not settings.DEFAULT_CREDS_ENABLED
+        ):
             raise_invalid_credentials_error(fields=[["creds"]])
         try:
             auth.authenticate(creds=config.creds, region=MAIN_REGION)
         except Exception:
-            if isinstance(config.creds, AWSAccessKeyCreds):
+            if is_core_model_instance(config.creds, AWSAccessKeyCreds):
                 raise_invalid_credentials_error(
                     fields=[
                         ["creds", "access_key"],

--- a/src/dstack/_internal/server/services/backends/configurators/azure.py
+++ b/src/dstack/_internal/server/services/backends/configurators/azure.py
@@ -44,6 +44,7 @@ from dstack._internal.core.models.backends.base import (
     ConfigElementValue,
     ConfigMultiElement,
 )
+from dstack._internal.core.models.common import is_core_model_instance
 from dstack._internal.server import settings
 from dstack._internal.server.models import BackendModel, ProjectModel
 from dstack._internal.server.services.backends.configurators.base import (
@@ -107,14 +108,17 @@ class AzureConfigurator(Configurator):
         )
         if config.creds is None:
             return config_values
-        if isinstance(config.creds, AzureDefaultCreds) and not settings.DEFAULT_CREDS_ENABLED:
+        if (
+            is_core_model_instance(config.creds, AzureDefaultCreds)
+            and not settings.DEFAULT_CREDS_ENABLED
+        ):
             raise_invalid_credentials_error(fields=[["creds"]])
-        if isinstance(config.creds, AzureClientCreds):
+        if is_core_model_instance(config.creds, AzureClientCreds):
             self._set_client_creds_tenant_id(config.creds, config.tenant_id)
         try:
             credential, creds_tenant_id = auth.authenticate(config.creds)
         except BackendAuthError:
-            if isinstance(config.creds, AzureClientCreds):
+            if is_core_model_instance(config.creds, AzureClientCreds):
                 raise_invalid_credentials_error(
                     fields=[
                         ["creds", "tenant_id"],
@@ -146,7 +150,7 @@ class AzureConfigurator(Configurator):
     ) -> BackendModel:
         if config.locations is None:
             config.locations = DEFAULT_LOCATIONS
-        if isinstance(config.creds, AzureClientCreds):
+        if is_core_model_instance(config.creds, AzureClientCreds):
             self._set_client_creds_tenant_id(config.creds, config.tenant_id)
         credential, _ = auth.authenticate(config.creds)
         resource_group = self._create_resource_group(

--- a/src/dstack/_internal/server/services/backends/configurators/gcp.py
+++ b/src/dstack/_internal/server/services/backends/configurators/gcp.py
@@ -21,6 +21,7 @@ from dstack._internal.core.models.backends.gcp import (
     GCPServiceAccountCreds,
     GCPStoredConfig,
 )
+from dstack._internal.core.models.common import is_core_model_instance
 from dstack._internal.server import settings
 from dstack._internal.server.models import BackendModel, ProjectModel
 from dstack._internal.server.services.backends.configurators.base import (
@@ -141,12 +142,15 @@ class GCPConfigurator(Configurator):
         )
         if config.creds is None:
             return config_values
-        if isinstance(config.creds, GCPDefaultCreds) and not settings.DEFAULT_CREDS_ENABLED:
+        if (
+            is_core_model_instance(config.creds, GCPDefaultCreds)
+            and not settings.DEFAULT_CREDS_ENABLED
+        ):
             raise_invalid_credentials_error(fields=[["creds"]])
         try:
             _, project_id = auth.authenticate(creds=config.creds)
         except BackendAuthError:
-            if isinstance(config.creds, GCPServiceAccountCreds):
+            if is_core_model_instance(config.creds, GCPServiceAccountCreds):
                 raise_invalid_credentials_error(fields=[["creds", "data"]])
             else:
                 raise_invalid_credentials_error(fields=[["creds"]])

--- a/src/dstack/_internal/server/services/projects.py
+++ b/src/dstack/_internal/server/services/projects.py
@@ -11,6 +11,7 @@ from dstack._internal.core.models.backends.dstack import (
     DstackBaseBackendConfigInfo,
     DstackConfigInfo,
 )
+from dstack._internal.core.models.common import is_core_model_instance
 from dstack._internal.core.models.projects import Member, Project
 from dstack._internal.core.models.users import GlobalRole, ProjectRole
 from dstack._internal.server.models import MemberModel, ProjectModel, UserModel
@@ -280,7 +281,7 @@ def project_model_to_project(project_model: ProjectModel) -> Project:
             logger.warning("Configurator for backend %s not found", b.type)
             continue
         config_info = configurator.get_config_info(model=b, include_creds=False)
-        if isinstance(config_info, DstackConfigInfo):
+        if is_core_model_instance(config_info, DstackConfigInfo):
             for backend_type in config_info.base_backends:
                 backends.append(
                     BackendInfo(


### PR DESCRIPTION
Fixes #1124

The PR replace isinstance() check for core models with is_core_model_instance() that checks against `__reponse__` explicitly. Changing isinstance() behaviour via metaclass doesn't work because pydantic-duality may depend on isinstance/subclass checks.

TODO: open a pydantic-duality discussion on this issue.

Tested:

- [x] AWS default creds
- [x] AWS access key creds
- [x] Azure default creds
- [x] Azure client creds
- [x] GCP default creds
- [x] GCP service account creds