### PR TITLE
Remove if backends configured check

### DIFF
--- a/src/dstack/_internal/server/services/runs.py
+++ b/src/dstack/_internal/server/services/runs.py
@@ -409,10 +409,6 @@ async def submit_run(
     if repo is None:
         raise RepoDoesNotExistError.with_id(run_spec.repo_id)
 
-    backends = await backends_services.get_project_backends(project)
-    if len(backends) == 0:
-        raise ServerClientError("No backends configured")
-
     if run_spec.run_name is None:
         run_spec.run_name = await _generate_run_name(
             session=session,


### PR DESCRIPTION
Fixed #1399 

This PR makes it possible to submit runs to ssh pool instances even if there are no backends configured. In case of no offers in backends or pools, run is FAILED_TO_START_DUE_TO_NO_CAPACITY.