### PR TITLE
Respect run filters for ssh instances

### DIFF
--- a/src/dstack/_internal/server/background/tasks/process_instances.py
+++ b/src/dstack/_internal/server/background/tasks/process_instances.py
@@ -187,6 +187,8 @@ async def add_remote(instance_id: UUID) -> None:
             )
         ).one()
 
+        logger.debug("Adding remote instance %s...", instance.name)
+
         if instance.status == InstanceStatus.PENDING:
             instance.status = InstanceStatus.PROVISIONING
             await session.commit()

--- a/src/dstack/_internal/server/services/pools.py
+++ b/src/dstack/_internal/server/services/pools.py
@@ -363,10 +363,6 @@ def filter_pool_instances(
         if status is not None and instance.status != status:
             continue
 
-        if instance.backend == BackendType.REMOTE:
-            candidates.append(instance)
-            continue
-
         # TODO: remove on prod
         if settings.LOCAL_BACKEND_ENABLED and instance.backend == BackendType.LOCAL:
             instances.append(instance)


### PR DESCRIPTION
Fixes #1244

`ssh` instances were always added to run offers even when they didn't match the filters. This is fixed.