### PR TITLE
Fix global admin restricted by manager role

### DIFF
--- a/src/dstack/_internal/server/services/projects.py
+++ b/src/dstack/_internal/server/services/projects.py
@@ -160,7 +160,7 @@ async def set_project_members(
         project_name=project.name,
     )
     project_role = get_user_project_role(user=user, project=project)
-    if project_role == ProjectRole.MANAGER:
+    if user.global_role != GlobalRole.ADMIN and project_role == ProjectRole.MANAGER:
         new_admins_members = {
             (m.username, m.project_role) for m in members if m.project_role == ProjectRole.ADMIN
         }


### PR DESCRIPTION
This PR fixes a bug with a new manager role (#1572) that prevented global admins to change admins if they are set to managers in a project.