### PR TITLE
Adding support for the `dstack pool add` to dstack Sky

### DIFF
--- a/src/dstack/_internal/core/backends/__init__.py
+++ b/src/dstack/_internal/core/backends/__init__.py
@@ -8,6 +8,7 @@ BACKENDS_WITH_MULTINODE_SUPPORT = [
 ]
 BACKENDS_WITH_CREATE_INSTANCE_SUPPORT = [
     BackendType.AWS,
+    BackendType.DSTACK,
     BackendType.AZURE,
     BackendType.CUDO,
     BackendType.DATACRUNCH,

--- a/src/dstack/_internal/core/models/instances.py
+++ b/src/dstack/_internal/core/models/instances.py
@@ -72,6 +72,7 @@ class DockerConfig(CoreModel):
 class InstanceConfiguration(CoreModel):
     project_name: str
     instance_name: str  # unique in pool
+    instance_id: str
     ssh_keys: List[SSHKey]
     job_docker_config: Optional[DockerConfig]
     user: str  # dstack user name

--- a/src/dstack/_internal/server/testing/common.py
+++ b/src/dstack/_internal/server/testing/common.py
@@ -385,6 +385,8 @@ async def create_instance(
         instance_configuration = InstanceConfiguration(
             project_name="test_proj",
             instance_name="test_instance_name",
+            instance_id="test instance id",
+            job_docker_config=None,
             ssh_keys=[],
             user="test_user",
         )


### PR DESCRIPTION
`dstack pool add` in stack sky requires determining the `InstanceModel` of the `InstanceCondiguration`. For this, I added the optional `instance_id` field to the `InstanceConfiguration` model.
The list of backends supporting the `dstack pool add` command now include the `DSTACK` backend.