### PR TITLE
Remove busy offers from the top of offers list

### DIFF
--- a/src/dstack/_internal/server/services/runs.py
+++ b/src/dstack/_internal/server/services/runs.py
@@ -309,8 +309,8 @@ async def get_run_plan(
         job_offers: List[InstanceOfferWithAvailability] = []
         job_offers.extend(pool_offers)
         job_offers.extend(offer for _, offer in offers)
+        job_offers.sort(key=lambda offer: not offer.availability.is_available())
 
-        # TODO(egor-s): merge job_offers and pool_offers based on (availability, use/create, price)
         job_plan = JobPlan(
             job_spec=job.job_spec,
             offers=job_offers[:50],


### PR DESCRIPTION
Now busy and unreachable pool instances are pushed to the bottom of the offers list, the same way we
push unavailable and no-quota cloud offers.

Fixes #1344 