### PR TITLE
Add dstack destroy command and improve dstack apply

### DIFF
--- a/docs/docs/reference/cli/index.md
+++ b/docs/docs/reference/cli/index.md
@@ -61,7 +61,7 @@ $ dstack run . --help
 
 ### dstack apply
 
-This command applies a given configuration. If a resources does not exist, `dstack apply` creates the resource.
+This command applies a given configuration. If a resource does not exist, `dstack apply` creates the resource.
 If a resource exists, `dstack apply` updates the resource in-place or re-creates the resource if the update is not possible.
 
 <div class="termy">
@@ -75,6 +75,23 @@ $ dstack apply --help
 
 !!! info "NOTE:"
     The `dstack apply` command currently supports only `gateway` configurations.
+    Support for other configuration types is coming soon.
+
+### dstack destroy
+
+This command destroys the resources defined by a given configuration.
+
+<div class="termy">
+
+```shell
+$ dstack destroy --help
+#GENERATE#
+```
+
+</div>
+
+!!! info "NOTE:"
+    The `dstack destroy` command currently supports only `gateway` configurations.
     Support for other configuration types is coming soon.
 
 ### dstack ps

--- a/src/dstack/_internal/cli/commands/destroy.py
+++ b/src/dstack/_internal/cli/commands/destroy.py
@@ -10,9 +10,9 @@ from dstack._internal.cli.utils.common import cli_error
 from dstack._internal.core.errors import ConfigurationError
 
 
-class ApplyCommand(APIBaseCommand):
-    NAME = "apply"
-    DESCRIPTION = "Apply dstack configuration"
+class DestroyCommand(APIBaseCommand):
+    NAME = "destroy"
+    DESCRIPTION = "Destroy resources defined by dstack configuration"
 
     def _register(self):
         super()._register()
@@ -23,11 +23,6 @@ class ApplyCommand(APIBaseCommand):
             metavar="FILE",
             help="The path to the configuration file. Defaults to [code]$PWD/.dstack.yml[/]",
             dest="configuration_file",
-        )
-        self._parser.add_argument(
-            "--force",
-            help="Force apply when no changes detected",
-            action="store_true",
         )
         self._parser.add_argument(
             "-y",
@@ -44,4 +39,4 @@ class ApplyCommand(APIBaseCommand):
             raise cli_error(e)
         configurator_class = get_apply_configurator_class(configuration.type)
         configurator = configurator_class(api_client=self.api)
-        configurator.apply_configuration(conf=configuration, args=args)
+        configurator.destroy_configuration(conf=configuration, args=args)

--- a/src/dstack/_internal/cli/main.py
+++ b/src/dstack/_internal/cli/main.py
@@ -5,6 +5,7 @@ from rich_argparse import RichHelpFormatter
 
 from dstack._internal.cli.commands.apply import ApplyCommand
 from dstack._internal.cli.commands.config import ConfigCommand
+from dstack._internal.cli.commands.destroy import DestroyCommand
 from dstack._internal.cli.commands.gateway import GatewayCommand
 from dstack._internal.cli.commands.init import InitCommand
 from dstack._internal.cli.commands.logs import LogsCommand
@@ -53,6 +54,7 @@ def main():
     subparsers = parser.add_subparsers(metavar="COMMAND")
     ApplyCommand.register(subparsers)
     ConfigCommand.register(subparsers)
+    DestroyCommand.register(subparsers)
     GatewayCommand.register(subparsers)
     PoolCommand.register(subparsers)
     InitCommand.register(subparsers)

--- a/src/dstack/_internal/cli/services/configurators/__init__.py
+++ b/src/dstack/_internal/cli/services/configurators/__init__.py
@@ -1,8 +1,16 @@
-from typing import Dict, Type
+from pathlib import Path
+from typing import Dict, Optional, Type
+
+import yaml
 
 from dstack._internal.cli.services.configurators.base import BaseApplyConfigurator
 from dstack._internal.cli.services.configurators.gateway import GatewayConfigurator
-from dstack._internal.core.models.configurations import ApplyConfigurationType
+from dstack._internal.core.errors import ConfigurationError
+from dstack._internal.core.models.configurations import (
+    AnyApplyConfiguration,
+    ApplyConfigurationType,
+    parse_apply_configuration,
+)
 
 apply_configurators_mapping: Dict[ApplyConfigurationType, Type[BaseApplyConfigurator]] = {
     cls.TYPE: cls for cls in [GatewayConfigurator]
@@ -11,3 +19,24 @@ apply_configurators_mapping: Dict[ApplyConfigurationType, Type[BaseApplyConfigur
 
 def get_apply_configurator_class(configurator_type: str) -> Type[BaseApplyConfigurator]:
     return apply_configurators_mapping[ApplyConfigurationType(configurator_type)]
+
+
+def load_apply_configuration(configuration_file: Optional[str]) -> AnyApplyConfiguration:
+    if configuration_file is None:
+        configuration_path = Path.cwd() / ".dstack.yml"
+        if not configuration_path.exists():
+            configuration_path = configuration_path.with_suffix(".yaml")
+        if not configuration_path.exists():
+            raise ConfigurationError(
+                "No configuration file specified via `-f` and no default .dstack.yml configuration found"
+            )
+    else:
+        configuration_path = Path(configuration_file)
+        if not configuration_path.exists():
+            raise ConfigurationError(f"Configuration file {configuration_file} does not exist")
+    try:
+        with open(configuration_path, "r") as f:
+            conf = parse_apply_configuration(yaml.safe_load(f))
+    except OSError:
+        raise ConfigurationError(f"Failed to load configuration from {configuration_path}")
+    return conf

--- a/src/dstack/_internal/cli/services/configurators/base.py
+++ b/src/dstack/_internal/cli/services/configurators/base.py
@@ -19,6 +19,10 @@ class BaseApplyConfigurator(ABC):
     def apply_configuration(self, conf: AnyApplyConfiguration, args: argparse.Namespace):
         pass
 
+    @abstractmethod
+    def destroy_configuration(self, conf: AnyApplyConfiguration, args: argparse.Namespace):
+        pass
+
     def register_args(self, parser: argparse.ArgumentParser):
         pass
 

--- a/src/dstack/_internal/cli/services/configurators/gateway.py
+++ b/src/dstack/_internal/cli/services/configurators/gateway.py
@@ -56,3 +56,27 @@ class GatewayConfigurator(BaseApplyConfigurator):
                 configuration=conf,
             )
         print_gateways_table([gateway])
+
+    def destroy_configuration(self, conf: GatewayConfiguration, args: argparse.Namespace):
+        if conf.name is None:
+            console.print("[error]Configuration specifies no gateway to destroy[/]")
+            return
+
+        try:
+            self.api_client.client.gateways.get(
+                project_name=self.api_client.project, gateway_name=conf.name
+            )
+        except ResourceNotExistsError:
+            console.print(f"Gateway [code]{conf.name}[/] does not exist")
+            return
+
+        if not args.yes and not confirm_ask(f"Delete the gateway [code]{conf.name}[/]?"):
+            console.print("\nExiting...")
+            return
+
+        with console.status("Deleting gateway..."):
+            self.api_client.client.gateways.delete(
+                project_name=self.api_client.project, gateways_names=[conf.name]
+            )
+
+        console.print(f"Gateway [code]{conf.name}[/] deleted")


### PR DESCRIPTION
Closes #1270 

* Add `dstack destroy` command for deleting resources defined by dstack configurations: `dstack destroy -f .dstack/confs/gateway.yaml` (currently supports only gateways).
* Change `dstack apply` command to accept the configuration file as specified by `-f/--file` argument. If `-f` is not specified, try using default `.dstack.yml`.
* Fix a bug when gateway compute could remain not deleted due to a stale db value.