### PR TITLE
More flexible OCI credentials - fixes

### DIFF
--- a/src/dstack/_internal/core/backends/oci/auth.py
+++ b/src/dstack/_internal/core/backends/oci/auth.py
@@ -8,7 +8,7 @@ from dstack._internal.core.models.common import is_core_model_instance
 
 def get_client_config(creds: AnyOCICreds) -> Mapping[str, Any]:
     if is_core_model_instance(creds, OCIDefaultCreds):
-        return oci.config.from_file(file_location=str(creds.file), profile_name=creds.profile)
+        return oci.config.from_file(file_location=creds.file, profile_name=creds.profile)
     return creds.dict(exclude={"type"})
 
 

--- a/src/dstack/_internal/core/models/backends/oci.py
+++ b/src/dstack/_internal/core/models/backends/oci.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Dict
 
 from pydantic import Field
@@ -27,7 +26,7 @@ class OCIClientCreds(CoreModel):
 
 class OCIDefaultCreds(CoreModel):
     type: Annotated[Literal["default"], Field(description="The type of credentials")] = "default"
-    file: Annotated[Path, Field(description="Path to the OCI CLI-compatible config file")] = Path(
+    file: Annotated[str, Field(description="Path to the OCI CLI-compatible config file")] = (
         "~/.oci/config"
     )
     profile: Annotated[str, Field(description="Profile to load from the config file")] = "DEFAULT"

--- a/src/tests/_internal/server/routers/test_backends.py
+++ b/src/tests/_internal/server/routers/test_backends.py
@@ -30,7 +30,12 @@ FAKE_OCI_CLIENT_CREDS = {
     "type": "client",
     "user": "ocid1.user.oc1..aaaaaaaa",
     "tenancy": "ocid1.tenancy.oc1..aaaaaaaa",
-    "key_file": "/dev/null",
+    "key_content": (
+        "-----BEGIN PRIVATE KEY-----\n"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+        "-----END PRIVATE KEY-----"
+    ),
     "fingerprint": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00",
     "region": "me-dubai-1",
 }


### PR DESCRIPTION
This fixes some issues introduced by PR #1289:
- Fix unit tests
- Do not use pathlib.Path in credentials model, as it is rendered incorrectly in YAML

Part of #1194