### PR TITLE
Fix list pool instances API

### DIFF
--- a/src/dstack/_internal/core/models/pools.py
+++ b/src/dstack/_internal/core/models/pools.py
@@ -1,5 +1,6 @@
 import datetime
 from typing import List, Optional
+from uuid import UUID
 
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.common import CoreModel
@@ -16,6 +17,7 @@ class Pool(CoreModel):
 
 
 class Instance(CoreModel):
+    id: UUID
     backend: Optional[BackendType] = None
     instance_type: Optional[InstanceType] = None
     name: str

--- a/src/dstack/_internal/server/app.py
+++ b/src/dstack/_internal/server/app.py
@@ -145,8 +145,8 @@ def add_no_api_version_check_routes(paths: List[str]):
 def register_routes(app: FastAPI):
     app.include_router(users.router)
     app.include_router(projects.router)
-    app.include_router(pools.router)
     app.include_router(pools.root_router)
+    app.include_router(pools.router)
     app.include_router(backends.root_router)
     app.include_router(backends.project_router)
     app.include_router(repos.router)

--- a/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Optional, Tuple
 from uuid import UUID
 
@@ -316,6 +317,7 @@ def _create_instance_model_for_job(
         termination_policy = TerminationPolicy.DESTROY_AFTER_IDLE
         termination_idle_time = 0
     instance = InstanceModel(
+        id=uuid.uuid4(),
         name=job.job_spec.job_name,  # TODO: make new name
         project=project_model,
         pool=pool,

--- a/src/dstack/_internal/server/routers/pools.py
+++ b/src/dstack/_internal/server/routers/pools.py
@@ -18,8 +18,8 @@ root_router = APIRouter(prefix="/api/pools", tags=["pool"])
 router = APIRouter(prefix="/api/project/{project_name}/pool", tags=["pool"])
 
 
-@root_router.post("/list")
-async def list_pools(
+@root_router.post("/list_instances")
+async def list_pool_instances(
     body: ListPoolsRequest,
     session: AsyncSession = Depends(get_session),
     user: UserModel = Depends(Authenticated()),
@@ -29,16 +29,16 @@ async def list_pools(
     A **project_name** and **pool_name** can be specified as filters.
 
     The results are paginated. To get the next page, pass created_at and id of
-    the last run from the previous page as **prev_created_at** and **prev_name**.
+    the last run from the previous page as **prev_created_at** and **prev_id**.
     """
-    return await pools.list_user_pool(
+    return await pools.list_user_pool_instances(
         session=session,
         user=user,
         project_name=body.project_name,
         pool_name=body.pool_name,
         only_active=body.only_active,
         prev_created_at=body.prev_created_at,
-        prev_name=body.prev_name,
+        prev_id=body.prev_id,
         limit=body.limit,
         ascending=body.ascending,
     )

--- a/src/dstack/_internal/server/schemas/pools.py
+++ b/src/dstack/_internal/server/schemas/pools.py
@@ -33,6 +33,6 @@ class ListPoolsRequest(CoreModel):
     pool_name: Optional[str]
     only_active: bool = False
     prev_created_at: Optional[datetime]
-    prev_name: Optional[UUID]
+    prev_id: Optional[UUID]
     limit: int = 1000
     ascending: bool = False

--- a/src/dstack/_internal/server/services/runs.py
+++ b/src/dstack/_internal/server/services/runs.py
@@ -588,6 +588,7 @@ async def create_instance(
         termination_idle_time = DEFAULT_POOL_TERMINATION_IDLE_TIME
 
     instance = InstanceModel(
+        id=uuid.uuid4(),
         name=instance_name,
         project=project,
         pool=pool,

--- a/src/dstack/_internal/server/testing/common.py
+++ b/src/dstack/_internal/server/testing/common.py
@@ -339,7 +339,10 @@ async def create_instance(
     profile: Optional[Profile] = None,
     requirements: Optional[Requirements] = None,
     instance_configuration: Optional[InstanceConfiguration] = None,
+    instance_id: Optional[UUID] = None,
 ) -> InstanceModel:
+    if instance_id is None:
+        instance_id = uuid.uuid4()
     job_provisioning_data = {
         "backend": "datacrunch",
         "instance_type": {
@@ -398,6 +401,7 @@ async def create_instance(
         )
 
     im = InstanceModel(
+        id=instance_id,
         name="test_instance",
         pool=pool,
         project=project,

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -914,9 +914,11 @@ class TestCreateInstance:
             profile=Profile(name="test_profile"),
             requirements=Requirements(resources=ResourcesSpec(cpu=1)),
         )
+        instance_id = UUID("1b0e1b45-2f8c-4ab6-8010-a0d1a3e44e0e")
         with patch(
             "dstack._internal.server.services.runs.get_offers_by_requirements"
-        ) as run_plan_by_req:
+        ) as run_plan_by_req, patch("uuid.uuid4") as uuid_mock:
+            uuid_mock.return_value = instance_id
             offer = InstanceOfferWithAvailability(
                 backend=BackendType.AWS,
                 instance=InstanceType(
@@ -953,6 +955,7 @@ class TestCreateInstance:
             assert response.status_code == 200
             result = response.json()
             expected = {
+                "id": str(instance_id),
                 "backend": None,
                 "instance_type": None,
                 "name": result["name"],

--- a/src/tests/_internal/server/services/test_pools.py
+++ b/src/tests/_internal/server/services/test_pools.py
@@ -47,8 +47,10 @@ class TestGenerateInstanceName:
 
 class TestInstanceModelToInstance:
     def test_converts_instance(self):
+        instance_id = uuid.uuid4()
         created = get_current_datetime()
         expected_instance = Instance(
+            id=instance_id,
             backend=BackendType.LOCAL,
             instance_type=InstanceType(
                 name="instance", resources=Resources(cpus=1, memory_mib=512, spot=False, gpus=[])
@@ -61,7 +63,7 @@ class TestInstanceModelToInstance:
             price=1.0,
         )
         im = InstanceModel(
-            id=str(uuid.uuid4()),
+            id=instance_id,
             created_at=created,
             name="test_instance",
             status=InstanceStatus.PENDING,


### PR DESCRIPTION
* Rename `/api/pools/list` to `/api/pools/list_instances` to avoid confusion with `/api/project/{project_name}/pool/list`.
* Return instances IDs in the API.
* Rename `prev_name` to `prev_id`.
* Tests for  `/api/pools/list_instances`.

TODO:
* Introduce `/api/pools/list` for listing pools for both users and admins with pagination.
* Deprecate `/api/project/{project_name}/pool/list` and `/api/project/{project_name}/pool/show` in favor of `/api/pools/*` endpoints.