### PR TITLE
Support multi-node tasks on OCI

### DIFF
--- a/docs/docs/reference/dstack.yml/task.md
+++ b/docs/docs/reference/dstack.yml/task.md
@@ -206,7 +206,7 @@ is pass the corresponding environment variables such as `DSTACK_GPUS_PER_NODE`, 
 `DSTACK_MASTER_NODE_IP`, and `DSTACK_GPUS_NUM` (see [System environment variables](#default-environment-variables)).
 
 ??? info "Backends"
-    Running on multiple nodes is supported only with the `aws`, `gcp`, `azure`, and instances added via
+    Running on multiple nodes is supported only with `aws`, `gcp`, `azure`, `oci`, and instances added via
     [`dstack pool add-ssh`](../../concepts/pools.md#adding-on-prem-servers).
 
 ### Arguments

--- a/src/dstack/_internal/core/backends/__init__.py
+++ b/src/dstack/_internal/core/backends/__init__.py
@@ -5,6 +5,7 @@ BACKENDS_WITH_MULTINODE_SUPPORT = [
     BackendType.AZURE,
     BackendType.GCP,
     BackendType.REMOTE,
+    BackendType.OCI,
 ]
 BACKENDS_WITH_CREATE_INSTANCE_SUPPORT = [
     BackendType.AWS,

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -99,8 +99,11 @@ def get_instance_name(run: Run, job: Job) -> str:
     return f"{run.project_name.lower()}-{job.job_spec.job_name}"
 
 
-def get_user_data(authorized_keys: List[str]) -> str:
-    commands = get_shim_commands(authorized_keys)
+def get_user_data(
+    authorized_keys: List[str], backend_specific_commands: Optional[List[str]] = None
+) -> str:
+    shim_commands = get_shim_commands(authorized_keys)
+    commands = (backend_specific_commands or []) + shim_commands
     return get_cloud_config(
         runcmd=[["sh", "-c", " && ".join(commands)]],
         ssh_authorized_keys=authorized_keys,

--- a/src/dstack/_internal/core/backends/oci/resources.py
+++ b/src/dstack/_internal/core/backends/oci/resources.py
@@ -559,6 +559,8 @@ def get_or_create_security_group(
 def update_security_group_rules_for_runner_instances(
     security_group_id: str, client: oci.core.VirtualNetworkClient
 ) -> None:
+    # These rules are combined with subnet's default Security List that allows
+    # ingress TCP on port 22 from anywhere
     rules = [
         SecurityRule(
             description="Allow all traffic within this security group",

--- a/src/dstack/_internal/utils/common.py
+++ b/src/dstack/_internal/utils/common.py
@@ -2,7 +2,7 @@ import re
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Iterable, List, Optional, TypeVar, Union
 
 
 def get_dstack_dir() -> Path:
@@ -166,6 +166,30 @@ def remove_prefix(text: str, prefix: str) -> str:
     if text.startswith(prefix):
         return text[len(prefix) :]
     return text
+
+
+T = TypeVar("T")
+
+
+def split_chunks(iterable: Iterable[T], chunk_size: int) -> Iterable[List[T]]:
+    """
+    Splits an iterable into chunks of at most `chunk_size` items.
+
+    >>> list(split_chunks([1, 2, 3, 4, 5], 2))
+    [[1, 2], [3, 4], [5]]
+    """
+
+    if chunk_size < 1:
+        raise ValueError(f"chunk_size should be a positive integer, not {chunk_size}")
+
+    chunk = []
+    for item in iterable:
+        chunk.append(item)
+        if len(chunk) == chunk_size:
+            yield chunk
+            chunk = []
+    if chunk:
+        yield chunk
 
 
 MEMORY_UNITS = {

--- a/src/tests/_internal/core/backends/oci/test_resources.py
+++ b/src/tests/_internal/core/backends/oci/test_resources.py
@@ -1,6 +1,9 @@
+import datetime
+
+import oci
 import pytest
 
-from dstack._internal.core.backends.oci.resources import ShapesQuota
+from dstack._internal.core.backends.oci.resources import SecurityRule, ShapesQuota
 
 
 class TestShapesQuota:
@@ -47,3 +50,41 @@ class TestShapesQuota:
     )
     def test_is_within_domain_quota(self, shape: str, domain: str, is_within_quota: str):
         assert is_within_quota == self.SAMPLE_QUOTA.is_within_domain_quota(shape, domain)
+
+
+class TestCompareSecurityRulesAfterConversion:
+    def test_equal(self) -> None:
+        first = SecurityRule(
+            direction=oci.core.models.SecurityRule.DIRECTION_INGRESS,
+            protocol="all",
+            source_type=oci.core.models.SecurityRule.SOURCE_TYPE_CIDR_BLOCK,
+            source="0.0.0.0/0",
+        )
+        second = oci.core.models.SecurityRule(
+            direction=oci.core.models.SecurityRule.DIRECTION_INGRESS,
+            protocol="all",
+            source_type=oci.core.models.SecurityRule.SOURCE_TYPE_CIDR_BLOCK,
+            source="0.0.0.0/0",
+            is_stateless=False,
+            id="AAAAAA",
+            time_created=datetime.datetime.now(),
+        )
+        assert first == SecurityRule.from_sdk_rule(second)
+
+    def test_unequal(self) -> None:
+        first = SecurityRule(
+            direction=oci.core.models.SecurityRule.DIRECTION_INGRESS,
+            protocol="all",
+            source_type=oci.core.models.SecurityRule.SOURCE_TYPE_CIDR_BLOCK,
+            source="0.0.0.0/0",
+        )
+        second = oci.core.models.SecurityRule(
+            direction=oci.core.models.SecurityRule.DIRECTION_INGRESS,
+            protocol="all",
+            source_type=oci.core.models.SecurityRule.SOURCE_TYPE_CIDR_BLOCK,
+            source="10.10.10.0/24",
+            is_stateless=False,
+            id="AAAAAA",
+            time_created=datetime.datetime.now(),
+        )
+        assert first != SecurityRule.from_sdk_rule(second)

--- a/src/tests/_internal/utils/test_common.py
+++ b/src/tests/_internal/utils/test_common.py
@@ -1,9 +1,10 @@
 from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable, List
 
 import pytest
 from freezegun import freeze_time
 
-from dstack._internal.utils.common import parse_memory, pretty_date
+from dstack._internal.utils.common import parse_memory, pretty_date, split_chunks
 
 
 @freeze_time(datetime(2023, 10, 4, 12, 0, tzinfo=timezone.utc))
@@ -84,3 +85,27 @@ class TestParseMemory:
     )
     def test_parses_memory(self, memory, as_units, expected):
         assert parse_memory(memory, as_untis=as_units) == expected
+
+
+class TestSplitChunks:
+    @pytest.mark.parametrize(
+        ("iterable", "chunk_size", "expected_chunks"),
+        [
+            ([1, 2, 3, 4], 2, [[1, 2], [3, 4]]),
+            ([1, 2, 3], 2, [[1, 2], [3]]),
+            ([1, 2], 2, [[1, 2]]),
+            ([1], 2, [[1]]),
+            ([], 2, []),
+            ({"a": 1, "b": 2, "c": 3}, 2, [["a", "b"], ["c"]]),
+            ((x for x in range(5)), 3, [[0, 1, 2], [3, 4]]),
+        ],
+    )
+    def test_split_chunks(
+        self, iterable: Iterable[Any], chunk_size: int, expected_chunks: List[List[Any]]
+    ) -> None:
+        assert list(split_chunks(iterable, chunk_size)) == expected_chunks
+
+    @pytest.mark.parametrize("chunk_size", [0, -1])
+    def test_raises_on_invalid_chunk_size(self, chunk_size: int) -> None:
+        with pytest.raises(ValueError):
+            list(split_chunks([1, 2, 3], chunk_size))


### PR DESCRIPTION
This commit adds support for multi-node tasks on OCI by allowing network traffic between instances in the same project and region. To achieve that, a network security group is created or discovered on instance launch and instance's OS-level firewall is reconfigured on boot via cloud-init.

#1194