### PR TITLE
Implement running OCI jobs and stopping instances

### DIFF
--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -69,10 +69,7 @@ class Compute(ABC):
         """
         raise NotImplementedError()
 
-    def update_provisioning_data(
-        self,
-        provisioning_data: JobProvisioningData,
-    ):
+    def update_provisioning_data(self, provisioning_data: JobProvisioningData) -> None:
         """
         This method is called if `JobProvisioningData` returned from `run_job()`/`create_instance()`
         is not complete, e.g. missing `hostname` or `ssh_port`.

--- a/src/dstack/_internal/core/backends/cudo/compute.py
+++ b/src/dstack/_internal/core/backends/cudo/compute.py
@@ -141,10 +141,7 @@ class CudoCompute(Compute):
                 return
             raise BackendError(e.response.text)
 
-    def update_provisioning_data(
-        self,
-        provisioning_data: JobProvisioningData,
-    ):
+    def update_provisioning_data(self, provisioning_data: JobProvisioningData) -> None:
         vm = self.api_client.get_vm(self.config.project_id, provisioning_data.instance_id)
         if vm["VM"]["state"] == "ACTIVE":
             provisioning_data.hostname = vm["VM"]["publicIpAddress"]

--- a/src/dstack/_internal/core/backends/datacrunch/compute.py
+++ b/src/dstack/_internal/core/backends/datacrunch/compute.py
@@ -159,10 +159,7 @@ class DataCrunchCompute(Compute):
     ) -> None:
         self.api_client.delete_instance(instance_id)
 
-    def update_provisioning_data(
-        self,
-        provisioning_data: JobProvisioningData,
-    ):
+    def update_provisioning_data(self, provisioning_data: JobProvisioningData) -> None:
         instance = self.api_client.get_instance_by_id(provisioning_data.instance_id)
         if instance is not None and instance.status == "running":
             provisioning_data.hostname = instance.ip

--- a/src/dstack/_internal/core/backends/oci/compute.py
+++ b/src/dstack/_internal/core/backends/oci/compute.py
@@ -119,11 +119,7 @@ class OCICompute(Compute):
         self, instance_id: str, region: str, backend_data: Optional[str] = None
     ) -> None:
         region_client = self.regions[region]
-        region_client.compute_client.terminate_instance(
-            instance_id=instance_id,
-            preserve_boot_volume=False,
-            preserve_data_volumes_created_at_launch=False,
-        )
+        resources.terminate_instance_if_exists(region_client.compute_client, instance_id)
 
     def create_instance(
         self,

--- a/src/dstack/_internal/core/backends/oci/compute.py
+++ b/src/dstack/_internal/core/backends/oci/compute.py
@@ -2,6 +2,7 @@ import json
 import os
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from functools import cached_property
 from typing import Dict, List, Optional, Set
 
 from dstack._internal.core.backends.base.compute import Compute, get_instance_name, get_user_data
@@ -63,7 +64,10 @@ class OCICompute(Compute):
         self.config = config
         self.pre_conf = PreConfiguredResources.load(set(config.regions or []))
         self.regions = make_region_clients_map(config.regions or [], config.creds)
-        self.shapes_quota = resources.ShapesQuota.load(self.regions, self.pre_conf.compartment_id)
+
+    @cached_property
+    def shapes_quota(self) -> resources.ShapesQuota:
+        return resources.ShapesQuota.load(self.regions, self.pre_conf.compartment_id)
 
     def get_offers(
         self, requirements: Optional[Requirements] = None

--- a/src/dstack/_internal/core/backends/oci/region.py
+++ b/src/dstack/_internal/core/backends/oci/region.py
@@ -25,6 +25,10 @@ class OCIRegionClient:
         return oci.identity.IdentityClient(self.client_config)
 
     @cached_property
+    def virtual_network_client(self) -> oci.core.VirtualNetworkClient:
+        return oci.core.VirtualNetworkClient(self.client_config)
+
+    @cached_property
     def availability_domains(self) -> List[oci.identity.models.AvailabilityDomain]:
         return self.identity_client.list_availability_domains(self.client_config["tenancy"]).data
 

--- a/src/dstack/_internal/core/backends/oci/resources.py
+++ b/src/dstack/_internal/core/backends/oci/resources.py
@@ -1,6 +1,8 @@
-from concurrent.futures import Executor, as_completed
+import base64
+from concurrent.futures import Executor, ThreadPoolExecutor, as_completed
+from functools import reduce
 from itertools import islice
-from typing import Dict, Iterable, List, Mapping, Set
+from typing import Dict, Iterable, List, Mapping, Optional, Set
 
 import oci
 
@@ -11,42 +13,84 @@ LIST_SHAPES_MAX_LIMIT = 100
 CAPACITY_REPORT_MAX_SHAPES = 10  # undocumented, found by experiment
 
 
+class ShapesQuota:
+    def __init__(self, region_to_domain_to_shape_names: Dict[str, Dict[str, Set[str]]]):
+        self._domain_to_shape_names = {
+            domain: shape_names
+            for domain_to_shape_names in region_to_domain_to_shape_names.values()
+            for domain, shape_names in domain_to_shape_names.items()
+        }
+        self._region_to_shape_names = {
+            region_name: reduce(set.union, domain_to_shape_names.values())
+            for region_name, domain_to_shape_names in region_to_domain_to_shape_names.items()
+        }
+
+    def is_within_region_quota(self, shape_name: str, region_name: str) -> bool:
+        return shape_name in self._region_to_shape_names.get(region_name, set())
+
+    def is_within_domain_quota(self, shape_name: str, domain_name: str) -> bool:
+        return shape_name in self._domain_to_shape_names.get(domain_name, set())
+
+    @staticmethod
+    def load(regions: Mapping[str, OCIRegionClient], compartment_id: str) -> "ShapesQuota":
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            return ShapesQuota(list_shapes(regions, compartment_id, executor))
+
+
+def list_shapes_in_domain(
+    availability_domain_name: str, client: oci.core.ComputeClient, compartment_id: str
+) -> Set[str]:
+    """
+    Returns a set of shape names allowed to be used in `availability_domain_name`.
+    """
+
+    shape_names = set()
+    page_id = oci.core.compute_client.missing  # first page
+
+    while page_id is not None:
+        resp = client.list_shapes(
+            availability_domain=availability_domain_name,
+            compartment_id=compartment_id,
+            limit=LIST_SHAPES_MAX_LIMIT,
+            page=page_id,
+        )
+        shape_names = shape_names.union(shape.shape for shape in resp.data)
+        page_id = resp.headers.get("opc-next-page")
+
+    return shape_names
+
+
+def list_shapes_in_region(region: OCIRegionClient, compartment_id: str) -> Dict[str, Set[str]]:
+    """
+    Returns a mapping of availability domain names to sets of shape names
+    allowed to be used in these domains.
+    """
+
+    result = {}
+    for availability_domain in region.availability_domains:
+        result[availability_domain.name] = list_shapes_in_domain(
+            availability_domain.name, region.compute_client, compartment_id
+        )
+    return result
+
+
 def list_shapes(
-    client: oci.core.ComputeClient, compartment_id: str
-) -> List[oci.core.models.Shape]:
-    """
-    Lists shapes allowed to be used in the region the `client` is bound to.
-    """
-
-    shapes = []
-    page = oci.core.compute_client.missing  # first page
-
-    while page is not None:
-        resp = client.list_shapes(compartment_id, limit=LIST_SHAPES_MAX_LIMIT, page=page)
-        shapes.extend(resp.data)
-        page = resp.headers.get("opc-next-page")
-
-    return shapes
-
-
-def get_shapes_quota(
     regions: Mapping[str, OCIRegionClient], compartment_id: str, executor: Executor
-) -> Dict[str, Set[str]]:
+) -> Dict[str, Dict[str, Set[str]]]:
     """
-    Returns a mapping of region names to sets of shape names allowed to be used
-    in these regions.
+    Returns a mapping of region names to mappings of availability domain names
+    to sets of shape names allowed to be used in these availability domains.
     """
 
     future_to_region_name = {}
     for region_name, region_client in regions.items():
-        future = executor.submit(list_shapes, region_client.compute_client, compartment_id)
+        future = executor.submit(list_shapes_in_region, region_client, compartment_id)
         future_to_region_name[future] = region_name
 
     result = {}
     for future in as_completed(future_to_region_name):
         region_name = future_to_region_name[future]
-        shape_names = {shape.shape for shape in future.result()}
-        result[region_name] = shape_names
+        result[region_name] = future.result()
 
     return result
 
@@ -89,7 +133,10 @@ def check_availability_in_domain(
 
 
 def check_availability_in_region(
-    shape_names: Iterable[str], region: OCIRegionClient, compartment_id: str
+    shape_names: Iterable[str],
+    shapes_quota: ShapesQuota,
+    region: OCIRegionClient,
+    compartment_id: str,
 ) -> Set[str]:
     """
     Returns a subset of `shape_names` with only the shapes available in at least
@@ -100,8 +147,13 @@ def check_availability_in_region(
     available_shapes = set()
 
     for availability_domain in region.availability_domains:
+        shapes_to_check = {
+            shape
+            for shape in all_shapes - available_shapes
+            if shapes_quota.is_within_domain_quota(shape, availability_domain.name)
+        }
         available_shapes |= check_availability_in_domain(
-            shape_names=all_shapes - available_shapes,
+            shape_names=shapes_to_check,
             availability_domain_name=availability_domain.name,
             client=region.compute_client,
             compartment_id=compartment_id,
@@ -112,6 +164,7 @@ def check_availability_in_region(
 
 def get_shapes_availability(
     offers: Iterable[InstanceOffer],
+    shapes_quota: ShapesQuota,
     regions: Mapping[str, OCIRegionClient],
     compartment_id: str,
     executor: Executor,
@@ -123,12 +176,17 @@ def get_shapes_availability(
 
     shape_names_per_region = {region: set() for region in regions}
     for offer in offers:
-        shape_names_per_region[offer.region].add(offer.instance.name)
+        if shapes_quota.is_within_region_quota(offer.instance.name, offer.region):
+            shape_names_per_region[offer.region].add(offer.instance.name)
 
     future_to_region_name = {}
     for region_name, shape_names in shape_names_per_region.items():
         future = executor.submit(
-            check_availability_in_region, shape_names, regions[region_name], compartment_id
+            check_availability_in_region,
+            shape_names,
+            shapes_quota,
+            regions[region_name],
+            compartment_id,
         )
         future_to_region_name[future] = region_name
 
@@ -138,3 +196,62 @@ def get_shapes_availability(
         result[region_name] = future.result()
 
     return result
+
+
+def choose_available_domain(
+    shape_name: str, shapes_quota: ShapesQuota, region: OCIRegionClient, compartment_id: str
+) -> Optional[str]:
+    """
+    Returns the name of any availability domain within `region` in which
+    `shape_name` is available. None if the shape is unavailable or not within
+    `shapes_quota` in all domains.
+    """
+
+    for domain in region.availability_domains:
+        if shapes_quota.is_within_domain_quota(
+            shape_name, domain.name
+        ) and check_availability_in_domain(
+            {shape_name}, domain.name, region.compute_client, compartment_id
+        ):
+            return domain.name
+    return None
+
+
+def get_instance_vnic(
+    instance_id: str, region: OCIRegionClient, compartment_id: str
+) -> Optional[oci.core.models.Vnic]:
+    attachments: List[oci.core.models.VnicAttachment] = (
+        region.compute_client.list_vnic_attachments(compartment_id, instance_id=instance_id).data
+    )
+    if not attachments:
+        return None
+    return region.virtual_network_client.get_vnic(attachments[0].vnic_id).data
+
+
+def launch_instance(
+    region: OCIRegionClient,
+    availability_domain: str,
+    compartment_id: str,
+    subnet_id: str,
+    display_name: str,
+    cloud_init_user_data: str,
+    shape: str,
+    image_id: str,
+) -> oci.core.models.Instance:
+    # TODO(#1194): allow setting disk size
+    return region.compute_client.launch_instance(
+        oci.core.models.LaunchInstanceDetails(
+            availability_domain=availability_domain,
+            compartment_id=compartment_id,
+            create_vnic_details=oci.core.models.CreateVnicDetails(subnet_id=subnet_id),
+            display_name=display_name,
+            instance_options=oci.core.models.InstanceOptions(
+                are_legacy_imds_endpoints_disabled=True
+            ),
+            metadata=dict(
+                user_data=base64.b64encode(cloud_init_user_data.encode()).decode(),
+            ),
+            shape=shape,
+            source_details=oci.core.models.InstanceSourceViaImageDetails(image_id=image_id),
+        )
+    ).data

--- a/src/dstack/_internal/core/backends/oci/resources.py
+++ b/src/dstack/_internal/core/backends/oci/resources.py
@@ -255,3 +255,15 @@ def launch_instance(
             source_details=oci.core.models.InstanceSourceViaImageDetails(image_id=image_id),
         )
     ).data
+
+
+def terminate_instance_if_exists(client: oci.core.ComputeClient, instance_id: str) -> None:
+    try:
+        client.terminate_instance(
+            instance_id=instance_id,
+            preserve_boot_volume=False,
+            preserve_data_volumes_created_at_launch=False,
+        )
+    except oci.exceptions.ServiceError as e:
+        if e.status != 404:
+            raise

--- a/src/dstack/_internal/core/backends/runpod/compute.py
+++ b/src/dstack/_internal/core/backends/runpod/compute.py
@@ -106,10 +106,7 @@ class RunpodCompute(Compute):
                 return
             raise
 
-    def update_provisioning_data(
-        self,
-        provisioning_data: JobProvisioningData,
-    ):
+    def update_provisioning_data(self, provisioning_data: JobProvisioningData) -> None:
         instance_id = provisioning_data.instance_id
         pod = self.api_client.get_pod(instance_id)
         if pod is None or pod["runtime"] is None:

--- a/src/dstack/_internal/core/backends/vastai/compute.py
+++ b/src/dstack/_internal/core/backends/vastai/compute.py
@@ -99,10 +99,7 @@ class VastAICompute(Compute):
     ):
         self.api_client.destroy_instance(instance_id)
 
-    def update_provisioning_data(
-        self,
-        provisioning_data: JobProvisioningData,
-    ):
+    def update_provisioning_data(self, provisioning_data: JobProvisioningData) -> None:
         resp = self.api_client.get_instance(provisioning_data.instance_id)
         if resp is not None:
             if resp["actual_status"] == "running":

--- a/src/tests/_internal/core/backends/oci/test_resources.py
+++ b/src/tests/_internal/core/backends/oci/test_resources.py
@@ -1,0 +1,49 @@
+import pytest
+
+from dstack._internal.core.backends.oci.resources import ShapesQuota
+
+
+class TestShapesQuota:
+    SAMPLE_QUOTA = ShapesQuota(
+        {
+            "region-1": {
+                "region-1-ad-1": {"shape.1", "shape.2"},
+                "region-1-ad-2": {"shape.2", "shape.3"},
+            },
+            "region-2": {
+                "region-2-ad-1": {"shape.1", "shape.3"},
+            },
+        }
+    )
+
+    @pytest.mark.parametrize(
+        ("shape", "region", "is_within_quota"),
+        [
+            ("shape.1", "region-1", True),
+            ("shape.2", "region-1", True),
+            ("shape.3", "region-1", True),
+            ("shape.1", "region-2", True),
+            ("shape.2", "region-2", False),
+            ("shape.3", "region-2", True),
+            ("shape.9", "region-1", False),
+            ("shape.1", "region-9", False),
+        ],
+    )
+    def test_is_within_region_quota(self, shape: str, region: str, is_within_quota: str):
+        assert is_within_quota == self.SAMPLE_QUOTA.is_within_region_quota(shape, region)
+
+    @pytest.mark.parametrize(
+        ("shape", "domain", "is_within_quota"),
+        [
+            ("shape.1", "region-1-ad-1", True),
+            ("shape.3", "region-1-ad-1", False),
+            ("shape.1", "region-1-ad-2", False),
+            ("shape.3", "region-1-ad-2", True),
+            ("shape.1", "region-2-ad-1", True),
+            ("shape.2", "region-2-ad-1", False),
+            ("shape.9", "region-1-ad1", False),
+            ("shape.1", "region-9-ad-9", False),
+        ],
+    )
+    def test_is_within_domain_quota(self, shape: str, domain: str, is_within_quota: str):
+        assert is_within_quota == self.SAMPLE_QUOTA.is_within_domain_quota(shape, domain)


### PR DESCRIPTION
This is part of the OCI backend Implementation (#1194). Behind the OCI_BACKEND feature flag.

- Implement `run_job`, `create_instance`, `terminate_instance`
- Temporarily allow configuring existing cloud resources with env variables. Later dstack will create or discover these resources automatically
- Check shapes quota per availability domain, not per region. Some shapes can be available in only one domain within a region