### PR TITLE
Multiple issues related to the runpod backend

### DIFF
--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -156,6 +156,8 @@ def get_docker_commands(
         # note: &> redirection doesn't work in /bin/sh
         # check in sshd is here, install if not
         "if ! command -v sshd >/dev/null 2>&1; then apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server || yum install -y openssh-server; fi",
+        # install curl if necessary
+        "if ! command -v curl >/dev/null 2>&1; then apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl || yum install -y curl; fi",
         # prohibit password authentication
         'sed -i "s/.*PasswordAuthentication.*/PasswordAuthentication no/g" /etc/ssh/sshd_config',
         # create ssh dirs and add public key

--- a/src/dstack/_internal/core/backends/runpod/api_client.py
+++ b/src/dstack/_internal/core/backends/runpod/api_client.py
@@ -1,10 +1,12 @@
 import time
+from datetime import timedelta
 from typing import Any, Dict, List, Optional
 
 import requests
 from requests import Response
 
 from dstack._internal.core.errors import BackendError, BackendInvalidCredentialsError
+from dstack._internal.utils.common import get_current_datetime
 
 API_URL = "https://api.runpod.io/graphql"
 
@@ -108,9 +110,11 @@ class RunpodApiClient:
             raise
 
     def wait_for_instance(self, instance_id) -> Optional[Dict]:
-        wait_for_instance_attempts = 60
-        wait_for_instance_interval = 1
-        for _ in range(wait_for_instance_attempts):
+        start = get_current_datetime()
+        wait_for_instance_interval = 5
+        # To change the status to "running," the image must be pulled and then started.
+        # We have to wait for 20 minutes while a large image is pulled.
+        while get_current_datetime() < (start + timedelta(minutes=20)):
             pod = self.get_pod(instance_id)
             if pod["runtime"] is not None:
                 return pod

--- a/src/dstack/_internal/core/backends/runpod/compute.py
+++ b/src/dstack/_internal/core/backends/runpod/compute.py
@@ -82,6 +82,7 @@ class RunpodCompute(Compute):
         # Wait until VM State is Active. This is necessary to get the ip_address.
         pod = self.api_client.wait_for_instance(instance_id)
         if pod is None:
+            self.terminate_instance(instance_id, region="")
             raise ComputeError(f"Wait instance {instance_id} timeout")
 
         for port in pod["runtime"]["ports"]:

--- a/src/dstack/_internal/core/backends/runpod/compute.py
+++ b/src/dstack/_internal/core/backends/runpod/compute.py
@@ -61,20 +61,13 @@ class RunpodCompute(Compute):
             job_docker_config=None,
             user=run.user,
         )
-        launched_instance_info = self.create_instance(instance_offer, instance_config)
-        return launched_instance_info
 
-    def create_instance(
-        self,
-        instance_offer: InstanceOfferWithAvailability,
-        instance_config: InstanceConfiguration,
-    ) -> LaunchedInstanceInfo:
         authorized_keys = instance_config.get_public_keys()
         memory_size = round(instance_offer.instance.resources.memory_mib / 1024)
         disk_size = round(instance_offer.instance.resources.disk.size_mib / 1024)
         resp = self.api_client.create_pod(
             name=instance_config.instance_name,
-            image_name="runpod/pytorch:2.1.1-py3.10-cuda12.1.1-devel-ubuntu22.04",
+            image_name=job.job_spec.image_name,
             gpu_type_id=instance_offer.instance.name,
             cloud_type="ALL",  # ["ALL", "COMMUNITY", "SECURE"]:
             gpu_count=len(instance_offer.instance.resources.gpus),

--- a/src/dstack/_internal/core/errors.py
+++ b/src/dstack/_internal/core/errors.py
@@ -86,6 +86,14 @@ class ComputeError(BackendError):
     pass
 
 
+class RunContainerError(BackendError):
+    pass
+
+
+class ContainerTimeoutError(BackendError):
+    pass
+
+
 class NoCapacityError(ComputeError):
     pass
 

--- a/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
@@ -163,9 +163,10 @@ async def _process_submitted_job(session: AsyncSession, job_model: JobModel):
             if isinstance(e, ContainerTimeoutError)
             else JobTerminationReason.CONTAINER_EXITED_WITH_ERROR
         )
-        logger.debug("%s: provisioning failed, error: %s", fmt(job_model), e)
+        logger.debug("%s: provisioning failed: %s", fmt(job_model), e)
         job_model.status = JobStatus.TERMINATING
         job_model.termination_reason = reason
+        job_model.termination_reason_message = str(e)
         job_model.last_processed_at = common_utils.get_current_datetime()
         await session.commit()
         return
@@ -290,7 +291,7 @@ async def _run_job_on_new_instance(
                 project_ssh_public_key,
                 project_ssh_private_key,
             )
-        except (ContainerTimeoutError, ContainerTimeoutError):
+        except (ContainerTimeoutError, RunContainerError):
             raise
         except BackendError as e:
             logger.warning(

--- a/src/dstack/_internal/server/services/runs.py
+++ b/src/dstack/_internal/server/services/runs.py
@@ -588,13 +588,13 @@ async def create_instance(
         public=project.ssh_public_key.strip(),
         private=project.ssh_private_key.strip(),
     )
-    image = parse_image_name(get_default_image(get_default_python_verison()))
+    dstack_default_image = parse_image_name(get_default_image(get_default_python_verison()))
     instance_config = InstanceConfiguration(
         project_name=project.name,
         instance_name=instance_name,
         ssh_keys=[user_ssh_key, project_ssh_key],
         job_docker_config=DockerConfig(
-            image=image,
+            image=dstack_default_image,
             registry_auth=None,
         ),
         user=user.name,


### PR DESCRIPTION
- [x] Use common `get_docker_args` instead custom `get_docker_args` in the runpod/compute.py
- [x] Wait 20 minutes until the pod pulls and terminate failed instance
- [x] The ability to use an image from the configuration from run configuration
- [x] Install curl if it necessary 
- [x] Dirty detect CONTAINER_EXITED_WITH_ERROR

Fixes #1133 