### PR TITLE
Add request timeouts to prevent code freezes

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -2,7 +2,7 @@ target-version = "py38"
 line-length = 99
 
 [lint]
-select = ['E', 'F', 'I' ,'Q', 'W', 'PGH', 'FLY']
+select = ['E', 'F', 'I' ,'Q', 'W', 'PGH', 'FLY', 'S113']
 ignore =[
   'E501',
   'E712',

--- a/src/dstack/_internal/cli/utils/updates.py
+++ b/src/dstack/_internal/cli/utils/updates.py
@@ -35,6 +35,7 @@ def get_latest_version() -> Optional[str]:
                 "anonymous_installation_id": anonymous_installation_id(),
                 "version": version.__version__,
             },
+            timeout=5,
         )
         if response.status_code == 200:
             return response.text.strip()

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -219,6 +219,7 @@ def get_latest_runner_build() -> Optional[str]:
         params={
             "status": "success",
         },
+        timeout=10,
     )
     resp.raise_for_status()
 
@@ -239,7 +240,7 @@ def get_dstack_gateway_wheel(build: str) -> str:
     channel = "release" if settings.DSTACK_RELEASE else "stgn"
     base_url = f"https://dstack-gateway-downloads.s3.amazonaws.com/{channel}"
     if build == "latest":
-        r = requests.get(f"{base_url}/latest-version")
+        r = requests.get(f"{base_url}/latest-version", timeout=5)
         r.raise_for_status()
         build = r.text.strip()
         logger.debug("Found the latest gateway build: %s", build)

--- a/src/dstack/_internal/core/backends/lambdalabs/api_client.py
+++ b/src/dstack/_internal/core/backends/lambdalabs/api_client.py
@@ -75,6 +75,7 @@ class LambdaAPIClient:
         resp.raise_for_status()
 
     def _make_request(self, method: str, path: str, data: Any = None):
+        # TODO: set adequate timeout here or in every method
         return requests.request(
             method=method,
             url=API_URL + path,

--- a/src/dstack/_internal/core/backends/nebius/api_client.py
+++ b/src/dstack/_internal/core/backends/nebius/api_client.py
@@ -17,6 +17,7 @@ from dstack._internal.utils.logging import get_logger
 
 logger = get_logger("nebius")
 API_URL = "api.ai.nebius.cloud"
+REQUEST_TIMEOUT = 15
 
 
 class NebiusAPIClient:
@@ -45,7 +46,7 @@ class NebiusAPIClient:
             headers={"kid": self.service_account["id"]},
         )
 
-        resp = requests.post(payload["aud"], json={"jwt": jwt_token})
+        resp = requests.post(payload["aud"], json={"jwt": jwt_token}, timeout=REQUEST_TIMEOUT)
         resp.raise_for_status()
         iam_token = resp.json()["iamToken"]
         self.s.headers["Authorization"] = f"Bearer {iam_token}"
@@ -54,7 +55,7 @@ class NebiusAPIClient:
     def compute_zones_list(self) -> List[dict]:
         logger.debug("Fetching compute zones")
         self.get_token()
-        resp = self.s.get(self.url("compute", "/zones"))
+        resp = self.s.get(self.url("compute", "/zones"), timeout=REQUEST_TIMEOUT)
         self.raise_for_status(resp)
         return resp.json()["zones"]
 
@@ -68,6 +69,7 @@ class NebiusAPIClient:
                 name=name,
                 **kwargs,
             ),
+            timeout=REQUEST_TIMEOUT,
         )
         self.raise_for_status(resp)
         return resp.json()
@@ -82,6 +84,7 @@ class NebiusAPIClient:
                 name=name,
                 **kwargs,
             ),
+            timeout=REQUEST_TIMEOUT,
         )
         self.raise_for_status(resp)
         return resp.json()
@@ -118,6 +121,7 @@ class NebiusAPIClient:
                 v4CidrBlocks=cird_blocks,
                 **kwargs,
             ),
+            timeout=REQUEST_TIMEOUT,
         )
         self.raise_for_status(resp)
         return resp.json()
@@ -147,6 +151,7 @@ class NebiusAPIClient:
                 ruleSpecs=rule_specs,
                 **kwargs,
             ),
+            timeout=REQUEST_TIMEOUT,
         )
         self.raise_for_status(resp)
         return resp.json()
@@ -165,7 +170,9 @@ class NebiusAPIClient:
     def vpc_security_groups_delete(self, security_group_id: str):
         logger.debug("Deleting security group %s", security_group_id)
         self.get_token()
-        resp = self.s.delete(self.url("vpc", f"/securityGroups/{security_group_id}"))
+        resp = self.s.delete(
+            self.url("vpc", f"/securityGroups/{security_group_id}"), timeout=REQUEST_TIMEOUT
+        )
         self.raise_for_status(resp)
 
     def compute_instances_create(
@@ -215,6 +222,7 @@ class NebiusAPIClient:
                 ],
                 **kwargs,
             ),
+            timeout=REQUEST_TIMEOUT,
         )
         self.raise_for_status(resp)
         return resp.json()
@@ -236,7 +244,9 @@ class NebiusAPIClient:
     def compute_instances_delete(self, instance_id: str):
         logger.debug("Deleting instance %s", instance_id)
         self.get_token()
-        resp = self.s.delete(self.url("compute", f"/instances/{instance_id}"))
+        resp = self.s.delete(
+            self.url("compute", f"/instances/{instance_id}"), timeout=REQUEST_TIMEOUT
+        )
         self.raise_for_status(resp)
 
     def compute_instances_get(self, instance_id: str, full: bool = False) -> dict:
@@ -247,6 +257,7 @@ class NebiusAPIClient:
             params=dict(
                 view="FULL" if full else "BASIC",
             ),
+            timeout=REQUEST_TIMEOUT,
         )
         self.raise_for_status(resp)
         return resp.json()
@@ -277,6 +288,7 @@ class NebiusAPIClient:
                     pageToken=page_token,
                     **params,
                 ),
+                timeout=REQUEST_TIMEOUT,
             )
             self.raise_for_status(resp)
             data = resp.json()

--- a/src/dstack/_internal/core/backends/runpod/api_client.py
+++ b/src/dstack/_internal/core/backends/runpod/api_client.py
@@ -90,6 +90,7 @@ class RunpodApiClient:
 
     def _make_request(self, data: Any = None) -> Response:
         try:
+            # TODO: set adequate timeout here or in every method
             response = requests.request(
                 method="POST",
                 url=f"{API_URL}?api_key={self.api_key}",

--- a/src/dstack/_internal/core/backends/tensordock/api_client.py
+++ b/src/dstack/_internal/core/backends/tensordock/api_client.py
@@ -15,7 +15,7 @@ class TensorDockAPIClient:
         self.api_url = "https://marketplace.tensordock.com/api/v0".rstrip("/")
         self.api_key = api_key
         self.api_token = api_token
-        self.s = requests.Session()
+        self.s = requests.Session()  # TODO: set adequate timeout everywhere the session is used
 
     def auth_test(self) -> bool:
         resp = self.s.post(

--- a/src/dstack/_internal/core/backends/vastai/api_client.py
+++ b/src/dstack/_internal/core/backends/vastai/api_client.py
@@ -14,7 +14,7 @@ class VastAIAPIClient:
     def __init__(self, api_key: str):
         self.api_url = "https://console.vast.ai/api/v0".rstrip("/")
         self.api_key = api_key
-        self.s = requests.Session()
+        self.s = requests.Session()  # TODO: set adequate timeout everywhere the session is used
         retries = Retry(
             total=5,
             backoff_factor=1,

--- a/src/dstack/_internal/core/services/repos.py
+++ b/src/dstack/_internal/core/services/repos.py
@@ -38,7 +38,7 @@ def get_local_repo_credentials(
     original_hostname: Optional[str] = None,
 ) -> RemoteRepoCreds:
     url = repo_data.make_url(RepoProtocol.HTTPS)  # no auth
-    r = requests.get(f"{url}/info/refs?service=git-upload-pack")
+    r = requests.get(f"{url}/info/refs?service=git-upload-pack", timeout=10)
     if r.status_code == 200:
         return RemoteRepoCreds(protocol=RepoProtocol.HTTPS, private_key=None, oauth_token=None)
 

--- a/src/dstack/_internal/server/services/gateways/options.py
+++ b/src/dstack/_internal/server/services/gateways/options.py
@@ -22,7 +22,7 @@ def complete_service_model(model_info: AnyModel):
 def get_tokenizer_config(model_id: str) -> dict:
     try:
         resp = requests.get(
-            f"https://huggingface.co/{model_id}/resolve/main/tokenizer_config.json"
+            f"https://huggingface.co/{model_id}/resolve/main/tokenizer_config.json", timeout=10
         )
         if resp.status_code == 403:
             raise ConfigurationError("Private HF models are not supported")

--- a/src/dstack/_internal/server/services/runner/client.py
+++ b/src/dstack/_internal/server/services/runner/client.py
@@ -63,7 +63,7 @@ class RunnerClient:
         resp.raise_for_status()
 
     def upload_code(self, file: Union[BinaryIO, bytes]):
-        resp = requests.post(self._url("/api/upload_code"), data=file, timeout=15)
+        resp = requests.post(self._url("/api/upload_code"), data=file, timeout=REQUEST_TIMEOUT)
         resp.raise_for_status()
 
     def run_job(self):

--- a/src/dstack/_internal/server/services/runner/client.py
+++ b/src/dstack/_internal/server/services/runner/client.py
@@ -17,7 +17,7 @@ from dstack._internal.server.schemas.runner import (
 
 REMOTE_SHIM_PORT = 10998
 REMOTE_RUNNER_PORT = 10999
-REQUEST_TIMEOUT = 5
+REQUEST_TIMEOUT = 15
 
 
 class RunnerClient:

--- a/src/dstack/_internal/server/services/runner/client.py
+++ b/src/dstack/_internal/server/services/runner/client.py
@@ -17,6 +17,7 @@ from dstack._internal.server.schemas.runner import (
 
 REMOTE_SHIM_PORT = 10998
 REMOTE_RUNNER_PORT = 10999
+REQUEST_TIMEOUT = 5
 
 
 class RunnerClient:
@@ -31,7 +32,7 @@ class RunnerClient:
 
     def healthcheck(self) -> Optional[HealthcheckResponse]:
         try:
-            resp = requests.get(self._url("/api/healthcheck"))
+            resp = requests.get(self._url("/api/healthcheck"), timeout=REQUEST_TIMEOUT)
             resp.raise_for_status()
             return HealthcheckResponse.__response__.parse_obj(resp.json())
         except requests.exceptions.RequestException:
@@ -57,26 +58,27 @@ class RunnerClient:
             self._url("/api/submit"),
             data=body.json(),
             headers={"Content-Type": "application/json"},
+            timeout=REQUEST_TIMEOUT,
         )
         resp.raise_for_status()
 
     def upload_code(self, file: Union[BinaryIO, bytes]):
-        resp = requests.post(self._url("/api/upload_code"), data=file)
+        resp = requests.post(self._url("/api/upload_code"), data=file, timeout=15)
         resp.raise_for_status()
 
     def run_job(self):
-        resp = requests.post(self._url("/api/run"))
+        resp = requests.post(self._url("/api/run"), timeout=REQUEST_TIMEOUT)
         resp.raise_for_status()
 
-    def pull(self, timestamp: int, timeout: int = 5) -> PullResponse:
+    def pull(self, timestamp: int) -> PullResponse:
         resp = requests.get(
-            self._url("/api/pull"), params={"timestamp": timestamp}, timeout=timeout
+            self._url("/api/pull"), params={"timestamp": timestamp}, timeout=REQUEST_TIMEOUT
         )
         resp.raise_for_status()
         return PullResponse.__response__.parse_obj(resp.json())
 
     def stop(self):
-        resp = requests.post(self._url("/api/stop"))
+        resp = requests.post(self._url("/api/stop"), timeout=REQUEST_TIMEOUT)
         resp.raise_for_status()
 
     def _url(self, path: str) -> str:
@@ -95,7 +97,7 @@ class ShimClient:
 
     def healthcheck(self, unmask_exeptions: bool = False) -> Optional[HealthcheckResponse]:
         try:
-            resp = requests.get(self._url("/api/healthcheck"), timeout=5)
+            resp = requests.get(self._url("/api/healthcheck"), timeout=REQUEST_TIMEOUT)
             resp.raise_for_status()
             return HealthcheckResponse.__response__.parse_obj(resp.json())
         except requests.exceptions.RequestException:
@@ -122,16 +124,17 @@ class ShimClient:
         resp = requests.post(
             self._url("/api/submit"),
             json=post_body,
+            timeout=REQUEST_TIMEOUT,
         )
         resp.raise_for_status()
 
     def stop(self, force: bool = False):
         body = StopBody(force=force)
-        resp = requests.post(self._url("/api/stop"), json=body.dict())
+        resp = requests.post(self._url("/api/stop"), json=body.dict(), timeout=REQUEST_TIMEOUT)
         resp.raise_for_status()
 
     def pull(self) -> PullBody:
-        resp = requests.get(self._url("/api/pull"))
+        resp = requests.get(self._url("/api/pull"), timeout=REQUEST_TIMEOUT)
         resp.raise_for_status()
         return PullBody.__response__.parse_obj(resp.json())
 

--- a/src/dstack/api/server/__init__.py
+++ b/src/dstack/api/server/__init__.py
@@ -104,6 +104,7 @@ class APIClient:
         logger.debug("POST /%s", path)
         for _ in range(_MAX_RETRIES):
             try:
+                # TODO: set adequate timeout here or everywhere the method is used
                 resp = self._s.post(f"{self._base_url}/{path}", **kwargs)
                 break
             except requests.exceptions.ConnectionError as e:


### PR DESCRIPTION
- Enable the ruff rule to prevent using requests without a timeout. The rule doesn't catch all the cases, but it's a best effort.
- Add missing timeouts where I am pretty confident about them.
- Leave TODOs where it would take me too much time to test and decide what the adequate timeout is.