### PR TITLE
Implement configurable default permissions

### DIFF
--- a/docs/docs/concepts/projects.md
+++ b/docs/docs/concepts/projects.md
@@ -30,10 +30,11 @@ A user can be added to a project and assigned or unassigned as a project role on
 
 ### Project roles
 
-* **Admin** – The project admin role allows a user to manage the project's settings, including backends and
-  members.
-* **User** – A user added to the project without the admin role can manage its resources, including runs,
-  fleets, gateways, and volumes.
+* **Admin** – The project admin role allows a user to manage the project's settings,
+  including backends, gateways, and members.
+* **Manager** – The project manager role allows a user to manage project members.
+  Unlike admins, managers cannot configure backends and gateways.
+* **User** – A user can manage project resources including runs, fleets, and volumes.
 
 ## Authorization
 

--- a/docs/docs/reference/server/config.yml.md
+++ b/docs/docs/reference/server/config.yml.md
@@ -843,6 +843,24 @@ projects: ...
 With this configuration, the `aes` key will still be used to decrypt the old data,
 but new writes will store the data in plaintext.
 
+## Default permissions
+
+`dstack` supports changing default permissions. For example, by default all users
+can create and manage their own projects. You can specify `default_permissions`
+so that only global admins can create and manage projects:
+
+<div editor-title="~/.dstack/server/config.yml">
+
+```yaml
+default_permissions:
+  allow_non_admins_create_projects: false
+projects: ...
+```
+
+</div>
+
+See the [reference table](#default-permissions) for all configurable permissions.
+
 ## Root reference
 
 #SCHEMA# dstack._internal.server.services.config.ServerConfig
@@ -1083,3 +1101,9 @@ but new writes will store the data in plaintext.
         show_root_heading: false
         type:
             required: true
+
+## `default_permissions` { #default-permissions data-toc-label="default-permissions" }
+
+#SCHEMA# dstack._internal.server.services.permissions.DefaultPermissions
+    overrides:
+        show_root_heading: false

--- a/src/dstack/_internal/core/models/projects.py
+++ b/src/dstack/_internal/core/models/projects.py
@@ -7,9 +7,14 @@ from dstack._internal.core.models.common import CoreModel
 from dstack._internal.core.models.users import ProjectRole, User
 
 
+class MemberPermissions(CoreModel):
+    can_manage_ssh_fleets: bool
+
+
 class Member(CoreModel):
     user: User
     project_role: ProjectRole
+    permissions: MemberPermissions
 
 
 class Project(CoreModel):

--- a/src/dstack/_internal/core/models/users.py
+++ b/src/dstack/_internal/core/models/users.py
@@ -17,12 +17,17 @@ class GlobalRole(str, enum.Enum):
     USER = "user"
 
 
+class UserPermissions(CoreModel):
+    can_create_projects: bool
+
+
 class User(CoreModel):
     id: UUID4
     username: str
     global_role: GlobalRole
     email: Optional[str]
     active: bool
+    permissions: UserPermissions
 
 
 class UserTokenCreds(CoreModel):

--- a/src/dstack/_internal/server/routers/fleets.py
+++ b/src/dstack/_internal/server/routers/fleets.py
@@ -64,8 +64,13 @@ async def delete_fleets(
     session: AsyncSession = Depends(get_session),
     user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectMember()),
 ):
-    _, project = user_project
-    await fleets_services.delete_fleets(session=session, project=project, names=body.names)
+    user, project = user_project
+    await fleets_services.delete_fleets(
+        session=session,
+        project=project,
+        user=user,
+        names=body.names,
+    )
 
 
 @router.post("/delete_instances")
@@ -74,7 +79,11 @@ async def delete_fleet_instances(
     session: AsyncSession = Depends(get_session),
     user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectMember()),
 ):
-    _, project = user_project
+    user, project = user_project
     await fleets_services.delete_fleets(
-        session=session, project=project, names=[body.name], instance_nums=body.instance_nums
+        session=session,
+        project=project,
+        user=user,
+        names=[body.name],
+        instance_nums=body.instance_nums,
     )

--- a/src/dstack/_internal/server/routers/gateways.py
+++ b/src/dstack/_internal/server/routers/gateways.py
@@ -57,7 +57,11 @@ async def delete_gateways(
     user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectAdmin()),
 ):
     _, project = user_project
-    await gateways.delete_gateways(session=session, project=project, gateways_names=body.names)
+    await gateways.delete_gateways(
+        session=session,
+        project=project,
+        gateways_names=body.names,
+    )
 
 
 @router.post("/set_default")

--- a/src/dstack/_internal/server/services/gateways/__init__.py
+++ b/src/dstack/_internal/server/services/gateways/__init__.py
@@ -202,7 +202,11 @@ async def connect_to_gateway_with_retry(
     return connection
 
 
-async def delete_gateways(session: AsyncSession, project: ProjectModel, gateways_names: List[str]):
+async def delete_gateways(
+    session: AsyncSession,
+    project: ProjectModel,
+    gateways_names: List[str],
+):
     tasks = []
     gateways = []
     for gateway in await list_project_gateway_models(session=session, project=project):

--- a/src/dstack/_internal/server/services/permissions.py
+++ b/src/dstack/_internal/server/services/permissions.py
@@ -1,0 +1,38 @@
+from typing import Annotated
+
+from pydantic import Field
+
+from dstack._internal.core.models.common import CoreModel
+
+
+class DefaultPermissions(CoreModel):
+    allow_non_admins_create_projects: Annotated[
+        bool,
+        Field(
+            description=(
+                "This flag controls whether regular users (non-global admins)"
+                " can create and manage their own projects"
+            )
+        ),
+    ] = True
+    allow_non_admins_manage_ssh_fleets: Annotated[
+        bool,
+        Field(
+            description=(
+                "This flag controls whether regular project members (i.e. Users)"
+                " can add and delete on-prem fleets"
+            )
+        ),
+    ] = True
+
+
+_default_permissions = DefaultPermissions()
+
+
+def set_default_permissions(default_permissions: DefaultPermissions):
+    global _default_permissions
+    _default_permissions = default_permissions
+
+
+def get_default_permissions() -> DefaultPermissions:
+    return _default_permissions

--- a/src/dstack/_internal/server/services/permissions.py
+++ b/src/dstack/_internal/server/services/permissions.py
@@ -1,6 +1,5 @@
-from typing import Annotated
-
 from pydantic import Field
+from typing_extensions import Annotated
 
 from dstack._internal.core.models.common import CoreModel
 

--- a/src/dstack/_internal/server/testing/common.py
+++ b/src/dstack/_internal/server/testing/common.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import Dict, Optional, Union
 from uuid import UUID
@@ -57,6 +58,11 @@ from dstack._internal.server.models import (
     VolumeModel,
 )
 from dstack._internal.server.services.jobs import get_job_specs_from_run_spec
+from dstack._internal.server.services.permissions import (
+    DefaultPermissions,
+    get_default_permissions,
+    set_default_permissions,
+)
 from dstack._internal.server.services.users import get_token_hash
 
 
@@ -551,6 +557,16 @@ def get_volume_provisioning_data(
         availability_zone=availability_zone,
         backend_data=backend_data,
     )
+
+
+@contextmanager
+def default_permissions_context(default_permissions: DefaultPermissions):
+    prev_default_permissions = get_default_permissions()
+    set_default_permissions(default_permissions)
+    try:
+        yield
+    finally:
+        set_default_permissions(prev_default_permissions)
 
 
 class AsyncContextManager:

--- a/src/tests/_internal/server/routers/test_users.py
+++ b/src/tests/_internal/server/routers/test_users.py
@@ -31,6 +31,9 @@ class TestListUsers:
                 "global_role": user.global_role,
                 "email": None,
                 "active": True,
+                "permissions": {
+                    "can_create_projects": True,
+                },
             }
         ]
 
@@ -61,6 +64,9 @@ class TestGetMyUser:
             "global_role": user.global_role,
             "email": None,
             "active": True,
+            "permissions": {
+                "can_create_projects": True,
+            },
         }
 
 
@@ -97,6 +103,9 @@ class TestGetUser:
             "email": None,
             "creds": {"token": "1234"},
             "active": True,
+            "permissions": {
+                "can_create_projects": True,
+            },
         }
 
 
@@ -127,6 +136,9 @@ class TestCreateUser:
             "global_role": "user",
             "email": "test@example.com",
             "active": True,
+            "permissions": {
+                "can_create_projects": True,
+            },
         }
         res = await session.execute(select(UserModel).where(UserModel.name == "test"))
         assert len(res.scalars().all()) == 1
@@ -151,6 +163,9 @@ class TestCreateUser:
             "global_role": "user",
             "email": None,
             "active": True,
+            "permissions": {
+                "can_create_projects": True,
+            },
         }
         # Username uniqueness check should be case insensitive
         for username in ["test", "Test", "TesT"]:


### PR DESCRIPTION
Closes #1559 

This PR introduces default configurable permissions that can be configured via server/config.yml:

```yaml
default_permissions:
  allow_non_admins_create_projects: false
  allow_non_admins_manage_ssh_fleets: false
projects: ...
```

The permissions can be user permissions (e.g. `allow_non_admins_create_projects`) or member permissions (e.g. `allow_non_admins_manage_ssh_fleets`). They are included in the API accordingly when returning users and members.
