### PR TITLE
Fix nvidia-smi not available on lambda

### DIFF
--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -69,7 +69,11 @@ class Compute(ABC):
         """
         raise NotImplementedError()
 
-    def update_provisioning_data(self, provisioning_data: JobProvisioningData) -> None:
+    def update_provisioning_data(
+        self,
+        provisioning_data: JobProvisioningData,
+        instance_config: InstanceConfiguration,
+    ):
         """
         This method is called if `JobProvisioningData` returned from `run_job()`/`create_instance()`
         is not complete, e.g. missing `hostname` or `ssh_port`.

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -72,7 +72,8 @@ class Compute(ABC):
     def update_provisioning_data(
         self,
         provisioning_data: JobProvisioningData,
-        instance_config: InstanceConfiguration,
+        project_ssh_public_key: str,
+        project_ssh_private_key: str,
     ):
         """
         This method is called if `JobProvisioningData` returned from `run_job()`/`create_instance()`

--- a/src/dstack/_internal/core/backends/cudo/compute.py
+++ b/src/dstack/_internal/core/backends/cudo/compute.py
@@ -141,7 +141,11 @@ class CudoCompute(Compute):
                 return
             raise BackendError(e.response.text)
 
-    def update_provisioning_data(self, provisioning_data: JobProvisioningData) -> None:
+    def update_provisioning_data(
+        self,
+        provisioning_data: JobProvisioningData,
+        instance_config: InstanceConfiguration,
+    ):
         vm = self.api_client.get_vm(self.config.project_id, provisioning_data.instance_id)
         if vm["VM"]["state"] == "ACTIVE":
             provisioning_data.hostname = vm["VM"]["publicIpAddress"]

--- a/src/dstack/_internal/core/backends/cudo/compute.py
+++ b/src/dstack/_internal/core/backends/cudo/compute.py
@@ -144,7 +144,8 @@ class CudoCompute(Compute):
     def update_provisioning_data(
         self,
         provisioning_data: JobProvisioningData,
-        instance_config: InstanceConfiguration,
+        project_ssh_public_key: str,
+        project_ssh_private_key: str,
     ):
         vm = self.api_client.get_vm(self.config.project_id, provisioning_data.instance_id)
         if vm["VM"]["state"] == "ACTIVE":

--- a/src/dstack/_internal/core/backends/datacrunch/compute.py
+++ b/src/dstack/_internal/core/backends/datacrunch/compute.py
@@ -162,7 +162,8 @@ class DataCrunchCompute(Compute):
     def update_provisioning_data(
         self,
         provisioning_data: JobProvisioningData,
-        instance_config: InstanceConfiguration,
+        project_ssh_public_key: str,
+        project_ssh_private_key: str,
     ):
         instance = self.api_client.get_instance_by_id(provisioning_data.instance_id)
         if instance is not None and instance.status == "running":

--- a/src/dstack/_internal/core/backends/datacrunch/compute.py
+++ b/src/dstack/_internal/core/backends/datacrunch/compute.py
@@ -159,7 +159,11 @@ class DataCrunchCompute(Compute):
     ) -> None:
         self.api_client.delete_instance(instance_id)
 
-    def update_provisioning_data(self, provisioning_data: JobProvisioningData) -> None:
+    def update_provisioning_data(
+        self,
+        provisioning_data: JobProvisioningData,
+        instance_config: InstanceConfiguration,
+    ):
         instance = self.api_client.get_instance_by_id(provisioning_data.instance_id)
         if instance is not None and instance.status == "running":
             provisioning_data.hostname = instance.ip

--- a/src/dstack/_internal/core/backends/lambdalabs/compute.py
+++ b/src/dstack/_internal/core/backends/lambdalabs/compute.py
@@ -196,7 +196,8 @@ def _setup_instance(
     setup_commands = (
         "mkdir /home/ubuntu/.dstack && "
         "sudo apt-get update && "
-        "sudo apt-get install -y --no-install-recommends nvidia-docker2 && "
+        "sudo apt-get install -y --no-install-recommends nvidia-container-toolkit && "
+        "sudo nvidia-ctk runtime configure --runtime=docker && "
         "sudo pkill -SIGHUP dockerd"
     )
     _run_ssh_command(hostname=hostname, ssh_private_key=ssh_private_key, command=setup_commands)

--- a/src/dstack/_internal/core/backends/lambdalabs/compute.py
+++ b/src/dstack/_internal/core/backends/lambdalabs/compute.py
@@ -74,20 +74,20 @@ class LambdaCompute(Compute):
     def update_provisioning_data(
         self,
         provisioning_data: JobProvisioningData,
-        instance_config: InstanceConfiguration,
+        project_ssh_public_key: str,
+        project_ssh_private_key: str,
     ):
         instance_info = _get_instance_info(self.api_client, provisioning_data.instance_id)
         if instance_info is not None and instance_info["status"] != "booting":
             provisioning_data.hostname = instance_info["ip"]
-            commands = get_shim_commands(authorized_keys=instance_config.get_public_keys())
+            commands = get_shim_commands(authorized_keys=[project_ssh_public_key])
             # shim is asssumed to be run under root
             launch_command = "sudo sh -c '" + "&& ".join(commands) + "'"
-            project_ssh_key = instance_config.ssh_keys[0]
             thread = Thread(
                 target=_start_runner,
                 kwargs={
                     "hostname": instance_info["ip"],
-                    "project_ssh_private_key": project_ssh_key.private,
+                    "project_ssh_private_key": project_ssh_private_key,
                     "launch_command": launch_command,
                 },
                 daemon=True,

--- a/src/dstack/_internal/core/backends/oci/compute.py
+++ b/src/dstack/_internal/core/backends/oci/compute.py
@@ -174,7 +174,11 @@ class OCICompute(Compute):
             backend_data=None,
         )
 
-    def update_provisioning_data(self, provisioning_data: JobProvisioningData) -> None:
+    def update_provisioning_data(
+        self,
+        provisioning_data: JobProvisioningData,
+        instance_config: InstanceConfiguration,
+    ):
         if vnic := resources.get_instance_vnic(
             provisioning_data.instance_id,
             self.regions[provisioning_data.region],

--- a/src/dstack/_internal/core/backends/oci/compute.py
+++ b/src/dstack/_internal/core/backends/oci/compute.py
@@ -177,7 +177,8 @@ class OCICompute(Compute):
     def update_provisioning_data(
         self,
         provisioning_data: JobProvisioningData,
-        instance_config: InstanceConfiguration,
+        project_ssh_public_key: str,
+        project_ssh_private_key: str,
     ):
         if vnic := resources.get_instance_vnic(
             provisioning_data.instance_id,

--- a/src/dstack/_internal/core/backends/runpod/compute.py
+++ b/src/dstack/_internal/core/backends/runpod/compute.py
@@ -143,7 +143,8 @@ class RunpodCompute(Compute):
     def update_provisioning_data(
         self,
         provisioning_data: JobProvisioningData,
-        instance_config: InstanceConfiguration,
+        project_ssh_public_key: str,
+        project_ssh_private_key: str,
     ):
         instance_id = provisioning_data.instance_id
         pod = self.api_client.get_pod(instance_id)

--- a/src/dstack/_internal/core/backends/runpod/compute.py
+++ b/src/dstack/_internal/core/backends/runpod/compute.py
@@ -140,7 +140,11 @@ class RunpodCompute(Compute):
                 return
             raise
 
-    def update_provisioning_data(self, provisioning_data: JobProvisioningData) -> None:
+    def update_provisioning_data(
+        self,
+        provisioning_data: JobProvisioningData,
+        instance_config: InstanceConfiguration,
+    ):
         instance_id = provisioning_data.instance_id
         pod = self.api_client.get_pod(instance_id)
         if pod is None or pod["runtime"] is None:

--- a/src/dstack/_internal/core/backends/vastai/compute.py
+++ b/src/dstack/_internal/core/backends/vastai/compute.py
@@ -12,6 +12,7 @@ from dstack._internal.core.errors import ProvisioningError
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.instances import (
     InstanceAvailability,
+    InstanceConfiguration,
     InstanceOfferWithAvailability,
     InstanceRuntime,
 )
@@ -98,7 +99,11 @@ class VastAICompute(Compute):
     ):
         self.api_client.destroy_instance(instance_id)
 
-    def update_provisioning_data(self, provisioning_data: JobProvisioningData) -> None:
+    def update_provisioning_data(
+        self,
+        provisioning_data: JobProvisioningData,
+        instance_config: InstanceConfiguration,
+    ):
         resp = self.api_client.get_instance(provisioning_data.instance_id)
         if resp is not None:
             if resp["actual_status"] == "running":

--- a/src/dstack/_internal/core/backends/vastai/compute.py
+++ b/src/dstack/_internal/core/backends/vastai/compute.py
@@ -12,7 +12,6 @@ from dstack._internal.core.errors import ProvisioningError
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.instances import (
     InstanceAvailability,
-    InstanceConfiguration,
     InstanceOfferWithAvailability,
     InstanceRuntime,
 )
@@ -102,7 +101,8 @@ class VastAICompute(Compute):
     def update_provisioning_data(
         self,
         provisioning_data: JobProvisioningData,
-        instance_config: InstanceConfiguration,
+        project_ssh_public_key: str,
+        project_ssh_private_key: str,
     ):
         resp = self.api_client.get_instance(provisioning_data.instance_id)
         if resp is not None:

--- a/src/dstack/_internal/server/background/tasks/process_instances.py
+++ b/src/dstack/_internal/server/background/tasks/process_instances.py
@@ -57,6 +57,7 @@ from dstack._internal.server.services.jobs import (
     PROCESSING_POOL_LOCK,
     terminate_job_provisioning_data_instance,
 )
+from dstack._internal.server.services.pools import get_instance_configuration
 from dstack._internal.server.services.runner import client as runner_client
 from dstack._internal.server.services.runner.client import HealthStatus
 from dstack._internal.server.services.runner.ssh import runner_ssh_tunnel
@@ -635,32 +636,48 @@ async def wait_for_instance_provisioning_data(
         )
         instance.status = InstanceStatus.TERMINATING
         instance.termination_reason = "Instance has not become running in time"
-    else:
-        backend = await backends_services.get_project_backend_by_type(
-            project=project,
-            backend_type=job_provisioning_data.backend,
+        return
+
+    backend = await backends_services.get_project_backend_by_type(
+        project=project,
+        backend_type=job_provisioning_data.backend,
+    )
+    if backend is None:
+        logger.warning(
+            "Instance %s failed because instance's backend is not available",
+            instance.name,
         )
-        if backend is None:
-            logger.warning(
-                "Cannot stop instance %s because instance's backend is not configured",
-                instance.name,
-            )
-        else:
-            try:
-                backend.compute().update_provisioning_data(job_provisioning_data)
-                instance.job_provisioning_data = job_provisioning_data.json()
-            except ProvisioningError as e:
-                logger.warning(
-                    "Error while waiting for instance %s to become running: %s",
-                    instance.name,
-                    repr(e),
-                )
-                instance.status = InstanceStatus.TERMINATING
-                instance.termination_reason = "Error while waiting for instance to become running"
-            except Exception:
-                logger.exception(
-                    "Got exception when updating instance %s provisioning data", instance.name
-                )
+        instance.status = InstanceStatus.TERMINATING
+        instance.termination_reason = "Backend not available"
+        return
+    instance_configuration = get_instance_configuration(instance)
+    if instance_configuration is None:
+        logger.error(
+            "Instance %s failed because instance_configuration is None",
+            instance.name,
+        )
+        instance.status = InstanceStatus.TERMINATING
+        instance.termination_reason = "instance_configuration is None"
+        return
+    try:
+        await run_async(
+            backend.compute().update_provisioning_data,
+            job_provisioning_data,
+            instance_configuration,
+        )
+        instance.job_provisioning_data = job_provisioning_data.json()
+    except ProvisioningError as e:
+        logger.warning(
+            "Error while waiting for instance %s to become running: %s",
+            instance.name,
+            repr(e),
+        )
+        instance.status = InstanceStatus.TERMINATING
+        instance.termination_reason = "Error while waiting for instance to become running"
+    except Exception:
+        logger.exception(
+            "Got exception when updating instance %s provisioning data", instance.name
+        )
 
 
 @runner_ssh_tunnel(ports=[runner_client.REMOTE_SHIM_PORT], retries=1)

--- a/src/dstack/_internal/server/services/pools.py
+++ b/src/dstack/_internal/server/services/pools.py
@@ -22,6 +22,7 @@ from dstack._internal.core.errors import (
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.instances import (
     InstanceAvailability,
+    InstanceConfiguration,
     InstanceOffer,
     InstanceOfferWithAvailability,
     InstanceType,
@@ -230,6 +231,12 @@ def instance_model_to_instance(instance_model: InstanceModel) -> Instance:
         instance.pool_name = instance_model.pool.name
 
     return instance
+
+
+def get_instance_configuration(instance: InstanceModel) -> Optional[InstanceConfiguration]:
+    if instance.instance_configuration is None:
+        return None
+    return InstanceConfiguration.__response__.parse_raw(instance.instance_configuration)
 
 
 _GENERATE_POOL_NAME_LOCK: Dict[str, asyncio.Lock] = {}

--- a/src/dstack/_internal/server/services/pools.py
+++ b/src/dstack/_internal/server/services/pools.py
@@ -22,7 +22,6 @@ from dstack._internal.core.errors import (
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.instances import (
     InstanceAvailability,
-    InstanceConfiguration,
     InstanceOffer,
     InstanceOfferWithAvailability,
     InstanceType,
@@ -231,12 +230,6 @@ def instance_model_to_instance(instance_model: InstanceModel) -> Instance:
         instance.pool_name = instance_model.pool.name
 
     return instance
-
-
-def get_instance_configuration(instance: InstanceModel) -> Optional[InstanceConfiguration]:
-    if instance.instance_configuration is None:
-        return None
-    return InstanceConfiguration.__response__.parse_raw(instance.instance_configuration)
 
 
 _GENERATE_POOL_NAME_LOCK: Dict[str, asyncio.Lock] = {}


### PR DESCRIPTION
Fixes #1356 

The PR fixes nvidia docker runtime not working on lambda instances.

The issue took place because we installed `nvidia-docker2` on lambda instances which is deprecated and doesn't work for the docker version shipped on lambda (24.0.7) . To enable nvidia in docker, `nvidia-container-toolkit` is now recommended. The fix replaces `nvidia-docker2` with `nvidia-container-toolkit`.

See https://github.com/NVIDIA/nvidia-docker/issues/1268#issuecomment-632692949 for more details.

In other backends where dstack uses its own VM images, docker 20.10.17 is installed which apparently still works with `nvidia-docker2`. We should consider migrating to `nvidia-container-toolkit` everywhere when updating the docker version.

Also, the PR refactors LambdaBackend to implement `update_provisioning_data()` to fix long waiting for ip address in create_instance() that lead to the blocking of jobs processing.