### PR TITLE
Allow to configure AWS vpc_ids

### DIFF
--- a/src/dstack/_internal/core/backends/aws/resources.py
+++ b/src/dstack/_internal/core/backends/aws/resources.py
@@ -324,6 +324,13 @@ def get_default_vpc_id(ec2_client: botocore.client.BaseClient) -> Optional[str]:
     return None
 
 
+def get_vpc_by_vpc_id(ec2_client: botocore.client.BaseClient, vpc_id: str) -> Optional[str]:
+    response = ec2_client.describe_vpcs(Filters=[{"Name": "vpc-id", "Values": [vpc_id]}])
+    if "Vpcs" in response and len(response["Vpcs"]) > 0:
+        return response["Vpcs"][0]
+    return None
+
+
 def get_subnet_id_for_vpc(
     ec2_client: botocore.client.BaseClient,
     vpc_id: str,

--- a/src/dstack/_internal/core/models/backends/aws.py
+++ b/src/dstack/_internal/core/models/backends/aws.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from pydantic import Field
 from typing_extensions import Annotated, List, Literal, Optional, Union
 
@@ -9,6 +11,7 @@ class AWSConfigInfo(CoreModel):
     type: Literal["aws"] = "aws"
     regions: Optional[List[str]] = None
     vpc_name: Optional[str] = None
+    vpc_ids: Optional[Dict[str, str]] = None
 
 
 class AWSAccessKeyCreds(CoreModel):
@@ -41,6 +44,8 @@ class AWSConfigInfoWithCredsPartial(CoreModel):
     type: Literal["aws"] = "aws"
     creds: Optional[AnyAWSCreds]
     regions: Optional[List[str]]
+    vpc_name: Optional[str]
+    vpc_ids: Optional[Dict[str, str]]
 
 
 class AWSConfigValues(CoreModel):

--- a/src/dstack/_internal/server/services/backends/configurators/aws.py
+++ b/src/dstack/_internal/server/services/backends/configurators/aws.py
@@ -1,9 +1,12 @@
 import json
 from typing import List
 
+from boto3.session import Session
+
 from dstack._internal.core.backends.aws import AWSBackend, auth
+from dstack._internal.core.backends.aws.compute import get_vpc_id_subnet_id_or_error
 from dstack._internal.core.backends.aws.config import AWSConfig
-from dstack._internal.core.errors import BackendAuthError
+from dstack._internal.core.errors import BackendAuthError, ComputeError, ServerClientError
 from dstack._internal.core.models.backends.aws import (
     AnyAWSConfigInfo,
     AWSAccessKeyCreds,
@@ -76,7 +79,7 @@ class AWSConfigurator(Configurator):
         ):
             raise_invalid_credentials_error(fields=[["creds"]])
         try:
-            auth.authenticate(creds=config.creds, region=MAIN_REGION)
+            session = auth.authenticate(creds=config.creds, region=MAIN_REGION)
         except Exception:
             if is_core_model_instance(config.creds, AWSAccessKeyCreds):
                 raise_invalid_credentials_error(
@@ -89,6 +92,10 @@ class AWSConfigurator(Configurator):
                 raise_invalid_credentials_error(fields=[["creds"]])
         config_values.regions = self._get_regions_element(
             selected=config.regions or DEFAULT_REGIONS
+        )
+        self._check_vpc_config(
+            session=session,
+            config=config,
         )
         return config_values
 
@@ -125,3 +132,20 @@ class AWSConfigurator(Configurator):
         for r in REGION_VALUES:
             element.values.append(ConfigElementValue(value=r, label=r))
         return element
+
+    def _check_vpc_config(self, session: Session, config: AWSConfigInfoWithCredsPartial):
+        if config.vpc_name is not None and config.vpc_ids is not None:
+            raise ServerClientError(msg="Only one of vpc_name and vpc_ids can be specified")
+        regions = config.regions
+        if regions is None:
+            regions = DEFAULT_REGIONS
+        for region in regions:
+            ec2_client = session.client("ec2", region_name=region)
+            try:
+                get_vpc_id_subnet_id_or_error(
+                    ec2_client=ec2_client,
+                    config=AWSConfig.parse_obj(config),
+                    region=region,
+                )
+            except ComputeError as e:
+                raise ServerClientError(e.args[0])

--- a/src/dstack/_internal/server/services/backends/configurators/aws.py
+++ b/src/dstack/_internal/server/services/backends/configurators/aws.py
@@ -3,8 +3,7 @@ from typing import List
 
 from boto3.session import Session
 
-from dstack._internal.core.backends.aws import AWSBackend, auth
-from dstack._internal.core.backends.aws.compute import get_vpc_id_subnet_id_or_error
+from dstack._internal.core.backends.aws import AWSBackend, auth, compute
 from dstack._internal.core.backends.aws.config import AWSConfig
 from dstack._internal.core.errors import BackendAuthError, ComputeError, ServerClientError
 from dstack._internal.core.models.backends.aws import (
@@ -142,7 +141,7 @@ class AWSConfigurator(Configurator):
         for region in regions:
             ec2_client = session.client("ec2", region_name=region)
             try:
-                get_vpc_id_subnet_id_or_error(
+                compute.get_vpc_id_subnet_id_or_error(
                     ec2_client=ec2_client,
                     config=AWSConfig.parse_obj(config),
                     region=region,

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Literal, Optional, Union
+from typing import Dict, List, Literal, Optional, Union
 
 import yaml
 from pydantic import BaseModel, Field, root_validator
@@ -32,6 +32,9 @@ class AWSConfig(CoreModel):
     type: Annotated[Literal["aws"], Field(description="The type of the backend")] = "aws"
     regions: Optional[List[str]] = None
     vpc_name: Annotated[Optional[str], Field(description="The VPC name")] = None
+    vpc_ids: Annotated[
+        Optional[Dict[str, str]], Field(description="The mapping from AWS regions to VPC IDs")
+    ] = None
     creds: AnyAWSCreds = Field(..., description="The credentials", discriminator="type")
 
 

--- a/src/tests/_internal/server/routers/test_backends.py
+++ b/src/tests/_internal/server/routers/test_backends.py
@@ -117,7 +117,9 @@ class TestGetBackendConfigValuesAWS:
             "dstack._internal.core.backends.aws.auth.default_creds_available"
         ) as default_creds_available_mock, patch(
             "dstack._internal.core.backends.aws.auth.authenticate"
-        ) as authenticate_mock:
+        ) as authenticate_mock, patch(
+            "dstack._internal.core.backends.aws.compute.get_vpc_id_subnet_id_or_error"
+        ):
             default_creds_available_mock.return_value = True
             response = client.post(
                 "/api/backends/config_values",
@@ -645,7 +647,7 @@ class TestCreateBackend:
             "dstack._internal.core.backends.aws.auth.default_creds_available"
         ) as default_creds_available_mock, patch(
             "dstack._internal.core.backends.aws.auth.authenticate"
-        ) as authenticate_mock:  # noqa: F841
+        ), patch("dstack._internal.core.backends.aws.compute.get_vpc_id_subnet_id_or_error"):
             default_creds_available_mock.return_value = False
             response = client.post(
                 f"/api/project/{project.name}/backends/create",
@@ -793,7 +795,7 @@ class TestCreateBackend:
             "dstack._internal.core.backends.aws.auth.default_creds_available"
         ) as default_creds_available_mock, patch(
             "dstack._internal.core.backends.aws.auth.authenticate"
-        ) as authenticate_mock:
+        ), patch("dstack._internal.core.backends.aws.compute.get_vpc_id_subnet_id_or_error"):
             default_creds_available_mock.return_value = False
             response = client.post(
                 f"/api/project/{project.name}/backends/create",
@@ -857,7 +859,7 @@ class TestUpdateBackend:
             "dstack._internal.core.backends.aws.auth.default_creds_available"
         ) as default_creds_available_mock, patch(
             "dstack._internal.core.backends.aws.auth.authenticate"
-        ) as authenticate_mock:  # noqa: F841
+        ), patch("dstack._internal.core.backends.aws.compute.get_vpc_id_subnet_id_or_error"):
             default_creds_available_mock.return_value = False
             response = client.post(
                 f"/api/project/{project.name}/backends/update",
@@ -956,5 +958,6 @@ class TestGetConfigInfo:
             "type": "aws",
             "regions": json.loads(backend.config)["regions"],
             "vpc_name": None,
+            "vpc_ids": None,
             "creds": json.loads(backend.auth),
         }

--- a/src/tests/_internal/server/routers/test_projects.py
+++ b/src/tests/_internal/server/routers/test_projects.py
@@ -63,6 +63,7 @@ class TestListProjects:
                             "type": backend.type,
                             "regions": json.loads(backend.config)["regions"],
                             "vpc_name": None,
+                            "vpc_ids": None,
                         },
                     }
                 ],

--- a/src/tests/_internal/server/services/test_config.py
+++ b/src/tests/_internal/server/services/test_config.py
@@ -94,7 +94,7 @@ class TestServerConfigManager:
                 yaml.dump(config, f)
             with patch("boto3.session.Session"), patch.object(
                 settings, "SERVER_CONFIG_FILE_PATH", config_filepath
-            ):
+            ), patch("dstack._internal.core.backends.aws.compute.get_vpc_id_subnet_id_or_error"):
                 manager = ServerConfigManager()
                 manager.load_config()
                 await manager.apply_config(session, owner)


### PR DESCRIPTION
Closes #1156.
Closes #1157.

This PR:
* Adds vpc_ids mapping to AWS config.
* Validates AWS VPC configuration on backend creation/update.