### PR TITLE
Fix cudo backend stuck && Improve docs for cudo

### DIFF
--- a/docs/docs/concepts/pools.md
+++ b/docs/docs/concepts/pools.md
@@ -11,7 +11,7 @@ requirements, `dstack` automatically provisions a new cloud instance and adds it
 
 ??? info "Reuse policy"
     To avoid provisioning new cloud instances with `dstack run`, use `--reuse`. Your run will be assigned to an idle instance in
-    the pool.
+    the pool. If there are no available idle instances in the pool, the run will fail.
 
 ??? info "Idle duration"
     By default, `dstack run` sets the idle duration of a newly provisioned instance to `5m`.

--- a/docs/docs/reference/server/config.yml.md
+++ b/docs/docs/reference/server/config.yml.md
@@ -909,6 +909,23 @@ In case of a self-managed cluster, also specify the IP address of any node in th
         type:
             required: true
 
+## `projects[n].backends[type=cudo]` { #cudo data-toc-label="backends[type=cudo]" }
+
+#SCHEMA# dstack._internal.server.services.config.CudoConfig
+    overrides:
+        show_root_heading: false
+        type:
+            required: true
+        item_id_prefix: cudo-
+
+## `projects[n].backends[type=cudo].creds` { #cudo-creds data-toc-label="backends[type=cudo].creds" }
+
+#SCHEMA# dstack._internal.core.models.backends.cudo.CudoAPIKeyCreds
+    overrides:
+        show_root_heading: false
+        type:
+            required: true
+
 ## `projects[n].backends[type=kubernetes]` { #kubernetes data-toc-label="backends[type=kubernetes]" }
 
 #SCHEMA# dstack._internal.server.services.config.KubernetesConfig

--- a/runner/internal/shim/docker.go
+++ b/runner/internal/shim/docker.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/user"
 	"path/filepath"
 	rt "runtime"
 	"strconv"
@@ -78,7 +79,7 @@ func (d *DockerRunner) Run(ctx context.Context, cfg TaskConfig) error {
 	var err error
 
 	if cfg.SshKey != "" {
-		ak := AuthorizedKeys{user: cfg.SshUser}
+		ak := AuthorizedKeys{user: cfg.SshUser, lookup: user.Lookup}
 		if err := ak.AppendPublicKeys([]string{cfg.SshKey}); err != nil {
 			return tracerr.Wrap(err)
 		}

--- a/src/dstack/_internal/core/models/backends/cudo.py
+++ b/src/dstack/_internal/core/models/backends/cudo.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
-from typing_extensions import Literal
+from pydantic.fields import Field
+from typing_extensions import Annotated, Literal
 
 from dstack._internal.core.models.backends.base import ConfigElement, ConfigMultiElement
 from dstack._internal.core.models.common import CoreModel
@@ -17,8 +18,8 @@ class CudoStoredConfig(CudoConfigInfo):
 
 
 class CudoAPIKeyCreds(CoreModel):
-    type: Literal["api_key"] = "api_key"
-    api_key: str
+    type: Annotated[Literal["api_key"], Field(description="The type of credentials")] = "api_key"
+    api_key: Annotated[str, Field(description="The API key")]
 
 
 AnyCudoCreds = CudoAPIKeyCreds


### PR DESCRIPTION
Fixes #1345
Closes #1342

The issue was with recent changes related to reusing instances by different users. A `GetAuthorizedKeysPath` method was introduced, which hardcoded the user home directory to `/home/{username}`. This was true for most cases except for the root user, who has two options for the home directory: `/root` and `/home/root`.