### PR TITLE
Support provisioning instances without public IPs on AWS

### DIFF
--- a/src/dstack/_internal/core/backends/aws/config.py
+++ b/src/dstack/_internal/core/backends/aws/config.py
@@ -4,3 +4,9 @@ from dstack._internal.core.models.backends.aws import AnyAWSCreds, AWSStoredConf
 
 class AWSConfig(AWSStoredConfig, BackendConfig):
     creds: AnyAWSCreds
+
+    @property
+    def allocate_public_ips(self) -> bool:
+        if self.public_ips is not None:
+            return self.public_ips
+        return True

--- a/src/dstack/_internal/core/models/backends/aws.py
+++ b/src/dstack/_internal/core/models/backends/aws.py
@@ -12,6 +12,7 @@ class AWSConfigInfo(CoreModel):
     regions: Optional[List[str]] = None
     vpc_name: Optional[str] = None
     vpc_ids: Optional[Dict[str, str]] = None
+    public_ips: Optional[bool] = None
 
 
 class AWSAccessKeyCreds(CoreModel):
@@ -46,6 +47,7 @@ class AWSConfigInfoWithCredsPartial(CoreModel):
     regions: Optional[List[str]]
     vpc_name: Optional[str]
     vpc_ids: Optional[Dict[str, str]]
+    public_ips: Optional[bool]
 
 
 class AWSConfigValues(CoreModel):

--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -195,9 +195,13 @@ class JobProvisioningData(CoreModel):
     backend: BackendType
     instance_type: InstanceType
     instance_id: str
-    # hostname may not be set immediately after instance provisioning
+    # hostname may not be set immediately after instance provisioning.
+    # It is set to a public IP or, if public IPs are disabled, to a private IP.
     hostname: Optional[str]
     internal_ip: Optional[str]
+    # public_ip_enabled can used to distinguished instances with and without public IPs.
+    # hostname being None is not enough since it can be filled after provisioning.
+    public_ip_enabled: bool = True
     region: str
     price: float
     username: str

--- a/src/dstack/_internal/server/services/backends/configurators/aws.py
+++ b/src/dstack/_internal/server/services/backends/configurators/aws.py
@@ -139,6 +139,7 @@ class AWSConfigurator(Configurator):
         regions = config.regions
         if regions is None:
             regions = DEFAULT_REGIONS
+        allocate_public_ip = config.public_ips if config.public_ips is not None else True
         # The number of workers should be >= the number of regions
         with concurrent.futures.ThreadPoolExecutor(max_workers=12) as executor:
             futures = []
@@ -149,6 +150,7 @@ class AWSConfigurator(Configurator):
                     ec2_client=ec2_client,
                     config=AWSConfig.parse_obj(config),
                     region=region,
+                    allocate_public_ip=allocate_public_ip,
                 )
                 futures.append(future)
             for future in concurrent.futures.as_completed(futures):

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -62,6 +62,12 @@ class AWSConfig(CoreModel):
     vpc_ids: Annotated[
         Optional[Dict[str, str]], Field(description="The mapping from AWS regions to VPC IDs")
     ] = None
+    public_ips: Annotated[
+        Optional[bool],
+        Field(
+            description="A flag to enable/disable public IP assigning on instances. Defaults to `true`."
+        ),
+    ] = None
     creds: AnyAWSCreds = Field(..., description="The credentials", discriminator="type")
 
 
@@ -76,8 +82,8 @@ class AzureConfig(CoreModel):
 class CudoConfig(CoreModel):
     type: Annotated[Literal["cudo"], Field(description="The type of backend")] = "cudo"
     regions: Optional[List[str]] = None
-    creds: Annotated[AnyCudoCreds, Field(description="The credentials")]
     project_id: Annotated[str, Field(description="The project ID")]
+    creds: Annotated[AnyCudoCreds, Field(description="The credentials")]
 
 
 class DataCrunchConfig(CoreModel):

--- a/src/tests/_internal/server/routers/test_backends.py
+++ b/src/tests/_internal/server/routers/test_backends.py
@@ -1118,6 +1118,7 @@ class TestGetConfigInfo:
             "regions": json.loads(backend.config)["regions"],
             "vpc_name": None,
             "vpc_ids": None,
+            "public_ips": None,
             "creds": json.loads(backend.auth),
         }
 

--- a/src/tests/_internal/server/routers/test_projects.py
+++ b/src/tests/_internal/server/routers/test_projects.py
@@ -64,6 +64,7 @@ class TestListProjects:
                             "regions": json.loads(backend.config)["regions"],
                             "vpc_name": None,
                             "vpc_ids": None,
+                            "public_ips": None,
                         },
                     }
                 ],


### PR DESCRIPTION
Closes #1201

Instances without public IPs require VPC to have a subnet with route to NAT Gateway so that instances can access internet. Configuring a backend without a proper VPC setup fails with an appropriate error.

Tested on a setup with a single VPC with NAT Gateway and remote access via AWS Client VPN.