### PR TITLE
Fix `KeyError: 'IpPermissions'` when using AWS

### DIFF
--- a/src/dstack/_internal/core/backends/aws/resources.py
+++ b/src/dstack/_internal/core/backends/aws/resources.py
@@ -348,7 +348,7 @@ def _add_ingress_security_group_rule_if_missing(
     security_group_id: str,
     rule: Dict,
 ) -> bool:
-    if _rule_exists(rule, security_group["IpPermissions"]):
+    if _rule_exists(rule, security_group.get("IpPermissions", [])):
         return False
     ec2_client.authorize_security_group_ingress(
         GroupId=security_group_id,
@@ -363,7 +363,7 @@ def _add_egress_security_group_rule_if_missing(
     security_group_id: str,
     rule: Dict,
 ) -> bool:
-    if _rule_exists(rule, security_group["IpPermissionsEgress"]):
+    if _rule_exists(rule, security_group.get("IpPermissionsEgress", [])):
         return False
     ec2_client.authorize_security_group_egress(
         GroupId=security_group_id,


### PR DESCRIPTION
AWS docs say `IpPermissions` and
`IpPermissionsEgress` can be missing.
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SecurityGroup.html

It is not mentioned whether a missing property is
equivalent to an empty list, but I assume it is.
Even if my assumption is wrong, we might at least
get a clearer error next time somebody manages to
reproduce this.

Fixes #1168 