### PR TITLE
Allow omitting vpc_ids for some regions when default_vpcs: true

### DIFF
--- a/docs/docs/reference/cli/index.md
+++ b/docs/docs/reference/cli/index.md
@@ -77,21 +77,21 @@ $ dstack apply --help
     The `dstack apply` command currently supports only `gateway` configurations.
     Support for other configuration types is coming soon.
 
-### dstack destroy
+### dstack delete
 
-This command destroys the resources defined by a given configuration.
+This command deletes the resources defined by a given configuration.
 
 <div class="termy">
 
 ```shell
-$ dstack destroy --help
+$ dstack delete --help
 #GENERATE#
 ```
 
 </div>
 
 !!! info "NOTE:"
-    The `dstack destroy` command currently supports only `gateway` configurations.
+    The `dstack delete` command currently supports only `gateway` configurations.
     Support for other configuration types is coming soon.
 
 ### dstack ps

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -204,7 +204,6 @@ nav:
               - gateway: docs/reference/dstack.yml/gateway.md
           - profiles.yml: docs/reference/profiles.yml.md
           - CLI: docs/reference/cli/index.md
-          - profiles.yml: docs/reference/profiles.yml.md
           - API:
               - Python API: docs/reference/api/python/index.md
               - REST API: docs/reference/api/rest/index.md

--- a/src/dstack/_internal/core/backends/aws/config.py
+++ b/src/dstack/_internal/core/backends/aws/config.py
@@ -10,3 +10,9 @@ class AWSConfig(AWSStoredConfig, BackendConfig):
         if self.public_ips is not None:
             return self.public_ips
         return True
+
+    @property
+    def use_default_vpcs(self) -> bool:
+        if self.default_vpcs is not None:
+            return self.default_vpcs
+        return True

--- a/src/dstack/_internal/core/models/backends/aws.py
+++ b/src/dstack/_internal/core/models/backends/aws.py
@@ -12,6 +12,7 @@ class AWSConfigInfo(CoreModel):
     regions: Optional[List[str]] = None
     vpc_name: Optional[str] = None
     vpc_ids: Optional[Dict[str, str]] = None
+    default_vpcs: Optional[bool] = None
     public_ips: Optional[bool] = None
 
 
@@ -47,6 +48,7 @@ class AWSConfigInfoWithCredsPartial(CoreModel):
     regions: Optional[List[str]]
     vpc_name: Optional[str]
     vpc_ids: Optional[Dict[str, str]]
+    default_vpcs: Optional[bool]
     public_ips: Optional[bool]
 
 

--- a/src/dstack/_internal/server/services/backends/configurators/aws.py
+++ b/src/dstack/_internal/server/services/backends/configurators/aws.py
@@ -136,10 +136,23 @@ class AWSConfigurator(Configurator):
     def _check_vpc_config(self, session: Session, config: AWSConfigInfoWithCredsPartial):
         if config.vpc_name is not None and config.vpc_ids is not None:
             raise ServerClientError(msg="Only one of vpc_name and vpc_ids can be specified")
+        allocate_public_ip = config.public_ips if config.public_ips is not None else True
+        use_default_vpcs = config.default_vpcs if config.default_vpcs is not None else True
         regions = config.regions
         if regions is None:
             regions = DEFAULT_REGIONS
-        allocate_public_ip = config.public_ips if config.public_ips is not None else True
+        if config.vpc_ids is not None and not use_default_vpcs:
+            vpc_ids_regions = list(config.vpc_ids.keys())
+            not_configured_regions = [r for r in regions if r not in vpc_ids_regions]
+            if config.regions is None:
+                raise ServerClientError(
+                    f"vpc_ids not configured for regions {not_configured_regions}. "
+                    "Configure vpc_ids for all regions or specify regions."
+                )
+            raise ServerClientError(
+                f"vpc_ids not configured for regions {not_configured_regions}. "
+                "Configure vpc_ids for all regions specified in regions."
+            )
         # The number of workers should be >= the number of regions
         with concurrent.futures.ThreadPoolExecutor(max_workers=12) as executor:
             futures = []

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -57,15 +57,31 @@ yaml.add_representer(list, seq_representer)
 
 class AWSConfig(CoreModel):
     type: Annotated[Literal["aws"], Field(description="The type of the backend")] = "aws"
-    regions: Optional[List[str]] = None
-    vpc_name: Annotated[Optional[str], Field(description="The VPC name")] = None
+    regions: Annotated[Optional[List[str]], Field(description="The list of AWS regions")] = None
+    vpc_name: Annotated[
+        Optional[str],
+        Field(description="The VPC name. All configured regions must have a VPC with this name"),
+    ] = None
     vpc_ids: Annotated[
-        Optional[Dict[str, str]], Field(description="The mapping from AWS regions to VPC IDs")
+        Optional[Dict[str, str]],
+        Field(
+            description="The mapping from AWS regions to VPC IDs. If `default_vpcs: true`, omitted regions will use default VPCs"
+        ),
+    ] = None
+    default_vpcs: Annotated[
+        Optional[bool],
+        Field(
+            description=(
+                "A flag to enable/disable using default VPCs in regions not configured by `vpc_ids`."
+                " Set to `false` if default VPCs should never be used."
+                " Defaults to `true`"
+            )
+        ),
     ] = None
     public_ips: Annotated[
         Optional[bool],
         Field(
-            description="A flag to enable/disable public IP assigning on instances. Defaults to `true`."
+            description="A flag to enable/disable public IP assigning on instances. Defaults to `true`"
         ),
     ] = None
     creds: AnyAWSCreds = Field(..., description="The credentials", discriminator="type")

--- a/src/tests/_internal/server/routers/test_backends.py
+++ b/src/tests/_internal/server/routers/test_backends.py
@@ -1118,6 +1118,7 @@ class TestGetConfigInfo:
             "regions": json.loads(backend.config)["regions"],
             "vpc_name": None,
             "vpc_ids": None,
+            "default_vpcs": None,
             "public_ips": None,
             "creds": json.loads(backend.auth),
         }

--- a/src/tests/_internal/server/routers/test_projects.py
+++ b/src/tests/_internal/server/routers/test_projects.py
@@ -64,6 +64,7 @@ class TestListProjects:
                             "regions": json.loads(backend.config)["regions"],
                             "vpc_name": None,
                             "vpc_ids": None,
+                            "default_vpcs": None,
                             "public_ips": None,
                         },
                     }


### PR DESCRIPTION
Closes #1191 

This PR introduces `default_vpcs` field for AWS backend config. When `default_vpcs: true`, users may omit specifying some regions in `vpc_ids` to use default VPCs:

```
projects:
- name: main
  backends:
  - type: aws
    regions: [eu-central-1, eu-west-1]
    creds:
      type: default
    vpc_ids:
      eu-central-1: vpc-12345
    default_vpcs: true
```

 When `default_vpcs: false`, dstack fails to configure the backend if VPC is not configured for some region via `vpc_ids` or `vpc_name`.