### PR TITLE
Fix checking remote repo token auth

### DIFF
--- a/src/dstack/_internal/core/models/repos/remote.py
+++ b/src/dstack/_internal/core/models/repos/remote.py
@@ -269,7 +269,7 @@ class GitRepoURL:
         raise RepoError(f"Unsupported URL scheme {url.scheme}")
 
     def as_https(self, oauth_token: Optional[str] = None) -> str:
-        optional_creds = f"{oauth_token}@" if oauth_token else ""
+        optional_creds = f"anything:{oauth_token}@" if oauth_token else ""
         optional_port = f":{self.https_port}" if self.https_port else ""
         return f"https://{optional_creds}{self.host}{optional_port}{self.path}"
 

--- a/src/tests/_internal/core/models/repos/test_remote.py
+++ b/src/tests/_internal/core/models/repos/test_remote.py
@@ -74,5 +74,6 @@ class TestGitRepoURL:
     def test_oauth_token(self):
         url = GitRepoURL.parse("https://github.com/dstackai/dstack.git")
         assert (
-            url.as_https("secret-token") == "https://secret-token@github.com/dstackai/dstack.git"
+            url.as_https("secret-token")
+            == "https://anything:secret-token@github.com/dstackai/dstack.git"
         )


### PR DESCRIPTION
Previously, `dstack` used the repo auth token
differently when checking authentication in
`dstack` CLI and when cloning the repo in
`dstack-runner`. This commit makes token usage
uniform. In particular, this allows to use
token-based auth with GitLab repos.

#1109