### PR TITLE
Interpolate env in registry_auth

### DIFF
--- a/src/tests/_internal/utils/test_interpolator.py
+++ b/src/tests/_internal/utils/test_interpolator.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dstack._internal.utils.interpolator import VariablesInterpolator
+from dstack._internal.utils.interpolator import InterpolatorError, VariablesInterpolator
 
 
 def get_interpolator():
@@ -35,17 +35,17 @@ class TestVariablesInterpolator:
         assert ["env.name"] == missing
 
     def test_unclosed_pattern(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(InterpolatorError):
             get_interpolator().interpolate("${{ secrets.password }")
 
     def test_illegal_name(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(InterpolatorError):
             get_interpolator().interpolate("${{ secrets.pass-word }}")
-        with pytest.raises(ValueError):
+        with pytest.raises(InterpolatorError):
             get_interpolator().interpolate("${{ .password }}")
-        with pytest.raises(ValueError):
+        with pytest.raises(InterpolatorError):
             get_interpolator().interpolate("${{ password. }}")
-        with pytest.raises(ValueError):
+        with pytest.raises(InterpolatorError):
             get_interpolator().interpolate("${{ secrets.password.hash }}")
-        with pytest.raises(ValueError):
+        with pytest.raises(InterpolatorError):
             get_interpolator().interpolate("${{ secrets.007 }}")


### PR DESCRIPTION
Closes #1539 

This PR makes the `env` context available in `registry_auth` of run configurations via `${{ env.ENV_NAME }}` syntax. This allows passing `registry_auth` without specifying registry creds in configuration files:

```yaml
type: task
image: my_registry/private_image
env:
  - REGISTRY_USER
  - REGISTRY_PASSWORD
registry_auth:
  username: ${{ env.REGISTRY_USER }}
  password: ${{ env.REGISTRY_PASSWORD }}

```

The interpolation is implemented on the client side. The support for specifying sensitive values without interpolation is to be addressed by #708.