### PR TITLE
Respect registry_auth for RunPod

### DIFF
--- a/src/dstack/_internal/core/backends/runpod/api_client.py
+++ b/src/dstack/_internal/core/backends/runpod/api_client.py
@@ -85,13 +85,8 @@ class RunpodApiClient:
         pod_id: str,
         image_name: str,
         container_disk_in_gb: int,
-        docker_args: str,
-        env: List[str],
-        port: str,
-        ports: str,
-        volume_in_gb: int,
-        volume_mount_path: str,
         container_registry_auth_id: str,
+        volume_in_gb: int = 0,
     ) -> int:
         resp = self._make_request(
             {
@@ -99,15 +94,10 @@ class RunpodApiClient:
                 mutation {{
                     podEditJob(input: {{
                         podId: "{pod_id}"
-                        dockerArgs: "{docker_args}"
                         imageName: "{image_name}"
-                        env: {env}
-                        port: "{port}"
-                        ports: "{ports}"
                         containerDiskInGb: {container_disk_in_gb}
-                        volumeInGb: {volume_in_gb}
-                        volumeMountPath: "{volume_mount_path}"
                         containerRegistryAuthId: "{container_registry_auth_id}"
+                        volumeInGb: {volume_in_gb}
                     }}) {{
                         id
                     }}
@@ -366,13 +356,6 @@ def generate_pod_deployment_mutation(
             id
             lastStatusChange
             imageName
-            containerDiskInGb
-            dockerArgs
-            env
-            port
-            ports
-            volumeInGb
-            volumeMountPath
             machine {{
               podHostId
             }}

--- a/src/dstack/_internal/core/backends/runpod/compute.py
+++ b/src/dstack/_internal/core/backends/runpod/compute.py
@@ -94,6 +94,10 @@ class RunpodCompute(Compute):
 
         instance_id = resp["id"]
 
+        # TODO: remove editPod once createPod supports docker's username and password
+        # editPod is temporary solution to set container_registry_auth_id because createPod does not
+        # support it currently. This will be removed once createPod supports container_registry_auth_id
+        # or username and password
         if container_registry_auth_id is not None:
             instance_id = self.api_client.edit_pod(
                 pod_id=instance_id,

--- a/src/dstack/_internal/core/backends/runpod/compute.py
+++ b/src/dstack/_internal/core/backends/runpod/compute.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
 from dstack._internal.core.backends.base import Compute
@@ -27,7 +27,7 @@ from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-CONTAINER_REGISTRY_AUTH_DELETE_TIMEOUT = 60 * 60  # 1 hour
+CONTAINER_REGISTRY_AUTH_DELETE_TIMEOUT = 60  # 60 seconds
 CONTAINER_REGISTRY_AUTH_CLEANUP_INTERVAL = 60 * 60 * 24  # 1 day
 
 
@@ -76,10 +76,9 @@ class RunpodCompute(Compute):
         authorized_keys = instance_config.get_public_keys()
         memory_size = round(instance_offer.instance.resources.memory_mib / 1024)
         disk_size = round(instance_offer.instance.resources.disk.size_mib / 1024)
-        # container_registry_auth_id = self._generate_container_registry_auth_id(
-        #     job.job_spec.registry_auth
-        # )
-        container_registry_auth_id = None
+        container_registry_auth_id = self._generate_container_registry_auth_id(
+            job.job_spec.registry_auth
+        )
         resp = self.api_client.create_pod(
             name=instance_config.instance_name,
             image_name=job.job_spec.image_name,
@@ -94,32 +93,14 @@ class RunpodCompute(Compute):
             ports="10022/tcp",
             bid_per_gpu=instance_offer.price if instance_offer.instance.resources.spot else None,
         )
-        raise Exception("123")
 
         instance_id = resp["id"]
-        instance_id = self.api_client.edit_pod(
-            pod_id=instance_id,
-            image_name=resp["imageName"],
-            container_disk_in_gb=resp["containerDiskInGb"],
-            docker_args=resp["dockerArgs"],
-            env=resp["env"],
-            port=resp["port"],
-            ports=resp["ports"],
-            volume_in_gb=resp["volumeInGb"],
-            volume_mount_path=resp["volumeMountPath"],
-            container_registry_auth_id=container_registry_auth_id,
-        )
+
         if container_registry_auth_id is not None:
             instance_id = self.api_client.edit_pod(
                 pod_id=instance_id,
-                image_name=resp["imageName"],
-                container_disk_in_gb=resp["containerDiskInGb"],
-                docker_args=resp["dockerArgs"],
-                env=resp["env"],
-                port=resp["port"],
-                ports=resp["ports"],
-                volume_in_gb=resp["volumeInGb"],
-                volume_mount_path=resp["volumeMountPath"],
+                image_name=job.job_spec.image_name,
+                container_disk_in_gb=disk_size,
                 container_registry_auth_id=container_registry_auth_id,
             )
             self._instance_id_to_container_registry_auth_id_mapping[instance_id] = (
@@ -152,10 +133,9 @@ class RunpodCompute(Compute):
     def terminate_instance(
         self, instance_id: str, region: str, backend_data: Optional[str] = None
     ) -> None:
-        self._delete_container_registry_auth_for_instance_id(instance_id)
-
         try:
             self.api_client.terminate_pod(instance_id)
+            self._delete_container_registry_auth_for_instance_id(instance_id)
         except BackendError as e:
             if e.args[0] == "Instance Not Found":
                 logger.debug("The instance with name %s not found", instance_id)
@@ -205,12 +185,19 @@ class RunpodCompute(Compute):
             except (IndexError, ValueError):
                 continue
 
-            create_time = datetime.fromtimestamp(timestamp)
+            create_time = datetime.fromtimestamp(timestamp, tz=timezone.utc)
             if create_time < get_current_datetime() - timedelta(
                 seconds=CONTAINER_REGISTRY_AUTH_DELETE_TIMEOUT
             ):
-                self.api_client.delete_container_registry_auth(container_registry_auth["id"])
-                deleted_ids.add(container_registry_auth["id"])
+                try:
+                    self.api_client.delete_container_registry_auth(container_registry_auth["id"])
+                    deleted_ids.add(container_registry_auth["id"])
+                except Exception as e:
+                    logger.warning(
+                        "Failed to delete container registry auth with id %s: %s",
+                        container_registry_auth["id"],
+                        e,
+                    )
 
         # Remove stale records from mapping in case when termination was not called for some reason to avoid memory leak
         for (
@@ -218,7 +205,7 @@ class RunpodCompute(Compute):
             container_registry_auth_id,
         ) in self._instance_id_to_container_registry_auth_id_mapping.items():
             if container_registry_auth_id in deleted_ids:
-                self._instance_id_to_container_registry_auth_id_mapping.pop(instance_id, None)
+                self._instance_id_to_container_registry_auth_id_mapping.pop(instance_id)
 
 
 def get_docker_args(authorized_keys: List[str]) -> str:

--- a/src/dstack/_internal/core/backends/runpod/compute.py
+++ b/src/dstack/_internal/core/backends/runpod/compute.py
@@ -1,4 +1,6 @@
 import json
+import uuid
+from datetime import datetime, timedelta
 from typing import List, Optional
 
 from dstack._internal.core.backends.base import Compute
@@ -12,6 +14,7 @@ from dstack._internal.core.errors import (
     BackendError,
 )
 from dstack._internal.core.models.backends.base import BackendType
+from dstack._internal.core.models.configurations import RegistryAuth
 from dstack._internal.core.models.instances import (
     InstanceAvailability,
     InstanceConfiguration,
@@ -19,12 +22,19 @@ from dstack._internal.core.models.instances import (
     SSHKey,
 )
 from dstack._internal.core.models.runs import Job, JobProvisioningData, Requirements, Run
+from dstack._internal.utils.common import get_current_datetime
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+CONTAINER_REGISTRY_AUTH_DELETE_TIMEOUT = 60 * 60  # 1 hour
+CONTAINER_REGISTRY_AUTH_CLEANUP_INTERVAL = 60 * 60 * 24  # 1 day
+
 
 class RunpodCompute(Compute):
+    _instance_id_to_container_registry_auth_id_mapping = {}
+    _last_cleanup_time = None
+
     def __init__(self, config):
         self.config = config
         self.api_client = RunpodApiClient(config.creds.api_key)
@@ -66,6 +76,10 @@ class RunpodCompute(Compute):
         authorized_keys = instance_config.get_public_keys()
         memory_size = round(instance_offer.instance.resources.memory_mib / 1024)
         disk_size = round(instance_offer.instance.resources.disk.size_mib / 1024)
+        # container_registry_auth_id = self._generate_container_registry_auth_id(
+        #     job.job_spec.registry_auth
+        # )
+        container_registry_auth_id = None
         resp = self.api_client.create_pod(
             name=instance_config.instance_name,
             image_name=job.job_spec.image_name,
@@ -79,9 +93,47 @@ class RunpodCompute(Compute):
             docker_args=get_docker_args(authorized_keys),
             ports="10022/tcp",
             bid_per_gpu=instance_offer.price if instance_offer.instance.resources.spot else None,
-            registry_auth=job.job_spec.registry_auth,
         )
+        raise Exception("123")
+
         instance_id = resp["id"]
+        instance_id = self.api_client.edit_pod(
+            pod_id=instance_id,
+            image_name=resp["imageName"],
+            container_disk_in_gb=resp["containerDiskInGb"],
+            docker_args=resp["dockerArgs"],
+            env=resp["env"],
+            port=resp["port"],
+            ports=resp["ports"],
+            volume_in_gb=resp["volumeInGb"],
+            volume_mount_path=resp["volumeMountPath"],
+            container_registry_auth_id=container_registry_auth_id,
+        )
+        if container_registry_auth_id is not None:
+            instance_id = self.api_client.edit_pod(
+                pod_id=instance_id,
+                image_name=resp["imageName"],
+                container_disk_in_gb=resp["containerDiskInGb"],
+                docker_args=resp["dockerArgs"],
+                env=resp["env"],
+                port=resp["port"],
+                ports=resp["ports"],
+                volume_in_gb=resp["volumeInGb"],
+                volume_mount_path=resp["volumeMountPath"],
+                container_registry_auth_id=container_registry_auth_id,
+            )
+            self._instance_id_to_container_registry_auth_id_mapping[instance_id] = (
+                container_registry_auth_id
+            )
+
+        if (
+            self._last_cleanup_time is None
+            or self._last_cleanup_time
+            < get_current_datetime() - timedelta(seconds=CONTAINER_REGISTRY_AUTH_CLEANUP_INTERVAL)
+        ):
+            self._clean_stale_container_registry_auths()
+            self._last_cleanup_time = get_current_datetime()
+
         return JobProvisioningData(
             backend=instance_offer.backend,
             instance_type=instance_offer.instance,
@@ -100,6 +152,8 @@ class RunpodCompute(Compute):
     def terminate_instance(
         self, instance_id: str, region: str, backend_data: Optional[str] = None
     ) -> None:
+        self._delete_container_registry_auth_for_instance_id(instance_id)
+
         try:
             self.api_client.terminate_pod(instance_id)
         except BackendError as e:
@@ -120,6 +174,51 @@ class RunpodCompute(Compute):
             if port["privatePort"] == 10022:
                 provisioning_data.hostname = port["ip"]
                 provisioning_data.ssh_port = port["publicPort"]
+
+    def _generate_container_registry_auth_id(
+        self, registry_auth: Optional[RegistryAuth]
+    ) -> Optional[str]:
+        if registry_auth is None:
+            return None
+
+        name = f"{uuid.uuid4().hex}#{int(get_current_datetime().timestamp())}"
+        return self.api_client.add_container_registry_auth(
+            name, registry_auth.username, registry_auth.password
+        )
+
+    def _delete_container_registry_auth_for_instance_id(self, instance_id: str) -> None:
+        container_registry_auth_id = self._instance_id_to_container_registry_auth_id_mapping.pop(
+            instance_id, None
+        )
+
+        if container_registry_auth_id is not None:
+            self.api_client.delete_container_registry_auth(container_registry_auth_id)
+
+    def _clean_stale_container_registry_auths(self) -> None:
+        container_registry_auths = self.api_client.get_container_registry_auths()
+
+        deleted_ids = set()
+
+        for container_registry_auth in container_registry_auths:
+            try:
+                timestamp = float(container_registry_auth["name"].rsplit("#", 1)[1])
+            except (IndexError, ValueError):
+                continue
+
+            create_time = datetime.fromtimestamp(timestamp)
+            if create_time < get_current_datetime() - timedelta(
+                seconds=CONTAINER_REGISTRY_AUTH_DELETE_TIMEOUT
+            ):
+                self.api_client.delete_container_registry_auth(container_registry_auth["id"])
+                deleted_ids.add(container_registry_auth["id"])
+
+        # Remove stale records from mapping in case when termination was not called for some reason to avoid memory leak
+        for (
+            instance_id,
+            container_registry_auth_id,
+        ) in self._instance_id_to_container_registry_auth_id_mapping.items():
+            if container_registry_auth_id in deleted_ids:
+                self._instance_id_to_container_registry_auth_id_mapping.pop(instance_id, None)
 
 
 def get_docker_args(authorized_keys: List[str]) -> str:

--- a/src/dstack/_internal/core/backends/runpod/compute.py
+++ b/src/dstack/_internal/core/backends/runpod/compute.py
@@ -79,6 +79,7 @@ class RunpodCompute(Compute):
             docker_args=get_docker_args(authorized_keys),
             ports="10022/tcp",
             bid_per_gpu=instance_offer.price if instance_offer.instance.resources.spot else None,
+            registry_auth=job.job_spec.registry_auth,
         )
         instance_id = resp["id"]
         return JobProvisioningData(

--- a/src/dstack/_internal/core/backends/vastai/compute.py
+++ b/src/dstack/_internal/core/backends/vastai/compute.py
@@ -69,14 +69,13 @@ class VastAICompute(Compute):
         commands = get_docker_commands(
             [run.run_spec.ssh_key_pub.strip(), project_ssh_public_key.strip()]
         )
-        registry_auth = None  # TODO(egor-s): registry auth secrets
         resp = self.api_client.create_instance(
             instance_name=get_instance_name(run, job),
             bundle_id=instance_offer.instance.name,
             image_name=job.job_spec.image_name,
             onstart=" && ".join(commands),
             disk_size=round(instance_offer.instance.resources.disk.size_mib / 1024),
-            registry_auth=registry_auth,
+            registry_auth=job.job_spec.registry_auth,
         )
         instance_id = resp["new_contract"]
         return JobProvisioningData(

--- a/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
@@ -296,7 +296,7 @@ async def _run_job_on_new_instance(
                 offer.backend.value,
                 offer.region,
             )
-            continue
+            break
     return None
 
 

--- a/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
@@ -259,7 +259,7 @@ async def _run_job_on_new_instance(
     )
     # Limit number of offers tried to prevent long-running processing
     # in case all offers fail.
-    for backend, offer in offers[:15]:
+    for backend, offer in offers[:3]:
         logger.debug(
             "%s: trying %s in %s/%s for $%0.4f per hour",
             fmt(job_model),
@@ -296,7 +296,7 @@ async def _run_job_on_new_instance(
                 offer.backend.value,
                 offer.region,
             )
-            break
+            continue
     return None
 
 

--- a/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
@@ -259,7 +259,7 @@ async def _run_job_on_new_instance(
     )
     # Limit number of offers tried to prevent long-running processing
     # in case all offers fail.
-    for backend, offer in offers[:3]:
+    for backend, offer in offers[:15]:
         logger.debug(
             "%s: trying %s in %s/%s for $%0.4f per hour",
             fmt(job_model),


### PR DESCRIPTION
Fixes #1297 

Add support for registry_auth for the RunPod and VastAI backends. RunPod does not have the feature to pass credentials directly to the create pod API. Instead, there is a containerRegistryAuths object that should be created and passed to the editPod API to use private registries. To remove stale objects, a function was implemented to delete stale objects every 24 hours during some user request executions.

This solution is considered a temporary workaround because it could have issues when running at scale. The containerRegistryAuth only supports querying all objects at once, and only one containerRegistryAuth can be deleted per API call. Therefore, if there are many users, it can become a bottleneck.