### PR TITLE
Approximate on-prem GPU memory size

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ BASE_DEPS = [
     "cachetools",
     "dnspython",
     "grpcio>=1.50",  # indirect
-    "gpuhunt>=0.0.15,<0.1.0",
+    "gpuhunt>=0.0.16,<0.1.0",
     "sentry-sdk[fastapi]",
     "httpx",
     "aiorwlock",

--- a/src/dstack/_internal/utils/gpu.py
+++ b/src/dstack/_internal/utils/gpu.py
@@ -20,8 +20,10 @@ def convert_gpu_name(name: str) -> str:
         return name.replace(" ", "")
 
     name = name.replace(" Ti", "Ti")
+    name = name.replace(" NVL", "NVL")
+    name = name.replace(" Ada Generation", "Ada")
     name = name.replace("RTX ", "RTX")
-    m = re.search(r"([A|H|L|P|T|V]\d+[Ti]?)", name)
+    m = re.search(r"([A|H|L|P|T|V]\d+\w*)", name)
     if m is not None:
         return m.group(0)
     return name.replace(" ", "")

--- a/src/dstack/_internal/utils/gpu.py
+++ b/src/dstack/_internal/utils/gpu.py
@@ -23,7 +23,7 @@ def convert_gpu_name(name: str) -> str:
     name = name.replace(" NVL", "NVL")
     name = name.replace(" Ada Generation", "Ada")
     name = name.replace("RTX ", "RTX")
-    m = re.search(r"([A|H|L|P|T|V]\d+\w*)", name)
+    m = re.search(r"([AHLPTV]\d+\w*)", name)
     if m is not None:
         return m.group(0)
     return name.replace(" ", "")

--- a/src/tests/_internal/utils/test_gpu.py
+++ b/src/tests/_internal/utils/test_gpu.py
@@ -5,10 +5,14 @@ from dstack._internal.utils.gpu import convert_gpu_name
 TESTS = [
     ("NVIDIA GeForce RTX 4060 Ti", "RTX4060Ti"),
     ("NVIDIA GeForce RTX 4060", "RTX4060"),
+    ("NVIDIA RTX 4000 Ada Generation", "RTX4000Ada"),
     ("NVIDIA L4", "L4"),
     ("NVIDIA GH200 120GB", "GH200"),
     ("NVIDIA A100-SXM4-80GB", "A100"),
-    ("NVIDIA A10G", "A10"),
+    ("NVIDIA A10G", "A10G"),
+    ("NVIDIA L40S", "L40S"),
+    ("NVIDIA H100 NVL", "H100NVL"),
+    ("NVIDIA H100 80GB HBM3", "H100"),
     ("Tesla T4", "T4"),
 ]
 


### PR DESCRIPTION
If the GPU memory size reported by `nvidia-smi` on
an on-prem instance differs slightly from the
memory this GPU model is known to have, `dstack`
will now use the known memory.

Additionally, this commit adjusts the translation
of on-prem GPU names for some edge cases so that
more on-prem GPU names match cloud GPU names and
are recognized during memory approximation.

Closes #1523