### PR TITLE
Avoid TGI error `logit_bias: invalid type`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.egg-info
 
 dist/
-/venv/
+venv/
 /.cache/
 .pytest_cache/
 .coverage

--- a/gateway/src/dstack/gateway/openai/clients/openai.py
+++ b/gateway/src/dstack/gateway/openai/clients/openai.py
@@ -19,11 +19,15 @@ class OpenAIChatCompletions(ChatCompletionsClient):
         )
 
     async def generate(self, request: ChatCompletionsRequest) -> ChatCompletionsResponse:
-        resp = await self.client.post("/chat/completions", json=request.model_dump())
+        resp = await self.client.post(
+            "/chat/completions", json=request.model_dump(exclude_unset=True)
+        )
         if resp.status_code != 200:
             raise GatewayError(resp.text)
         return ChatCompletionsResponse.model_validate(resp.json())
 
     async def stream(self, request: ChatCompletionsRequest) -> AsyncIterator[ChatCompletionsChunk]:
-        async for data in self.client.stream_sse("/chat/completions", json=request.model_dump()):
+        async for data in self.client.stream_sse(
+            "/chat/completions", json=request.model_dump(exclude_unset=True)
+        ):
             yield ChatCompletionsChunk.model_validate(data)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
+build~=1.2  # For building dstack-gateway wheels
 pre-commit
 httpx>=0.23
 pytest~=7.2


### PR DESCRIPTION
TGI's OpenAI interface implementation does not
seem to handle the logit_bias property correctly,
so dstack-gateway will now avoid sending any
properties that were not explicitly set in the
user's request.

Fixes #1549 