### PR TITLE
Support H100 in GCP

### DIFF
--- a/src/dstack/_internal/core/backends/gcp/compute.py
+++ b/src/dstack/_internal/core/backends/gcp/compute.py
@@ -462,6 +462,7 @@ def _supported_instances_and_zones(
             "e2-highcpu-",
             "m1-",
             "a2-",
+            "a3-",
             "g2-",
         ]:
             if offer.instance.name.startswith(family):
@@ -479,6 +480,9 @@ def _has_gpu_quota(quotas: Dict[str, float], resources: Resources) -> bool:
         return True
     gpu = resources.gpus[0]
     if _is_tpu(gpu.name):
+        return True
+    if gpu.name == "H100":
+        # H100 and H100_MEGA quotas are not returned by `regions_client.list`
         return True
     quota_name = f"NVIDIA_{gpu.name}_GPUS"
     if gpu.name == "A100" and gpu.memory_mib == 80 * 1024:

--- a/src/dstack/_internal/core/backends/gcp/resources.py
+++ b/src/dstack/_internal/core/backends/gcp/resources.py
@@ -132,8 +132,13 @@ def create_instance_struct(
     if accelerators:
         instance.guest_accelerators = accelerators
 
-    if accelerators or machine_type.startswith("a2-") or machine_type.startswith("g2-"):
-        # Attachable GPUs, A100, and L4
+    if (
+        accelerators
+        or machine_type.startswith("a3-")
+        or machine_type.startswith("a2-")
+        or machine_type.startswith("g2-")
+    ):
+        # Attachable GPUs, H100, A100, and L4
         instance.scheduling.on_host_maintenance = "TERMINATE"
 
     if spot:
@@ -265,8 +270,8 @@ def create_gateway_firewall_rules(
 def get_accelerators(
     project_id: str, zone: str, gpus: List[Gpu]
 ) -> List[compute_v1.AcceleratorConfig]:
-    if len(gpus) == 0 or gpus[0].name in {"A100", "L4"}:
-        # A100 and L4 are bundled with the instance
+    if len(gpus) == 0 or gpus[0].name in {"H100", "A100", "L4"}:
+        # H100, A100, and L4 are bundled with the instance
         return []
     accelerator_config = compute_v1.AcceleratorConfig()
     accelerator_config.accelerator_count = len(gpus)


### PR DESCRIPTION
This adds two instance types: a3-highgpu-8g and a3-megagpu-8g. Both on-demand and spot versions.
Closes #1240