### PR TITLE
Support non-default VPCs for GCP

### DIFF
--- a/docs/docs/reference/server/config.yml.md
+++ b/docs/docs/reference/server/config.yml.md
@@ -319,6 +319,15 @@ There are two ways to configure GCP: using a service account or using the defaul
     gcloud projects list --format="json(projectId)"
     ```
 
+??? info "Using Shared VPC"
+    You can set up `dstack` to use a [Shared VPC](https://cloud.google.com/vpc/docs/shared-vpc)
+    from another GCP project in your organization by specifying both `vpc_name` and `vpc_project_id`.
+
+    When using a Shared VPC, you'll need to configure firewall rules:
+
+    * An SSH rule allowing INGRESS traffic on port 22 and target tag "dstack-runner-instance"
+    * A gateway rule allowing INGRESS traffic on ports 22, 80, 443 and target tag "dstack-gateway-instance"
+
 ??? info "Required GCP permissions"
     The following GCP permissions are sufficient for `dstack` to work:
 
@@ -332,8 +341,10 @@ There are two ways to configure GCP: using a service account or using the defaul
     compute.instances.setLabels
     compute.instances.setMetadata
     compute.instances.setTags
+    compute.networks.get
     compute.networks.updatePolicy
     compute.regions.list
+    compute.subnetworks.list
     compute.subnetworks.use
     compute.subnetworks.useExternalIp
     compute.zoneOperations.get

--- a/src/dstack/_internal/core/backends/gcp/compute.py
+++ b/src/dstack/_internal/core/backends/gcp/compute.py
@@ -114,6 +114,7 @@ class GCPCompute(Compute):
         gcp_resources.create_runner_firewall_rules(
             firewalls_client=self.firewalls_client,
             project_id=self.config.project_id,
+            network=self.config.vpc_id,
         )
         disk_size = round(instance_offer.instance.resources.disk.size_mib / 1024)
 
@@ -146,6 +147,7 @@ class GCPCompute(Compute):
                 tags=[gcp_resources.DSTACK_INSTANCE_TAG],
                 instance_name=instance_name,
                 zone=zone,
+                network=self.config.vpc_id,
             )
             try:
                 operation = self.instances_client.insert(request=request)
@@ -228,6 +230,7 @@ class GCPCompute(Compute):
             instance_name=configuration.instance_name,
             zone=zone,
             service_account=None,
+            network=self.config.vpc_id,
         )
         operation = self.instances_client.insert(request=request)
         gcp_resources.wait_for_extended_operation(operation, "instance creation")

--- a/src/dstack/_internal/core/backends/gcp/config.py
+++ b/src/dstack/_internal/core/backends/gcp/config.py
@@ -6,8 +6,11 @@ class GCPConfig(GCPStoredConfig, BackendConfig):
     creds: AnyGCPCreds
 
     @property
-    def vpc_id(self) -> str:
+    def vpc_resource_name(self) -> str:
         vpc_name = self.vpc_name
         if vpc_name is None:
             vpc_name = "default"
-        return f"projects/{self.project_id}/global/networks/{vpc_name}"
+        project_id = self.project_id
+        if self.vpc_project_id is not None:
+            project_id = self.vpc_project_id
+        return f"projects/{project_id}/global/networks/{vpc_name}"

--- a/src/dstack/_internal/core/backends/gcp/config.py
+++ b/src/dstack/_internal/core/backends/gcp/config.py
@@ -4,3 +4,10 @@ from dstack._internal.core.models.backends.gcp import AnyGCPCreds, GCPStoredConf
 
 class GCPConfig(GCPStoredConfig, BackendConfig):
     creds: AnyGCPCreds
+
+    @property
+    def vpc_id(self) -> str:
+        vpc_name = self.vpc_name
+        if vpc_name is None:
+            vpc_name = "default"
+        return f"projects/{self.project_id}/global/networks/{vpc_name}"

--- a/src/dstack/_internal/core/backends/gcp/resources.py
+++ b/src/dstack/_internal/core/backends/gcp/resources.py
@@ -162,8 +162,12 @@ def create_runner_firewall_rules(
     project_id: str,
     network: str = "global/networks/default",
 ):
+    network_name = network.split("/")[-1]
+    firewall_rule_name = "dstack-ssh-in-" + network.replace("/", "-")
+    if not is_valid_resource_name(firewall_rule_name):
+        firewall_rule_name = "dstack-ssh-in-" + network_name
     firewall_rule = compute_v1.Firewall()
-    firewall_rule.name = "dstack-ssh-in-" + network.replace("/", "-")
+    firewall_rule.name = firewall_rule_name
     firewall_rule.direction = "INGRESS"
 
     allowed_ssh_port = compute_v1.Allowed()
@@ -189,8 +193,12 @@ def create_gateway_firewall_rules(
     project_id: str,
     network: str = "global/networks/default",
 ):
+    network_name = network.split("/")[-1]
+    firewall_rule_name = "dstack-gateway-in-all-" + network.replace("/", "-")
+    if not is_valid_resource_name(firewall_rule_name):
+        firewall_rule_name = "dstack-gateway-in-all-" + network_name
     firewall_rule = compute_v1.Firewall()
-    firewall_rule.name = "dstack-gateway-in-all-" + network.replace("/", "-")
+    firewall_rule.name = firewall_rule_name
     firewall_rule.direction = "INGRESS"
 
     allowed_ports = compute_v1.Allowed()
@@ -266,7 +274,7 @@ def is_valid_label_value(value: str) -> bool:
     return match is not None
 
 
-def generate_random_resource_name() -> str:
+def generate_random_resource_name(length: int = 40) -> str:
     return random.choice(string.ascii_lowercase) + "".join(
-        random.choice(string.ascii_lowercase + string.digits) for _ in range(40)
+        random.choice(string.ascii_lowercase + string.digits) for _ in range(length)
     )

--- a/src/dstack/_internal/core/backends/gcp/resources.py
+++ b/src/dstack/_internal/core/backends/gcp/resources.py
@@ -42,8 +42,7 @@ def create_instance_struct(
     network: str = "global/networks/default",
 ) -> compute_v1.Instance:
     network_interface = compute_v1.NetworkInterface()
-    network_interface.name = network
-
+    network_interface.network = network
     access = compute_v1.AccessConfig()
     access.type_ = compute_v1.AccessConfig.Type.ONE_TO_ONE_NAT.name
     access.name = "External NAT"

--- a/src/dstack/_internal/core/models/backends/gcp.py
+++ b/src/dstack/_internal/core/models/backends/gcp.py
@@ -11,6 +11,7 @@ class GCPConfigInfo(CoreModel):
     type: Literal["gcp"] = "gcp"
     project_id: str
     regions: Optional[List[str]] = None
+    vpc_name: Optional[str] = None
 
 
 class GCPServiceAccountCreds(CoreModel):
@@ -42,6 +43,7 @@ class GCPConfigInfoWithCredsPartial(CoreModel):
     creds: Optional[AnyGCPCreds]
     project_id: Optional[str]
     regions: Optional[List[str]]
+    vpc_name: Optional[str] = None
 
 
 class GCPConfigValues(CoreModel):

--- a/src/dstack/_internal/core/models/backends/gcp.py
+++ b/src/dstack/_internal/core/models/backends/gcp.py
@@ -12,6 +12,7 @@ class GCPConfigInfo(CoreModel):
     project_id: str
     regions: Optional[List[str]] = None
     vpc_name: Optional[str] = None
+    vpc_project_id: Optional[str] = None
 
 
 class GCPServiceAccountCreds(CoreModel):
@@ -44,6 +45,7 @@ class GCPConfigInfoWithCredsPartial(CoreModel):
     project_id: Optional[str]
     regions: Optional[List[str]]
     vpc_name: Optional[str] = None
+    vpc_project_id: Optional[str] = None
 
 
 class GCPConfigValues(CoreModel):

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -146,6 +146,10 @@ class GCPConfig(CoreModel):
     project_id: Annotated[str, Field(description="The project ID")]
     regions: Optional[List[str]] = None
     vpc_name: Annotated[Optional[str], Field(description="The VPC name")] = None
+    vpc_project_id: Annotated[
+        Optional[str],
+        Field(description="The shared VPC hosted project ID. Required for shared VPC only"),
+    ] = None
     creds: AnyGCPCreds = Field(..., description="The credentials", discriminator="type")
 
 
@@ -154,6 +158,10 @@ class GCPAPIConfig(CoreModel):
     project_id: Annotated[str, Field(description="The project ID")]
     regions: Optional[List[str]] = None
     vpc_name: Annotated[Optional[str], Field(description="The VPC name")] = None
+    vpc_project_id: Annotated[
+        Optional[str],
+        Field(description="The shared VPC hosted project ID. Required for shared VPC only"),
+    ] = None
     creds: AnyGCPAPICreds = Field(..., description="The credentials", discriminator="type")
 
 

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -49,7 +49,7 @@ def seq_representer(dumper, sequence):
 yaml.add_representer(list, seq_representer)
 
 
-# Below we difine pydantic models for configs allowed in server/config.yml and YAML-based API.
+# Below we define pydantic models for configs allowed in server/config.yml and YAML-based API.
 # There are some differences between the two, e.g. server/config.yml fills file-based
 # credentials by looking for a file, while YAML-based API doesn't do this.
 # So for some backends there are two sets of config models.
@@ -145,6 +145,7 @@ class GCPConfig(CoreModel):
     type: Annotated[Literal["gcp"], Field(description="The type of backend")] = "gcp"
     project_id: Annotated[str, Field(description="The project ID")]
     regions: Optional[List[str]] = None
+    vpc_name: Annotated[Optional[str], Field(description="The VPC name")] = None
     creds: AnyGCPCreds = Field(..., description="The credentials", discriminator="type")
 
 
@@ -152,6 +153,7 @@ class GCPAPIConfig(CoreModel):
     type: Annotated[Literal["gcp"], Field(description="The type of backend")] = "gcp"
     project_id: Annotated[str, Field(description="The project ID")]
     regions: Optional[List[str]] = None
+    vpc_name: Annotated[Optional[str], Field(description="The VPC name")] = None
     creds: AnyGCPAPICreds = Field(..., description="The credentials", discriminator="type")
 
 

--- a/src/tests/_internal/server/routers/test_backends.py
+++ b/src/tests/_internal/server/routers/test_backends.py
@@ -440,7 +440,9 @@ class TestGetBackendConfigValuesGCP:
             "dstack._internal.core.backends.gcp.auth.default_creds_available"
         ) as default_creds_available_mock, patch(
             "dstack._internal.core.backends.gcp.auth.authenticate"
-        ) as authenticate_mock:
+        ) as authenticate_mock, patch(
+            "dstack._internal.core.backends.gcp.resources.check_vpc"
+        ) as check_vpc_mock:
             default_creds_available_mock.return_value = False
             authenticate_mock.return_value = None, "test_project"
             response = client.post(
@@ -449,6 +451,7 @@ class TestGetBackendConfigValuesGCP:
                 json=body,
             )
             authenticate_mock.assert_called()
+            check_vpc_mock.assert_called()
         assert response.status_code == 200, response.json()
         assert response.json() == {
             "type": "gcp",
@@ -793,7 +796,9 @@ class TestCreateBackend:
             "dstack._internal.core.backends.gcp.auth.default_creds_available"
         ) as default_creds_available_mock, patch(
             "dstack._internal.core.backends.gcp.auth.authenticate"
-        ) as authenticate_mock:
+        ) as authenticate_mock, patch(
+            "dstack._internal.core.backends.gcp.resources.check_vpc"
+        ) as check_vpc_mock:
             default_creds_available_mock.return_value = False
             credentials_mock = Mock()
             authenticate_mock.return_value = credentials_mock, "test_project"
@@ -802,6 +807,7 @@ class TestCreateBackend:
                 headers=get_auth_headers(user.token),
                 json=body,
             )
+            check_vpc_mock.assert_called()
         assert response.status_code == 200, response.json()
         res = await session.execute(select(BackendModel))
         assert len(res.scalars().all()) == 1

--- a/src/tests/_internal/server/routers/test_backends.py
+++ b/src/tests/_internal/server/routers/test_backends.py
@@ -444,7 +444,7 @@ class TestGetBackendConfigValuesGCP:
             "dstack._internal.core.backends.gcp.resources.check_vpc"
         ) as check_vpc_mock:
             default_creds_available_mock.return_value = False
-            authenticate_mock.return_value = None, "test_project"
+            authenticate_mock.return_value = {}, "test_project"
             response = client.post(
                 "/api/backends/config_values",
                 headers=get_auth_headers(user.token),


### PR DESCRIPTION
Closes #1304 

This PR:
* Adds `vpc_name` to GCP config to allow configuring non-default VPC.
* Adds `vpc_project_id` to GCP config to allow configuring a Shared VPC.
* Implements automatic selection of custom VPC subnetwork.
* Adds GCP VPC config validation.
* Updates docs on GCP VPC configuration.