### PR TITLE
Fix failing runner-test workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,11 @@ on:
     branches:
       - 'master'
   workflow_dispatch:
+    inputs:
+      intergation-tests:
+        type: boolean
+        required: true
+        default: false
 
 env:
   BUILD_INCREMENT: 150
@@ -79,11 +84,19 @@ jobs:
           args: --timeout=20m
           working-directory: runner
       - name: Test
+        # Do not run slow integration tests automatically.
+        # Slow tests can be run manually via workflow_dispatch when required.
         run: |
+          SHORT="-short"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            if [[ "${{ github.event.inputs.intergation-tests }}" == "true" ]]; then
+              SHORT=""
+            fi
+          fi
           go version
           go fmt $(go list ./... | grep -v /vendor/)
           go vet $(go list ./... | grep -v /vendor/)
-          go test -race $(go list ./... | grep -v /vendor/)
+          go test $SHORT -race $(go list ./... | grep -v /vendor/)
 
   runner-compile:
     needs: [runner-test]

--- a/runner/internal/shim/docker_test.go
+++ b/runner/internal/shim/docker_test.go
@@ -28,7 +28,7 @@ func TestDocker_SSHServer(t *testing.T) {
 		sshPort:  nextPort(),
 	}
 
-	timeout := 60 // seconds
+	timeout := 180 // seconds
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 	defer cancel()
 
@@ -54,7 +54,7 @@ func TestDocker_SSHServerConnect(t *testing.T) {
 		publicSSHKey: string(publicBytes),
 	}
 
-	timeout := 60 // seconds
+	timeout := 180 // seconds
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 	defer cancel()
 


### PR DESCRIPTION
Fixes #1324

This PR disables slow runner integration tests from Build workflow by default. Since the tested code is rarely changed, the  suggestion is to run integration tests manually when required. For this, the workflow is updated to run integration tests on workflow-dispatch.