### PR TITLE
More flexible OCI credentials configuration

### DIFF
--- a/src/dstack/_internal/core/backends/oci/auth.py
+++ b/src/dstack/_internal/core/backends/oci/auth.py
@@ -8,7 +8,7 @@ from dstack._internal.core.models.common import is_core_model_instance
 
 def get_client_config(creds: AnyOCICreds) -> Mapping[str, Any]:
     if is_core_model_instance(creds, OCIDefaultCreds):
-        return oci.config.from_file()
+        return oci.config.from_file(file_location=str(creds.file), profile_name=creds.profile)
     return creds.dict(exclude={"type"})
 
 

--- a/src/dstack/_internal/core/models/backends/oci.py
+++ b/src/dstack/_internal/core/models/backends/oci.py
@@ -18,8 +18,8 @@ class OCIClientCreds(CoreModel):
     type: Annotated[Literal["client"], Field(description="The type of credentials")] = "client"
     user: Annotated[str, Field(description="User OCID")]
     tenancy: Annotated[str, Field(description="Tenancy OCID")]
-    key_file: Annotated[Path, Field(description="Path to the PEM key")]
-    fingerprint: Annotated[str, Field(description="Key fingerprint")]
+    key_content: Annotated[str, Field(description="Content of the user's private PEM key")]
+    fingerprint: Annotated[str, Field(description="User's public key fingerprint")]
     region: Annotated[
         str, Field(description="Name or key of any region the tenancy is subscribed to")
     ]
@@ -27,6 +27,10 @@ class OCIClientCreds(CoreModel):
 
 class OCIDefaultCreds(CoreModel):
     type: Annotated[Literal["default"], Field(description="The type of credentials")] = "default"
+    file: Annotated[Path, Field(description="Path to the OCI CLI-compatible config file")] = Path(
+        "~/.oci/config"
+    )
+    profile: Annotated[str, Field(description="Profile to load from the config file")] = "DEFAULT"
 
 
 AnyOCICreds = Union[OCIClientCreds, OCIDefaultCreds]


### PR DESCRIPTION
- In client credentials, replace the key path with the key content to allow configuring without any file paths
- In default credentials, allow overriding the config file path and choosing a profile from the config file

This is part of the OCI backend implementation (#1194). Behind the OCI_BACKEND feature flag.