### PR TITLE
Add Ray example

### DIFF
--- a/examples/misc/ray/README.md
+++ b/examples/misc/ray/README.md
@@ -1,0 +1,71 @@
+# Ray
+
+This example shows how use `dstack` to spin up a [Ray](https://docs.ray.io/en/latest/ray-overview/index.html) cluster and run Ray jobs on it.
+
+## Create fleet
+
+First create a fleet for the Ray cluster. We'll use one instance for a master node and three instances for worker nodes:
+
+```yaml
+type: fleet
+name: ray-fleet
+nodes: 4
+placement: cluster
+backends: [gcp]
+resources: 
+  cpu: 8..
+  memory: 32GB..
+  gpu: 1
+```
+
+```shell
+dstack apply -f fleet.dstack.yaml
+```
+
+## Launch Ray cluster
+
+The following `dstack` task launches Ray master and worker nodes.
+`dstack` makes the Ray dashboard available at `localhost:8265`.
+
+```yaml
+type: task
+name: ray-cluster
+nodes: 4
+commands:
+  - pip install -U "ray[default]"
+  - >
+    if [ $DSTACK_NODE_RANK = 0 ]; then 
+      ray start --head --port=6379;
+    else
+      ray start --address=$DSTACK_MASTER_NODE_IP:6379
+    fi
+ports:
+  - 8265 # ray dashboard port
+resources:
+  shm_size: 8GB
+```
+
+```shell
+dstack apply -f cluster.dstack.yaml
+```
+
+## Run Ray jobs
+
+Install Ray locally:
+
+```shell
+pip install ray
+```
+
+Now you can submit Ray jobs to the cluster available at `localhost:8265`:
+
+```shell
+RAY_ADDRESS='http://localhost:8265' ray job submit \
+--working-dir . \
+--runtime-env-json='{"pip": ["ray[train]", "torch", "torchvision", "tqdm", "filelock"]}' \
+-- python tasks/pytorch-mnist.py
+```
+
+See more examples in the [Ray docs](https://docs.ray.io/en/latest/train/examples.html).
+
+Using Ray via `dstack` is a powerful way to get access to the rich Ray ecosystem while benefiting from `dstack`'s provisioning capabilities.

--- a/examples/misc/ray/cluster.dstack.yaml
+++ b/examples/misc/ray/cluster.dstack.yaml
@@ -1,0 +1,15 @@
+type: task
+name: ray-cluster
+nodes: 4
+commands:
+  - pip install -U "ray[default]"
+  - >
+    if [ $DSTACK_NODE_RANK = 0 ]; then 
+      ray start --head --port=6379;
+    else
+      ray start --address=$DSTACK_MASTER_NODE_IP:6379
+    fi
+ports:
+  - 8265 # ray dashboard port
+resources: 
+  shm_size: 8GB

--- a/examples/misc/ray/fleet.dstack.yaml
+++ b/examples/misc/ray/fleet.dstack.yaml
@@ -1,0 +1,9 @@
+type: fleet
+name: ray-fleet
+nodes: 4
+placement: cluster
+backends: [gcp]
+resources: 
+  cpu: 8..
+  memory: 32GB..
+  gpu: 1

--- a/examples/misc/ray/tasks/pytorch-mnist.py
+++ b/examples/misc/ray/tasks/pytorch-mnist.py
@@ -1,0 +1,168 @@
+# This example runs distributed training of a PyTorch model on Fashion MNIST with Ray Train.
+# Source: https://docs.ray.io/en/latest/train/examples/pytorch/torch_fashion_mnist_example.html
+
+# Copyright 2023 Ray Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import Dict
+
+import ray.train
+import torch
+from filelock import FileLock
+from ray.train import ScalingConfig
+from ray.train.torch import TorchTrainer
+from torch import nn
+from torch.utils.data import DataLoader
+from torchvision import datasets, transforms
+from torchvision.transforms import Normalize, ToTensor
+from tqdm import tqdm
+
+
+def get_dataloaders(batch_size):
+    # Transform to normalize the input images
+    transform = transforms.Compose([ToTensor(), Normalize((0.5,), (0.5,))])
+
+    with FileLock(os.path.expanduser("~/data.lock")):
+        # Download training data from open datasets
+        training_data = datasets.FashionMNIST(
+            root="~/data",
+            train=True,
+            download=True,
+            transform=transform,
+        )
+
+        # Download test data from open datasets
+        test_data = datasets.FashionMNIST(
+            root="~/data",
+            train=False,
+            download=True,
+            transform=transform,
+        )
+
+    # Create data loaders
+    train_dataloader = DataLoader(training_data, batch_size=batch_size, shuffle=True)
+    test_dataloader = DataLoader(test_data, batch_size=batch_size)
+
+    return train_dataloader, test_dataloader
+
+
+# Model Definition
+class NeuralNetwork(nn.Module):
+    def __init__(self):
+        super(NeuralNetwork, self).__init__()
+        self.flatten = nn.Flatten()
+        self.linear_relu_stack = nn.Sequential(
+            nn.Linear(28 * 28, 512),
+            nn.ReLU(),
+            nn.Dropout(0.25),
+            nn.Linear(512, 512),
+            nn.ReLU(),
+            nn.Dropout(0.25),
+            nn.Linear(512, 10),
+            nn.ReLU(),
+        )
+
+    def forward(self, x):
+        x = self.flatten(x)
+        logits = self.linear_relu_stack(x)
+        return logits
+
+
+def train_func_per_worker(config: Dict):
+    lr = config["lr"]
+    epochs = config["epochs"]
+    batch_size = config["batch_size_per_worker"]
+
+    # Get dataloaders inside the worker training function
+    train_dataloader, test_dataloader = get_dataloaders(batch_size=batch_size)
+
+    # [1] Prepare Dataloader for distributed training
+    # Shard the datasets among workers and move batches to the correct device
+    # =======================================================================
+    train_dataloader = ray.train.torch.prepare_data_loader(train_dataloader)
+    test_dataloader = ray.train.torch.prepare_data_loader(test_dataloader)
+
+    model = NeuralNetwork()
+
+    # [2] Prepare and wrap your model with DistributedDataParallel
+    # Move the model to the correct GPU/CPU device
+    # ============================================================
+    model = ray.train.torch.prepare_model(model)
+
+    loss_fn = nn.CrossEntropyLoss()
+    optimizer = torch.optim.SGD(model.parameters(), lr=lr, momentum=0.9)
+
+    # Model training loop
+    for epoch in range(epochs):
+        if ray.train.get_context().get_world_size() > 1:
+            # Required for the distributed sampler to shuffle properly across epochs.
+            train_dataloader.sampler.set_epoch(epoch)
+
+        model.train()
+        for X, y in tqdm(train_dataloader, desc=f"Train Epoch {epoch}"):
+            pred = model(X)
+            loss = loss_fn(pred, y)
+
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+        model.eval()
+        test_loss, num_correct, num_total = 0, 0, 0
+        with torch.no_grad():
+            for X, y in tqdm(test_dataloader, desc=f"Test Epoch {epoch}"):
+                pred = model(X)
+                loss = loss_fn(pred, y)
+
+                test_loss += loss.item()
+                num_total += y.shape[0]
+                num_correct += (pred.argmax(1) == y).sum().item()
+
+        test_loss /= len(test_dataloader)
+        accuracy = num_correct / num_total
+
+        # [3] Report metrics to Ray Train
+        # ===============================
+        ray.train.report(metrics={"loss": test_loss, "accuracy": accuracy})
+
+
+def train_fashion_mnist(num_workers=2, use_gpu=False):
+    global_batch_size = 32
+
+    train_config = {
+        "lr": 1e-3,
+        "epochs": 10,
+        "batch_size_per_worker": global_batch_size // num_workers,
+    }
+
+    # Configure computation resources
+    scaling_config = ScalingConfig(num_workers=num_workers, use_gpu=use_gpu)
+
+    # Initialize a Ray TorchTrainer
+    trainer = TorchTrainer(
+        train_loop_per_worker=train_func_per_worker,
+        train_loop_config=train_config,
+        scaling_config=scaling_config,
+    )
+
+    # [4] Start distributed training
+    # Run `train_func_per_worker` on all workers
+    # =============================================
+    result = trainer.fit()
+    print(f"Training result: {result}")
+
+
+if __name__ == "__main__":
+    train_fashion_mnist(num_workers=3, use_gpu=True)

--- a/examples/misc/ray/tasks/quicksort.py
+++ b/examples/misc/ray/tasks/quicksort.py
@@ -1,0 +1,72 @@
+# This example sorts the list in a distributed and parallel fashion.
+# Source: https://docs.ray.io/en/latest/ray-core/patterns/nested-tasks.html#code-example
+
+# Copyright 2023 Ray Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+import ray
+from numpy import random
+
+
+def partition(collection):
+    # Use the last element as the pivot
+    pivot = collection.pop()
+    greater, lesser = [], []
+    for element in collection:
+        if element > pivot:
+            greater.append(element)
+        else:
+            lesser.append(element)
+    return lesser, pivot, greater
+
+
+def quick_sort(collection):
+    if len(collection) <= 200000:  # magic number
+        return sorted(collection)
+    else:
+        lesser, pivot, greater = partition(collection)
+        lesser = quick_sort(lesser)
+        greater = quick_sort(greater)
+    return lesser + [pivot] + greater
+
+
+@ray.remote
+def quick_sort_distributed(collection):
+    # Tiny tasks are an antipattern.
+    # Thus, in our example we have a "magic number" to
+    # toggle when distributed recursion should be used vs
+    # when the sorting should be done in place. The rule
+    # of thumb is that the duration of an individual task
+    # should be at least 1 second.
+    if len(collection) <= 200000:  # magic number
+        return sorted(collection)
+    else:
+        lesser, pivot, greater = partition(collection)
+        lesser = quick_sort_distributed.remote(lesser)
+        greater = quick_sort_distributed.remote(greater)
+        return ray.get(lesser) + [pivot] + ray.get(greater)
+
+
+for size in [200000, 4000000, 8000000]:
+    print(f"Array size: {size}")
+    unsorted = random.randint(1000000, size=(size)).tolist()
+    s = time.time()
+    quick_sort(unsorted)
+    print(f"Sequential execution: {(time.time() - s):.3f}")
+    s = time.time()
+    ray.get(quick_sort_distributed.remote(unsorted))
+    print(f"Distributed execution: {(time.time() - s):.3f}")
+    print("--" * 10)


### PR DESCRIPTION
The PR adds an example of running Ray via dstack.

TODO:
* The example uses the same instance type for head and worker nodes. This can lead to ineffective usage of head resources. Consider using different instance types once dstack supports it.