### PR TITLE
Fix creating TensorDock instances

### DIFF
--- a/src/dstack/_internal/core/backends/tensordock/compute.py
+++ b/src/dstack/_internal/core/backends/tensordock/compute.py
@@ -95,7 +95,7 @@ class TensorDockCompute(Compute):
             region=instance_offer.region,
             price=instance_offer.price,
             username="user",
-            ssh_port={v: k for k, v in resp["port_forwards"].items()}["22"],
+            ssh_port={int(v): int(k) for k, v in resp["port_forwards"].items()}[22],
             dockerized=True,
             ssh_proxy=None,
             backend_data=None,


### PR DESCRIPTION
Seems to be a change in the TensorDock API. In case the change was unintentional, this fix will work with both the new and the old API versions.

Closes #1504