### PR TITLE
Fix instances not added to existing fleets

### DIFF
--- a/src/dstack/_internal/server/db.py
+++ b/src/dstack/_internal/server/db.py
@@ -28,7 +28,7 @@ class Database:
                 cursor = dbapi_connection.cursor()
                 cursor.execute("PRAGMA journal_mode=WAL;")
                 cursor.execute("PRAGMA foreign_keys=ON;")
-                cursor.execute("PRAGMA busy_timeout=5000;")
+                cursor.execute("PRAGMA busy_timeout=10000;")
                 cursor.close()
 
     def get_dialect_name(self) -> str:


### PR DESCRIPTION
The PR fixes a bug with missing `.unique()` on `session.execute()` that caused an instance added for a job in existing fleet not being created in the DB. The job may still execute successfully, but the instance will fail to terminate in the cloud.