### PR TITLE
Fix filtering offers by disk size

### DIFF
--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -31,6 +31,7 @@ from dstack._internal.core.models.instances import (
     InstanceOfferWithAvailability,
     SSHKey,
 )
+from dstack._internal.core.models.resources import Memory, Range
 from dstack._internal.core.models.runs import Job, JobProvisioningData, Requirements, Run
 from dstack._internal.core.models.volumes import (
     Volume,
@@ -40,6 +41,8 @@ from dstack._internal.core.models.volumes import (
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
+# gp2 volumes can be 1GB-16TB, dstack AMIs are 100GB
+CONFIGURABLE_DISK_SIZE = Range[Memory](min=Memory.parse("100GB"), max=Memory.parse("16TB"))
 
 
 class AWSGatewayBackendData(CoreModel):
@@ -71,6 +74,7 @@ class AWSCompute(Compute):
             backend=BackendType.AWS,
             locations=self.config.regions,
             requirements=requirements,
+            configurable_disk_size=CONFIGURABLE_DISK_SIZE,
             extra_filter=_supported_instances,
         )
         regions = set(i.region for i in offers)

--- a/src/dstack/_internal/core/backends/azure/compute.py
+++ b/src/dstack/_internal/core/backends/azure/compute.py
@@ -55,11 +55,14 @@ from dstack._internal.core.models.instances import (
     InstanceType,
     SSHKey,
 )
+from dstack._internal.core.models.resources import Memory, Range
 from dstack._internal.core.models.runs import Job, JobProvisioningData, Requirements, Run
 from dstack._internal.core.models.volumes import Volume
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
+# OS disks can be 1GB-4095GB, dstack images are 30GB
+CONFIGURABLE_DISK_SIZE = Range[Memory](min=Memory.parse("30GB"), max=Memory.parse("4095GB"))
 
 
 class AzureCompute(Compute):
@@ -80,6 +83,7 @@ class AzureCompute(Compute):
             backend=BackendType.AZURE,
             locations=self.config.locations,
             requirements=requirements,
+            configurable_disk_size=CONFIGURABLE_DISK_SIZE,
             extra_filter=_supported_instances,
         )
         offers_with_availability = _get_offers_with_availability(

--- a/src/dstack/_internal/core/backends/base/offers.py
+++ b/src/dstack/_internal/core/backends/base/offers.py
@@ -11,6 +11,7 @@ from dstack._internal.core.models.instances import (
     InstanceType,
     Resources,
 )
+from dstack._internal.core.models.resources import DEFAULT_DISK, Memory, Range
 from dstack._internal.core.models.runs import Requirements
 
 
@@ -18,6 +19,7 @@ def get_catalog_offers(
     backend: BackendType,
     locations: Optional[List[str]] = None,
     requirements: Optional[Requirements] = None,
+    configurable_disk_size: Range[Memory] = Range[Memory](min=Memory.parse("1GB"), max=None),
     extra_filter: Optional[Callable[[InstanceOffer], bool]] = None,
     catalog: Optional[gpuhunt.Catalog] = None,
 ) -> List[InstanceOffer]:
@@ -32,7 +34,9 @@ def get_catalog_offers(
     for item in catalog.query(**asdict(q)):
         if locations is not None and item.location not in locations:
             continue
-        offer = catalog_item_to_offer(backend, item, requirements)
+        offer = catalog_item_to_offer(backend, item, requirements, configurable_disk_size)
+        if offer is None:
+            continue
         if extra_filter is not None and not extra_filter(offer):
             continue
         offers.append(offer)
@@ -40,18 +44,23 @@ def get_catalog_offers(
 
 
 def catalog_item_to_offer(
-    backend: BackendType, item: gpuhunt.CatalogItem, requirements: Optional[Requirements]
-) -> InstanceOffer:
+    backend: BackendType,
+    item: gpuhunt.CatalogItem,
+    requirements: Optional[Requirements],
+    configurable_disk_size: Range[Memory],
+) -> Optional[InstanceOffer]:
     gpus = []
     if item.gpu_count > 0:
         gpus = [Gpu(name=item.gpu_name, memory_mib=round(item.gpu_memory * 1024))] * item.gpu_count
-    disk_size_mib = round(
-        item.disk_size * 1024
-        if item.disk_size
-        else requirements.resources.disk.size.min * 1024
+    disk_size_mib = choose_disk_size_mib(
+        catalog_item_disk_size_gib=item.disk_size,
+        requirements_disk_size=requirements.resources.disk.size
         if requirements and requirements.resources.disk
-        else 102400  # TODO: Make requirements' fields required
+        else None,
+        configurable_disk_size=configurable_disk_size,
     )
+    if disk_size_mib is None:
+        return None
     resources = Resources(
         cpus=item.cpu,
         memory_mib=round(item.memory * 1024),
@@ -90,7 +99,7 @@ def offer_to_catalog_item(offer: InstanceOffer) -> gpuhunt.CatalogItem:
         gpu_name=gpu_name,
         gpu_memory=gpu_memory,
         spot=offer.instance.resources.spot,
-        disk_size=offer.instance.resources.disk.size_mib,
+        disk_size=offer.instance.resources.disk.size_mib / 1024,
     )
 
 
@@ -140,3 +149,20 @@ def match_requirements(
         if gpuhunt.matches(catalog_item, q=query_filter):
             filtered_offers.append(offer)
     return filtered_offers
+
+
+def choose_disk_size_mib(
+    catalog_item_disk_size_gib: Optional[float],
+    requirements_disk_size: Optional[Range[Memory]],
+    configurable_disk_size: Range[Memory],
+) -> Optional[int]:
+    if catalog_item_disk_size_gib:
+        disk_size_gib = catalog_item_disk_size_gib
+    else:
+        disk_size_range = requirements_disk_size or DEFAULT_DISK.size
+        disk_size_range = disk_size_range.intersect(configurable_disk_size)
+        if disk_size_range is None:
+            return None
+        disk_size_gib = disk_size_range.min
+
+    return round(disk_size_gib * 1024)

--- a/src/dstack/_internal/core/backends/datacrunch/api_client.py
+++ b/src/dstack/_internal/core/backends/datacrunch/api_client.py
@@ -71,7 +71,7 @@ class DataCrunchAPIClient:
                 location=location,
                 os_volume={"name": "OS volume", "size": disk_size},
             )
-        except APIException:
-            raise NoCapacityError()
+        except APIException as e:
+            raise NoCapacityError(f"DataCrunch API error: {e.message}")
 
         return instance

--- a/src/dstack/_internal/core/backends/gcp/compute.py
+++ b/src/dstack/_internal/core/backends/gcp/compute.py
@@ -39,6 +39,7 @@ from dstack._internal.core.models.instances import (
     Resources,
     SSHKey,
 )
+from dstack._internal.core.models.resources import Memory, Range
 from dstack._internal.core.models.runs import Job, JobProvisioningData, Requirements, Run
 from dstack._internal.core.models.volumes import (
     Volume,
@@ -49,6 +50,10 @@ from dstack._internal.utils.common import get_or_error
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+# pd-balanced disks can be 10GB-64TB, but dstack images are 20GB and cannot grow larger
+# than 32TB because of filesystem settings
+CONFIGURABLE_DISK_SIZE = Range[Memory](min=Memory.parse("20GB"), max=Memory.parse("32TB"))
 
 
 class GCPVolumeDiskBackendData(CoreModel):
@@ -74,6 +79,7 @@ class GCPCompute(Compute):
         offers = get_catalog_offers(
             backend=BackendType.GCP,
             requirements=requirements,
+            configurable_disk_size=CONFIGURABLE_DISK_SIZE,
             extra_filter=_supported_instances_and_zones(self.config.regions),
         )
         quotas: Dict[str, Dict[str, float]] = defaultdict(dict)

--- a/src/dstack/_internal/core/backends/nebius/compute.py
+++ b/src/dstack/_internal/core/backends/nebius/compute.py
@@ -23,11 +23,14 @@ from dstack._internal.core.models.instances import (
     InstanceOfferWithAvailability,
     SSHKey,
 )
+from dstack._internal.core.models.resources import Memory, Range
 from dstack._internal.core.models.runs import Job, JobProvisioningData, Requirements, Run
 from dstack._internal.core.models.volumes import Volume
 
 MEGABYTE = 1024**2
 INSTANCE_PULL_INTERVAL = 10
+# TODO: find out the actual lower bound considering dstack image size, 50GB is made up
+CONFIGURABLE_DISK_SIZE = Range[Memory](min=Memory.parse("50GB"), max=Memory.parse("4TB"))
 
 
 class NebiusCompute(Compute):
@@ -42,6 +45,7 @@ class NebiusCompute(Compute):
             backend=BackendType.NEBIUS,
             locations=self.config.regions,
             requirements=requirements,
+            configurable_disk_size=CONFIGURABLE_DISK_SIZE,
         )
         # TODO(egor-s) quotas
         return [

--- a/src/dstack/_internal/core/backends/oci/compute.py
+++ b/src/dstack/_internal/core/backends/oci/compute.py
@@ -18,6 +18,7 @@ from dstack._internal.core.models.instances import (
     InstanceOfferWithAvailability,
     SSHKey,
 )
+from dstack._internal.core.models.resources import Memory, Range
 from dstack._internal.core.models.runs import Job, JobProvisioningData, Requirements, Run
 from dstack._internal.core.models.volumes import Volume
 
@@ -37,6 +38,7 @@ SUPPORTED_SHAPE_FAMILIES = [
     "VM.GPU.A10.",
     "BM.GPU.A10.",
 ]
+CONFIGURABLE_DISK_SIZE = Range[Memory](min=Memory.parse("50GB"), max=Memory.parse("32TB"))
 
 
 class OCICompute(Compute):
@@ -55,6 +57,7 @@ class OCICompute(Compute):
             backend=BackendType.OCI,
             locations=self.config.regions,
             requirements=requirements,
+            configurable_disk_size=CONFIGURABLE_DISK_SIZE,
             extra_filter=_supported_instances,
         )
 

--- a/src/tests/_internal/core/models/test_resources.py
+++ b/src/tests/_internal/core/models/test_resources.py
@@ -130,3 +130,24 @@ class TestGPU:
         assert parse_obj_as(GPUSpec, "16GB..32") == parse_obj_as(
             GPUSpec, {"memory": {"min": 16, "max": 32}}
         )
+
+
+@pytest.mark.parametrize(
+    ("r1", "r2", "intersection"),
+    [
+        (Range[int](min=1, max=2), Range[int](min=3, max=4), None),
+        (Range[int](min=1, max=2), Range[int](min=2, max=3), Range[int](min=2, max=2)),
+        (Range[int](min=1, max=2), Range[int](min=1, max=2), Range[int](min=1, max=2)),
+        (Range[int](min=1, max=3), Range[int](min=2, max=4), Range[int](min=2, max=3)),
+        (Range[int](min=1, max=4), Range[int](min=2, max=3), Range[int](min=2, max=3)),
+        (Range[int](min=None, max=1), Range[int](min=2, max=None), None),
+        (Range[int](min=None, max=1), Range[int](min=1, max=None), Range[int](min=1, max=1)),
+        (Range[int](min=None, max=2), Range[int](min=1, max=None), Range[int](min=1, max=2)),
+        (Range[int](min=None, max=1), Range[int](min=None, max=2), Range[int](min=None, max=1)),
+        (Range[int](min=1, max=None), Range[int](min=2, max=None), Range[int](min=2, max=None)),
+        (Range[int](min=1, max=None), Range[int](min=None, max=2), Range[int](min=1, max=2)),
+    ],
+)
+def test_intersect_ranges(r1: Range[int], r2: Range[int], intersection: Range[int]) -> None:
+    assert r1.intersect(r2) == intersection
+    assert r2.intersect(r1) == intersection


### PR DESCRIPTION
- Add missing MiB -> GiB conversion (fixes #1516)
- Drop global 50GB.. disk size constraint and add per-backend constraints in order to:
  - allow using on-prem instances with <50GB disks
  - avoid offering cloud instances impossible to create
  - fix ..X disk size ranges (fixes #1515)