### PR TITLE
Implement creating OCI resources

### DIFF
--- a/src/dstack/_internal/core/models/backends/oci.py
+++ b/src/dstack/_internal/core/models/backends/oci.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Dict
 
 from pydantic import Field
 from typing_extensions import Annotated, List, Literal, Optional, Union
@@ -10,6 +11,7 @@ from dstack._internal.core.models.common import CoreModel
 class OCIConfigInfo(CoreModel):
     type: Literal["oci"] = "oci"
     regions: Optional[List[str]] = None
+    compartment_id: Optional[str] = None
 
 
 class OCIClientCreds(CoreModel):
@@ -45,13 +47,16 @@ class OCIConfigInfoWithCredsPartial(CoreModel):
     type: Literal["oci"] = "oci"
     creds: Optional[AnyOCICreds]
     regions: Optional[List[str]]
+    compartment_id: Optional[str]
 
 
 class OCIConfigValues(CoreModel):
     type: Literal["oci"] = "oci"
     default_creds: bool = False
     regions: Optional[ConfigMultiElement]
+    compartment_id: Optional[str] = None
 
 
 class OCIStoredConfig(OCIConfigInfo):
-    pass
+    compartment_id: str
+    subnet_ids_per_region: Dict[str, str]

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -223,6 +223,7 @@ class OCIConfig(CoreModel):
     type: Literal["oci"] = "oci"
     creds: Optional[AnyOCICreds]
     regions: Optional[List[str]] = None
+    compartment_id: Optional[str] = None
 
 
 class RunpodConfig(CoreModel):


### PR DESCRIPTION
This enables dstack to automatically create OCI compartments and network resources on server launch. This is part of the OCI backend implementation (#1194). Behind the OCI_BACKEND feature flag.