### PR TITLE
[Internal] Fix linter errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.4
+    rev: v0.4.8
     hooks:
       - id: ruff
         name: ruff common

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,4 +3,4 @@ httpx>=0.23
 pytest~=7.2
 pytest-asyncio>=0.21
 freezegun>=1.2.0
-ruff~=0.4.1
+ruff==0.4.8

--- a/src/dstack/_internal/core/backends/lambdalabs/api_client.py
+++ b/src/dstack/_internal/core/backends/lambdalabs/api_client.py
@@ -75,8 +75,8 @@ class LambdaAPIClient:
         resp.raise_for_status()
 
     def _make_request(self, method: str, path: str, data: Any = None):
-        # TODO: set adequate timeout here or in every method
-        return requests.request(
+        # TODO: fix S113 by setting an adequate timeout here or in every method
+        return requests.request(  # noqa: S113
             method=method,
             url=API_URL + path,
             json=data,

--- a/src/dstack/_internal/core/backends/runpod/api_client.py
+++ b/src/dstack/_internal/core/backends/runpod/api_client.py
@@ -92,8 +92,8 @@ class RunpodApiClient:
 
     def _make_request(self, data: Any = None) -> Response:
         try:
-            # TODO: set adequate timeout here or in every method
-            response = requests.request(
+            # TODO: fix S113 by setting an adequate timeout here or in every method
+            response = requests.request(  # noqa: S113
                 method="POST",
                 url=f"{API_URL}?api_key={self.api_key}",
                 json=data,


### PR DESCRIPTION
New errors appeared with ruff 0.4.6 and were only visible in local virtual environments, not in pre-commit hooks. So this commit additionally pins the ruff version so that it is the same in all environments.