### PR TITLE
Fixes to forcing root in custom Docker images

### DIFF
--- a/runner/internal/shim/docker.go
+++ b/runner/internal/shim/docker.go
@@ -501,6 +501,8 @@ func runContainer(ctx context.Context, client docker.APIClient, containerID stri
 
 func getSSHShellCommands(openSSHPort int, publicSSHKey string) []string {
 	return []string{
+		// TODO(#1535): support non-root images properly
+		"mkdir -p /root && chown root:root /root && export HOME=/root",
 		// note: &> redirection doesn't work in /bin/sh
 		// check in sshd is here, install if not
 		"if ! command -v sshd >/dev/null 2>&1; then { apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server; } || { yum -y install openssh-server; }; fi",

--- a/src/dstack/_internal/core/services/ssh/attach.py
+++ b/src/dstack/_internal/core/services/ssh/attach.py
@@ -83,7 +83,7 @@ class SSHAttach:
             self.container_config = {
                 "HostName": "localhost",
                 "Port": 10022,
-                "User": "root",
+                "User": "root",  # TODO(#1535): support non-root images properly
                 "IdentityFile": id_rsa_path,
                 "IdentitiesOnly": "yes",
                 "StrictHostKeyChecking": "no",

--- a/src/dstack/_internal/server/background/tasks/process_running_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_running_jobs.py
@@ -396,6 +396,7 @@ def _process_provisioning_with_shim(
         image_name=job_spec.image_name,
         container_name=job_model.job_name,
         # Images may use non-root users but dstack requires root, so force it.
+        # TODO(#1535): support non-root images properly
         container_user="root",
         shm_size=job_spec.requirements.resources.shm_size,
         public_keys=public_keys,


### PR DESCRIPTION
In some images, the `/root` directory could be
missing or owned by another user and the `HOME`
variable could be set to another user's home
directory, which lead to inability to log in as
root via SSH.

#1502 