### PR TITLE
Optimize listing runs for Python API and CLI

### DIFF
--- a/src/dstack/_internal/server/schemas/runs.py
+++ b/src/dstack/_internal/server/schemas/runs.py
@@ -2,6 +2,8 @@ from datetime import datetime
 from typing import List, Optional
 from uuid import UUID
 
+from pydantic import Field
+
 from dstack._internal.core.models.common import CoreModel
 from dstack._internal.core.models.instances import SSHKey
 from dstack._internal.core.models.profiles import Profile
@@ -15,7 +17,7 @@ class ListRunsRequest(CoreModel):
     only_active: bool = False
     prev_submitted_at: Optional[datetime]
     prev_run_id: Optional[UUID]
-    limit: int = 1000
+    limit: int = Field(100, ge=0, le=100)
     ascending: bool = False
 
 

--- a/src/dstack/api/server/_runs.py
+++ b/src/dstack/api/server/_runs.py
@@ -1,4 +1,6 @@
+from datetime import datetime
 from typing import List, Optional
+from uuid import UUID
 
 from pydantic import parse_obj_as
 
@@ -25,8 +27,27 @@ from dstack.api.server._group import APIClientGroup
 
 
 class RunsAPIClient(APIClientGroup):
-    def list(self, project_name: Optional[str], repo_id: Optional[str]) -> List[Run]:
-        body = ListRunsRequest(project_name=project_name, repo_id=repo_id)
+    def list(
+        self,
+        project_name: Optional[str],
+        repo_id: Optional[str],
+        username: Optional[str] = None,
+        only_active: bool = False,
+        prev_submitted_at: Optional[datetime] = None,
+        prev_run_id: Optional[UUID] = None,
+        limit: int = 100,
+        ascending: bool = False,
+    ) -> List[Run]:
+        body = ListRunsRequest(
+            project_name=project_name,
+            repo_id=repo_id,
+            username=username,
+            only_active=only_active,
+            prev_submitted_at=prev_submitted_at,
+            prev_run_id=prev_run_id,
+            limit=limit,
+            ascending=ascending,
+        )
         resp = self._request("/api/runs/list", body=body.json())
         return parse_obj_as(List[Run.__response__], resp.json())
 


### PR DESCRIPTION
Closes #1429 

* Extends Python low-level API to support list runs pagination.
* Optimizes Python high-level API for listing runs.