### PR TITLE
[Internal]: Improve closing stale issues workflow

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -16,7 +16,8 @@ jobs:
           days-before-issue-close: 14
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
-          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale. Please reopen the issue if it is still relevant."
+          close-issue-reason: not_planned
           days-before-pr-stale: -1
           days-before-pr-close: -1
           repo-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
- Be explicit that reopening is OK.
- Close as not planned, not as completed. This is more accurate semantically and will distinguish such issues visually.