### PR TITLE
Start dstack-shim service after network-online

### DIFF
--- a/src/dstack/_internal/core/backends/remote/provisioning.py
+++ b/src/dstack/_internal/core/backends/remote/provisioning.py
@@ -89,7 +89,7 @@ def run_shim_as_systemd_service(client: paramiko.SSHClient, working_dir: str, de
     shim_service = f"""\
     [Unit]
     Description=dstack-shim
-    After=network.target
+    After=network-online.target
 
     [Service]
     Type=simple


### PR DESCRIPTION
Fixes: https://github.com/dstackai/dstack/issues/1476
See: https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/

```
$ systemd-analyze critical-chain dstack-shim.service

[...]
dstack-shim.service @3h 2min 49.127s
└─network-online.target @4.379s
  └─NetworkManager-wait-online.service @838ms +3.538s
    └─NetworkManager.service @775ms +53ms
      └─dbus.service @772ms
        └─basic.target @763ms
          └─sockets.target @762ms
[...]
```