### PR TITLE
Fix unexpected error if system Python version is unknown

### DIFF
--- a/src/dstack/_internal/server/services/jobs/configurators/base.py
+++ b/src/dstack/_internal/server/services/jobs/configurators/base.py
@@ -28,7 +28,14 @@ from dstack._internal.server.utils.common import run_async
 
 def get_default_python_verison() -> str:
     version_info = sys.version_info
-    return PythonVersion(f"{version_info.major}.{version_info.minor}").value
+    python_version_str = f"{version_info.major}.{version_info.minor}"
+    try:
+        return PythonVersion(python_version_str).value
+    except ValueError:
+        raise ServerClientError(
+            "Failed to use the system Python version. "
+            f"Python {python_version_str} is not supported."
+        )
 
 
 def get_default_image(python_version: str) -> str:


### PR DESCRIPTION
Fixes #1030.

If user's system Python version is not supported, they'll get the following message:

```
✗ dstack run .
Failed to use the system Python version. Python 3.13 is not supported.
```