### PR TITLE
Add OCI packer templates

### DIFF
--- a/scripts/packer/oci-image-cuda.json
+++ b/scripts/packer/oci-image-cuda.json
@@ -1,0 +1,73 @@
+{
+  "variables": {
+    "build_prefix": "",
+    "docker_version": "20.10.17",
+    "image_version": "",
+    "oci_availability_domain": "kZql:EU-FRANKFURT-1-AD-3",
+    "oci_compartment_ocid": "ocid1.compartment.oc1..aaaaaaaaxu2uq64unfa2imwkp37icxqv6f7gwp2mczdt2mukuqbkauwqmbtq",
+    "oci_subnet_ocid": "ocid1.subnet.oc1.eu-frankfurt-1.aaaaaaaaewxkaqsmbi2tig5sfw4eexzo3mkb4zrpm4gwvfhqdddnxicxe4fa"
+  },
+  "builders": [
+    {
+      "type": "oracle-oci",
+      "availability_domain": "{{user `oci_availability_domain`}}",
+      "compartment_ocid": "{{user `oci_compartment_ocid`}}",
+      "subnet_ocid": "{{user `oci_subnet_ocid`}}",
+      "shape": "VM.Standard2.1",
+      "base_image_ocid": "ocid1.image.oc1.eu-frankfurt-1.aaaaaaaaxroekfbow3kdrdjlwao6tsxxfcb23xmqrdjtjcay2ow52eijvzqa",
+      "image_name": "{{user `build_prefix`}}dstack-cuda-{{user `image_version`}}",
+      "instance_name": "packer-{{user `build_prefix`}}dstack-cuda-{{user `image_version`}}",
+      "ssh_username": "ubuntu"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": ["cloud-init status --long --wait"]
+    },
+    {
+      "type": "shell",
+      "script": "provisioners/wait-for-dpkg-lock.sh"
+    },
+    {
+      "type": "shell",
+      "scripts": [
+        "provisioners/kernel/apt-upgrade.sh",
+        "provisioners/kernel/apt-daily.sh",
+        "provisioners/kernel/apt-packages.sh",
+        "provisioners/kernel/kernel-tuning.sh"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "provisioners/install-docker.sh",
+      "destination": "/tmp/install-docker.sh"
+    },
+    {
+      "type": "file",
+      "source": "provisioners/run-docker",
+      "destination": "/tmp/run-docker"
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "cd /tmp",
+        "chmod +x install-docker.sh",
+        "./install-docker.sh --version {{user `docker_version`}}"]
+    },
+    {
+      "type": "shell",
+      "environment_vars": ["CUDA_DRIVERS_VERSION={{user `cuda_drivers_version`}}"],
+      "script": "provisioners/cuda.sh"
+    },
+    {
+      "type": "shell",
+      "script": "provisioners/install-nvidia-docker.sh"
+    },
+    {
+      "type": "shell",
+      "environment_vars": ["IMAGE_VERSION={{user `image_version`}}"],
+      "script": "provisioners/docker-image-with-cuda.sh"
+    }
+  ]
+}

--- a/scripts/packer/oci-image.json
+++ b/scripts/packer/oci-image.json
@@ -1,0 +1,64 @@
+{
+  "variables": {
+    "build_prefix": "",
+    "docker_version": "20.10.17",
+    "image_version": "",
+    "oci_availability_domain": "kZql:EU-FRANKFURT-1-AD-3",
+    "oci_compartment_ocid": "ocid1.compartment.oc1..aaaaaaaaxu2uq64unfa2imwkp37icxqv6f7gwp2mczdt2mukuqbkauwqmbtq",
+    "oci_subnet_ocid": "ocid1.subnet.oc1.eu-frankfurt-1.aaaaaaaaewxkaqsmbi2tig5sfw4eexzo3mkb4zrpm4gwvfhqdddnxicxe4fa"
+  },
+  "builders": [
+    {
+      "type": "oracle-oci",
+      "availability_domain": "{{user `oci_availability_domain`}}",
+      "compartment_ocid": "{{user `oci_compartment_ocid`}}",
+      "subnet_ocid": "{{user `oci_subnet_ocid`}}",
+      "shape": "VM.Standard2.1",
+      "base_image_ocid": "ocid1.image.oc1.eu-frankfurt-1.aaaaaaaaxroekfbow3kdrdjlwao6tsxxfcb23xmqrdjtjcay2ow52eijvzqa",
+      "image_name": "{{user `build_prefix`}}dstack-{{user `image_version`}}",
+      "instance_name": "packer-{{user `build_prefix`}}dstack-{{user `image_version`}}",
+      "ssh_username": "ubuntu"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": ["cloud-init status --long --wait"]
+    },
+    {
+      "type": "shell",
+      "script": "provisioners/wait-for-dpkg-lock.sh"
+    },
+    {
+      "type": "shell",
+      "scripts": [
+        "provisioners/kernel/apt-upgrade.sh",
+        "provisioners/kernel/apt-daily.sh",
+        "provisioners/kernel/apt-packages.sh",
+        "provisioners/kernel/kernel-tuning.sh"
+      ]
+    },
+    {
+      "type": "file",
+      "source": "provisioners/install-docker.sh",
+      "destination": "/tmp/install-docker.sh"
+    },
+    {
+      "type": "file",
+      "source": "provisioners/run-docker",
+      "destination": "/tmp/run-docker"
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "cd /tmp",
+        "chmod +x install-docker.sh",
+        "./install-docker.sh --version {{user `docker_version`}}"]
+    },
+    {
+      "type": "shell",
+      "environment_vars": ["IMAGE_VERSION={{user `image_version`}}"],
+      "script": "provisioners/docker-image-without-cuda.sh"
+    }
+  ]
+}

--- a/scripts/packer/provisioners/kernel/apt-upgrade.sh
+++ b/scripts/packer/provisioners/kernel/apt-upgrade.sh
@@ -6,6 +6,4 @@
 set -e
 
 sudo apt-get update
-
-# https://devops.stackexchange.com/questions/1139/how-to-avoid-interactive-dialogs-when-running-apt-get-upgrade-y-in-ubuntu-16
-sudo DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y -q
+sudo DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=60 dist-upgrade -y -q

--- a/scripts/packer/provisioners/wait-for-dpkg-lock.sh
+++ b/scripts/packer/provisioners/wait-for-dpkg-lock.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Wait until another process releases an apt/dpkg lock.
+#
+# This is a hack and it might not work for all cases. A better way of handling
+# apt races is the `-o DPkg::Lock::Timeout=X` option, but it does not work for
+# `apt-get update`.
+#
+
+while sudo fuser /var/{lib/{dpkg,apt/lists},cache/apt/archives}/lock >/dev/null 2>&1; do
+   sleep 1
+done


### PR DESCRIPTION
Note: image builds on OCI are a bit fragile
because OCI's instance monitoring plugin conflicts
with our build by calling apt-get in parallel.
This commit includes workarounds to avoid
conflicts, but builds can still fail in rare
cases.

A stable solution could be to disable the OCI's
monitoring plugin once packer-plugin-oracle adds
support for disabling plugins.
(https://github.com/hashicorp/packer-plugin-oracle/issues/50)

Part of #1194