### PR TITLE
Prepare future OCI spot instances support

### DIFF
--- a/src/dstack/_internal/core/backends/oci/compute.py
+++ b/src/dstack/_internal/core/backends/oci/compute.py
@@ -151,6 +151,7 @@ class OCICompute(Compute):
                 display_name=instance_config.instance_name,
                 cloud_init_user_data=cloud_init_user_data,
                 shape=instance_offer.instance.name,
+                is_spot=instance_offer.instance.resources.spot,
                 disk_size_gb=round(instance_offer.instance.resources.disk.size_mib / 1024),
                 image_id=package.image_id,
             )

--- a/src/dstack/_internal/core/backends/oci/resources.py
+++ b/src/dstack/_internal/core/backends/oci/resources.py
@@ -284,9 +284,16 @@ def launch_instance(
     display_name: str,
     cloud_init_user_data: str,
     shape: str,
+    is_spot: bool,
     disk_size_gb: int,
     image_id: str,
 ) -> oci.core.models.Instance:
+    preemptible_config = None
+    if is_spot:
+        preemptible_config = oci.core.models.PreemptibleInstanceConfigDetails(
+            preemption_action=oci.core.models.TerminatePreemptionAction(preserve_boot_volume=False)
+        )
+
     return region.compute_client.launch_instance(
         oci.core.models.LaunchInstanceDetails(
             availability_domain=availability_domain,
@@ -301,6 +308,7 @@ def launch_instance(
             metadata=dict(
                 user_data=base64.b64encode(cloud_init_user_data.encode()).decode(),
             ),
+            preemptible_instance_config=preemptible_config,
             shape=shape,
             source_details=oci.core.models.InstanceSourceViaImageDetails(
                 image_id=image_id,


### PR DESCRIPTION
This commit implements launching OCI spot instances. However, spot offers will not be added to `gpuhunt` catalog yet, as they would break previous `dstack` versions that do not distinguish between on-demand and spot offers. We can add spot offers to catalog later, once `dstack` versions 0.18.3 and 0.18.4 become irrelevant.

#1375