### PR TITLE
Fix unlocking on transaction rollback

### DIFF
--- a/src/dstack/_internal/server/background/tasks/process_fleets.py
+++ b/src/dstack/_internal/server/background/tasks/process_fleets.py
@@ -39,9 +39,10 @@ async def process_fleets():
             PROCESSING_FLEETS_IDS.add(fleet_model.id)
 
     try:
-        await _process_fleet(fleet_id=fleet_model.id)
+        fleet_model_id = fleet_model.id
+        await _process_fleet(fleet_id=fleet_model_id)
     finally:
-        PROCESSING_FLEETS_IDS.remove(fleet_model.id)
+        PROCESSING_FLEETS_IDS.remove(fleet_model_id)
 
 
 async def _process_fleet(fleet_id: UUID):

--- a/src/dstack/_internal/server/background/tasks/process_gateways.py
+++ b/src/dstack/_internal/server/background/tasks/process_gateways.py
@@ -49,9 +49,10 @@ async def process_submitted_gateways():
             PROCESSING_GATEWAYS_IDS.add(gateway_model.id)
 
     try:
-        await _process_gateway(gateway_id=gateway_model.id)
+        gateway_model_id = gateway_model.id
+        await _process_gateway(gateway_id=gateway_model_id)
     finally:
-        PROCESSING_GATEWAYS_IDS.remove(gateway_model.id)
+        PROCESSING_GATEWAYS_IDS.remove(gateway_model_id)
 
 
 async def _process_connection(conn: GatewayConnection):

--- a/src/dstack/_internal/server/background/tasks/process_running_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_running_jobs.py
@@ -78,9 +78,10 @@ async def process_running_jobs():
             RUNNING_PROCESSING_JOBS_IDS.add(job_model.id)
 
     try:
-        await _process_job(job_id=job_model.id)
+        job_model_id = job_model.id
+        await _process_job(job_id=job_model_id)
     finally:
-        RUNNING_PROCESSING_JOBS_IDS.remove(job_model.id)
+        RUNNING_PROCESSING_JOBS_IDS.remove(job_model_id)
 
 
 async def _process_job(job_id: UUID):

--- a/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
@@ -99,9 +99,10 @@ async def process_submitted_jobs():
             SUBMITTED_PROCESSING_JOBS_IDS.add(job_model.id)
 
     try:
-        await _process_job(job_id=job_model.id)
+        job_model_id = job_model.id
+        await _process_job(job_id=job_model_id)
     finally:
-        SUBMITTED_PROCESSING_JOBS_IDS.remove(job_model.id)
+        SUBMITTED_PROCESSING_JOBS_IDS.remove(job_model_id)
 
 
 async def _process_job(job_id: UUID):

--- a/src/dstack/_internal/server/background/tasks/process_terminating_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_terminating_jobs.py
@@ -36,9 +36,10 @@ async def process_terminating_jobs():
                 return
             TERMINATING_PROCESSING_JOBS_IDS.add(job_model.id)
     try:
-        await _process_job(job_id=job_model.id)
+        job_model_id = job_model.id
+        await _process_job(job_id=job_model_id)
     finally:
-        TERMINATING_PROCESSING_JOBS_IDS.remove(job_model.id)
+        TERMINATING_PROCESSING_JOBS_IDS.remove(job_model_id)
 
 
 async def _process_job(job_id: uuid.UUID):

--- a/src/dstack/_internal/server/background/tasks/process_volumes.py
+++ b/src/dstack/_internal/server/background/tasks/process_volumes.py
@@ -40,9 +40,10 @@ async def process_submitted_volumes():
             PROCESSING_VOLUMES_IDS.add(volume_model.id)
 
     try:
-        await _process_volume(volume_id=volume_model.id)
+        volume_model_id = volume_model.id
+        await _process_volume(volume_id=volume_model_id)
     finally:
-        PROCESSING_VOLUMES_IDS.remove(volume_model.id)
+        PROCESSING_VOLUMES_IDS.remove(volume_model_id)
 
 
 async def _process_volume(volume_id: UUID):

--- a/src/dstack/_internal/server/services/jobs/__init__.py
+++ b/src/dstack/_internal/server/services/jobs/__init__.py
@@ -275,7 +275,6 @@ async def process_terminating_job(session: AsyncSession, job_model: JobModel):
             await gateways.unregister_replica(
                 session, job_model
             )  # TODO(egor-s) ensure always runs
-
         finally:
             PROCESSING_INSTANCES_IDS.remove(instance.id)
 

--- a/src/dstack/_internal/server/services/runs.py
+++ b/src/dstack/_internal/server/services/runs.py
@@ -509,8 +509,8 @@ async def stop_runs(
 
 
 async def stop_run(session: AsyncSession, run: RunModel, abort: bool):
-    await wait_to_lock(PROCESSING_RUNS_LOCK, PROCESSING_RUNS_IDS, run.id)
-
+    run_id = run.id  # run.id won't load if transaction is rolled back
+    await wait_to_lock(PROCESSING_RUNS_LOCK, PROCESSING_RUNS_IDS, run_id)
     try:
         await session.refresh(run)
         if run.status.is_finished():
@@ -529,7 +529,7 @@ async def stop_run(session: AsyncSession, run: RunModel, abort: bool):
         run.last_processed_at = common_utils.get_current_datetime()
         await session.commit()
     finally:
-        PROCESSING_RUNS_IDS.remove(run.id)
+        PROCESSING_RUNS_IDS.remove(run_id)
 
 
 async def delete_runs(


### PR DESCRIPTION
As observed by Sentry reports, the server may fail to unlock a resource when calling `LOCK_SET.remove(resource.id)` because `resource.id` won't load in case of a rollback transaction. This PR ensures `resource.id` is not loaded where rollbacks are possible.