### PR TITLE
Change vm type for GCP gateway

### DIFF
--- a/src/dstack/_internal/core/backends/gcp/compute.py
+++ b/src/dstack/_internal/core/backends/gcp/compute.py
@@ -197,7 +197,7 @@ class GCPCompute(Compute):
         request.instance_resource = gcp_resources.create_instance_struct(
             disk_size=10,
             image_id=gcp_resources.get_gateway_image_id(),
-            machine_type="e2-micro",
+            machine_type="e2-small",
             accelerators=[],
             spot=False,
             user_data=get_gateway_user_data(configuration.ssh_key_pub),


### PR DESCRIPTION
Fixes #1221 

The GCP gateway startup time was very long (~10 min) because of the small instance type (e2-micro has 0.25x2 vCPU). This PR changes the instance type to e2-small that has 0.5x2 vCPU. That's enough for reasonably quick gateway startup.