### PR TITLE
Refactor backends to wait for instance IP address outside run_job/create_instance

### DIFF
--- a/src/dstack/_internal/core/backends/aws/resources.py
+++ b/src/dstack/_internal/core/backends/aws/resources.py
@@ -5,7 +5,7 @@ import botocore.client
 import botocore.exceptions
 
 import dstack.version as version
-from dstack._internal.core.errors import ResourceNotFoundError
+from dstack._internal.core.errors import ComputeResourceNotFoundError
 
 
 def get_image_id(ec2_client: botocore.client.BaseClient, cuda: bool) -> str:
@@ -20,7 +20,7 @@ def get_image_id(ec2_client: botocore.client.BaseClient, cuda: bool) -> str:
         reverse=True,
     )
     if not images:
-        raise ResourceNotFoundError()
+        raise ComputeResourceNotFoundError()
     return images[0]["ImageId"]
 
 

--- a/src/dstack/_internal/core/backends/datacrunch/api_client.py
+++ b/src/dstack/_internal/core/backends/datacrunch/api_client.py
@@ -1,4 +1,3 @@
-import time
 from typing import Optional
 
 from datacrunch import DataCrunchClient
@@ -47,16 +46,6 @@ class DataCrunchAPIClient:
             return self.client.instances.get_by_id(instance_id)
         except APIException:
             return None
-
-    def wait_for_instance(self, instance_id: str) -> Optional[Instance]:
-        WAIT_FOR_INSTANCE_ATTEMPTS = 60
-        WAIT_FOR_INSTANCE_INTERVAL = 10
-        for _ in range(WAIT_FOR_INSTANCE_ATTEMPTS):
-            instance = self.get_instance_by_id(instance_id)
-            if instance is not None and instance.status == "running":
-                return instance
-            time.sleep(WAIT_FOR_INSTANCE_INTERVAL)
-        return
 
     def deploy_instance(
         self,

--- a/src/dstack/_internal/core/backends/kubernetes/compute.py
+++ b/src/dstack/_internal/core/backends/kubernetes/compute.py
@@ -30,11 +30,10 @@ from dstack._internal.core.models.instances import (
     InstanceRuntime,
     InstanceType,
     LaunchedGatewayInfo,
-    LaunchedInstanceInfo,
     Resources,
     SSHConnectionParams,
 )
-from dstack._internal.core.models.runs import Job, Requirements, Run
+from dstack._internal.core.models.runs import Job, JobProvisioningData, Requirements, Run
 from dstack._internal.utils.common import parse_memory
 from dstack._internal.utils.logging import get_logger
 
@@ -92,7 +91,7 @@ class KubernetesCompute(Compute):
         instance_offer: InstanceOfferWithAvailability,
         project_ssh_public_key: str,
         project_ssh_private_key: str,
-    ) -> LaunchedInstanceInfo:
+    ) -> JobProvisioningData:
         instance_name = get_instance_name(run, job)
         commands = get_docker_commands(
             [run.run_spec.ssh_key_pub.strip(), project_ssh_public_key.strip()]
@@ -167,10 +166,14 @@ class KubernetesCompute(Compute):
             ),
         )
         service_ip = service_response.spec.cluster_ip
-        return LaunchedInstanceInfo(
+        return JobProvisioningData(
+            backend=instance_offer.backend,
+            instance_type=instance_offer.instance,
             instance_id=instance_name,
-            ip_address=service_ip,
+            hostname=service_ip,
+            internal_ip=None,
             region="local",
+            price=instance_offer.price,
             username="root",
             ssh_port=RUNNER_SSH_PORT,
             dockerized=False,

--- a/src/dstack/_internal/core/backends/local/compute.py
+++ b/src/dstack/_internal/core/backends/local/compute.py
@@ -4,13 +4,13 @@ from dstack._internal.core.backends.base.compute import Compute
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.instances import (
     InstanceAvailability,
+    InstanceConfiguration,
     InstanceOfferWithAvailability,
     InstanceRuntime,
     InstanceType,
-    LaunchedInstanceInfo,
     Resources,
 )
-from dstack._internal.core.models.runs import Job, Requirements, Run
+from dstack._internal.core.models.runs import Job, JobProvisioningData, Requirements, Run
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -39,17 +39,25 @@ class LocalCompute(Compute):
     ):
         pass
 
-    def create_instance(self, instance_offer, instance_config) -> LaunchedInstanceInfo:
-        launched_instance = LaunchedInstanceInfo(
+    def create_instance(
+        self,
+        instance_offer: InstanceOfferWithAvailability,
+        instance_config: InstanceConfiguration,
+    ) -> JobProvisioningData:
+        return JobProvisioningData(
+            backend=instance_offer.backend,
+            instance_type=instance_offer.instance,
             instance_id="local",
-            ip_address="127.0.0.1",
+            hostname="127.0.0.1",
+            internal_ip=None,
             region="",
+            price=instance_offer.price,
             username="root",
             ssh_port=10022,
+            ssh_proxy=None,
             dockerized=True,
             backend_data=None,
         )
-        return launched_instance
 
     def run_job(
         self,
@@ -58,14 +66,18 @@ class LocalCompute(Compute):
         instance_offer: InstanceOfferWithAvailability,
         project_ssh_public_key: str,
         project_ssh_private_key: str,
-    ) -> LaunchedInstanceInfo:
-        return LaunchedInstanceInfo(
+    ) -> JobProvisioningData:
+        return JobProvisioningData(
+            backend=instance_offer.backend,
+            instance_type=instance_offer.instance,
             instance_id="local",
-            ip_address="127.0.0.1",
+            hostname="127.0.0.1",
+            internal_ip=None,
             region="",
+            price=instance_offer.price,
             username="root",
             ssh_port=10022,
-            dockerized=True,
             ssh_proxy=None,
+            dockerized=True,
             backend_data=None,
         )

--- a/src/dstack/_internal/core/errors.py
+++ b/src/dstack/_internal/core/errors.py
@@ -86,19 +86,15 @@ class ComputeError(BackendError):
     pass
 
 
-class RunContainerError(BackendError):
-    pass
-
-
-class ContainerTimeoutError(BackendError):
-    pass
-
-
 class NoCapacityError(ComputeError):
     pass
 
 
-class ResourceNotFoundError(ComputeError):
+class ProvisioningError(ComputeError):
+    pass
+
+
+class ComputeResourceNotFoundError(ComputeError):
     pass
 
 

--- a/src/dstack/_internal/core/models/instances.py
+++ b/src/dstack/_internal/core/models/instances.py
@@ -1,8 +1,6 @@
 from enum import Enum
 from typing import List, Optional
 
-from pydantic import Field
-
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.common import CoreModel
 from dstack._internal.core.models.configurations import RegistryAuth
@@ -73,18 +71,6 @@ class InstanceConfiguration(CoreModel):
 
     def get_public_keys(self) -> List[str]:
         return [ssh_key.public.strip() for ssh_key in self.ssh_keys]
-
-
-class LaunchedInstanceInfo(CoreModel):
-    instance_id: str
-    region: str
-    ip_address: str
-    internal_ip: Optional[str] = None
-    username: str
-    ssh_port: int  # could be different from 22 for some backends
-    dockerized: bool  # True if backend starts shim
-    ssh_proxy: Optional[SSHConnectionParams] = Field(default=None)
-    backend_data: Optional[str] = Field(default=None)  # backend-specific data in json
 
 
 class InstanceRuntime(Enum):

--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -97,7 +97,9 @@ class RunTerminationReason(str, Enum):
 class JobTerminationReason(str, Enum):
     # Set by the server
     FAILED_TO_START_DUE_TO_NO_CAPACITY = "failed_to_start_due_to_no_capacity"
+    FAILED_TO_START_DUE_TO_PROVISIONING_ERROR = "failed_to_start_due_to_provisioning_error"
     INTERRUPTED_BY_NO_CAPACITY = "interrupted_by_no_capacity"
+    WAITING_INSTANCE_LIMIT_EXCEEDED = "waiting_instance_limit_exceeded"
     WAITING_RUNNER_LIMIT_EXCEEDED = "waiting_runner_limit_exceeded"
     TERMINATED_BY_USER = "terminated_by_user"
     GATEWAY_ERROR = "gateway_error"
@@ -193,12 +195,15 @@ class JobProvisioningData(CoreModel):
     backend: BackendType
     instance_type: InstanceType
     instance_id: str
-    hostname: str
+    # hostname may not be set immediately after instance provisioning
+    hostname: Optional[str]
     internal_ip: Optional[str]
     region: str
     price: float
     username: str
-    ssh_port: int  # could be different from 22 for some backends
+    # ssh_port be different from 22 for some backends.
+    # ssh_port may not be set immediately after instance provisioning
+    ssh_port: Optional[int]
     dockerized: bool  # True if backend starts shim
     ssh_proxy: Optional[SSHConnectionParams]
     backend_data: Optional[str]  # backend-specific data in json

--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -97,7 +97,6 @@ class RunTerminationReason(str, Enum):
 class JobTerminationReason(str, Enum):
     # Set by the server
     FAILED_TO_START_DUE_TO_NO_CAPACITY = "failed_to_start_due_to_no_capacity"
-    FAILED_TO_START_DUE_TO_PROVISIONING_ERROR = "failed_to_start_due_to_provisioning_error"
     INTERRUPTED_BY_NO_CAPACITY = "interrupted_by_no_capacity"
     WAITING_INSTANCE_LIMIT_EXCEEDED = "waiting_instance_limit_exceeded"
     WAITING_RUNNER_LIMIT_EXCEEDED = "waiting_runner_limit_exceeded"
@@ -117,6 +116,7 @@ class JobTerminationReason(str, Enum):
         mapping = {
             self.FAILED_TO_START_DUE_TO_NO_CAPACITY: JobStatus.FAILED,
             self.INTERRUPTED_BY_NO_CAPACITY: JobStatus.FAILED,
+            self.WAITING_INSTANCE_LIMIT_EXCEEDED: JobStatus.FAILED,
             self.WAITING_RUNNER_LIMIT_EXCEEDED: JobStatus.FAILED,
             self.TERMINATED_BY_USER: JobStatus.TERMINATED,
             self.GATEWAY_ERROR: JobStatus.FAILED,

--- a/src/dstack/_internal/server/background/__init__.py
+++ b/src/dstack/_internal/server/background/__init__.py
@@ -4,7 +4,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 from dstack._internal.server.background.tasks.process_gateways import process_gateways
 from dstack._internal.server.background.tasks.process_instances import (
     process_instances,
-    terminate_idle_instance,
+    terminate_idle_instances,
 )
 from dstack._internal.server.background.tasks.process_running_jobs import process_running_jobs
 from dstack._internal.server.background.tasks.process_runs import process_runs
@@ -25,7 +25,7 @@ def start_background_tasks() -> AsyncIOScheduler:
     _scheduler.add_job(process_running_jobs, IntervalTrigger(seconds=2))
     _scheduler.add_job(process_terminating_jobs, IntervalTrigger(seconds=2))
     _scheduler.add_job(process_instances, IntervalTrigger(seconds=5))
-    _scheduler.add_job(terminate_idle_instance, IntervalTrigger(seconds=10))
+    _scheduler.add_job(terminate_idle_instances, IntervalTrigger(seconds=10))
     _scheduler.add_job(process_runs, IntervalTrigger(seconds=1))
     _scheduler.add_job(process_gateways, IntervalTrigger(seconds=15))
     _scheduler.start()

--- a/src/dstack/_internal/server/background/tasks/process_instances.py
+++ b/src/dstack/_internal/server/background/tasks/process_instances.py
@@ -364,11 +364,8 @@ async def wait_for_instance_provisioning_data(
         "Waiting for instance %s to become running",
         instance.name,
     )
-    timeout_interval = _get_instance_timeout_interval(backend_type=instance.backend)
-    provisioning_time_threshold = (
-        instance.started_at.replace(tzinfo=datetime.timezone.utc) + timeout_interval
-    )
-    if get_current_datetime() > provisioning_time_threshold:
+    provisioning_deadline = _get_provisioning_deadline(instance)
+    if get_current_datetime() > provisioning_deadline:
         logger.warning(
             "Instance %s failed because instance has not become running in time", instance.name
         )

--- a/src/dstack/_internal/server/background/tasks/process_instances.py
+++ b/src/dstack/_internal/server/background/tasks/process_instances.py
@@ -13,7 +13,6 @@ from dstack._internal.core.errors import BackendError
 from dstack._internal.core.models.instances import (
     InstanceConfiguration,
     InstanceRuntime,
-    LaunchedInstanceInfo,
 )
 from dstack._internal.core.models.profiles import Profile, TerminationPolicy
 from dstack._internal.core.models.runs import InstanceStatus, JobProvisioningData, Requirements
@@ -201,7 +200,7 @@ async def create_instance(instance_id: UUID) -> None:
                 instance_offer.price,
             )
             try:
-                launched_instance_info: LaunchedInstanceInfo = await run_async(
+                job_provisioning_data = await run_async(
                     backend.compute().create_instance,
                     instance_offer,
                     instance_configuration,
@@ -219,19 +218,6 @@ async def create_instance(instance_id: UUID) -> None:
             except NotImplementedError:
                 # skip a backend without create_instance support, continue with next backend and offer
                 continue
-            job_provisioning_data = JobProvisioningData(
-                backend=backend.TYPE,
-                instance_type=instance_offer.instance,
-                instance_id=launched_instance_info.instance_id,
-                hostname=launched_instance_info.ip_address,
-                region=launched_instance_info.region,
-                price=instance_offer.price,
-                username=launched_instance_info.username,
-                ssh_port=launched_instance_info.ssh_port,
-                dockerized=launched_instance_info.dockerized,
-                backend_data=launched_instance_info.backend_data,
-                ssh_proxy=None,
-            )
 
             instance.status = InstanceStatus.PROVISIONING
             instance.backend = backend.TYPE

--- a/src/dstack/_internal/server/services/jobs/__init__.py
+++ b/src/dstack/_internal/server/services/jobs/__init__.py
@@ -10,7 +10,7 @@ import sqlalchemy.orm as sa_orm
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import dstack._internal.server.services.gateways as gateways
-from dstack._internal.core.errors import ResourceNotFoundError, SSHError
+from dstack._internal.core.errors import ComputeResourceNotFoundError, SSHError
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.configurations import ConfigurationType
 from dstack._internal.core.models.runs import (
@@ -100,7 +100,7 @@ def find_job(jobs: List[Job], replica_num: int, job_num: int) -> Job:
     for job in jobs:
         if job.job_spec.replica_num == replica_num and job.job_spec.job_num == job_num:
             return job
-    raise ResourceNotFoundError(
+    raise ComputeResourceNotFoundError(
         f"Job with replica_num={replica_num} and job_num={job_num} not found"
     )
 

--- a/src/tests/_internal/server/background/tasks/test_process_submitted_jobs.py
+++ b/src/tests/_internal/server/background/tasks/test_process_submitted_jobs.py
@@ -11,11 +11,15 @@ from dstack._internal.core.models.instances import (
     InstanceAvailability,
     InstanceOfferWithAvailability,
     InstanceType,
-    LaunchedInstanceInfo,
     Resources,
 )
 from dstack._internal.core.models.profiles import DEFAULT_POOL_NAME, Profile, ProfileRetryPolicy
-from dstack._internal.core.models.runs import InstanceStatus, JobStatus, JobTerminationReason
+from dstack._internal.core.models.runs import (
+    InstanceStatus,
+    JobProvisioningData,
+    JobStatus,
+    JobTerminationReason,
+)
 from dstack._internal.server.background.tasks.process_submitted_jobs import process_submitted_jobs
 from dstack._internal.server.models import JobModel
 from dstack._internal.server.services.pools import (
@@ -90,13 +94,19 @@ class TestProcessSubmittedJobs:
             m.return_value = [backend_mock]
             backend_mock.TYPE = BackendType.AWS
             backend_mock.compute.return_value.get_offers.return_value = [offer]
-            backend_mock.compute.return_value.run_job.return_value = LaunchedInstanceInfo(
+            backend_mock.compute.return_value.run_job.return_value = JobProvisioningData(
+                backend=offer.backend,
+                instance_type=offer.instance,
                 instance_id="instance_id",
-                region="us",
-                ip_address="1.1.1.1",
+                hostname="1.1.1.1",
+                internal_ip=None,
+                region=offer.region,
+                price=offer.price,
                 username="ubuntu",
                 ssh_port=22,
+                ssh_proxy=None,
                 dockerized=True,
+                backend_data=None,
             )
             await process_submitted_jobs()
             m.assert_called_once()

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -14,13 +14,13 @@ from dstack._internal.core.models.instances import (
     InstanceAvailability,
     InstanceOfferWithAvailability,
     InstanceType,
-    LaunchedInstanceInfo,
     Resources,
     SSHKey,
 )
 from dstack._internal.core.models.profiles import DEFAULT_POOL_NAME, Profile
 from dstack._internal.core.models.resources import ResourcesSpec
 from dstack._internal.core.models.runs import (
+    JobProvisioningData,
     JobSpec,
     JobStatus,
     JobTerminationReason,
@@ -917,13 +917,19 @@ class TestCreateInstance:
             )
             backend = Mock()
             backend.compute.return_value.get_offers.return_value = [offer]
-            backend.compute.return_value.create_instance.return_value = LaunchedInstanceInfo(
+            backend.compute.return_value.create_instance.return_value = JobProvisioningData(
+                backend=offer.backend,
+                instance_type=offer.instance,
                 instance_id="test_instance",
-                region="eu",
-                ip_address="127.0.0.1",
+                hostname="1.1.1.1",
+                internal_ip=None,
+                region=offer.region,
+                price=offer.price,
                 username="ubuntu",
                 ssh_port=22,
-                dockerized=False,
+                ssh_proxy=None,
+                dockerized=True,
+                backend_data=None,
             )
             backend.TYPE = BackendType.AWS
             run_plan_by_req.return_value = [(backend, offer)]


### PR DESCRIPTION
Closes #1148
Fixes #1145

This PR:
* allows backends to return IP address and ssh_port from `run_job()`/`create_instance()` optionally.
* allows backends to implement `Compute.update_provisioning_data()` to ping instance for IP address and ssh_port.
* refactors job and instance processing logic to wait for IP address and ssh_port outside of `run_job()`/`create_instance()`.
* removes `LaunchedInstanceInfo` in favor of `JobProvisioingData`.
* and minor job and instance processing logic improvements.

Tested `dstack run` for:
* [x] aws
* [x] azure
* [x] cudo
* [ ] datacrunch
* [x] gcp
* [ ] kubernetes
* [x] lambda
* [ ] local
* [ ] nebius
* [x] runpod
* [x] tensordock
* [ ] vastai

Tested `dstack pool add` for:
* [x] aws
* [ ] azure
* [x] cudo
* [ ] datacrunch
* [x] gcp
* [ ] lambda
* [ ] local
* [ ] nebius
* [ ] tensordock

Other tests:
* [x] backend never returning IP address terminates instance/job on timeout.