### PR TITLE
Fix spot offers suggested for on-demand dev envs

### DIFF
--- a/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
@@ -27,7 +27,6 @@ from dstack._internal.core.models.runs import (
     JobProvisioningData,
     JobStatus,
     JobTerminationReason,
-    Requirements,
     Run,
     RunSpec,
 )
@@ -276,16 +275,10 @@ async def _run_job_on_pool_instance(
 ) -> Optional[InstanceModel]:
     profile = run_spec.merged_profile
     async with PROCESSING_INSTANCES_LOCK:
-        pool_instances = get_pool_instances(pool)
-        requirements = Requirements(
-            resources=run_spec.configuration.resources,
-            max_price=profile.max_price,
-            spot=job.job_spec.requirements.spot,
-        )
         relevant_instances = filter_pool_instances(
-            pool_instances=pool_instances,
+            pool_instances=get_pool_instances(pool),
             profile=profile,
-            requirements=requirements,
+            requirements=job.job_spec.requirements,
             status=InstanceStatus.IDLE,
             fleet_model=fleet_model,
             multinode=job.job_spec.jobs_per_replica > 1,

--- a/src/dstack/_internal/server/services/runs.py
+++ b/src/dstack/_internal/server/services/runs.py
@@ -37,7 +37,6 @@ from dstack._internal.core.models.profiles import (
     DEFAULT_POOL_TERMINATION_IDLE_TIME,
     CreationPolicy,
     Profile,
-    SpotPolicy,
     TerminationPolicy,
 )
 from dstack._internal.core.models.runs import (
@@ -55,7 +54,6 @@ from dstack._internal.core.models.runs import (
     RunStatus,
     RunTerminationReason,
     ServiceSpec,
-    get_policy_map,
 )
 from dstack._internal.core.models.users import GlobalRole
 from dstack._internal.core.models.volumes import Volume, VolumeStatus
@@ -746,16 +744,10 @@ def _get_pool_offers(
     job: Job,
     volumes: List[Volume],
 ) -> List[InstanceOfferWithAvailability]:
-    profile = run_spec.merged_profile
-    requirements = Requirements(
-        resources=run_spec.configuration.resources,
-        max_price=profile.max_price,
-        spot=get_policy_map(profile.spot_policy, default=SpotPolicy.AUTO),
-    )
     pool_filtered_instances = filter_pool_instances(
         pool_instances=get_pool_instances(pool),
-        profile=profile,
-        requirements=requirements,
+        profile=run_spec.merged_profile,
+        requirements=job.job_spec.requirements,
         multinode=job.job_spec.jobs_per_replica > 1,
         volumes=volumes,
     )


### PR DESCRIPTION
The bug was caused by redundant construction of
`Requirements` that used `SpotPolicy.AUTO` as
default spot policy. The actual default spot
policy depends on the run configuration type and
can be found in job requirements.

Fixes #1449