### PR TITLE
tpu initial release

### DIFF
--- a/runner/cmd/shim/main.go
+++ b/runner/cmd/shim/main.go
@@ -97,6 +97,11 @@ func main() {
 						Usage:       "Do not delete container on exit",
 						Destination: &args.Docker.KeepContainer,
 					},
+                    &cli.BoolFlag{
+						Name:        "privileged",
+						Usage:       "Give extended privileges to the container",
+						Destination: &args.Docker.Privileged,
+					},
 					&cli.StringFlag{
 						Name:        "ssh-key",
 						Usage:       "Public SSH key",

--- a/runner/cmd/shim/main.go
+++ b/runner/cmd/shim/main.go
@@ -97,7 +97,7 @@ func main() {
 						Usage:       "Do not delete container on exit",
 						Destination: &args.Docker.KeepContainer,
 					},
-                    &cli.BoolFlag{
+					&cli.BoolFlag{
 						Name:        "privileged",
 						Usage:       "Give extended privileges to the container",
 						Destination: &args.Docker.Privileged,
@@ -108,6 +108,12 @@ func main() {
 						Required:    true,
 						Destination: &args.Docker.ConcatinatedPublicSSHKeys,
 						EnvVars:     []string{"DSTACK_PUBLIC_SSH_KEY"},
+					},
+					&cli.StringFlag{
+						Name:        "pjrt-device",
+						Usage:       "Set the PJRT_DEVICE environment variable (e.g., TPU, GPU)",
+						Destination: &args.Docker.PJRTDevice,
+						EnvVars:     []string{"PJRT_DEVICE"},
 					},
 					&cli.BoolFlag{
 						Name:        "service",

--- a/runner/internal/shim/docker.go
+++ b/runner/internal/shim/docker.go
@@ -318,11 +318,11 @@ func createContainer(ctx context.Context, client docker.APIClient, runnerDir str
 		Entrypoint:   []string{"/bin/sh", "-c"},
 		ExposedPorts: exposePorts(dockerParams.DockerPorts()...),
 		Env: []string{
-			"PJRT_DEVICE=TPU",
+			fmt.Sprintf("PJRT_DEVICE=%s", dockerParams.DockerPJRTDevice()),
 		},
 	}
 	hostConfig := &container.HostConfig{
-	    Privileged:      dockerParams.DockerPrivileged(),
+		Privileged:      dockerParams.DockerPrivileged(),
 		NetworkMode:     getNetworkMode(),
 		PortBindings:    bindPorts(dockerParams.DockerPorts()...),
 		PublishAllPorts: true,
@@ -432,6 +432,10 @@ func (c CLIArgs) DockerKeepContainer() bool {
 
 func (c CLIArgs) DockerPrivileged() bool {
 	return c.Docker.Privileged
+}
+
+func (c CLIArgs) DockerPJRTDevice() string {
+	return c.Docker.PJRTDevice
 }
 
 func (c CLIArgs) DockerShellCommands(publicKeys []string) []string {

--- a/runner/internal/shim/docker.go
+++ b/runner/internal/shim/docker.go
@@ -312,14 +312,18 @@ func createContainer(ctx context.Context, client docker.APIClient, runnerDir str
 		return "", tracerr.Wrap(err)
 	}
 
+	//Set the environment variables
+	envVars := []string{}
+	if dockerParams.DockerPJRTDevice() != "" {
+		envVars = append(envVars, fmt.Sprintf("PJRT_DEVICE=%s", dockerParams.DockerPJRTDevice()))
+	}
+
 	containerConfig := &container.Config{
 		Image:        taskConfig.ImageName,
 		Cmd:          []string{strings.Join(dockerParams.DockerShellCommands(taskConfig.PublicKeys), " && ")},
 		Entrypoint:   []string{"/bin/sh", "-c"},
 		ExposedPorts: exposePorts(dockerParams.DockerPorts()...),
-		Env: []string{
-			fmt.Sprintf("PJRT_DEVICE=%s", dockerParams.DockerPJRTDevice()),
-		},
+		Env:          envVars,
 	}
 	hostConfig := &container.HostConfig{
 		Privileged:      dockerParams.DockerPrivileged(),

--- a/runner/internal/shim/docker.go
+++ b/runner/internal/shim/docker.go
@@ -317,8 +317,12 @@ func createContainer(ctx context.Context, client docker.APIClient, runnerDir str
 		Cmd:          []string{strings.Join(dockerParams.DockerShellCommands(taskConfig.PublicKeys), " && ")},
 		Entrypoint:   []string{"/bin/sh", "-c"},
 		ExposedPorts: exposePorts(dockerParams.DockerPorts()...),
+		Env: []string{
+			"PJRT_DEVICE=TPU",
+		},
 	}
 	hostConfig := &container.HostConfig{
+	    Privileged:      dockerParams.DockerPrivileged(),
 		NetworkMode:     getNetworkMode(),
 		PortBindings:    bindPorts(dockerParams.DockerPorts()...),
 		PublishAllPorts: true,
@@ -424,6 +428,10 @@ func requestGpuIfAvailable(ctx context.Context, client docker.APIClient) ([]cont
 
 func (c CLIArgs) DockerKeepContainer() bool {
 	return c.Docker.KeepContainer
+}
+
+func (c CLIArgs) DockerPrivileged() bool {
+	return c.Docker.Privileged
 }
 
 func (c CLIArgs) DockerShellCommands(publicKeys []string) []string {

--- a/runner/internal/shim/docker_test.go
+++ b/runner/internal/shim/docker_test.go
@@ -98,6 +98,10 @@ func (c *dockerParametersMock) DockerKeepContainer() bool {
 	return false
 }
 
+func (c *dockerParametersMock) DockerPrivileged() bool {
+	return false
+}
+
 func (c *dockerParametersMock) DockerShellCommands(publicKeys []string) []string {
 	userPublicKey := c.publicSSHKey
 	if len(publicKeys) > 0 {

--- a/runner/internal/shim/docker_test.go
+++ b/runner/internal/shim/docker_test.go
@@ -102,6 +102,10 @@ func (c *dockerParametersMock) DockerPrivileged() bool {
 	return false
 }
 
+func (c *dockerParametersMock) DockerPJRTDevice() string {
+	return ""
+}
+
 func (c *dockerParametersMock) DockerShellCommands(publicKeys []string) []string {
 	userPublicKey := c.publicSSHKey
 	if len(publicKeys) > 0 {

--- a/runner/internal/shim/models.go
+++ b/runner/internal/shim/models.go
@@ -10,6 +10,7 @@ import (
 )
 
 type DockerParameters interface {
+    DockerPrivileged() bool
 	DockerKeepContainer() bool
 	DockerShellCommands([]string) []string
 	DockerMounts(string) ([]mount.Mount, error)
@@ -38,6 +39,7 @@ type CLIArgs struct {
 		SSHPort                   int
 		KeepContainer             bool
 		ConcatinatedPublicSSHKeys string
+		Privileged                bool
 	}
 }
 

--- a/runner/internal/shim/models.go
+++ b/runner/internal/shim/models.go
@@ -10,12 +10,13 @@ import (
 )
 
 type DockerParameters interface {
-    DockerPrivileged() bool
+	DockerPrivileged() bool
 	DockerKeepContainer() bool
 	DockerShellCommands([]string) []string
 	DockerMounts(string) ([]mount.Mount, error)
 	DockerPorts() []int
 	MakeRunnerDir() (string, error)
+	DockerPJRTDevice() string
 }
 
 type CLIArgs struct {
@@ -40,6 +41,7 @@ type CLIArgs struct {
 		KeepContainer             bool
 		ConcatinatedPublicSSHKeys string
 		Privileged                bool
+		PJRTDevice                string
 	}
 }
 

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -20,7 +20,6 @@ from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-
 DSTACK_WORKING_DIR = "/root/.dstack"
 
 
@@ -121,14 +120,14 @@ def get_shim_env(build: str, authorized_keys: List[str]) -> Dict[str, str]:
     return envs
 
 
-def get_shim_commands(authorized_keys: List[str]) -> List[str]:
+def get_shim_commands(authorized_keys: List[str], *, is_privileged: bool = False) -> List[str]:
     build = get_dstack_runner_version()
     commands = get_shim_pre_start_commands(
         build,
     )
     for k, v in get_shim_env(build, authorized_keys).items():
         commands += [f'export "{k}={v}"']
-    commands += get_run_shim_script()
+    commands += get_run_shim_script(is_privileged)
     return commands
 
 
@@ -161,10 +160,11 @@ def get_shim_pre_start_commands(build: str) -> List[str]:
     ]
 
 
-def get_run_shim_script() -> List[str]:
+def get_run_shim_script(is_privileged: bool) -> List[str]:
     dev_flag = "" if settings.DSTACK_VERSION is not None else "--dev"
+    privileged_flag = "--privileged" if is_privileged else ""
     return [
-        f"nohup dstack-shim {dev_flag} docker --keep-container >{DSTACK_WORKING_DIR}/shim.log 2>&1 &",
+        f"nohup dstack-shim {dev_flag} docker --keep-container {privileged_flag} >{DSTACK_WORKING_DIR}/shim.log 2>&1 &",
     ]
 
 

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -120,14 +120,16 @@ def get_shim_env(build: str, authorized_keys: List[str]) -> Dict[str, str]:
     return envs
 
 
-def get_shim_commands(authorized_keys: List[str], *, is_privileged: bool = False) -> List[str]:
+def get_shim_commands(
+    authorized_keys: List[str], *, is_privileged: bool = False, pjrt_device: Optional[str] = None
+) -> List[str]:
     build = get_dstack_runner_version()
     commands = get_shim_pre_start_commands(
         build,
     )
     for k, v in get_shim_env(build, authorized_keys).items():
         commands += [f'export "{k}={v}"']
-    commands += get_run_shim_script(is_privileged)
+    commands += get_run_shim_script(is_privileged, pjrt_device)
     return commands
 
 
@@ -160,11 +162,13 @@ def get_shim_pre_start_commands(build: str) -> List[str]:
     ]
 
 
-def get_run_shim_script(is_privileged: bool) -> List[str]:
+def get_run_shim_script(is_privileged: bool, pjrt_device: Optional[str]) -> List[str]:
     dev_flag = "" if settings.DSTACK_VERSION is not None else "--dev"
     privileged_flag = "--privileged" if is_privileged else ""
+    pjrt_device_env = f"--pjrt-device={pjrt_device}" if pjrt_device else ""
+
     return [
-        f"nohup dstack-shim {dev_flag} docker --keep-container {privileged_flag} >{DSTACK_WORKING_DIR}/shim.log 2>&1 &",
+        f"nohup dstack-shim {dev_flag} docker --keep-container {privileged_flag} {pjrt_device_env} >{DSTACK_WORKING_DIR}/shim.log 2>&1 &",
     ]
 
 

--- a/src/dstack/_internal/core/backends/gcp/compute.py
+++ b/src/dstack/_internal/core/backends/gcp/compute.py
@@ -443,7 +443,9 @@ def _get_instance_zones(instance_offer: InstanceOffer) -> List[str]:
 
 
 def _get_tpu_startup_script(authorized_keys: List[str]) -> str:
-    commands = get_shim_commands(authorized_keys=authorized_keys, is_privileged=True)
+    commands = get_shim_commands(
+        authorized_keys=authorized_keys, is_privileged=True, pjrt_device="TPU"
+    )
     startup_script = " ".join([" && ".join(commands)])
     startup_script = "#! /bin/bash\n" + startup_script
     return startup_script

--- a/src/dstack/_internal/core/backends/gcp/compute.py
+++ b/src/dstack/_internal/core/backends/gcp/compute.py
@@ -443,7 +443,7 @@ def _get_instance_zones(instance_offer: InstanceOffer) -> List[str]:
 
 
 def _get_tpu_startup_script(authorized_keys: List[str]) -> str:
-    commands = get_shim_commands(authorized_keys=authorized_keys)
+    commands = get_shim_commands(authorized_keys=authorized_keys, is_privileged=True)
     startup_script = " ".join([" && ".join(commands)])
     startup_script = "#! /bin/bash\n" + startup_script
     return startup_script
@@ -469,9 +469,9 @@ def _is_pod(instance_name: str) -> bool:
         tensor_cores = int(tensor_cores)
     except ValueError:
         raise ValueError(f"Invalid number in tpu tensor cores: {tensor_cores}")
-    if version in ["v2", "v3"]:
+    if version in ["v2", "v3", "v5p", "v5litepod"]:
         return tensor_cores > 8
-    elif version in ["v4", "v5p", "v5litepod"]:
+    elif version == "v4":
         return True
     else:
         raise ValueError(f"Unknown TPU version: {version}")


### PR DESCRIPTION
**Fixes**
1. TPU is detected from actual workloads
`--privileged` flag added to docker run
2. Env variable `PJRT_DEVICE` set to TPU
This is necessary otherwise Warning is issued while running training script.
3. Ensure all single-VM TPUs can be used
v2, v3, v4, v5p, v5litepod are different versions of TPUs provides by GCP. Except v4, all TPU versions containing number v2-{number} where number <= 8 is a single VM TPU. v4 version are all TPU Pods
Note: To use TPU version v4, v5p and v5litepod quotas should be requested.
4. dstack-runner automatically sets env LD_LIBRARY_PATH in the container

**Before Starting the Test**
1. Since there is modification in dstack-shim and dstack-runner ensure that latest dstack-shim-linux-amd64 and dstack-runner binary is used.

**How to test TPU** 
1. `% dstack run . -b gcp --gpu tpu-v2-8`
2. After provisioning is complete set env LD_LIBRARY_PATH in the container as below
`(workflow) root@t1v-n-345435e8-w-0:~ export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$(python3-config --prefix)/lib"`
3. `(workflow) root@t1v-n-345435e8-w-0:~ pip install torch~=2.3.0 torch_xla[tpu]~=2.3.0 torchvision -f https://storage.googleapis.com/libtpu-releases/index.html`
4. `(workflow) root@t1v-n-345435e8-w-0:~ git clone --recursive https://github.com/pytorch/xla.git`
5. `(workflow) root@t1v-n-345435e8-w-0:~ python3 xla/test/test_train_mp_imagenet.py --fake_data --model=resnet50 --num_epochs=1`



**Test Using Task**

```type: task

python: "3.11"


commands:
  - pip install torch~=2.3.0 torch_xla[tpu]~=2.3.0 torchvision -f https://storage.googleapis.com/libtpu-releases/index.html
  - git clone --recursive https://github.com/pytorch/xla.git
  - python3 xla/test/test_train_mp_imagenet.py --fake_data --model=resnet50 --num_epochs=1

# (Optional) Configure `gpu`, `memory`, `disk`, etc
resources:
  gpu:  tpu-v2-8



