### PR TITLE
Allow configuring OCI backend

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,9 @@ KUBERNETES_DEPS = ["kubernetes"]
 
 LAMBDA_DEPS = AWS_DEPS
 
-ALL_DEPS = AWS_DEPS + AZURE_DEPS + GCP_DEPS + DATACRUNCH_DEPS + KUBERNETES_DEPS
+OCI_DEPS = ["oci"]
+
+ALL_DEPS = AWS_DEPS + AZURE_DEPS + GCP_DEPS + DATACRUNCH_DEPS + KUBERNETES_DEPS + OCI_DEPS
 
 
 setup(
@@ -134,6 +136,7 @@ setup(
         "gcp": GCP_DEPS,
         "kubernetes": KUBERNETES_DEPS,
         "lambda": LAMBDA_DEPS,
+        "oci": OCI_DEPS,
     },
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",

--- a/src/dstack/_internal/core/backends/oci/__init__.py
+++ b/src/dstack/_internal/core/backends/oci/__init__.py
@@ -1,0 +1,17 @@
+from dstack._internal.core.backends.base import Backend
+from dstack._internal.core.backends.oci.compute import OCICompute
+from dstack._internal.core.backends.oci.config import OCIConfig
+from dstack._internal.core.models.backends.base import BackendType
+from dstack._internal.settings import FeatureFlags
+
+
+class OCIBackend(Backend):
+    if FeatureFlags.OCI_BACKEND:
+        TYPE: BackendType = BackendType.OCI
+
+    def __init__(self, config: OCIConfig):
+        self.config = config
+        self._compute = OCICompute(self.config)
+
+    def compute(self) -> OCICompute:
+        return self._compute

--- a/src/dstack/_internal/core/backends/oci/auth.py
+++ b/src/dstack/_internal/core/backends/oci/auth.py
@@ -1,0 +1,18 @@
+import oci
+
+from dstack._internal.core.backends.oci.exceptions import any_oci_exception
+from dstack._internal.core.models.backends.oci import AnyOCICreds, OCIDefaultCreds
+
+
+def creds_valid(creds: AnyOCICreds) -> bool:
+    try:
+        config = creds.to_client_config()
+        client = oci.identity.IdentityClient(config)
+        client.get_tenancy(config["tenancy"])
+    except any_oci_exception:
+        return False
+    return True
+
+
+def default_creds_available() -> bool:
+    return creds_valid(OCIDefaultCreds())

--- a/src/dstack/_internal/core/backends/oci/auth.py
+++ b/src/dstack/_internal/core/backends/oci/auth.py
@@ -1,12 +1,20 @@
 import oci
+from typing_extensions import Any, Mapping
 
 from dstack._internal.core.backends.oci.exceptions import any_oci_exception
 from dstack._internal.core.models.backends.oci import AnyOCICreds, OCIDefaultCreds
+from dstack._internal.core.models.common import is_core_model_instance
+
+
+def get_client_config(creds: AnyOCICreds) -> Mapping[str, Any]:
+    if is_core_model_instance(creds, OCIDefaultCreds):
+        return oci.config.from_file()
+    return creds.dict(exclude={"type"})
 
 
 def creds_valid(creds: AnyOCICreds) -> bool:
     try:
-        config = creds.to_client_config()
+        config = get_client_config(creds)
         client = oci.identity.IdentityClient(config)
         client.get_tenancy(config["tenancy"])
     except any_oci_exception:

--- a/src/dstack/_internal/core/backends/oci/compute.py
+++ b/src/dstack/_internal/core/backends/oci/compute.py
@@ -1,0 +1,31 @@
+from typing import List, Optional
+
+from dstack._internal.core.backends.base.compute import Compute
+from dstack._internal.core.backends.oci.config import OCIConfig
+from dstack._internal.core.models.instances import InstanceOfferWithAvailability
+from dstack._internal.core.models.runs import Job, JobProvisioningData, Requirements, Run
+
+
+class OCICompute(Compute):
+    def __init__(self, config: OCIConfig):
+        self.config = config
+
+    def get_offers(
+        self, requirements: Optional[Requirements] = None
+    ) -> List[InstanceOfferWithAvailability]:
+        raise NotImplementedError
+
+    def run_job(
+        self,
+        run: Run,
+        job: Job,
+        instance_offer: InstanceOfferWithAvailability,
+        project_ssh_public_key: str,
+        project_ssh_private_key: str,
+    ) -> JobProvisioningData:
+        raise NotImplementedError
+
+    def terminate_instance(
+        self, instance_id: str, region: str, backend_data: Optional[str] = None
+    ) -> None:
+        raise NotImplementedError

--- a/src/dstack/_internal/core/backends/oci/config.py
+++ b/src/dstack/_internal/core/backends/oci/config.py
@@ -1,0 +1,6 @@
+from dstack._internal.core.backends.base.config import BackendConfig
+from dstack._internal.core.models.backends.oci import AnyOCICreds, OCIStoredConfig
+
+
+class OCIConfig(OCIStoredConfig, BackendConfig):
+    creds: AnyOCICreds

--- a/src/dstack/_internal/core/backends/oci/exceptions.py
+++ b/src/dstack/_internal/core/backends/oci/exceptions.py
@@ -1,0 +1,15 @@
+from oci.exceptions import (
+    BaseRequestException,
+    ClientError,
+    CompositeOperationError,
+    MultipartUploadError,
+    ServiceError,
+)
+
+any_oci_exception = (
+    BaseRequestException,
+    ClientError,
+    CompositeOperationError,
+    MultipartUploadError,
+    ServiceError,
+)

--- a/src/dstack/_internal/core/backends/oci/region.py
+++ b/src/dstack/_internal/core/backends/oci/region.py
@@ -7,7 +7,7 @@ from dstack._internal.core.backends.oci.auth import get_client_config
 from dstack._internal.core.models.backends.oci import AnyOCICreds
 
 
-class OCIRegion:
+class OCIRegionClient:
     """
     A structure for region-specific objects, including region-bound API clients
     """
@@ -30,7 +30,7 @@ class OCIRegion:
 
 def get_subscribed_region_names(creds: AnyOCICreds) -> List[str]:
     config = get_client_config(creds)
-    region = OCIRegion(config)
+    region = OCIRegionClient(config)
 
     subscriptions: List[oci.identity.models.RegionSubscription] = (
         region.identity_client.list_region_subscriptions(config["tenancy"]).data

--- a/src/dstack/_internal/core/backends/oci/region.py
+++ b/src/dstack/_internal/core/backends/oci/region.py
@@ -1,0 +1,37 @@
+from functools import cached_property
+
+import oci
+from typing_extensions import Any, List, Mapping
+
+from dstack._internal.core.models.backends.oci import AnyOCICreds
+
+
+class OCIRegion:
+    """
+    A structure for region-specific objects, including region-bound API clients
+    """
+
+    def __init__(self, client_config: Mapping[str, Any]):
+        self.client_config = client_config
+
+    @cached_property
+    def compute_client(self) -> oci.core.ComputeClient:
+        return oci.core.ComputeClient(self.client_config)
+
+    @cached_property
+    def identity_client(self) -> oci.identity.IdentityClient:
+        return oci.identity.IdentityClient(self.client_config)
+
+    @cached_property
+    def availability_domains(self) -> List[oci.identity.models.AvailabilityDomain]:
+        return self.identity_client.list_availability_domains(self.client_config["tenancy"]).data
+
+
+def get_subscribed_region_names(creds: AnyOCICreds) -> List[str]:
+    config = creds.to_client_config()
+    region = OCIRegion(config)
+
+    subscriptions: List[oci.identity.models.RegionSubscription] = (
+        region.identity_client.list_region_subscriptions(config["tenancy"]).data
+    )
+    return [s.region_name for s in subscriptions if s.status == s.STATUS_READY]

--- a/src/dstack/_internal/core/backends/oci/region.py
+++ b/src/dstack/_internal/core/backends/oci/region.py
@@ -3,6 +3,7 @@ from functools import cached_property
 import oci
 from typing_extensions import Any, List, Mapping
 
+from dstack._internal.core.backends.oci.auth import get_client_config
 from dstack._internal.core.models.backends.oci import AnyOCICreds
 
 
@@ -28,7 +29,7 @@ class OCIRegion:
 
 
 def get_subscribed_region_names(creds: AnyOCICreds) -> List[str]:
-    config = creds.to_client_config()
+    config = get_client_config(creds)
     region = OCIRegion(config)
 
     subscriptions: List[oci.identity.models.RegionSubscription] = (

--- a/src/dstack/_internal/core/models/backends/__init__.py
+++ b/src/dstack/_internal/core/models/backends/__init__.py
@@ -53,6 +53,12 @@ from dstack._internal.core.models.backends.nebius import (
     NebiusConfigInfoWithCredsPartial,
     NebiusConfigValues,
 )
+from dstack._internal.core.models.backends.oci import (
+    OCIConfigInfo,
+    OCIConfigInfoWithCreds,
+    OCIConfigInfoWithCredsPartial,
+    OCIConfigValues,
+)
 from dstack._internal.core.models.backends.runpod import (
     RunpodConfigInfo,
     RunpodConfigInfoWithCreds,
@@ -72,6 +78,7 @@ from dstack._internal.core.models.backends.vastai import (
     VastAIConfigValues,
 )
 from dstack._internal.core.models.common import CoreModel
+from dstack._internal.settings import FeatureFlags
 
 # Backend config returned by the API
 AnyConfigInfoWithoutCreds = Union[
@@ -89,6 +96,8 @@ AnyConfigInfoWithoutCreds = Union[
     DstackConfigInfo,
     DstackBaseBackendConfigInfo,
 ]
+if FeatureFlags.OCI_BACKEND:
+    AnyConfigInfoWithoutCreds = Union[AnyConfigInfoWithoutCreds, OCIConfigInfo]
 
 # Same as AnyConfigInfoWithoutCreds but also includes creds.
 # Used to create/update backend.
@@ -107,6 +116,8 @@ AnyConfigInfoWithCreds = Union[
     VastAIConfigInfoWithCreds,
     DstackConfigInfo,
 ]
+if FeatureFlags.OCI_BACKEND:
+    AnyConfigInfoWithCreds = Union[AnyConfigInfoWithCreds, OCIConfigInfoWithCreds]
 
 AnyConfigInfo = Union[AnyConfigInfoWithoutCreds, AnyConfigInfoWithCreds]
 
@@ -127,6 +138,10 @@ AnyConfigInfoWithCredsPartial = Union[
     VastAIConfigInfoWithCredsPartial,
     DstackConfigInfo,
 ]
+if FeatureFlags.OCI_BACKEND:
+    AnyConfigInfoWithCredsPartial = Union[
+        AnyConfigInfoWithCredsPartial, OCIConfigInfoWithCredsPartial
+    ]
 
 # Suggestions for unfilled fields used in interactive setup.
 AnyConfigValues = Union[
@@ -143,6 +158,8 @@ AnyConfigValues = Union[
     VastAIConfigValues,
     DstackConfigValues,
 ]
+if FeatureFlags.OCI_BACKEND:
+    AnyConfigValues = Union[AnyConfigValues, OCIConfigValues]
 
 
 # In case we'll support multiple backends of the same type,

--- a/src/dstack/_internal/core/models/backends/base.py
+++ b/src/dstack/_internal/core/models/backends/base.py
@@ -2,6 +2,7 @@ import enum
 from typing import List, Optional
 
 from dstack._internal.core.models.common import CoreModel
+from dstack._internal.settings import FeatureFlags
 
 
 class BackendType(str, enum.Enum):
@@ -31,6 +32,8 @@ class BackendType(str, enum.Enum):
     LOCAL = "local"
     REMOTE = "remote"  # TODO: replace for LOCAL
     NEBIUS = "nebius"
+    if FeatureFlags.OCI_BACKEND:
+        OCI = "oci"
     RUNPOD = "runpod"
     TENSORDOCK = "tensordock"
     VASTAI = "vastai"

--- a/src/dstack/_internal/core/models/backends/oci.py
+++ b/src/dstack/_internal/core/models/backends/oci.py
@@ -1,8 +1,7 @@
 from pathlib import Path
 
-import oci
 from pydantic import Field
-from typing_extensions import Annotated, Any, List, Literal, Mapping, Optional, Union
+from typing_extensions import Annotated, List, Literal, Optional, Union
 
 from dstack._internal.core.models.backends.base import ConfigMultiElement
 from dstack._internal.core.models.common import CoreModel
@@ -23,15 +22,9 @@ class OCIClientCreds(CoreModel):
         str, Field(description="Name or key of any region the tenancy is subscribed to")
     ]
 
-    def to_client_config(self) -> Mapping[str, Any]:
-        return self.dict(exclude={"type"})
-
 
 class OCIDefaultCreds(CoreModel):
     type: Annotated[Literal["default"], Field(description="The type of credentials")] = "default"
-
-    def to_client_config(self) -> Mapping[str, Any]:
-        return oci.config.from_file()
 
 
 AnyOCICreds = Union[OCIClientCreds, OCIDefaultCreds]

--- a/src/dstack/_internal/core/models/backends/oci.py
+++ b/src/dstack/_internal/core/models/backends/oci.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+import oci
+from pydantic import Field
+from typing_extensions import Annotated, Any, List, Literal, Mapping, Optional, Union
+
+from dstack._internal.core.models.backends.base import ConfigMultiElement
+from dstack._internal.core.models.common import CoreModel
+
+
+class OCIConfigInfo(CoreModel):
+    type: Literal["oci"] = "oci"
+    regions: Optional[List[str]] = None
+
+
+class OCIClientCreds(CoreModel):
+    type: Annotated[Literal["client"], Field(description="The type of credentials")] = "client"
+    user: Annotated[str, Field(description="User OCID")]
+    tenancy: Annotated[str, Field(description="Tenancy OCID")]
+    key_file: Annotated[Path, Field(description="Path to the PEM key")]
+    fingerprint: Annotated[str, Field(description="Key fingerprint")]
+    region: Annotated[
+        str, Field(description="Name or key of any region the tenancy is subscribed to")
+    ]
+
+    def to_client_config(self) -> Mapping[str, Any]:
+        return self.dict(exclude={"type"})
+
+
+class OCIDefaultCreds(CoreModel):
+    type: Annotated[Literal["default"], Field(description="The type of credentials")] = "default"
+
+    def to_client_config(self) -> Mapping[str, Any]:
+        return oci.config.from_file()
+
+
+AnyOCICreds = Union[OCIClientCreds, OCIDefaultCreds]
+
+
+class OCICreds(CoreModel):
+    __root__: AnyOCICreds = Field(..., discriminator="type")
+
+
+class OCIConfigInfoWithCreds(OCIConfigInfo):
+    creds: AnyOCICreds
+
+
+AnyOCIConfigInfo = Union[OCIConfigInfo, OCIConfigInfoWithCreds]
+
+
+class OCIConfigInfoWithCredsPartial(CoreModel):
+    type: Literal["oci"] = "oci"
+    creds: Optional[AnyOCICreds]
+    regions: Optional[List[str]]
+
+
+class OCIConfigValues(CoreModel):
+    type: Literal["oci"] = "oci"
+    default_creds: bool = False
+    regions: Optional[ConfigMultiElement]
+
+
+class OCIStoredConfig(OCIConfigInfo):
+    pass

--- a/src/dstack/_internal/server/services/backends/__init__.py
+++ b/src/dstack/_internal/server/services/backends/__init__.py
@@ -28,6 +28,7 @@ from dstack._internal.server.models import BackendModel, ProjectModel
 from dstack._internal.server.services.backends.configurators.base import Configurator
 from dstack._internal.server.settings import LOCAL_BACKEND_ENABLED
 from dstack._internal.server.utils.common import run_async
+from dstack._internal.settings import FeatureFlags
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -95,6 +96,14 @@ try:
     from dstack._internal.server.services.backends.configurators.nebius import NebiusConfigurator
 
     _CONFIGURATOR_CLASSES.append(NebiusConfigurator)
+except ImportError:
+    pass
+
+try:
+    from dstack._internal.server.services.backends.configurators.oci import OCIConfigurator
+
+    if FeatureFlags.OCI_BACKEND:
+        _CONFIGURATOR_CLASSES.append(OCIConfigurator)
 except ImportError:
     pass
 

--- a/src/dstack/_internal/server/services/backends/configurators/oci.py
+++ b/src/dstack/_internal/server/services/backends/configurators/oci.py
@@ -1,0 +1,123 @@
+import json
+from typing import List
+
+from dstack._internal.core.backends.oci import OCIBackend, auth
+from dstack._internal.core.backends.oci.config import OCIConfig
+from dstack._internal.core.backends.oci.exceptions import any_oci_exception
+from dstack._internal.core.backends.oci.region import get_subscribed_region_names
+from dstack._internal.core.errors import ServerClientError
+from dstack._internal.core.models.backends.base import (
+    BackendType,
+    ConfigElementValue,
+    ConfigMultiElement,
+)
+from dstack._internal.core.models.backends.oci import (
+    AnyOCIConfigInfo,
+    OCIConfigInfo,
+    OCIConfigInfoWithCreds,
+    OCIConfigInfoWithCredsPartial,
+    OCIConfigValues,
+    OCICreds,
+    OCIDefaultCreds,
+    OCIStoredConfig,
+)
+from dstack._internal.core.models.common import is_core_model_instance
+from dstack._internal.server import settings
+from dstack._internal.server.models import BackendModel, ProjectModel
+from dstack._internal.server.services.backends.configurators.base import (
+    Configurator,
+    raise_invalid_credentials_error,
+)
+from dstack._internal.settings import FeatureFlags
+
+
+class OCIConfigurator(Configurator):
+    if FeatureFlags.OCI_BACKEND:
+        TYPE: BackendType = BackendType.OCI
+
+    def get_default_configs(self) -> List[OCIConfigInfoWithCreds]:
+        creds = OCIDefaultCreds()
+        try:
+            regions = get_subscribed_region_names(creds)
+        except any_oci_exception:
+            return []
+        return [
+            OCIConfigInfoWithCreds(
+                regions=regions,
+                creds=creds,
+            )
+        ]
+
+    def get_config_values(self, config: OCIConfigInfoWithCredsPartial) -> OCIConfigValues:
+        config_values = OCIConfigValues(regions=None)
+        config_values.default_creds = (
+            settings.DEFAULT_CREDS_ENABLED and auth.default_creds_available()
+        )
+        if config.creds is None:
+            return config_values
+        if (
+            is_core_model_instance(config.creds, OCIDefaultCreds)
+            and not settings.DEFAULT_CREDS_ENABLED
+        ):
+            raise_invalid_credentials_error(fields=[["creds"]])
+
+        try:
+            available_regions = get_subscribed_region_names(config.creds)
+        except any_oci_exception:
+            raise_invalid_credentials_error(fields=[["creds"]])
+
+        if config.regions:
+            selected_regions = [r for r in config.regions if r in available_regions]
+        else:
+            selected_regions = available_regions
+
+        config_values.regions = self._get_regions_element(
+            available=available_regions,
+            selected=selected_regions,
+        )
+        return config_values
+
+    def create_backend(
+        self, project: ProjectModel, config: OCIConfigInfoWithCreds
+    ) -> BackendModel:
+        try:
+            available_regions = get_subscribed_region_names(config.creds)
+        except any_oci_exception:
+            raise_invalid_credentials_error(fields=[["creds"]])
+
+        if config.regions is None:
+            config.regions = available_regions
+        elif unsubscribed_regions := set(config.regions) - set(available_regions):
+            msg = f"Regions {unsubscribed_regions} are configured but not subscribed to in OCI"
+            raise ServerClientError(msg, fields=["regions"])
+
+        return BackendModel(
+            project_id=project.id,
+            type=self.TYPE.value,
+            config=OCIStoredConfig.__response__.parse_obj(config).json(),
+            auth=OCICreds.parse_obj(config.creds).json(),
+        )
+
+    def get_config_info(self, model: BackendModel, include_creds: bool) -> AnyOCIConfigInfo:
+        config = self._get_backend_config(model)
+        if include_creds:
+            return OCIConfigInfoWithCreds.__response__.parse_obj(config)
+        return OCIConfigInfo.__response__.parse_obj(config)
+
+    def get_backend(self, model: BackendModel) -> OCIBackend:
+        config = self._get_backend_config(model)
+        return OCIBackend(config=config)
+
+    def _get_backend_config(self, model: BackendModel) -> OCIConfig:
+        return OCIConfig.__response__(
+            **json.loads(model.config),
+            creds=OCICreds.parse_raw(model.auth).__root__,
+        )
+
+    def _get_regions_element(
+        self, available: List[str], selected: List[str]
+    ) -> ConfigMultiElement:
+        element = ConfigMultiElement(selected=selected)
+        for region in available:
+            element.values.append(ConfigElementValue(value=region, label=region))
+        return element

--- a/src/dstack/_internal/server/services/backends/configurators/oci.py
+++ b/src/dstack/_internal/server/services/backends/configurators/oci.py
@@ -89,7 +89,7 @@ class OCIConfigurator(Configurator):
             config.regions = available_regions
         elif unsubscribed_regions := set(config.regions) - set(available_regions):
             msg = f"Regions {unsubscribed_regions} are configured but not subscribed to in OCI"
-            raise ServerClientError(msg, fields=["regions"])
+            raise ServerClientError(msg, fields=[["regions"]])
 
         return BackendModel(
             project_id=project.id,

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -18,6 +18,7 @@ from dstack._internal.core.models.backends.cudo import AnyCudoCreds
 from dstack._internal.core.models.backends.datacrunch import AnyDataCrunchCreds
 from dstack._internal.core.models.backends.kubernetes import KubernetesNetworkingConfig
 from dstack._internal.core.models.backends.lambdalabs import AnyLambdaCreds
+from dstack._internal.core.models.backends.oci import AnyOCICreds
 from dstack._internal.core.models.backends.runpod import AnyRunpodCreds
 from dstack._internal.core.models.backends.tensordock import AnyTensorDockCreds
 from dstack._internal.core.models.backends.vastai import AnyVastAICreds
@@ -27,6 +28,7 @@ from dstack._internal.server.models import ProjectModel, UserModel
 from dstack._internal.server.services import backends as backends_services
 from dstack._internal.server.services import projects as projects_services
 from dstack._internal.server.utils.common import run_async
+from dstack._internal.settings import FeatureFlags
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -211,6 +213,12 @@ class NebiusAPIConfig(CoreModel):
     creds: AnyNebiusAPICreds
 
 
+class OCIConfig(CoreModel):
+    type: Literal["oci"] = "oci"
+    creds: Optional[AnyOCICreds]
+    regions: Optional[List[str]] = None
+
+
 class RunpodConfig(CoreModel):
     type: Literal["runpod"] = "runpod"
     regions: Optional[List[str]] = None
@@ -247,6 +255,8 @@ AnyBackendConfig = Union[
     VastAIConfig,
     DstackConfig,
 ]
+if FeatureFlags.OCI_BACKEND:
+    AnyBackendConfig = Union[AnyBackendConfig, OCIConfig]
 
 BackendConfig = Annotated[AnyBackendConfig, Field(..., discriminator="type")]
 
@@ -269,6 +279,8 @@ AnyBackendAPIConfig = Union[
     VastAIConfig,
     DstackConfig,
 ]
+if FeatureFlags.OCI_BACKEND:
+    AnyBackendAPIConfig = Union[AnyBackendAPIConfig, OCIConfig]
 
 
 BackendAPIConfig = Annotated[AnyBackendAPIConfig, Field(..., discriminator="type")]

--- a/src/dstack/_internal/settings.py
+++ b/src/dstack/_internal/settings.py
@@ -5,3 +5,13 @@ from dstack import version
 DSTACK_VERSION = os.getenv("DSTACK_VERSION", version.__version__)
 DSTACK_RELEASE = os.getenv("DSTACK_RELEASE") is not None or version.__is_release__
 DSTACK_USE_LATEST_FROM_BRANCH = os.getenv("DSTACK_USE_LATEST_FROM_BRANCH") is not None
+
+
+class FeatureFlags:
+    """
+    dstack feature flags. Feature flags are temporary and can be used when developing
+    large features. This class may be empty if there are no such features in
+    development. Feature flags are environment variables of the form DSTACK_FF_*
+    """
+
+    OCI_BACKEND = os.getenv("DSTACK_FF_OCI_BACKEND") is not None


### PR DESCRIPTION
This is the first part of the Oracle Cloud Infrastructure backend implementation (#1194). Behind the `OCI_BACKEND` feature flag.