### PR TITLE
Fix retry policy backward compatibility

### DIFF
--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -22,6 +22,7 @@ from dstack._internal.core.models.profiles import (
     CreationPolicy,
     Profile,
     ProfileParams,
+    ProfileRetryPolicy,
     RetryEvent,
     SpotPolicy,
     TerminationPolicy,
@@ -194,6 +195,9 @@ class JobSpec(CoreModel):
     registry_auth: Optional[RegistryAuth]
     requirements: Requirements
     retry: Optional[Retry]
+    # For backward compatibility with 0.18.x when retry_policy was required.
+    # TODO: remove in 0.19
+    retry_policy: ProfileRetryPolicy = ProfileRetryPolicy(retry=False)
     working_dir: Optional[str]
 
 

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -162,6 +162,7 @@ def get_dev_env_run_plan_dict(
                         "spot": True,
                     },
                     "retry": None,
+                    "retry_policy": {"retry": False, "duration": None},
                     "working_dir": ".",
                 },
                 "offers": [json.loads(o.json()) for o in offers],
@@ -293,6 +294,7 @@ def get_dev_env_run_dict(
                         "spot": True,
                     },
                     "retry": None,
+                    "retry_policy": {"retry": False, "duration": None},
                     "working_dir": ".",
                 },
                 "job_submissions": [


### PR DESCRIPTION
dstack 0.18.2 expects "retry_policy" in JobSpec to be always present. 