### PR TITLE
Support resubmitted runs in dstack run attached mode

### DIFF
--- a/src/dstack/_internal/core/models/profiles.py
+++ b/src/dstack/_internal/core/models/profiles.py
@@ -87,7 +87,7 @@ class ProfileRetry(CoreModel):
 
     @root_validator
     def _validate_fields(cls, values):
-        if len(values["on_events"]) == 0:
+        if "on_events" in values and len(values["on_events"]) == 0:
             raise ValueError("`on_events` cannot be empty")
         return values
 


### PR DESCRIPTION
Closes #1284

This PR makes `dstack run` work with the retry `interruption` and `error` events in the attached mode. While the run is retried, the CLI keeps attaching to the run:

```
✗ dstack run . -f .dstack/confs/task2.yaml -b gcp
 Configuration          .dstack/confs/task2.yaml             
 Project                main                                 
 User                   admin                                
 Pool name              default-pool                         
 Min resources          2..xCPU, 8GB.., 100GB.. (disk)       
 Max price              -                                    
 Max duration           72h                                  
 Spot policy            auto                                 
 Retry policy           1h[no-capacity, interruption, error] 
 Creation policy        reuse-or-create                      
 Termination policy     destroy-after-idle                   
 Termination idle time  5m                                   

 #  BACKEND  REGION       INSTANCE     RESOURCES    SPOT  PRICE           
 1  gcp      europe-wes…  e2-standar…  2xCPU, 8GB,  yes   $0.02544   idle 
                                       100.0GB                            
                                       (disk)                             
 2  gcp      europe-wes…  e2-standar…  2xCPU, 8GB,  yes   $0.02544        
                                       100.0GB                            
                                       (disk)                             
 3  gcp      europe-wes…  e2-standar…  2xCPU, 8GB,  yes   $0.029472       
                                       100.0GB                            
                                       (disk)                             
    ...                                                                   
 Shown 3 of 391 offers, $56.6266 max

Continue? [y/n]: y
fresh-owl-1 provisioning completed (running)
bash: asdf: command not found
fresh-owl-1 provisioning completed (running)
```

There are also other improvements to `dstack run`:

* Remove aborting logic on the run disconnect.
* Improved messages when the run is finished.