### PR TITLE
Fix git repo URL parsing

### DIFF
--- a/runner/consts/consts.go
+++ b/runner/consts/consts.go
@@ -16,8 +16,3 @@ const HostInfoFile = "host_info.json"
 
 // GPU constants
 const NVIDIA_RUNTIME = "nvidia"
-
-const (
-	REPO_HTTPS_URL = "https://%s/%s/%s.git"
-	REPO_GIT_URL   = "git@%s:%s/%s.git"
-)

--- a/runner/internal/executor/executor_test.go
+++ b/runner/internal/executor/executor_test.go
@@ -53,7 +53,7 @@ func TestExecutor_SSHCredentials(t *testing.T) {
 	ex := makeTestExecutor(t)
 	ex.jobSpec.Commands = append(ex.jobSpec.Commands, "cat ~/.ssh/id_rsa")
 	ex.repoCredentials = &schemas.RepoCredentials{
-		Protocol:   "ssh",
+		CloneURL:   "ssh://git@example.example/example/example.git",
 		PrivateKey: &key,
 	}
 
@@ -115,10 +115,6 @@ func TestExecutor_RemoteRepo(t *testing.T) {
 	ex := makeTestExecutor(t)
 	ex.run.RepoData = schemas.RepoData{
 		RepoType:        "remote",
-		RepoHostName:    "github.com",
-		RepoPort:        0,
-		RepoUserName:    "dstackai",
-		RepoName:        "dstack-examples",
 		RepoBranch:      "main",
 		RepoHash:        "2b83592e506ed6fe8e49f4eaa97c3866bc9402b1",
 		RepoConfigName:  "Dstack Developer",
@@ -161,8 +157,10 @@ func makeTestExecutor(t *testing.T) *RunExecutor {
 			MaxDuration: 0, // no timeout
 			WorkingDir:  &workingDir,
 		},
-		Secrets:         make(map[string]string),
-		RepoCredentials: &schemas.RepoCredentials{Protocol: "https"},
+		Secrets: make(map[string]string),
+		RepoCredentials: &schemas.RepoCredentials{
+			CloneURL: "https://example.example/example/example.git",
+		},
 	}
 
 	temp := filepath.Join(baseDir, "temp")

--- a/runner/internal/executor/repo.go
+++ b/runner/internal/executor/repo.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/codeclysm/extract/v3"
-	"github.com/dstackai/dstack/runner/consts"
 	"github.com/dstackai/dstack/runner/internal/gerrors"
 	"github.com/dstackai/dstack/runner/internal/log"
 	"github.com/dstackai/dstack/runner/internal/repo"
@@ -36,10 +35,10 @@ func (ex *RunExecutor) setupRepo(ctx context.Context) error {
 }
 
 func (ex *RunExecutor) prepareGit(ctx context.Context) error {
-	repoManager := repo.NewManager(ctx, ex.run.RepoData.FormatURL(consts.REPO_HTTPS_URL), ex.run.RepoData.RepoBranch, ex.run.RepoData.RepoHash).WithLocalPath(ex.workingDir)
+	repoManager := repo.NewManager(ctx, ex.repoCredentials.CloneURL, ex.run.RepoData.RepoBranch, ex.run.RepoData.RepoHash).WithLocalPath(ex.workingDir)
 	if ex.repoCredentials != nil {
 		log.Trace(ctx, "Credentials is not empty")
-		switch ex.repoCredentials.Protocol {
+		switch ex.repoCredentials.GetProtocol() {
 		case "https":
 			log.Trace(ctx, "Select HTTPS protocol")
 			if ex.repoCredentials.OAuthToken == nil {
@@ -52,10 +51,10 @@ func (ex *RunExecutor) prepareGit(ctx context.Context) error {
 			if ex.repoCredentials.PrivateKey == nil {
 				return gerrors.Newf("private key is empty")
 			}
-			repoManager = repo.NewManager(ctx, ex.run.RepoData.FormatURL(consts.REPO_GIT_URL), ex.run.RepoData.RepoBranch, ex.run.RepoData.RepoHash).WithLocalPath(ex.workingDir)
+			repoManager = repo.NewManager(ctx, ex.repoCredentials.CloneURL, ex.run.RepoData.RepoBranch, ex.run.RepoData.RepoHash).WithLocalPath(ex.workingDir)
 			repoManager.WithSSHAuth(*ex.repoCredentials.PrivateKey, "") // we don't support passphrase
 		default:
-			return gerrors.Newf("unsupported remote repo protocol: %s", ex.repoCredentials.Protocol)
+			return gerrors.Newf("unsupported remote repo protocol: %s", ex.repoCredentials.GetProtocol())
 		}
 	} else {
 		log.Trace(ctx, "Credentials is empty")

--- a/runner/internal/schemas/schemas.go
+++ b/runner/internal/schemas/schemas.go
@@ -1,6 +1,6 @@
 package schemas
 
-import "fmt"
+import "strings"
 
 type JobStateEvent struct {
 	State     string `json:"state"`
@@ -55,17 +55,13 @@ type ClusterInfo struct {
 }
 
 type RepoCredentials struct {
-	Protocol   string  `json:"protocol"`
+	CloneURL   string  `json:"clone_url"`
 	PrivateKey *string `json:"private_key"`
 	OAuthToken *string `json:"oauth_token"`
 }
 
 type RepoData struct {
-	RepoType     string `json:"repo_type"`
-	RepoHostName string `json:"repo_host_name"`
-	RepoPort     int    `json:"repo_port"`
-	RepoUserName string `json:"repo_user_name"`
-	RepoName     string `json:"repo_name"`
+	RepoType string `json:"repo_type"`
 
 	RepoBranch string `json:"repo_branch"`
 	RepoHash   string `json:"repo_hash"`
@@ -93,12 +89,8 @@ type HealthcheckResponse struct {
 	Version string `json:"version"`
 }
 
-func (d *RepoData) FormatURL(format string) string {
-	host := d.RepoHostName
-	if d.RepoPort != 0 {
-		host = fmt.Sprintf("%s:%d", d.RepoHostName, d.RepoPort)
-	}
-	return fmt.Sprintf(format, host, d.RepoUserName, d.RepoName)
+func (c *RepoCredentials) GetProtocol() string {
+	return strings.SplitN(c.CloneURL, "://", 2)[0]
 }
 
 func (e JobStateEvent) GetTimestamp() int64 {

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ BASE_DEPS = [
     "gitpython",
     "jsonschema",
     "paramiko",
-    "git-url-parse",
     "cursor",
     "rich",
     "rich-argparse",

--- a/src/dstack/_internal/core/models/repos/base.py
+++ b/src/dstack/_internal/core/models/repos/base.py
@@ -12,11 +12,6 @@ class RepoType(str, Enum):
     VIRTUAL = "virtual"
 
 
-class RepoProtocol(str, Enum):
-    SSH = "ssh"
-    HTTPS = "https"
-
-
 class BaseRepoInfo(CoreModel):
     repo_type: str
 

--- a/src/dstack/_internal/core/models/repos/base.py
+++ b/src/dstack/_internal/core/models/repos/base.py
@@ -12,6 +12,11 @@ class RepoType(str, Enum):
     VIRTUAL = "virtual"
 
 
+class RepoProtocol(str, Enum):
+    SSH = "ssh"
+    HTTPS = "https"
+
+
 class BaseRepoInfo(CoreModel):
     repo_type: str
 

--- a/src/dstack/_internal/core/services/repos.py
+++ b/src/dstack/_internal/core/services/repos.py
@@ -10,6 +10,7 @@ from git.exc import GitCommandError
 from dstack._internal.core.errors import DstackError
 from dstack._internal.core.models.config import RepoConfig
 from dstack._internal.core.models.repos import LocalRepo, RemoteRepo, RemoteRepoCreds
+from dstack._internal.core.models.repos.base import RepoProtocol
 from dstack._internal.core.models.repos.remote import GitRepoURL
 from dstack._internal.utils.path import PathLike
 from dstack._internal.utils.ssh import (
@@ -36,7 +37,12 @@ def get_local_repo_credentials(
     # no auth
     r = requests.get(f"{url.as_https()}/info/refs?service=git-upload-pack", timeout=10)
     if r.status_code == 200:
-        return RemoteRepoCreds(clone_url=url.as_https(), private_key=None, oauth_token=None)
+        return RemoteRepoCreds(
+            protocol=RepoProtocol.HTTPS,
+            clone_url=url.as_https(),
+            private_key=None,
+            oauth_token=None,
+        )
 
     # user-provided ssh key
     if identity_file is not None:
@@ -83,7 +89,12 @@ def check_remote_repo_credentials_https(url: GitRepoURL, oauth_token: str) -> Re
         raise InvalidRepoCredentialsError(
             f"Can't access `{url.as_https()}` using the `{masked}` token"
         )
-    return RemoteRepoCreds(clone_url=url.as_https(), oauth_token=oauth_token, private_key=None)
+    return RemoteRepoCreds(
+        protocol=RepoProtocol.HTTPS,
+        clone_url=url.as_https(),
+        oauth_token=oauth_token,
+        private_key=None,
+    )
 
 
 def check_remote_repo_credentials_ssh(url: GitRepoURL, identity_file: PathLike) -> RemoteRepoCreds:
@@ -108,7 +119,12 @@ def check_remote_repo_credentials_ssh(url: GitRepoURL, identity_file: PathLike) 
             f"Can't access `{url.as_ssh()}` using the `{identity_file}` private SSH key"
         )
 
-    return RemoteRepoCreds(clone_url=url.as_ssh(), private_key=private_key, oauth_token=None)
+    return RemoteRepoCreds(
+        protocol=RepoProtocol.SSH,
+        clone_url=url.as_ssh(),
+        private_key=private_key,
+        oauth_token=None,
+    )
 
 
 def load_repo(config: RepoConfig) -> Union[RemoteRepo, LocalRepo]:

--- a/src/dstack/_internal/server/background/tasks/process_running_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_running_jobs.py
@@ -546,9 +546,9 @@ def _submit_job_to_runner(
 ):
     logger.debug("%s: submitting job spec", fmt(job_model))
     logger.debug(
-        "%s: repo credentials are %s",
+        "%s: repo clone URL is %s",
         fmt(job_model),
-        None if repo_credentials is None else repo_credentials.protocol.value,
+        None if repo_credentials is None else repo_credentials.clone_url,
     )
     runner_client.submit_job(
         run_spec=run.run_spec,

--- a/src/dstack/_internal/server/migrations/versions/3cf77fb8bcf1_store_repo_clone_url.py
+++ b/src/dstack/_internal/server/migrations/versions/3cf77fb8bcf1_store_repo_clone_url.py
@@ -1,0 +1,76 @@
+"""Store repo clone URL
+
+Revision ID: 3cf77fb8bcf1
+Revises: 91ac5e543037
+Create Date: 2024-07-15 23:09:40.150763
+
+"""
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "3cf77fb8bcf1"
+down_revision = "91ac5e543037"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    repos_table = sa.Table("repos", sa.MetaData(), autoload_with=op.get_bind().engine)
+    select_stmt = sa.select(repos_table.c.id, repos_table.c.info, repos_table.c.creds).where(
+        repos_table.c.creds.isnot(None)
+    )
+
+    batch_update_params = []
+
+    for row in op.get_bind().execute(select_stmt).all():
+        creds = json.loads(row.creds)
+        info = json.loads(row.info)
+
+        repo_host_name = info["repo_host_name"]
+        repo_port = info.get("repo_port")
+        repo_user_name = info["repo_user_name"]
+        repo_name = info["repo_name"]
+
+        netloc = f"{repo_host_name}:{repo_port}" if repo_port else repo_host_name
+
+        if creds["protocol"] == "ssh":
+            clone_url = f"ssh://git@{netloc}/{repo_user_name}/{repo_name}.git"
+        else:
+            clone_url = f"https://{netloc}/{repo_user_name}/{repo_name}.git"
+
+        creds["clone_url"] = clone_url
+        batch_update_params.append({"_id": row.id, "creds": json.dumps(creds)})
+
+    update_stmt = (
+        repos_table.update()
+        .where(repos_table.c.id == sa.bindparam("_id"))
+        .values(creds=sa.bindparam("creds"))
+    )
+    if batch_update_params:
+        op.get_bind().execute(update_stmt, batch_update_params)
+
+
+def downgrade() -> None:
+    repos_table = sa.Table("repos", sa.MetaData(), autoload_with=op.get_bind().engine)
+    select_stmt = sa.select(repos_table.c.id, repos_table.c.creds).where(
+        repos_table.c.creds.isnot(None)
+    )
+
+    batch_update_params = []
+
+    for row in op.get_bind().execute(select_stmt).all():
+        creds = json.loads(row.creds)
+        creds.pop("clone_url", None)
+        batch_update_params.append({"_id": row.id, "creds": json.dumps(creds)})
+
+    update_stmt = (
+        repos_table.update()
+        .where(repos_table.c.id == sa.bindparam("_id"))
+        .values(creds=sa.bindparam("creds"))
+    )
+    if batch_update_params:
+        op.get_bind().execute(update_stmt, batch_update_params)

--- a/src/dstack/_internal/server/migrations/versions/91ac5e543037_extend_repos_creds_column.py
+++ b/src/dstack/_internal/server/migrations/versions/91ac5e543037_extend_repos_creds_column.py
@@ -1,0 +1,36 @@
+"""Extend repos.creds column
+
+Revision ID: 91ac5e543037
+Revises: 5ad8debc8fe6
+Create Date: 2024-07-14 21:43:03.242059
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "91ac5e543037"
+down_revision = "5ad8debc8fe6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("repos", schema=None) as batch_op:
+        batch_op.alter_column(
+            "creds",
+            existing_type=sa.VARCHAR(length=2000),
+            type_=sa.String(length=5000),
+            existing_nullable=True,
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("repos", schema=None) as batch_op:
+        batch_op.alter_column(
+            "creds",
+            existing_type=sa.String(length=5000),
+            type_=sa.VARCHAR(length=2000),
+            existing_nullable=True,
+        )

--- a/src/dstack/_internal/server/models.py
+++ b/src/dstack/_internal/server/models.py
@@ -170,7 +170,7 @@ class RepoModel(BaseModel):
     type: Mapped[RepoType] = mapped_column(Enum(RepoType))
 
     info: Mapped[str] = mapped_column(String(2000))
-    creds: Mapped[Optional[str]] = mapped_column(String(2000))
+    creds: Mapped[Optional[str]] = mapped_column(String(5000))
 
 
 class CodeModel(BaseModel):

--- a/src/dstack/_internal/server/routers/repos.py
+++ b/src/dstack/_internal/server/routers/repos.py
@@ -53,12 +53,13 @@ async def init_repo(
     user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectMember()),
 ):
     _, project = user_project
+    repo_creds = body.repo_creds.to_remote_repo_creds(body.repo_info) if body.repo_creds else None
     await repos.init_repo(
         session=session,
         project=project,
         repo_id=body.repo_id,
         repo_info=body.repo_info,
-        repo_creds=body.repo_creds,
+        repo_creds=repo_creds,
     )
 
 

--- a/src/dstack/_internal/server/schemas/repos.py
+++ b/src/dstack/_internal/server/schemas/repos.py
@@ -2,8 +2,44 @@ from typing import List, Optional
 
 from dstack._internal.core.models.common import CoreModel
 from dstack._internal.core.models.repos import AnyRepoInfo
-from dstack._internal.core.models.repos.remote import RemoteRepoCreds
+from dstack._internal.core.models.repos.base import RepoProtocol
+from dstack._internal.core.models.repos.remote import RemoteRepoCreds, RemoteRepoInfo
 from dstack._internal.server.schemas.common import RepoRequest
+
+
+# TODO: in 0.19, either remove this model or make clone_url required
+class RemoteRepoCredsDto(CoreModel):
+    protocol: RepoProtocol
+    clone_url: Optional[str]
+    private_key: Optional[str]
+    oauth_token: Optional[str]
+
+    @staticmethod
+    def from_remote_repo_creds(creds: RemoteRepoCreds) -> "RemoteRepoCredsDto":
+        return RemoteRepoCredsDto(
+            protocol=creds.protocol,
+            clone_url=creds.clone_url,
+            private_key=creds.private_key,
+            oauth_token=creds.oauth_token,
+        )
+
+    def to_remote_repo_creds(self, info: RemoteRepoInfo) -> RemoteRepoCreds:
+        if (clone_url := self.clone_url) is None:
+            netloc = (
+                f"{info.repo_host_name}:{info.repo_port}"
+                if info.repo_port
+                else info.repo_host_name
+            )
+            if self.protocol == RepoProtocol.SSH:
+                clone_url = f"ssh://git@{netloc}/{info.repo_user_name}/{info.repo_name}.git"
+            else:
+                clone_url = f"https://{netloc}/{info.repo_user_name}/{info.repo_name}.git"
+        return RemoteRepoCreds(
+            protocol=self.protocol,
+            clone_url=clone_url,
+            private_key=self.private_key,
+            oauth_token=self.oauth_token,
+        )
 
 
 class GetRepoRequest(RepoRequest):
@@ -12,7 +48,7 @@ class GetRepoRequest(RepoRequest):
 
 class SaveRepoCredsRequest(RepoRequest):
     repo_info: AnyRepoInfo
-    repo_creds: Optional[RemoteRepoCreds]
+    repo_creds: Optional[RemoteRepoCredsDto]
 
 
 class DeleteReposRequest(CoreModel):

--- a/src/dstack/_internal/server/services/repos.py
+++ b/src/dstack/_internal/server/services/repos.py
@@ -201,14 +201,14 @@ def repo_model_to_repo_head(
     include_creds: bool = False,
 ) -> AnyRepoHead:
     if include_creds:
-        return RepoHeadWithCreds.parse_obj(
+        return RepoHeadWithCreds.__response__.parse_obj(
             {
                 "repo_id": repo_model.name,
                 "repo_info": json.loads(repo_model.info),
                 "repo_creds": json.loads(repo_model.creds) if repo_model.creds else None,
             }
         )
-    return RepoHead.parse_obj(
+    return RepoHead.__response__.parse_obj(
         {
             "repo_id": repo_model.name,
             "repo_info": json.loads(repo_model.info),

--- a/src/dstack/_internal/server/testing/common.py
+++ b/src/dstack/_internal/server/testing/common.py
@@ -135,14 +135,11 @@ async def create_repo(
     if info is None:
         info = {
             "repo_type": "remote",
-            "repo_host_name": "github.com",
-            "repo_port": None,
-            "repo_user_name": "dstackai",
             "repo_name": "dstack",
         }
     if creds is None:
         creds = {
-            "protocol": "https",
+            "clone_url": "https://github.com/dstackai/dstack.git",
             "private_key": None,
             "oauth_token": "test_token",
         }

--- a/src/dstack/_internal/server/testing/common.py
+++ b/src/dstack/_internal/server/testing/common.py
@@ -135,10 +135,14 @@ async def create_repo(
     if info is None:
         info = {
             "repo_type": "remote",
+            "repo_host_name": "",
+            "repo_port": None,
+            "repo_user_name": "",
             "repo_name": "dstack",
         }
     if creds is None:
         creds = {
+            "protocol": "https",
             "clone_url": "https://github.com/dstackai/dstack.git",
             "private_key": None,
             "oauth_token": "test_token",

--- a/src/dstack/api/_public/repos.py
+++ b/src/dstack/api/_public/repos.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from typing import Optional, Union
 
-import giturlparse
 from git import InvalidGitRepositoryError
 
 from dstack._internal.core.errors import ConfigurationError, ResourceNotExistsError
@@ -71,10 +70,9 @@ class RepoCollection:
         if isinstance(repo, RemoteRepo):
             try:
                 creds = get_local_repo_credentials(
-                    repo_data=repo.run_repo_data,
+                    repo_url=repo.repo_url,
                     identity_file=git_identity_file,
                     oauth_token=oauth_token,
-                    original_hostname=giturlparse.parse(repo.repo_url).resource,
                 )
             except InvalidRepoCredentialsError as e:
                 raise ConfigurationError(*e.args)

--- a/src/dstack/api/server/_repos.py
+++ b/src/dstack/api/server/_repos.py
@@ -6,6 +6,7 @@ from dstack._internal.core.models.repos import AnyRepoInfo, RemoteRepoCreds, Rep
 from dstack._internal.server.schemas.repos import (
     DeleteReposRequest,
     GetRepoRequest,
+    RemoteRepoCredsDto,
     SaveRepoCredsRequest,
 )
 from dstack.api.server._group import APIClientGroup
@@ -28,7 +29,13 @@ class ReposAPIClient(APIClientGroup):
         repo_info: AnyRepoInfo,
         repo_creds: Optional[RemoteRepoCreds] = None,
     ):
-        body = SaveRepoCredsRequest(repo_id=repo_id, repo_info=repo_info, repo_creds=repo_creds)
+        body = SaveRepoCredsRequest(
+            repo_id=repo_id,
+            repo_info=repo_info,
+            repo_creds=RemoteRepoCredsDto.from_remote_repo_creds(repo_creds)
+            if repo_creds
+            else None,
+        )
         self._request(f"/api/project/{project_name}/repos/init", body=body.json())
 
     def delete(self, project_name: str, repos_ids: List[str]):

--- a/src/tests/_internal/core/models/repos/test_remote.py
+++ b/src/tests/_internal/core/models/repos/test_remote.py
@@ -1,0 +1,78 @@
+import pytest
+
+from dstack._internal.core.models.repos.remote import GitRepoURL, RepoError
+
+
+class TestGitRepoURL:
+    def test_parse_https_url(self):
+        url = GitRepoURL.parse("https://github.com/dstackai/dstack.git")
+        assert url.as_https() == "https://github.com/dstackai/dstack.git"
+        assert url.as_ssh() == "ssh://git@github.com/dstackai/dstack.git"
+
+    def test_parse_https_url_with_port(self):
+        url = GitRepoURL.parse("https://github.com:8443/dstackai/dstack.git")
+        assert url.as_https() == "https://github.com:8443/dstackai/dstack.git"
+        assert url.as_ssh() == "ssh://git@github.com/dstackai/dstack.git"
+
+    def test_parse_https_url_with_ssh_config(self):
+        ssh_config = {
+            "github.com": {
+                "user": "test-user",
+                "port": "2222",
+                "hostname": "test.github.com",
+            }
+        }
+        url = GitRepoURL.parse(
+            "https://github.com:8443/dstackai/dstack.git",
+            get_ssh_config=lambda host: ssh_config.get(host, {}),
+        )
+        assert url.as_https() == "https://github.com:8443/dstackai/dstack.git"
+        assert url.as_ssh() == "ssh://test-user@github.com:2222/dstackai/dstack.git"
+
+    def test_parse_scp_location(self):
+        url = GitRepoURL.parse("test-user@test.example:a/b/c.git")
+        assert url.as_https() == "https://test.example/a/b/c.git"
+        assert url.as_ssh() == "ssh://test-user@test.example/a/b/c.git"
+
+    def test_parse_scp_location_with_ssh_config(self):
+        ssh_config = {
+            "test.example": {
+                "user": "test-user-2",
+                "port": "2222",
+                "hostname": "test2.example",
+            }
+        }
+        url = GitRepoURL.parse(
+            "test-user@test.example:a/b/c.git",
+            get_ssh_config=lambda host: ssh_config.get(host, {}),
+        )
+        assert url.as_https() == "https://test2.example/a/b/c.git"
+        assert url.as_ssh() == "ssh://test-user@test2.example:2222/a/b/c.git"
+
+    def test_parse_ssh_url_with_ssh_config(self):
+        ssh_config = {
+            "test": {
+                "user": "test-user",
+                "port": "2222",
+                "hostname": "test.example",
+            }
+        }
+        url = GitRepoURL.parse(
+            "ssh://test/repo.git", get_ssh_config=lambda host: ssh_config.get(host, {})
+        )
+        assert url.as_https() == "https://test.example/repo.git"
+        assert url.as_ssh() == "ssh://test-user@test.example:2222/repo.git"
+
+    def test_parse_unsupported_scheme(self):
+        with pytest.raises(RepoError):
+            GitRepoURL.parse("ftp://test.example/group/repo.git")
+
+    def test_parse_garbage(self):
+        with pytest.raises(RepoError):
+            GitRepoURL.parse("garbage")
+
+    def test_oauth_token(self):
+        url = GitRepoURL.parse("https://github.com/dstackai/dstack.git")
+        assert (
+            url.as_https("secret-token") == "https://secret-token@github.com/dstackai/dstack.git"
+        )

--- a/src/tests/_internal/server/routers/test_repos.py
+++ b/src/tests/_internal/server/routers/test_repos.py
@@ -153,13 +153,10 @@ class TestInitRepo:
             "repo_id": "test_repo",
             "repo_info": {
                 "repo_type": "remote",
-                "repo_host_name": "github.com",
-                "repo_port": None,
-                "repo_user_name": "dstackai",
                 "repo_name": "dstack",
             },
             "repo_creds": {
-                "protocol": "https",
+                "clone_url": "https://github.com/dstackai/dstack.git",
                 "private_key": None,
                 "oauth_token": "test_token",
             },
@@ -187,13 +184,10 @@ class TestInitRepo:
             "repo_id": "test_repo",
             "repo_info": {
                 "repo_type": "remote",
-                "repo_host_name": "github.com",
-                "repo_port": None,
-                "repo_user_name": "dstackai",
                 "repo_name": "dstack",
             },
             "repo_creds": {
-                "protocol": "https",
+                "clone_url": "https://github.com/dstackai/dstack.git",
                 "private_key": None,
                 "oauth_token": "test_token",
             },
@@ -208,13 +202,10 @@ class TestInitRepo:
             "repo_id": "test_repo",
             "repo_info": {
                 "repo_type": "remote",
-                "repo_host_name": "github.com",
-                "repo_port": None,
-                "repo_user_name": "dstackai",
                 "repo_name": "dstack",
             },
             "repo_creds": {
-                "protocol": "https",
+                "clone_url": "https://github.com/dstackai/dstack.git",
                 "private_key": None,
                 "oauth_token": "test_token_updated",
             },

--- a/src/tests/_internal/server/routers/test_repos.py
+++ b/src/tests/_internal/server/routers/test_repos.py
@@ -153,9 +153,13 @@ class TestInitRepo:
             "repo_id": "test_repo",
             "repo_info": {
                 "repo_type": "remote",
+                "repo_host_name": "",
+                "repo_port": None,
+                "repo_user_name": "",
                 "repo_name": "dstack",
             },
             "repo_creds": {
+                "protocol": "https",
                 "clone_url": "https://github.com/dstackai/dstack.git",
                 "private_key": None,
                 "oauth_token": "test_token",
@@ -184,9 +188,13 @@ class TestInitRepo:
             "repo_id": "test_repo",
             "repo_info": {
                 "repo_type": "remote",
+                "repo_host_name": "",
+                "repo_port": None,
+                "repo_user_name": "",
                 "repo_name": "dstack",
             },
             "repo_creds": {
+                "protocol": "https",
                 "clone_url": "https://github.com/dstackai/dstack.git",
                 "private_key": None,
                 "oauth_token": "test_token",
@@ -202,9 +210,13 @@ class TestInitRepo:
             "repo_id": "test_repo",
             "repo_info": {
                 "repo_type": "remote",
+                "repo_host_name": "",
+                "repo_port": None,
+                "repo_user_name": "",
                 "repo_name": "dstack",
             },
             "repo_creds": {
+                "protocol": "https",
                 "clone_url": "https://github.com/dstackai/dstack.git",
                 "private_key": None,
                 "oauth_token": "test_token_updated",


### PR DESCRIPTION
Previously, dstack assumed that all git repo URLs
have `/user/repo.git` paths. This commit removes
this assumption and introduces other minor URL
parsing correctness enhancements.

#1109 