### PR TITLE
Improve Overview page

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -3,37 +3,43 @@
 `dstack` is an open-source container orchestration engine for running AI workloads across diverse cloud providers
 and on-premises data centers. It simplifies provisioning compute resources, managing dev environments, executing tasks on clusters, and deploying services.
 
-!!! info "Supported clouds"
-    `dstack` supports many cloud providers including AWS, GCP, Azure, OCI, Lambda, TensorDock, Vast.ai, RunPod, and CUDO, as well as on-premises clusters.
+!!! info "Cloud and on-premises"
+    `dstack` allows workload orchestration on both cloud and on-premises clusters.
+    Supported cloud providers include AWS, GCP, Azure, OCI, Lambda, TensorDock, Vast.ai, RunPod, and CUDO.
 
-!!! info "Supported accelerators"
-    `dstack` offers native support for NVIDIA GPU and Google Cloud TPU chips.
-
-## Why use dstack?
-
-1. Simplifies the development, training, and deployment for AI teams
-2. Operates seamlessly with any cloud provider and data center
-3. Easily integrates with any open-source training or serving frameworks
-4. Reduces compute costs while enhancing workload efficiency
-5. Provides a more AI-centric and simplified alternative to Kubernetes
+!!! info "Accelerators"
+    `dstack` supports NVIDIA GPUs and Google Cloud TPUs out of the box.
 
 ## How does it work?
 
-1. [Install](installation/index.md) `dstack`.
-   Configure the open-source server or sign up with [`dstack Sky`](https://sky.dstack.ai/).
-   With the open-source option, you host the server and bring your cloud credentials.
-   With `dstack Sky`, the server is managed for you and you can run on any cloud without setting up an account for each.
-2. Define configurations such as [dev environments](concepts/dev-environments.md), [tasks](concepts/tasks.md), 
-   and [services](concepts/services.md).
-   `dstack` offers three types of configurations optimized for development, batch jobs, and service deployment.
-   You can configure commands to execute, required compute resources, retry policy, autoscaling, authorization and more.
-2. Run configurations via `dstack`'s CLI or API.
-   `dstack` will provision the best compute offer on the market that meets the requirements,
-   be it a GPU cluster or a CPU instance, and execute the configuration commands.
-   With retry enabled, `dstack` can handle no capacity situations, spot interruptions, and run failures.
-3. Use [pools](concepts/pools.md) to manage cloud instances and on-prem clusters.
-   `dstack` gives you the control to terminate instances as soon as runs finish or keep them in a pool
-    to save on provisioning time and guarantee compute availability.
+!!! info "Installation"
+    Before using `dstack`, [install](installation/index.md) the `dstack` server and configure credentials
+    and other settings for each cloud account that you intend to use.
+
+#### 1. Define configurations
+
+`dstack` supports three types of run configurations:
+   
+* [`dev environment`](concepts/dev-environments.md) &mdash; for interactive development using a desktop IDE
+* [`task`](concepts/tasks.md) &mdash; for any kind of batch jobs or web applications (supports distributed jobs)
+* [`service`](concepts/services.md)&mdash; for production-grade deployment (supports auto-scaling and authorization)
+
+Each type of run configuration allows you to specify commands for execution, required compute resources, retry policies, auto-scaling rules, authorization settings, and more.
+
+Configuration can be defined as YAML files within your repo.
+
+#### 2. Run configurations
+
+Run any defined configuration either via `dstack` CLI or API.
+   
+`dstack` automatically provisions compute resources (whether from the cloud or on-premises), executes commands, handles interruptions, port-forwarding, auto-scaling, network, volumes, run failures, out-of-capacity errors, and more.
+
+#### 3. Manage pools
+
+Use [pools](concepts/pools.md) to manage the lifecycle of cloud instances and add/remove on-prem clusters.
+   
+You can manually add or remove cloud instances from the pool, or have them provisioned on-demand and configure how long they remain idle before automatic termination.
+
 
 ## Where do I start?
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,13 +1,13 @@
 # What is dstack?
 
-`dstack` is a robust, open-source container orchestration engine for running AI workloads across diverse cloud platforms
-and on-premises data centers.
-It streamlines the management of dev environments, task execution on clusters, and deployment.
+`dstack` is an open-source container orchestration engine for running AI workloads across diverse cloud providers
+and on-premises data centers. It simplifies provisioning compute resources, managing dev environments, executing tasks on clusters, and deploying services.
 
-> Compatible with any cloud provider, including AWS, GCP, Azure, OCI, Lambda, TensorDock, Vast.ai, RunPod, and CUDO, as
-> well as on-premises clusters.
->
-> Offers native support for NVIDIA GPU and Google Cloud TPU accelerator chips.
+!!! info "Supported clouds"
+    `dstack` supports many cloud providers including AWS, GCP, Azure, OCI, Lambda, TensorDock, Vast.ai, RunPod, and CUDO, as well as on-premises clusters.
+
+!!! info "Supported accelerators"
+    `dstack` offers native support for NVIDIA GPU and Google Cloud TPU chips.
 
 ## Why use dstack?
 
@@ -19,15 +19,21 @@ It streamlines the management of dev environments, task execution on clusters, a
 
 ## How does it work?
 
-!!! info "Installation"
-    Before using `dstack`, either set up the open-source server, or sign up
-    with `dstack Sky`.
-    See [Installation](installation/index.md) for more details.
-
-1. Define configurations such as [dev environments](concepts/dev-environments.md), [tasks](concepts/tasks.md), 
+1. [Install](installation/index.md) `dstack`.
+   Configure the open-source server or sign up with [`dstack Sky`](https://sky.dstack.ai/).
+   With the open-source option, you host the server and bring your cloud credentials.
+   With `dstack Sky`, the server is managed for you and you can run on any cloud without setting up an account for each.
+2. Define configurations such as [dev environments](concepts/dev-environments.md), [tasks](concepts/tasks.md), 
    and [services](concepts/services.md).
+   `dstack` offers three types of configurations optimized for development, batch jobs, and service deployment.
+   You can configure commands to execute, required compute resources, retry policy, autoscaling, authorization and more.
 2. Run configurations via `dstack`'s CLI or API.
+   `dstack` will provision the best compute offer on the market that meets the requirements,
+   be it a GPU cluster or a CPU instance, and execute the configuration commands.
+   With retry enabled, `dstack` can handle no capacity situations, spot interruptions, and run failures.
 3. Use [pools](concepts/pools.md) to manage cloud instances and on-prem clusters.
+   `dstack` gives you the control to terminate instances as soon as runs finish or keep them in a pool
+    to save on provisioning time and guarantee compute availability.
 
 ## Where do I start?
 


### PR DESCRIPTION
This PR addresses Overview page issues described in #1374:

* Mentions that dstack takes care of provisioning compute resource, not only container orchestration.
* Expands "How does it work?" to make it more useful, better present dstack features, and prepare for the further reading of the docs.