### PR TITLE
Create public ssh key is it not exist in `dstack pool add-ssh`

### DIFF
--- a/src/dstack/_internal/server/background/tasks/process_instances.py
+++ b/src/dstack/_internal/server/background/tasks/process_instances.py
@@ -126,6 +126,10 @@ async def add_remote(instance_id: UUID) -> None:
             )
         ).one()
 
+        if instance.status == InstanceStatus.PENDING:
+            instance.status = InstanceStatus.PROVISIONING
+            await session.commit()
+
         retry_duration_deadline = instance.created_at.replace(
             tzinfo=datetime.timezone.utc
         ) + timedelta(seconds=PROVISIONING_TIMEOUT_SECONDS)

--- a/src/dstack/_internal/server/background/tasks/process_instances.py
+++ b/src/dstack/_internal/server/background/tasks/process_instances.py
@@ -195,7 +195,8 @@ async def add_remote(instance_id: UUID) -> None:
                 host_info = get_host_info(client, DSTACK_WORKING_DIR)
                 logger.debug("Received a host_info %s", host_info)
 
-        except ProvisioningError:
+        except ProvisioningError as e:
+            logger.warning("Provisioning could not be completed because of the error: %s", e)
             instance.last_retry_at = get_current_datetime()
             await session.commit()
             return

--- a/src/dstack/_internal/utils/ssh.py
+++ b/src/dstack/_internal/utils/ssh.py
@@ -137,6 +137,8 @@ def convert_pkcs8_to_pem(private_string: str) -> str:
                 capture_output=True,
                 text=True,
             )
+        except FileNotFoundError:
+            logger.error("Use a PEM key or install ssh-keygen to convert it automatically")
         except subprocess.CalledProcessError as e:
             logger.error("Fail to convert ssh key: stdout=%s, stderr=%s", e.stdout, e.stderr)
 
@@ -150,3 +152,8 @@ def rsa_pkey_from_str(private_string: str) -> PKey:
     pkey = paramiko.RSAKey.from_private_key(key_file)
     key_file.close()
     return pkey
+
+
+def generate_public_key(private_key: PKey) -> str:
+    public_key = private_key.get_base64()
+    return public_key


### PR DESCRIPTION
- Log on provisioning error
- Update status when provisioning starts
- Try all of the ssh keys to connect to a remote instance
- Create the public key automatically from the private