### PR TITLE
[CLI] Show run name before detaching

### DIFF
--- a/src/dstack/_internal/cli/services/configurators/run.py
+++ b/src/dstack/_internal/cli/services/configurators/run.py
@@ -175,7 +175,7 @@ class BaseRunConfigurator(ApplyEnvVarsConfiguratorMixin, BaseApplyConfigurator):
                     exit(1)
         except KeyboardInterrupt:
             try:
-                if not confirm_ask("\nStop the run before detaching?"):
+                if not confirm_ask(f"\nStop the run [code]{run.name}[/] before detaching?"):
                     console.print("Detached")
                     abort_at_exit = False
                     return


### PR DESCRIPTION
Previously, if you ran a configuration and then
detached, you had to use `dstack ps` to find out
the run name. Now the run name is kept on screen
after you detach.