### PR TITLE
Prepare OCI backend for release

### DIFF
--- a/src/dstack/_internal/core/backends/__init__.py
+++ b/src/dstack/_internal/core/backends/__init__.py
@@ -1,5 +1,4 @@
 from dstack._internal.core.models.backends.base import BackendType
-from dstack._internal.settings import FeatureFlags
 
 BACKENDS_WITH_MULTINODE_SUPPORT = [
     BackendType.AWS,
@@ -15,7 +14,7 @@ BACKENDS_WITH_CREATE_INSTANCE_SUPPORT = [
     BackendType.DATACRUNCH,
     BackendType.GCP,
     BackendType.LAMBDA,
-    *([BackendType.OCI] if FeatureFlags.OCI_BACKEND else []),
+    BackendType.OCI,
     BackendType.TENSORDOCK,
 ]
 BACKENDS_WITH_PRIVATE_GATEWAY_SUPPORT = [BackendType.AWS]

--- a/src/dstack/_internal/core/backends/oci/__init__.py
+++ b/src/dstack/_internal/core/backends/oci/__init__.py
@@ -2,12 +2,10 @@ from dstack._internal.core.backends.base import Backend
 from dstack._internal.core.backends.oci.compute import OCICompute
 from dstack._internal.core.backends.oci.config import OCIConfig
 from dstack._internal.core.models.backends.base import BackendType
-from dstack._internal.settings import FeatureFlags
 
 
 class OCIBackend(Backend):
-    if FeatureFlags.OCI_BACKEND:
-        TYPE: BackendType = BackendType.OCI
+    TYPE: BackendType = BackendType.OCI
 
     def __init__(self, config: OCIConfig):
         self.config = config

--- a/src/dstack/_internal/core/backends/oci/compute.py
+++ b/src/dstack/_internal/core/backends/oci/compute.py
@@ -22,8 +22,6 @@ from dstack._internal.core.models.runs import Job, JobProvisioningData, Requirem
 
 SUPPORTED_SHAPE_FAMILIES = [
     "VM.Standard2.",
-    "VM.DenseIO1.",
-    "VM.DenseIO2.",
     "VM.GPU2.",
     "VM.GPU3.",
     "VM.GPU.A10.",

--- a/src/dstack/_internal/core/models/backends/__init__.py
+++ b/src/dstack/_internal/core/models/backends/__init__.py
@@ -78,7 +78,6 @@ from dstack._internal.core.models.backends.vastai import (
     VastAIConfigValues,
 )
 from dstack._internal.core.models.common import CoreModel
-from dstack._internal.settings import FeatureFlags
 
 # Backend config returned by the API
 AnyConfigInfoWithoutCreds = Union[
@@ -90,14 +89,13 @@ AnyConfigInfoWithoutCreds = Union[
     KubernetesConfigInfo,
     LambdaConfigInfo,
     NebiusConfigInfo,
+    OCIConfigInfo,
     RunpodConfigInfo,
     TensorDockConfigInfo,
     VastAIConfigInfo,
     DstackConfigInfo,
     DstackBaseBackendConfigInfo,
 ]
-if FeatureFlags.OCI_BACKEND:
-    AnyConfigInfoWithoutCreds = Union[AnyConfigInfoWithoutCreds, OCIConfigInfo]
 
 # Same as AnyConfigInfoWithoutCreds but also includes creds.
 # Used to create/update backend.
@@ -111,13 +109,12 @@ AnyConfigInfoWithCreds = Union[
     KubernetesConfigInfoWithCreds,
     LambdaConfigInfoWithCreds,
     NebiusConfigInfoWithCreds,
+    OCIConfigInfoWithCreds,
     RunpodConfigInfoWithCreds,
     TensorDockConfigInfoWithCreds,
     VastAIConfigInfoWithCreds,
     DstackConfigInfo,
 ]
-if FeatureFlags.OCI_BACKEND:
-    AnyConfigInfoWithCreds = Union[AnyConfigInfoWithCreds, OCIConfigInfoWithCreds]
 
 AnyConfigInfo = Union[AnyConfigInfoWithoutCreds, AnyConfigInfoWithCreds]
 
@@ -133,15 +130,12 @@ AnyConfigInfoWithCredsPartial = Union[
     KubernetesConfigInfoWithCredsPartial,
     LambdaConfigInfoWithCredsPartial,
     NebiusConfigInfoWithCredsPartial,
+    OCIConfigInfoWithCredsPartial,
     RunpodConfigInfoWithCredsPartial,
     TensorDockConfigInfoWithCredsPartial,
     VastAIConfigInfoWithCredsPartial,
     DstackConfigInfo,
 ]
-if FeatureFlags.OCI_BACKEND:
-    AnyConfigInfoWithCredsPartial = Union[
-        AnyConfigInfoWithCredsPartial, OCIConfigInfoWithCredsPartial
-    ]
 
 # Suggestions for unfilled fields used in interactive setup.
 AnyConfigValues = Union[
@@ -153,13 +147,12 @@ AnyConfigValues = Union[
     KubernetesConfigValues,
     LambdaConfigValues,
     NebiusConfigValues,
+    OCIConfigValues,
     RunpodConfigValues,
     TensorDockConfigValues,
     VastAIConfigValues,
     DstackConfigValues,
 ]
-if FeatureFlags.OCI_BACKEND:
-    AnyConfigValues = Union[AnyConfigValues, OCIConfigValues]
 
 
 # In case we'll support multiple backends of the same type,

--- a/src/dstack/_internal/core/models/backends/base.py
+++ b/src/dstack/_internal/core/models/backends/base.py
@@ -2,7 +2,6 @@ import enum
 from typing import List, Optional
 
 from dstack._internal.core.models.common import CoreModel
-from dstack._internal.settings import FeatureFlags
 
 
 class BackendType(str, enum.Enum):
@@ -32,8 +31,7 @@ class BackendType(str, enum.Enum):
     LOCAL = "local"
     REMOTE = "remote"  # TODO: replace for LOCAL
     NEBIUS = "nebius"
-    if FeatureFlags.OCI_BACKEND:
-        OCI = "oci"
+    OCI = "oci"
     RUNPOD = "runpod"
     TENSORDOCK = "tensordock"
     VASTAI = "vastai"

--- a/src/dstack/_internal/server/services/backends/__init__.py
+++ b/src/dstack/_internal/server/services/backends/__init__.py
@@ -29,7 +29,6 @@ from dstack._internal.server.models import BackendModel, ProjectModel
 from dstack._internal.server.services.backends.configurators.base import Configurator
 from dstack._internal.server.settings import LOCAL_BACKEND_ENABLED
 from dstack._internal.server.utils.common import run_async
-from dstack._internal.settings import FeatureFlags
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -103,8 +102,7 @@ except ImportError:
 try:
     from dstack._internal.server.services.backends.configurators.oci import OCIConfigurator
 
-    if FeatureFlags.OCI_BACKEND:
-        _CONFIGURATOR_CLASSES.append(OCIConfigurator)
+    _CONFIGURATOR_CLASSES.append(OCIConfigurator)
 except ImportError:
     pass
 

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -28,7 +28,6 @@ from dstack._internal.server.models import ProjectModel, UserModel
 from dstack._internal.server.services import backends as backends_services
 from dstack._internal.server.services import projects as projects_services
 from dstack._internal.server.utils.common import run_async
-from dstack._internal.settings import FeatureFlags
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -273,13 +272,12 @@ AnyBackendConfig = Union[
     KubernetesConfig,
     LambdaConfig,
     NebiusConfig,
+    OCIConfig,
     RunpodConfig,
     TensorDockConfig,
     VastAIConfig,
     DstackConfig,
 ]
-if FeatureFlags.OCI_BACKEND:
-    AnyBackendConfig = Union[AnyBackendConfig, OCIConfig]
 
 BackendConfig = Annotated[AnyBackendConfig, Field(..., discriminator="type")]
 
@@ -297,13 +295,12 @@ AnyBackendAPIConfig = Union[
     KubernetesAPIConfig,
     LambdaConfig,
     NebiusAPIConfig,
+    OCIConfig,
     RunpodConfig,
     TensorDockConfig,
     VastAIConfig,
     DstackConfig,
 ]
-if FeatureFlags.OCI_BACKEND:
-    AnyBackendAPIConfig = Union[AnyBackendAPIConfig, OCIConfig]
 
 
 BackendAPIConfig = Annotated[AnyBackendAPIConfig, Field(..., discriminator="type")]

--- a/src/dstack/_internal/settings.py
+++ b/src/dstack/_internal/settings.py
@@ -13,5 +13,3 @@ class FeatureFlags:
     large features. This class may be empty if there are no such features in
     development. Feature flags are environment variables of the form DSTACK_FF_*
     """
-
-    OCI_BACKEND = os.getenv("DSTACK_FF_OCI_BACKEND") is not None

--- a/src/tests/_internal/server/routers/test_backends.py
+++ b/src/tests/_internal/server/routers/test_backends.py
@@ -21,7 +21,6 @@ from dstack._internal.server.testing.common import (
     create_user,
     get_auth_headers,
 )
-from dstack._internal.settings import FeatureFlags
 
 client = TestClient(app)
 
@@ -62,7 +61,7 @@ class TestListBackendTypes:
             "kubernetes",
             "lambda",
             "nebius",
-            *(["oci"] if FeatureFlags.OCI_BACKEND else []),
+            "oci",
             "runpod",
             "tensordock",
             "vastai",
@@ -641,7 +640,6 @@ class TestGetBackendConfigValuesLambda:
         }
 
 
-@pytest.mark.skipif(not FeatureFlags.OCI_BACKEND, reason="behind a feature flag")
 class TestGetBackendConfigValuesOCI:
     @pytest.mark.asyncio
     async def test_returns_initial_config(self, test_db, session: AsyncSession):
@@ -838,7 +836,6 @@ class TestCreateBackend:
         res = await session.execute(select(BackendModel))
         assert len(res.scalars().all()) == 1
 
-    @pytest.mark.skipif(not FeatureFlags.OCI_BACKEND, reason="behind a feature flag")
     @pytest.mark.asyncio
     async def test_creates_oci_backend(self, test_db, session: AsyncSession):
         user = await create_user(session=session, global_role=GlobalRole.USER)
@@ -869,7 +866,6 @@ class TestCreateBackend:
         res = await session.execute(select(BackendModel))
         assert len(res.scalars().all()) == 1
 
-    @pytest.mark.skipif(not FeatureFlags.OCI_BACKEND, reason="behind a feature flag")
     @pytest.mark.asyncio
     async def test_not_creates_oci_backend_if_regions_not_subscribed(
         self, test_db, session: AsyncSession
@@ -1194,7 +1190,6 @@ class TestCreateBackendYAML:
         res = await session.execute(select(BackendModel))
         assert len(res.scalars().all()) == 1
 
-    @pytest.mark.skipif(not FeatureFlags.OCI_BACKEND, reason="behind a feature flag")
     @pytest.mark.asyncio
     async def test_creates_oci_backend(self, test_db, session: AsyncSession):
         user = await create_user(session=session, global_role=GlobalRole.USER)


### PR DESCRIPTION
- Remove the feature flag
- Drop support for DenseIO instances, as we cannot test them now and they are probably not relevant for our users
- Add 3 new regions and a message if the user is not subscribed to any of the supported regions

#1194 