### PR TITLE
Fix ResourcesSpecRequest references in configuration json schema

### DIFF
--- a/src/dstack/_internal/core/models/resources.py
+++ b/src/dstack/_internal/core/models/resources.py
@@ -214,7 +214,7 @@ class ResourcesSpec(CoreModel):
         def schema_extra(schema: Dict[str, Any]):
             schema.clear()
             # replace strict schema with a more permissive one
-            ref_template = "#/definitions/ResourcesSpec/definitions/{model}"
+            ref_template = "#/definitions/ResourcesSpecRequest/definitions/{model}"
             for field, value in ResourcesSpecSchema.schema(ref_template=ref_template).items():
                 schema[field] = value
 


### PR DESCRIPTION
Fixes #1192

TODO: Add tests to validate generated json schemas. I haven't found an easy way to validate the references using `jsonschema`. Consider opening a separate issue for that.