### PR TITLE
Even more flexible OCI client credentials

### DIFF
--- a/docs/docs/reference/server/config.yml.md
+++ b/docs/docs/reference/server/config.yml.md
@@ -407,9 +407,9 @@ There are two ways to configure OCI: using client credentials or using the defau
 === "Client credentials"
 
     Log into the [OCI Console :material-arrow-top-right-thin:{ .external }](https://cloud.oracle.com), go to `My profile`, 
-    select `API keys`, anc click `Add API key`.
+    select `API keys`, and click `Add API key`.
 
-    Once created, you'll see the configuration file. Copy its values to configure the backend as follows:
+    Once you add a key, you'll see the configuration file. Copy its values to configure the backend as follows:
 
     <div editor-title="~/.dstack/server/config.yml">
     
@@ -424,21 +424,12 @@ There are two ways to configure OCI: using client credentials or using the defau
           tenancy: ocid1.tenancy.oc1..ajqsftvk4qarcfaak3ha4ycdsaahxmaita5frdwg3tqo2bcokpd3n7oizwai
           region: eu-frankfurt-1
           fingerprint: 77:32:77:00:49:7c:cb:56:84:75:8e:77:96:7d:53:17
-          key_content: |
-            -----BEGIN PRIVATE KEY-----
-            MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDcp9beQPfM/Kwj
-            DkE2ZrtFJccWxzMEQLn5ulDkNIhsx1q2t3KbYMHht0UgrtdWzCujxE1kg3fDxUuQ
-            ...
-            msDimnquNtbXho5QP0GhWXcJwbHvS2u+Kp0V1HX2jY3r78479hfveTvC4yQ5/kBr
-            aFbZPi45n5lKl+ElwK+YNAQ=
-            -----END PRIVATE KEY-----
+          key_file: ~/.oci/private_key.pem
     ```
     
     </div>
 
-    Make sure to include the contents of your private key in the backend configuration via `key_content`.
-
-[//]: # (TODO: Add support for `key_file` as an alternative to `key_content`)
+    Make sure to include either the path to your private key via `key_file` or the contents of the key via `key_content`.
 
 === "Default credentials"
     If you have default credentials set up in `~/.oci/config`, configure the backend like this:

--- a/src/dstack/_internal/core/models/backends/oci.py
+++ b/src/dstack/_internal/core/models/backends/oci.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from pydantic import Field
+from pydantic import Field, root_validator
 from typing_extensions import Annotated, List, Literal, Optional, Union
 
 from dstack._internal.core.models.backends.base import ConfigMultiElement
@@ -17,11 +17,34 @@ class OCIClientCreds(CoreModel):
     type: Annotated[Literal["client"], Field(description="The type of credentials")] = "client"
     user: Annotated[str, Field(description="User OCID")]
     tenancy: Annotated[str, Field(description="Tenancy OCID")]
-    key_content: Annotated[str, Field(description="Content of the user's private PEM key")]
+    key_file: Annotated[
+        Optional[str],
+        Field(
+            description="Path to the user's private PEM key. Either this or `key_content` should be set"
+        ),
+    ]
+    key_content: Annotated[
+        Optional[str],
+        Field(
+            description="Content of the user's private PEM key. Either this or `key_file` should be set"
+        ),
+    ]
+    pass_phrase: Annotated[
+        Optional[str], Field(description="Passphrase for the private PEM key if it is encrypted")
+    ]
     fingerprint: Annotated[str, Field(description="User's public key fingerprint")]
     region: Annotated[
         str, Field(description="Name or key of any region the tenancy is subscribed to")
     ]
+
+    @root_validator
+    def key_file_xor_key_content(cls, values):
+        key_file, key_content = values["key_file"], values["key_content"]
+        if key_file and key_content:
+            raise ValueError("key_file and key_content are mutually exclusive")
+        if not key_file and not key_content:
+            raise ValueError("Either key_file or key_content should be set")
+        return values
 
 
 class OCIDefaultCreds(CoreModel):

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -246,17 +246,19 @@ class NebiusAPIConfig(CoreModel):
 
 class OCIConfig(CoreModel):
     type: Annotated[Literal["oci"], Field(description="The type of backend")] = "oci"
-    creds: Annotated[AnyOCICreds, Field(description="The credentials")]
+    creds: Annotated[AnyOCICreds, Field(description="The credentials", discriminator="type")]
     regions: Annotated[
         Optional[List[str]],
-        Field(description="List of region names for running dstack jobs. Omit to use all regions"),
+        Field(
+            description="List of region names for running `dstack` jobs. Omit to use all regions"
+        ),
     ] = None
     compartment_id: Annotated[
         Optional[str],
         Field(
             description=(
-                "Compartment where dstack will create all resources. "
-                "Omit to instruct dstack to create a new compartment"
+                "Compartment where `dstack` will create all resources. "
+                "Omit to instruct `dstack` to create a new compartment"
             )
         ),
     ] = None


### PR DESCRIPTION
- Allow specifying path to the API key
- Allow specifying key passphrase
- Add missing `type` discriminator for better error messages
- Minor docs tweaks

Part of #1194