### PR TITLE
[Internal] Install all deps in JSON schema CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Install AWS
         run: pip install awscli
       - name: Install dstack
-        run: pip install .
+        run: pip install .[all]
       - name: Generate json schema
         run: |
           python -c "from dstack._internal.core.models.configurations import RunConfiguration; print(RunConfiguration.schema_json(indent=2))" > configuration.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,7 @@ jobs:
       - name: Install AWS
         run: pip install awscli
       - name: Install dstack
-        run: pip install .
+        run: pip install .[all]
       - name: Generate json schema
         run: |
           python -c "from dstack._internal.core.models.configurations import RunConfiguration; print(RunConfiguration.schema_json(indent=2))" > configuration.json


### PR DESCRIPTION
It can be handy to use backend-specific
dependencies in the pydantic models used for
schema generation. See PR #1197 for an example of
the `generate-json-schema` CI job failing without
these dependencies.