### PR TITLE
Remove commitment-only OCI shapes

### DIFF
--- a/src/dstack/_internal/core/backends/oci/compute.py
+++ b/src/dstack/_internal/core/backends/oci/compute.py
@@ -35,8 +35,6 @@ SUPPORTED_SHAPE_FAMILIES = [
     "BM.GPU4.",
     "VM.GPU.A10.",
     "BM.GPU.A10.",
-    "BM.GPU.A100-",
-    "BM.GPU.H100.",
 ]
 
 


### PR DESCRIPTION
Turns out you cannot run BM.GPU.A100-v2.8 and BM.GPU.H100.8 on-demand, so dstack does not actually support them.

#1194 