### PR TITLE
Add Postgres tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,9 +76,11 @@ jobs:
           name: frontend-build
           path: src/dstack/_internal/server/statics
       - name: Run pytest
+        # Skip Postgres tests on macos since macos runner doesn't have Docker.
+        # Skip Postgres tests for Python 3.8 since testcontainers<4 doesn't support asyncpg correctly.
         run: |
           RUNPOSTGRES=""
-          if [ "${{ matrix.os }}" != "macos-latest" ]; then
+          if [ "${{ matrix.os }}" != "macos-latest" ] && [ "${{ matrix.python-version }}" != "3.8" ]; then
             RUNPOSTGRES="--runpostgres"
           fi
           pytest src/tests --runui $RUNPOSTGRES

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,8 @@ jobs:
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -77,7 +79,7 @@ jobs:
           path: src/dstack/_internal/server/statics
       - name: Run pytest
         run: |
-          pytest src/tests --runui
+          pytest src/tests --runui --runpostgres
 
   update-get-dstack:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,8 +64,6 @@ jobs:
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -79,7 +77,11 @@ jobs:
           path: src/dstack/_internal/server/statics
       - name: Run pytest
         run: |
-          pytest src/tests --runui --runpostgres
+          RUNPOSTGRES=""
+          if [ "${{ matrix.os }}" != "macos-latest" ]; then
+            RUNPOSTGRES="--runpostgres"
+          fi
+          pytest src/tests --runui $RUNPOSTGRES
 
   update-get-dstack:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,29 @@ jobs:
       - run: python -m pip install pre-commit
       - run: pre-commit run -a --show-diff-on-failure
 
+  frontend-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Install packages
+        run: npm install
+      - name: Build dist
+        run: npm run build
+      - name: Upload dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-build
+          path: frontend/build
+
   python-test:
-    needs: [ python-lint ]
+    needs: [ python-lint, frontend-build ]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -40,8 +61,20 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: pip install -U '.[all]' -r requirements_dev.txt
+      - name: Download frontend build
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-build
+          path: src/dstack/_internal/server/statics
       - name: Run pytest
-        run: pytest src/tests
+        # Skip Postgres tests on macos since macos runner doesn't have Docker.
+        # Skip Postgres tests for Python 3.8 since testcontainers<4 doesn't support asyncpg correctly.
+        run: |
+          RUNPOSTGRES=""
+          if [ "${{ matrix.os }}" != "macos-latest" ] && [ "${{ matrix.python-version }}" != "3.8" ]; then
+            RUNPOSTGRES="--runpostgres"
+          fi
+          pytest src/tests --runui $RUNPOSTGRES
 
   runner-test:
     defaults:
@@ -133,30 +166,9 @@ jobs:
           WHEEL=dstack_gateway-${{ env.VERSION }}-py3-none-any.whl
           aws s3 cp dist/$WHEEL "s3://dstack-gateway-downloads/release/$WHEEL"
           echo "${{ env.VERSION }}" | aws s3 cp - "s3://dstack-gateway-downloads/release/latest-version"
-  
-  frontend-build:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-      - name: Install packages
-        run: npm install
-      - name: Build dist
-        run: npm run build
-      - name: Upload dist
-        uses: actions/upload-artifact@v4
-        with:
-          name: frontend-build
-          path: frontend/build
 
   runner-upload:
-    needs: [runner-compile, gateway-build, frontend-build]
+    needs: [runner-compile, gateway-build, python-test]
     runs-on: ubuntu-latest
     steps:
       - name: Install AWS

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,4 +5,4 @@ pytest~=7.2
 pytest-asyncio>=0.21
 freezegun>=1.2.0
 ruff==0.5.3  # Should match .pre-commit-config.yaml
-testcontainers>=4.8.0
+testcontainers # testcontainers<4 may not work with asyncpg

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,4 +5,4 @@ pytest~=7.2
 pytest-asyncio>=0.21
 freezegun>=1.2.0
 ruff==0.5.3  # Should match .pre-commit-config.yaml
-testcontainers
+testcontainers>=4.8.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,3 +5,4 @@ pytest~=7.2
 pytest-asyncio>=0.21
 freezegun>=1.2.0
 ruff==0.5.3  # Should match .pre-commit-config.yaml
+testcontainers

--- a/src/dstack/_internal/server/migrations/env.py
+++ b/src/dstack/_internal/server/migrations/env.py
@@ -59,7 +59,7 @@ def run_migrations(connection: Connection):
     # Temporarily disable foreign keys,
     # so that sqlite batch table migrations are performed without data loss:
     # https://alembic.sqlalchemy.org/en/latest/batch.html#dealing-with-referencing-foreign-keys
-    if db.get_dialect_name() == "sqlite":
+    if connection.dialect.name == "sqlite":
         connection.execute(text("PRAGMA foreign_keys=OFF;"))
     connection.commit()
     context.configure(
@@ -70,7 +70,7 @@ def run_migrations(connection: Connection):
     )
     with context.begin_transaction():
         context.run_migrations()
-    if db.get_dialect_name() == "sqlite":
+    if connection.dialect.name == "sqlite":
         connection.execute(text("PRAGMA foreign_keys=ON;"))
     connection.commit()
 

--- a/src/dstack/_internal/server/migrations/versions/4b4319398164_introduce_runs_processing.py
+++ b/src/dstack/_internal/server/migrations/versions/4b4319398164_introduce_runs_processing.py
@@ -114,7 +114,7 @@ def downgrade() -> None:
         batch_op.drop_column("gateway_id")
         batch_op.drop_column("last_processed_at")
     op.execute("UPDATE runs SET status = 'SUBMITTED'")
-    op.execute("UPDATE jobs SET removed = 1")
+    op.execute("UPDATE jobs SET removed = TRUE")
 
     run_termination_reason_enum = sa.Enum(
         "ALL_JOBS_DONE",

--- a/src/dstack/_internal/server/migrations/versions/5ad8debc8fe6_fixes_for_psql.py
+++ b/src/dstack/_internal/server/migrations/versions/5ad8debc8fe6_fixes_for_psql.py
@@ -290,6 +290,7 @@ def downgrade() -> None:
                 name="jobstatus",
             ),
             existing_nullable=False,
+            postgresql_using="status::VARCHAR::jobstatus",
         )
 
     with op.batch_alter_table("jobs", schema=None) as batch_op:

--- a/src/dstack/_internal/server/models.py
+++ b/src/dstack/_internal/server/models.py
@@ -284,7 +284,9 @@ class RunModel(BaseModel):
     run_name: Mapped[str] = mapped_column(String(100))
     status: Mapped[RunStatus] = mapped_column(Enum(RunStatus))
     run_spec: Mapped[str] = mapped_column(String(4000))
-    jobs: Mapped[List["JobModel"]] = relationship(back_populates="run", lazy="selectin")
+    jobs: Mapped[List["JobModel"]] = relationship(
+        back_populates="run", lazy="selectin", order_by="[JobModel.replica_num, JobModel.job_num]"
+    )
     last_processed_at: Mapped[datetime] = mapped_column(NaiveDateTime)
     gateway_id: Mapped[Optional[uuid.UUID]] = mapped_column(
         ForeignKey("gateways.id", ondelete="SET NULL")

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -386,7 +386,8 @@ class ServerConfigManager:
 
     async def apply_encryption(self):
         if self.config is None:
-            raise ValueError("Config is not loaded")
+            logger.warning("server/config.yml not loaded. Skipping encryption configuration.")
+            return
         if self.config.encryption is not None:
             encryption_services.init_encryption_keys(self.config.encryption.keys)
 

--- a/src/tests/_internal/server/background/tasks/test_process_fleets.py
+++ b/src/tests/_internal/server/background/tasks/test_process_fleets.py
@@ -18,6 +18,7 @@ from dstack._internal.server.testing.common import (
 
 class TestProcessEmptyFleets:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_deletes_empty_autocreated_fleet(self, test_db, session: AsyncSession):
         project = await create_project(session)
         spec = get_fleet_spec()
@@ -32,6 +33,7 @@ class TestProcessEmptyFleets:
         assert fleet.deleted
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_deletes_terminating_user_fleet(self, test_db, session: AsyncSession):
         project = await create_project(session)
         spec = get_fleet_spec()
@@ -46,6 +48,7 @@ class TestProcessEmptyFleets:
         assert fleet.deleted
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_does_not_delete_non_terminating_empty_user_fleets(
         self, test_db, session: AsyncSession
     ):
@@ -62,6 +65,7 @@ class TestProcessEmptyFleets:
         assert not fleet.deleted
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_does_not_delete_fleet_with_active_run(self, test_db, session: AsyncSession):
         project = await create_project(session)
         fleet = await create_fleet(

--- a/src/tests/_internal/server/background/tasks/test_process_gateways.py
+++ b/src/tests/_internal/server/background/tasks/test_process_gateways.py
@@ -16,6 +16,7 @@ from dstack._internal.server.testing.common import (
 
 class TestProcessSubmittedGateways:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_provisions_gateway(self, test_db, session: AsyncSession):
         project = await create_project(session=session)
         backend = await create_backend(session=session, project_id=project.id)
@@ -48,6 +49,7 @@ class TestProcessSubmittedGateways:
         assert gateway.gateway_compute.ip_address == "2.2.2.2"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_marks_gateway_as_failed_if_gateway_creation_errors(
         self, test_db, session: AsyncSession
     ):
@@ -72,6 +74,7 @@ class TestProcessSubmittedGateways:
         assert gateway.status_message == "Some error"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_marks_gateway_as_failed_if_fails_to_connect(
         self, test_db, session: AsyncSession
     ):

--- a/src/tests/_internal/server/background/tasks/test_process_instances.py
+++ b/src/tests/_internal/server/background/tasks/test_process_instances.py
@@ -38,6 +38,7 @@ from dstack._internal.utils.common import get_current_datetime
 
 class TestCheckShim:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_check_shim_transitions_provisioning_on_ready(
         self, test_db, session: AsyncSession
     ):
@@ -66,6 +67,7 @@ class TestCheckShim:
         assert instance.health_status is None
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_check_shim_transitions_provisioning_on_terminating(
         self, test_db, session: AsyncSession
     ):
@@ -96,6 +98,7 @@ class TestCheckShim:
         assert instance.health_status == health_reason
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_check_shim_transitions_provisioning_on_busy(
         self, test_db, session: AsyncSession
     ):
@@ -144,6 +147,7 @@ class TestCheckShim:
         assert instance.job == job
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_check_shim_start_termination_deadline(self, test_db, session: AsyncSession):
         project = await create_project(session=session)
         pool = await create_pool(session, project)
@@ -168,6 +172,7 @@ class TestCheckShim:
         assert instance.health_status == health_status
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_check_shim_stop_termination_deadline(self, test_db, session: AsyncSession):
         project = await create_project(session=session)
         pool = await create_pool(session, project)
@@ -190,6 +195,7 @@ class TestCheckShim:
         assert instance.health_status is None
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_check_shim_terminate_instance_by_dedaline(self, test_db, session: AsyncSession):
         project = await create_project(session=session)
         pool = await create_pool(session, project)
@@ -220,6 +226,7 @@ class TestCheckShim:
 
 class TestTerminateIdleTime:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_terminate_by_idle_timeout(self, test_db, session: AsyncSession):
         project = await create_project(session=session)
         pool = await create_pool(session, project)
@@ -240,6 +247,7 @@ class TestTerminateIdleTime:
 
 class TestTerminate:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_terminate(self, test_db, session: AsyncSession):
         project = await create_project(session=session)
         pool = await create_pool(session, project)
@@ -274,6 +282,7 @@ class TestTerminate:
 
 class TestCreateInstance:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_create_instance(self, test_db, session: AsyncSession):
         project = await create_project(session=session)
         pool = await create_pool(session, project)
@@ -316,6 +325,7 @@ class TestCreateInstance:
         assert instance.status == InstanceStatus.PROVISIONING
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_expire_retry_duration(self, test_db, session: AsyncSession):
         project = await create_project(session=session)
         pool = await create_pool(session, project)
@@ -331,6 +341,7 @@ class TestCreateInstance:
         assert instance.termination_reason == "Retry duration expired"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_retry_delay(self, test_db, session: AsyncSession):
         project = await create_project(session=session)
         pool = await create_pool(session, project)

--- a/src/tests/_internal/server/background/tasks/test_process_running_jobs.py
+++ b/src/tests/_internal/server/background/tasks/test_process_running_jobs.py
@@ -48,6 +48,7 @@ def get_job_provisioning_data(dockerized: bool) -> JobProvisioningData:
 
 class TestProcessRunningJobs:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_leaves_provisioning_job_unchanged_if_runner_not_alive(
         self, test_db, session: AsyncSession
     ):
@@ -90,6 +91,7 @@ class TestProcessRunningJobs:
         assert job.status == JobStatus.PROVISIONING
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_runs_provisioning_job(self, test_db, session: AsyncSession):
         project = await create_project(session=session)
         user = await create_user(session=session)
@@ -130,6 +132,7 @@ class TestProcessRunningJobs:
         assert job.status == JobStatus.RUNNING
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_updates_running_job(self, test_db, session: AsyncSession, tmp_path: Path):
         project = await create_project(session=session)
         user = await create_user(session=session)
@@ -189,6 +192,7 @@ class TestProcessRunningJobs:
         assert job.runner_timestamp == 2
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_provisioning_shim(self, test_db, session: AsyncSession):
         project_ssh_pub_key = "__project_ssh_pub_key__"
         project = await create_project(session=session, ssh_public_key=project_ssh_pub_key)
@@ -244,6 +248,7 @@ class TestProcessRunningJobs:
         assert job.status == JobStatus.PULLING
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_pulling_shim(self, test_db, session: AsyncSession):
         project = await create_project(session=session)
         user = await create_user(session=session)
@@ -287,6 +292,7 @@ class TestProcessRunningJobs:
         assert job.status == JobStatus.RUNNING
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_pulling_shim_failed(self, test_db, session: AsyncSession):
         project = await create_project(session=session)
         user = await create_user(session=session)

--- a/src/tests/_internal/server/background/tasks/test_process_runs.py
+++ b/src/tests/_internal/server/background/tasks/test_process_runs.py
@@ -70,6 +70,7 @@ async def make_run(
 
 class TestProcessRuns:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_submitted_to_provisioning(self, test_db, session: AsyncSession):
         run = await make_run(session, status=RunStatus.SUBMITTED)
         await create_job(session=session, run=run, status=JobStatus.PROVISIONING)
@@ -79,6 +80,7 @@ class TestProcessRuns:
         assert run.status == RunStatus.PROVISIONING
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_provisioning_to_running(self, test_db, session: AsyncSession):
         run = await make_run(session, status=RunStatus.PROVISIONING)
         await create_job(session=session, run=run, status=JobStatus.RUNNING)
@@ -88,6 +90,7 @@ class TestProcessRuns:
         assert run.status == RunStatus.RUNNING
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_keep_provisioning(self, test_db, session: AsyncSession):
         run = await make_run(session, status=RunStatus.PROVISIONING)
         await create_job(session=session, run=run, status=JobStatus.PULLING)
@@ -97,6 +100,7 @@ class TestProcessRuns:
         assert run.status == RunStatus.PROVISIONING
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_running_to_done(self, test_db, session: AsyncSession):
         run = await make_run(session, status=RunStatus.RUNNING)
         await create_job(session=session, run=run, status=JobStatus.DONE)
@@ -107,6 +111,7 @@ class TestProcessRuns:
         assert run.termination_reason == RunTerminationReason.ALL_JOBS_DONE
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_terminate_run_jobs(self, test_db, session: AsyncSession):
         run = await make_run(session, status=RunStatus.TERMINATING)
         run.termination_reason = RunTerminationReason.JOB_FAILED
@@ -127,6 +132,7 @@ class TestProcessRuns:
         assert run.status == RunStatus.TERMINATING
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_retry_running_to_pending(self, test_db, session: AsyncSession):
         run = await make_run(session, status=RunStatus.RUNNING)
         instance = await create_instance(
@@ -149,6 +155,7 @@ class TestProcessRuns:
         assert run.status == RunStatus.PENDING
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_retry_running_to_failed(self, test_db, session: AsyncSession):
         run = await make_run(session, status=RunStatus.RUNNING)
         instance = await create_instance(
@@ -171,6 +178,7 @@ class TestProcessRuns:
         assert run.termination_reason == RunTerminationReason.JOB_FAILED
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_pending_to_submitted(self, test_db, session: AsyncSession):
         run = await make_run(session, status=RunStatus.PENDING)
         await create_job(session=session, run=run, status=JobStatus.FAILED)
@@ -185,6 +193,7 @@ class TestProcessRuns:
 
 class TestProcessRunsReplicas:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_submitted_to_provisioning_if_any(self, test_db, session: AsyncSession):
         run = await make_run(session, status=RunStatus.SUBMITTED, replicas=2)
         await create_job(session=session, run=run, status=JobStatus.SUBMITTED, replica_num=0)
@@ -195,6 +204,7 @@ class TestProcessRunsReplicas:
         assert run.status == RunStatus.PROVISIONING
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_provisioning_to_running_if_any(self, test_db, session: AsyncSession):
         run = await make_run(session, status=RunStatus.PROVISIONING, replicas=2)
         await create_job(session=session, run=run, status=JobStatus.RUNNING, replica_num=0)
@@ -205,6 +215,7 @@ class TestProcessRunsReplicas:
         assert run.status == RunStatus.RUNNING
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_all_no_capacity_to_pending(self, test_db, session: AsyncSession):
         run = await make_run(session, status=RunStatus.RUNNING, replicas=2)
         await create_job(
@@ -240,6 +251,7 @@ class TestProcessRunsReplicas:
         assert run.status == RunStatus.PENDING
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_some_no_capacity_keep_running(self, test_db, session: AsyncSession):
         run = await make_run(session, status=RunStatus.RUNNING, replicas=2)
         await create_job(
@@ -270,10 +282,11 @@ class TestProcessRunsReplicas:
         await session.refresh(run)
         assert run.status == RunStatus.RUNNING
         assert len(run.jobs) == 3
-        assert run.jobs[2].status == JobStatus.SUBMITTED
-        assert run.jobs[2].replica_num == 0
+        assert run.jobs[1].replica_num == 0
+        assert run.jobs[1].status == JobStatus.SUBMITTED
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_some_failed_to_terminating(self, test_db, session: AsyncSession):
         run = await make_run(session, status=RunStatus.RUNNING, replicas=2)
         await create_job(
@@ -291,6 +304,7 @@ class TestProcessRunsReplicas:
         assert run.termination_reason == RunTerminationReason.JOB_FAILED
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_pending_to_submitted_adds_replicas(self, test_db, session: AsyncSession):
         run = await make_run(session, status=RunStatus.PENDING, replicas=2)
         await create_job(

--- a/src/tests/_internal/server/background/tasks/test_process_submitted_jobs.py
+++ b/src/tests/_internal/server/background/tasks/test_process_submitted_jobs.py
@@ -40,6 +40,7 @@ from dstack._internal.server.testing.common import (
 
 class TestProcessSubmittedJobs:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_fails_job_when_no_backends(self, test_db, session: AsyncSession):
         project = await create_project(session=session)
         user = await create_user(session=session)
@@ -64,6 +65,7 @@ class TestProcessSubmittedJobs:
         assert job.termination_reason == JobTerminationReason.FAILED_TO_START_DUE_TO_NO_CAPACITY
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_provisiones_job(self, test_db, session: AsyncSession):
         project = await create_project(session=session)
         user = await create_user(session=session)
@@ -136,6 +138,7 @@ class TestProcessSubmittedJobs:
         assert pool_job_provisioning_data == job.job_provisioning_data
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_fails_job_when_no_capacity(self, test_db, session: AsyncSession):
         project = await create_project(session=session)
         user = await create_user(session=session)
@@ -181,6 +184,7 @@ class TestProcessSubmittedJobs:
         assert not project.default_pool.instances
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_job_with_instance(self, test_db, session: AsyncSession):
         project = await create_project(session)
         user = await create_user(session)
@@ -214,6 +218,7 @@ class TestProcessSubmittedJobs:
         assert job.instance is not None and job.instance.id == instance.id
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_creates_new_instance_in_existing_fleet(self, test_db, session: AsyncSession):
         project = await create_project(session)
         user = await create_user(session)

--- a/src/tests/_internal/server/conftest.py
+++ b/src/tests/_internal/server/conftest.py
@@ -26,6 +26,8 @@ def get_database_url(db_type: str) -> str:
 @pytest_asyncio.fixture
 async def test_db(request):
     db_type = getattr(request, "param", "sqlite")
+    if db_type == "postgres" and not request.config.getoption("--runpostgres"):
+        pytest.skip("Skipping Postgres tests as --runpostgres was not provided")
     db_url = get_database_url(db_type)
     db = Database(db_url)
     override_db(db)

--- a/src/tests/_internal/server/conftest.py
+++ b/src/tests/_internal/server/conftest.py
@@ -1,30 +1,53 @@
+import os
 from pathlib import Path
 
+import httpx
 import pytest
 import pytest_asyncio
 
 from dstack._internal.server.db import Database, override_db
+from dstack._internal.server.main import app
 from dstack._internal.server.models import BaseModel
 from dstack._internal.server.services import encryption as encryption  # import for side-effect
 from dstack._internal.server.services import logs as logs_services
 
-db = Database("sqlite+aiosqlite://")
-override_db(db)
+
+def get_database_url(db_type: str) -> str:
+    if db_type == "sqlite":
+        return "sqlite+aiosqlite://"
+    if db_type == "postgres":
+        db_url = os.getenv("DSTACK_DATABASE_TEST_URL")
+        if db_url is None:
+            raise ValueError("DSTACK_DATABASE_TEST_URL not set")
+        return db_url
+    raise ValueError(f"Unknown db_type {db_type}")
 
 
 @pytest_asyncio.fixture
-async def test_db():
+async def test_db(request):
+    db_type = getattr(request, "param", "sqlite")
+    db_url = get_database_url(db_type)
+    db = Database(db_url)
+    override_db(db)
     async with db.engine.begin() as conn:
-        await conn.run_sync(BaseModel.metadata.create_all)
-        yield conn
         await conn.run_sync(BaseModel.metadata.drop_all)
+        await conn.run_sync(BaseModel.metadata.create_all)
+    yield db
+    async with db.engine.begin() as conn:
+        await conn.run_sync(BaseModel.metadata.drop_all)
+    await db.engine.dispose()
 
 
 @pytest_asyncio.fixture
-async def session():
+async def session(test_db):
+    db = test_db
     async with db.get_session() as session:
         yield session
-        await session.commit()
+
+
+@pytest.fixture
+def client(event_loop):
+    return httpx.AsyncClient(app=app, base_url="http://test")
 
 
 @pytest.fixture

--- a/src/tests/_internal/server/conftest.py
+++ b/src/tests/_internal/server/conftest.py
@@ -49,7 +49,8 @@ async def session(test_db):
 
 @pytest.fixture
 def client(event_loop):
-    return httpx.AsyncClient(app=app, base_url="http://test")
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://test")
 
 
 @pytest.fixture

--- a/src/tests/_internal/server/routers/test_backends.py
+++ b/src/tests/_internal/server/routers/test_backends.py
@@ -67,6 +67,7 @@ class TestListBackendTypes:
 
 class TestGetBackendConfigValuesAWS:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_initial_config(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -90,6 +91,7 @@ class TestGetBackendConfigValuesAWS:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_invalid_credentials(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -132,6 +134,7 @@ class TestGetBackendConfigValuesAWS:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_config_on_valid_creds(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -196,6 +199,7 @@ class TestGetBackendConfigValuesAWS:
 
 class TestGetBackendConfigValuesAzure:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_initial_config(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -221,6 +225,7 @@ class TestGetBackendConfigValuesAzure:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_invalid_credentials(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -270,6 +275,7 @@ class TestGetBackendConfigValuesAzure:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     @pytest.mark.parametrize(
         "body",
         [
@@ -384,6 +390,7 @@ class TestGetBackendConfigValuesAzure:
 
 class TestGetBackendConfigValuesGCP:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_initial_config(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -405,6 +412,7 @@ class TestGetBackendConfigValuesGCP:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_invalid_credentials(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -442,6 +450,7 @@ class TestGetBackendConfigValuesGCP:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_config_on_valid_creds(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -571,6 +580,7 @@ class TestGetBackendConfigValuesGCP:
 
 class TestGetBackendConfigValuesLambda:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_initial_config(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -588,6 +598,7 @@ class TestGetBackendConfigValuesLambda:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_invalid_credentials(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -619,6 +630,7 @@ class TestGetBackendConfigValuesLambda:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_config_on_valid_creds(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -666,6 +678,7 @@ class TestGetBackendConfigValuesLambda:
 
 class TestGetBackendConfigValuesOCI:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_initial_config(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -690,6 +703,7 @@ class TestGetBackendConfigValuesOCI:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_invalid_credentials(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -713,6 +727,7 @@ class TestGetBackendConfigValuesOCI:
         assert error["msg"].startswith("Invalid credentials")
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_config_on_valid_creds(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -755,6 +770,7 @@ class TestGetBackendConfigValuesOCI:
 
 class TestCreateBackend:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_admin(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -771,6 +787,7 @@ class TestCreateBackend:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_creates_aws_backend(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -802,6 +819,7 @@ class TestCreateBackend:
         assert len(res.scalars().all()) == 1
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_creates_gcp_backend(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -839,6 +857,7 @@ class TestCreateBackend:
         assert len(res.scalars().all()) == 1
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_creates_lambda_backend(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -868,6 +887,7 @@ class TestCreateBackend:
         assert len(res.scalars().all()) == 1
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_creates_oci_backend(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -898,6 +918,7 @@ class TestCreateBackend:
         assert len(res.scalars().all()) == 1
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_not_creates_oci_backend_if_regions_not_subscribed(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -929,6 +950,7 @@ class TestCreateBackend:
         assert len(res.scalars().all()) == 0
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_create_azure_backend(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -985,6 +1007,7 @@ class TestCreateBackend:
         assert len(res.scalars().all()) == 1
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_400_if_backend_exists(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -1034,6 +1057,7 @@ class TestCreateBackend:
 
 class TestUpdateBackend:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_admin(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -1050,6 +1074,7 @@ class TestUpdateBackend:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_updates_backend(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -1084,6 +1109,7 @@ class TestUpdateBackend:
         assert json.loads(backend.config)["regions"] == ["us-east-1"]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_400_if_backend_does_not_exist(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -1111,6 +1137,7 @@ class TestUpdateBackend:
 
 class TestDeleteBackends:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_admin(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -1126,6 +1153,7 @@ class TestDeleteBackends:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_deletes_backends(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -1145,6 +1173,7 @@ class TestDeleteBackends:
 
 class TestGetConfigInfo:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_admin(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -1161,6 +1190,7 @@ class TestGetConfigInfo:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_config_info(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -1186,6 +1216,7 @@ class TestGetConfigInfo:
 
 class TestCreateBackendYAML:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_admin(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -1202,6 +1233,7 @@ class TestCreateBackendYAML:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_creates_aws_backend(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -1234,6 +1266,7 @@ class TestCreateBackendYAML:
         assert len(res.scalars().all()) == 1
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_creates_oci_backend(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -1267,6 +1300,7 @@ class TestCreateBackendYAML:
 
 class TestUpdateBackendYAML:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_admin(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -1283,6 +1317,7 @@ class TestUpdateBackendYAML:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_updates_aws_backend(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -1323,6 +1358,7 @@ class TestUpdateBackendYAML:
 
 class TestGetConfigYAML:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_admin(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -1345,6 +1381,7 @@ class TestGetConfigYAML:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_config_yaml(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)

--- a/src/tests/_internal/server/routers/test_fleets.py
+++ b/src/tests/_internal/server/routers/test_fleets.py
@@ -33,6 +33,7 @@ from dstack._internal.server.testing.common import (
 
 class TestListFleets:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_40x_if_not_authenticated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -40,6 +41,7 @@ class TestListFleets:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_lists_fleets(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
@@ -71,6 +73,7 @@ class TestListFleets:
 
 class TestGetFleet:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_40x_if_not_authenticated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -78,6 +81,7 @@ class TestGetFleet:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_fleet(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
@@ -106,6 +110,7 @@ class TestGetFleet:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_400_if_fleet_does_not_exist(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -124,6 +129,7 @@ class TestGetFleet:
 
 class TestCreateFleet:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_40x_if_not_authenticated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -131,6 +137,7 @@ class TestCreateFleet:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     @freeze_time(datetime(2023, 1, 2, 3, 4, tzinfo=timezone.utc))
     async def test_creates_fleet(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session, global_role=GlobalRole.USER)
@@ -221,6 +228,7 @@ class TestCreateFleet:
         assert res.scalar_one()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     @freeze_time(datetime(2023, 1, 2, 3, 4, tzinfo=timezone.utc))
     async def test_creates_ssh_fleet(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session, global_role=GlobalRole.USER)
@@ -339,6 +347,7 @@ class TestCreateFleet:
         assert instance.remote_connection_info is not None
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_forbids_if_no_permission_to_manage_ssh_fleets(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -371,6 +380,7 @@ class TestCreateFleet:
 
 class TestDeleteFleets:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_40x_if_not_authenticated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -378,6 +388,7 @@ class TestDeleteFleets:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_terminates_fleet_instances(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -407,6 +418,7 @@ class TestDeleteFleets:
         assert instance.status == InstanceStatus.TERMINATING
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_400_when_fleets_in_use(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -451,6 +463,7 @@ class TestDeleteFleets:
         assert instance.status == InstanceStatus.BUSY
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_forbids_if_no_permission_to_manage_ssh_fleets(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -484,6 +497,7 @@ class TestDeleteFleets:
 
 class TestDeleteFleetInstances:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_40x_if_not_authenticated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -491,6 +505,7 @@ class TestDeleteFleetInstances:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_terminates_fleet_instances(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -531,6 +546,7 @@ class TestDeleteFleetInstances:
         assert fleet.status != FleetStatus.TERMINATING
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_400_when_deleting_busy_instances(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):

--- a/src/tests/_internal/server/routers/test_fleets.py
+++ b/src/tests/_internal/server/routers/test_fleets.py
@@ -4,15 +4,14 @@ from unittest.mock import patch
 from uuid import UUID
 
 import pytest
-from fastapi.testclient import TestClient
 from freezegun import freeze_time
+from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dstack._internal.core.models.fleets import FleetConfiguration, FleetStatus, SSHParams
 from dstack._internal.core.models.instances import InstanceStatus, SSHKey
 from dstack._internal.core.models.users import GlobalRole, ProjectRole
-from dstack._internal.server.main import app
 from dstack._internal.server.models import FleetModel, InstanceModel
 from dstack._internal.server.services.permissions import DefaultPermissions
 from dstack._internal.server.services.projects import add_project_member
@@ -31,17 +30,17 @@ from dstack._internal.server.testing.common import (
     get_fleet_spec,
 )
 
-client = TestClient(app)
-
 
 class TestListFleets:
     @pytest.mark.asyncio
-    async def test_returns_40x_if_not_authenticated(self, test_db, session: AsyncSession):
-        response = client.post("/api/project/main/fleets/list")
+    async def test_returns_40x_if_not_authenticated(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        response = await client.post("/api/project/main/fleets/list")
         assert response.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_lists_fleets(self, test_db, session: AsyncSession):
+    async def test_lists_fleets(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
         await add_project_member(
@@ -52,7 +51,7 @@ class TestListFleets:
             project=project,
             created_at=datetime(2023, 1, 2, 3, 4, tzinfo=timezone.utc),
         )
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/fleets/list",
             headers=get_auth_headers(user.token),
         )
@@ -72,12 +71,14 @@ class TestListFleets:
 
 class TestGetFleet:
     @pytest.mark.asyncio
-    async def test_returns_40x_if_not_authenticated(self, test_db, session: AsyncSession):
-        response = client.post("/api/project/main/fleets/get")
+    async def test_returns_40x_if_not_authenticated(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        response = await client.post("/api/project/main/fleets/get")
         assert response.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_returns_fleet(self, test_db, session: AsyncSession):
+    async def test_returns_fleet(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
         await add_project_member(
@@ -88,7 +89,7 @@ class TestGetFleet:
             project=project,
             created_at=datetime(2023, 1, 2, 3, 4, tzinfo=timezone.utc),
         )
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/fleets/get",
             headers=get_auth_headers(user.token),
             json={"name": fleet.name},
@@ -105,13 +106,15 @@ class TestGetFleet:
         }
 
     @pytest.mark.asyncio
-    async def test_returns_400_if_fleet_does_not_exist(self, test_db, session: AsyncSession):
+    async def test_returns_400_if_fleet_does_not_exist(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
         await add_project_member(
             session=session, project=project, user=user, project_role=ProjectRole.USER
         )
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/fleets/get",
             headers=get_auth_headers(user.token),
             json={"name": "some_fleet"},
@@ -121,13 +124,15 @@ class TestGetFleet:
 
 class TestCreateFleet:
     @pytest.mark.asyncio
-    async def test_returns_40x_if_not_authenticated(self, test_db, session: AsyncSession):
-        response = client.post("/api/project/main/fleets/create")
+    async def test_returns_40x_if_not_authenticated(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        response = await client.post("/api/project/main/fleets/create")
         assert response.status_code == 403
 
     @pytest.mark.asyncio
     @freeze_time(datetime(2023, 1, 2, 3, 4, tzinfo=timezone.utc))
-    async def test_creates_fleet(self, test_db, session: AsyncSession):
+    async def test_creates_fleet(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
         await add_project_member(
@@ -136,7 +141,7 @@ class TestCreateFleet:
         spec = get_fleet_spec(conf=get_fleet_configuration())
         with patch("uuid.uuid4") as m:
             m.return_value = UUID("1b0e1b45-2f8c-4ab6-8010-a0d1a3e44e0e")
-            response = client.post(
+            response = await client.post(
                 f"/api/project/{project.name}/fleets/create",
                 headers=get_auth_headers(user.token),
                 json={"spec": spec.dict()},
@@ -217,7 +222,7 @@ class TestCreateFleet:
 
     @pytest.mark.asyncio
     @freeze_time(datetime(2023, 1, 2, 3, 4, tzinfo=timezone.utc))
-    async def test_creates_ssh_fleet(self, test_db, session: AsyncSession):
+    async def test_creates_ssh_fleet(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
         await add_project_member(
@@ -236,7 +241,7 @@ class TestCreateFleet:
         )
         with patch("uuid.uuid4") as m:
             m.return_value = UUID("1b0e1b45-2f8c-4ab6-8010-a0d1a3e44e0e")
-            response = client.post(
+            response = await client.post(
                 f"/api/project/{project.name}/fleets/create",
                 headers=get_auth_headers(user.token),
                 json={"spec": spec.dict()},
@@ -335,7 +340,7 @@ class TestCreateFleet:
 
     @pytest.mark.asyncio
     async def test_forbids_if_no_permission_to_manage_ssh_fleets(
-        self, test_db, session: AsyncSession
+        self, test_db, session: AsyncSession, client: AsyncClient
     ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session)
@@ -356,7 +361,7 @@ class TestCreateFleet:
         with default_permissions_context(
             DefaultPermissions(allow_non_admins_manage_ssh_fleets=False)
         ):
-            response = client.post(
+            response = await client.post(
                 f"/api/project/{project.name}/fleets/create",
                 headers=get_auth_headers(user.token),
                 json={"spec": spec.dict()},
@@ -366,12 +371,16 @@ class TestCreateFleet:
 
 class TestDeleteFleets:
     @pytest.mark.asyncio
-    async def test_returns_40x_if_not_authenticated(self, test_db, session: AsyncSession):
-        response = client.post("/api/project/main/fleets/delete")
+    async def test_returns_40x_if_not_authenticated(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        response = await client.post("/api/project/main/fleets/delete")
         assert response.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_terminates_fleet_instances(self, test_db, session: AsyncSession):
+    async def test_terminates_fleet_instances(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
         await add_project_member(
@@ -386,7 +395,7 @@ class TestDeleteFleets:
         )
         fleet.instances.append(instance)
         await session.commit()
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/fleets/delete",
             headers=get_auth_headers(user.token),
             json={"names": [fleet.name]},
@@ -398,7 +407,9 @@ class TestDeleteFleets:
         assert instance.status == InstanceStatus.TERMINATING
 
     @pytest.mark.asyncio
-    async def test_returns_400_when_fleets_in_use(self, test_db, session: AsyncSession):
+    async def test_returns_400_when_fleets_in_use(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
         pool = await create_pool(session=session, project=project)
@@ -429,7 +440,7 @@ class TestDeleteFleets:
         )
         fleet.instances.append(instance)
         await session.commit()
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/fleets/delete",
             headers=get_auth_headers(user.token),
             json={"names": [fleet.name]},
@@ -441,7 +452,7 @@ class TestDeleteFleets:
 
     @pytest.mark.asyncio
     async def test_forbids_if_no_permission_to_manage_ssh_fleets(
-        self, test_db, session: AsyncSession
+        self, test_db, session: AsyncSession, client: AsyncClient
     ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session)
@@ -463,7 +474,7 @@ class TestDeleteFleets:
         with default_permissions_context(
             DefaultPermissions(allow_non_admins_manage_ssh_fleets=False)
         ):
-            response = client.post(
+            response = await client.post(
                 f"/api/project/{project.name}/fleets/delete",
                 headers=get_auth_headers(user.token),
                 json={"names": [fleet.name]},
@@ -473,12 +484,16 @@ class TestDeleteFleets:
 
 class TestDeleteFleetInstances:
     @pytest.mark.asyncio
-    async def test_returns_40x_if_not_authenticated(self, test_db, session: AsyncSession):
-        response = client.post("/api/project/main/fleets/delete_instances")
+    async def test_returns_40x_if_not_authenticated(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        response = await client.post("/api/project/main/fleets/delete_instances")
         assert response.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_terminates_fleet_instances(self, test_db, session: AsyncSession):
+    async def test_terminates_fleet_instances(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
         await add_project_member(
@@ -501,7 +516,7 @@ class TestDeleteFleetInstances:
         fleet.instances.append(instance1)
         fleet.instances.append(instance2)
         await session.commit()
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/fleets/delete_instances",
             headers=get_auth_headers(user.token),
             json={"name": fleet.name, "instance_nums": [1]},
@@ -516,7 +531,9 @@ class TestDeleteFleetInstances:
         assert fleet.status != FleetStatus.TERMINATING
 
     @pytest.mark.asyncio
-    async def test_returns_400_when_deleting_busy_instances(self, test_db, session: AsyncSession):
+    async def test_returns_400_when_deleting_busy_instances(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
         await add_project_member(
@@ -548,7 +565,7 @@ class TestDeleteFleetInstances:
         )
         fleet.instances.append(instance)
         await session.commit()
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/fleets/delete_instances",
             headers=get_auth_headers(user.token),
             json={"name": fleet.name, "instance_nums": [1]},

--- a/src/tests/_internal/server/routers/test_gateways.py
+++ b/src/tests/_internal/server/routers/test_gateways.py
@@ -24,6 +24,7 @@ from dstack._internal.server.testing.common import (
 
 class TestListAndGetGateways:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_40x_if_not_authenticated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -31,6 +32,7 @@ class TestListAndGetGateways:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_list(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
@@ -80,6 +82,7 @@ class TestListAndGetGateways:
         ]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_get(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
@@ -128,6 +131,7 @@ class TestListAndGetGateways:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_get_missing(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
@@ -144,6 +148,7 @@ class TestListAndGetGateways:
 
 class TestCreateGateway:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_only_admin_can_create(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -159,6 +164,7 @@ class TestCreateGateway:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_create_gateway(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
@@ -197,6 +203,7 @@ class TestCreateGateway:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_create_gateway_without_name(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -240,6 +247,7 @@ class TestCreateGateway:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_create_gateway_missing_backend(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -258,6 +266,7 @@ class TestCreateGateway:
 
 class TestDefaultGateway:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_get_default_gateway(self, test_db, session: AsyncSession, client: AsyncClient):
         project = await create_project(session)
         backend = await create_backend(session, project.id)
@@ -271,6 +280,7 @@ class TestDefaultGateway:
         assert res.dict() == gateway_model_to_gateway(gateway).dict()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_default_gateway_is_missing(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -282,6 +292,7 @@ class TestDefaultGateway:
         assert res is None
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_only_admin_can_set_default_gateway(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -300,6 +311,7 @@ class TestDefaultGateway:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_set_default_gateway(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
@@ -355,6 +367,7 @@ class TestDefaultGateway:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_set_default_gateway_missing(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -373,6 +386,7 @@ class TestDefaultGateway:
 
 class TestDeleteGateway:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_only_admin_can_delete(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -388,6 +402,7 @@ class TestDeleteGateway:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_delete_gateway(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
@@ -474,6 +489,7 @@ class TestDeleteGateway:
 
 class TestUpdateGateway:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_only_admin_can_set_wildcard_domain(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -489,6 +505,7 @@ class TestUpdateGateway:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_set_wildcard_domain(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
@@ -537,6 +554,7 @@ class TestUpdateGateway:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_set_wildcard_domain_missing(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):

--- a/src/tests/_internal/server/routers/test_logs.py
+++ b/src/tests/_internal/server/routers/test_logs.py
@@ -10,6 +10,7 @@ from dstack._internal.server.testing.common import create_project, create_user, 
 
 class TestPollLogs:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_project_member(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -22,6 +23,7 @@ class TestPollLogs:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_logs(
         self, test_db, test_log_storage: FileLogStorage, session: AsyncSession, client: AsyncClient
     ):

--- a/src/tests/_internal/server/routers/test_logs.py
+++ b/src/tests/_internal/server/routers/test_logs.py
@@ -1,22 +1,21 @@
 import pytest
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dstack._internal.core.models.users import GlobalRole, ProjectRole
-from dstack._internal.server.main import app
 from dstack._internal.server.services.logs import FileLogStorage
 from dstack._internal.server.services.projects import add_project_member
 from dstack._internal.server.testing.common import create_project, create_user, get_auth_headers
 
-client = TestClient(app)
-
 
 class TestPollLogs:
     @pytest.mark.asyncio
-    async def test_returns_403_if_not_project_member(self, test_db, session: AsyncSession):
+    async def test_returns_403_if_not_project_member(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/logs/poll",
             headers=get_auth_headers(user.token),
         )
@@ -24,7 +23,7 @@ class TestPollLogs:
 
     @pytest.mark.asyncio
     async def test_returns_logs(
-        self, test_db, test_log_storage: FileLogStorage, session: AsyncSession
+        self, test_db, test_log_storage: FileLogStorage, session: AsyncSession, client: AsyncClient
     ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -46,7 +45,7 @@ class TestPollLogs:
             '{"timestamp": "2023-10-06T10:01:53.234235+00:00", "log_source": "stdout", "message": "World"}\n'
             '{"timestamp": "2023-10-06T10:01:53.234236+00:00", "log_source": "stdout", "message": "!"}\n'
         )
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/logs/poll",
             headers=get_auth_headers(user.token),
             json={
@@ -75,7 +74,7 @@ class TestPollLogs:
                 },
             ]
         }
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/logs/poll",
             headers=get_auth_headers(user.token),
             json={

--- a/src/tests/_internal/server/routers/test_pools.py
+++ b/src/tests/_internal/server/routers/test_pools.py
@@ -32,6 +32,7 @@ TEST_POOL_NAME = "test_router_pool_name"
 
 class TestListPools:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_authenticated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -44,6 +45,7 @@ class TestListPools:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     @freeze_time(dt.datetime(2023, 10, 4, 12, 0, tzinfo=dt.timezone.utc))
     async def test_creates_and_lists_default_pool(
         self, test_db, session: AsyncSession, client: AsyncClient
@@ -74,6 +76,7 @@ class TestListPools:
 
 class TestDeletePool:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_authenticated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -86,6 +89,7 @@ class TestDeletePool:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_delete_last_pool(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -116,6 +120,7 @@ class TestDeletePool:
         assert dt.datetime.fromisoformat(default_pool["created_at"]) > pool.created_at
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_deletes_pool(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -136,6 +141,7 @@ class TestDeletePool:
         assert pool.name == pool2.name
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_400_if_pool_missing(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -154,6 +160,7 @@ class TestDeletePool:
 
 class TestSetDefaultPool:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_authenticated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -166,6 +173,7 @@ class TestSetDefaultPool:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_sets_default(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -183,6 +191,7 @@ class TestSetDefaultPool:
         assert project.default_pool_id == pool.id
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_400_if_pool_missing(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -201,6 +210,7 @@ class TestSetDefaultPool:
 
 class TestCreatePool:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_authenticated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -213,6 +223,7 @@ class TestCreatePool:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_create_pool(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -230,6 +241,7 @@ class TestCreatePool:
         res.scalar_one()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_400_on_duplicate_name(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -255,6 +267,7 @@ class TestCreatePool:
 
 class TestShowPool:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_authenticated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -267,6 +280,7 @@ class TestShowPool:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_show_pool(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -318,6 +332,7 @@ class TestShowPool:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_show_missing_pool(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -343,6 +358,7 @@ class TestShowPool:
 
 class TestAddRemote:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_authenticated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -365,6 +381,7 @@ class TestAddRemote:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_add_remote(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -395,6 +412,7 @@ class TestAddRemote:
 
 class TestRemoveInstance:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_authenticated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -417,6 +435,7 @@ class TestRemoveInstance:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_remove_instance(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -481,6 +500,7 @@ class TestRemoveInstance:
 
 class TestListInstances:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_authenticated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -491,6 +511,7 @@ class TestListInstances:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_lists_instances(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -522,6 +543,7 @@ class TestListInstances:
         assert response_json[1]["id"] == str(instance1.id)
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_lists_paginated_instances(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):

--- a/src/tests/_internal/server/routers/test_pools.py
+++ b/src/tests/_internal/server/routers/test_pools.py
@@ -1,15 +1,14 @@
 import datetime as dt
 
 import pytest
-from fastapi.testclient import TestClient
 from freezegun import freeze_time
+from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dstack._internal.core.models.instances import SSHKey
 from dstack._internal.core.models.profiles import DEFAULT_POOL_NAME
 from dstack._internal.core.models.users import GlobalRole, ProjectRole
-from dstack._internal.server.main import app
 from dstack._internal.server.models import PoolModel
 from dstack._internal.server.schemas.pools import (
     CreatePoolRequest,
@@ -28,17 +27,17 @@ from dstack._internal.server.testing.common import (
     get_auth_headers,
 )
 
-client = TestClient(app)
-
 TEST_POOL_NAME = "test_router_pool_name"
 
 
 class TestListPools:
     @pytest.mark.asyncio
-    async def test_returns_403_if_not_authenticated(self, test_db, session: AsyncSession):
+    async def test_returns_403_if_not_authenticated(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/list",
             json={},
         )
@@ -46,13 +45,15 @@ class TestListPools:
 
     @pytest.mark.asyncio
     @freeze_time(dt.datetime(2023, 10, 4, 12, 0, tzinfo=dt.timezone.utc))
-    async def test_creates_and_lists_default_pool(self, test_db, session: AsyncSession):
+    async def test_creates_and_lists_default_pool(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
             session=session, project=project, user=user, project_role=ProjectRole.USER
         )
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/list",
             headers=get_auth_headers(user.token),
             json={},
@@ -73,24 +74,26 @@ class TestListPools:
 
 class TestDeletePool:
     @pytest.mark.asyncio
-    async def test_returns_403_if_not_authenticated(self, test_db, session: AsyncSession):
+    async def test_returns_403_if_not_authenticated(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/delete",
             json=DeletePoolRequest(name=TEST_POOL_NAME, force=False).dict(),
         )
         assert response.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_delete_last_pool(self, test_db, session: AsyncSession):
+    async def test_delete_last_pool(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
             session=session, project=project, user=user, project_role=ProjectRole.ADMIN
         )
         pool = await create_pool(session, project, pool_name=TEST_POOL_NAME)
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/delete",
             headers=get_auth_headers(user.token),
             json=DeletePoolRequest(name=TEST_POOL_NAME, force=False).dict(),
@@ -98,7 +101,7 @@ class TestDeletePool:
         assert response.status_code == 200
         assert response.json() is None
 
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/list",
             headers=get_auth_headers(user.token),
             json={},
@@ -113,7 +116,7 @@ class TestDeletePool:
         assert dt.datetime.fromisoformat(default_pool["created_at"]) > pool.created_at
 
     @pytest.mark.asyncio
-    async def test_deletes_pool(self, test_db, session: AsyncSession):
+    async def test_deletes_pool(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
@@ -121,7 +124,7 @@ class TestDeletePool:
         )
         pool1 = await create_pool(session, project, pool_name=f"{TEST_POOL_NAME}-left")
         pool2 = await create_pool(session, project, pool_name=f"{TEST_POOL_NAME}-right")
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/delete",
             headers=get_auth_headers(user.token),
             json=DeletePoolRequest(name=pool1.name, force=False).dict(),
@@ -133,13 +136,15 @@ class TestDeletePool:
         assert pool.name == pool2.name
 
     @pytest.mark.asyncio
-    async def test_returns_400_if_pool_missing(self, test_db, session: AsyncSession):
+    async def test_returns_400_if_pool_missing(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
             session=session, project=project, user=user, project_role=ProjectRole.ADMIN
         )
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/delete",
             headers=get_auth_headers(user.token),
             json=DeletePoolRequest(name="missing name", force=False).dict(),
@@ -149,24 +154,26 @@ class TestDeletePool:
 
 class TestSetDefaultPool:
     @pytest.mark.asyncio
-    async def test_returns_403_if_not_authenticated(self, test_db, session: AsyncSession):
+    async def test_returns_403_if_not_authenticated(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/set_default",
             json=SetDefaultPoolRequest(pool_name=TEST_POOL_NAME).dict(),
         )
         assert response.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_sets_default(self, test_db, session: AsyncSession):
+    async def test_sets_default(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
             session=session, project=project, user=user, project_role=ProjectRole.ADMIN
         )
         pool = await create_pool(session, project, pool_name=f"{TEST_POOL_NAME}-right")
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/set_default",
             headers=get_auth_headers(user.token),
             json=SetDefaultPoolRequest(pool_name=pool.name).dict(),
@@ -176,13 +183,15 @@ class TestSetDefaultPool:
         assert project.default_pool_id == pool.id
 
     @pytest.mark.asyncio
-    async def test_returns_400_if_pool_missing(self, test_db, session: AsyncSession):
+    async def test_returns_400_if_pool_missing(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
             session=session, project=project, user=user, project_role=ProjectRole.ADMIN
         )
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/set_default",
             headers=get_auth_headers(user.token),
             json=SetDefaultPoolRequest(pool_name="missing pool").dict(),
@@ -192,23 +201,25 @@ class TestSetDefaultPool:
 
 class TestCreatePool:
     @pytest.mark.asyncio
-    async def test_returns_403_if_not_authenticated(self, test_db, session: AsyncSession):
+    async def test_returns_403_if_not_authenticated(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/create",
             json=CreatePoolRequest(name=TEST_POOL_NAME).dict(),
         )
         assert response.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_create_pool(self, test_db, session: AsyncSession):
+    async def test_create_pool(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
             session=session, project=project, user=user, project_role=ProjectRole.ADMIN
         )
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/create",
             headers=get_auth_headers(user.token),
             json=CreatePoolRequest(name=TEST_POOL_NAME).dict(),
@@ -219,20 +230,22 @@ class TestCreatePool:
         res.scalar_one()
 
     @pytest.mark.asyncio
-    async def test_returns_400_on_duplicate_name(self, test_db, session: AsyncSession):
+    async def test_returns_400_on_duplicate_name(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
             session=session, project=project, user=user, project_role=ProjectRole.ADMIN
         )
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/create",
             headers=get_auth_headers(user.token),
             json=CreatePoolRequest(name=TEST_POOL_NAME).dict(),
         )
         assert response.status_code == 200
         assert response.json() is None
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/create",
             headers=get_auth_headers(user.token),
             json=CreatePoolRequest(name=TEST_POOL_NAME).dict(),
@@ -242,17 +255,19 @@ class TestCreatePool:
 
 class TestShowPool:
     @pytest.mark.asyncio
-    async def test_returns_403_if_not_authenticated(self, test_db, session: AsyncSession):
+    async def test_returns_403_if_not_authenticated(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/show",
             json=CreatePoolRequest(name=TEST_POOL_NAME).dict(),
         )
         assert response.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_show_pool(self, test_db, session: AsyncSession):
+    async def test_show_pool(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
@@ -264,7 +279,7 @@ class TestShowPool:
             project=project,
             pool=pool,
         )
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/show",
             headers=get_auth_headers(user.token),
             json=ShowPoolRequest(name=TEST_POOL_NAME).dict(),
@@ -303,7 +318,7 @@ class TestShowPool:
         }
 
     @pytest.mark.asyncio
-    async def test_show_missing_pool(self, test_db, session: AsyncSession):
+    async def test_show_missing_pool(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
@@ -315,7 +330,7 @@ class TestShowPool:
             project=project,
             pool=pool,
         )
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/show",
             headers=get_auth_headers(user.token),
             json=ShowPoolRequest(name="missing_pool").dict(),
@@ -328,7 +343,9 @@ class TestShowPool:
 
 class TestAddRemote:
     @pytest.mark.asyncio
-    async def test_returns_403_if_not_authenticated(self, test_db, session: AsyncSession):
+    async def test_returns_403_if_not_authenticated(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         remote = AddRemoteInstanceRequest(
@@ -341,14 +358,14 @@ class TestAddRemote:
             ssh_user="user",
             ssh_keys=[SSHKey(public="abc")],
         )
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/add_remote",
             json=remote.dict(),
         )
         assert response.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_add_remote(self, test_db, session: AsyncSession):
+    async def test_add_remote(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
@@ -364,7 +381,7 @@ class TestAddRemote:
             ssh_user="user",
             ssh_keys=[SSHKey(public="abc")],
         )
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/add_remote",
             headers=get_auth_headers(user.token),
             json=remote.dict(),
@@ -378,7 +395,9 @@ class TestAddRemote:
 
 class TestRemoveInstance:
     @pytest.mark.asyncio
-    async def test_returns_403_if_not_authenticated(self, test_db, session: AsyncSession):
+    async def test_returns_403_if_not_authenticated(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         remote = AddRemoteInstanceRequest(
@@ -391,14 +410,14 @@ class TestRemoveInstance:
             ssh_user="user",
             ssh_keys=[SSHKey(public="abc")],
         )
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/add_remote",
             json=remote.dict(),
         )
         assert response.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_remove_instance(self, test_db, session: AsyncSession):
+    async def test_remove_instance(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
@@ -410,7 +429,7 @@ class TestRemoveInstance:
             project=project,
             pool=pool,
         )
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/remove",
             headers=get_auth_headers(user.token),
             json=RemoveInstanceRequest(
@@ -421,7 +440,7 @@ class TestRemoveInstance:
         assert response.status_code == 200
         assert response.json() is None
 
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/pool/show",
             headers=get_auth_headers(user.token),
             json=ShowPoolRequest(name=TEST_POOL_NAME).dict(),
@@ -462,15 +481,17 @@ class TestRemoveInstance:
 
 class TestListInstances:
     @pytest.mark.asyncio
-    async def test_returns_403_if_not_authenticated(self, test_db, session: AsyncSession):
-        response = client.post(
+    async def test_returns_403_if_not_authenticated(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        response = await client.post(
             "/api/pools/list_instances",
             json={},
         )
         assert response.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_lists_instances(self, test_db, session: AsyncSession):
+    async def test_lists_instances(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
@@ -489,7 +510,7 @@ class TestListInstances:
             pool=pool,
             created_at=dt.datetime(2023, 10, 5, 12, 0, tzinfo=dt.timezone.utc),
         )
-        response = client.post(
+        response = await client.post(
             "/api/pools/list_instances",
             headers=get_auth_headers(user.token),
             json={},
@@ -501,7 +522,9 @@ class TestListInstances:
         assert response_json[1]["id"] == str(instance1.id)
 
     @pytest.mark.asyncio
-    async def test_lists_paginated_instances(self, test_db, session: AsyncSession):
+    async def test_lists_paginated_instances(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
@@ -526,7 +549,7 @@ class TestListInstances:
             pool=pool,
             created_at=dt.datetime(2023, 10, 6, 12, 0, tzinfo=dt.timezone.utc),
         )
-        response = client.post(
+        response = await client.post(
             "/api/pools/list_instances",
             headers=get_auth_headers(user.token),
             json={"limit": 2},
@@ -536,7 +559,7 @@ class TestListInstances:
         assert len(response_json) == 2
         assert response_json[0]["id"] == str(instance3.id)
         assert response_json[1]["id"] == str(instance1.id)
-        response = client.post(
+        response = await client.post(
             "/api/pools/list_instances",
             headers=get_auth_headers(user.token),
             json={

--- a/src/tests/_internal/server/routers/test_projects.py
+++ b/src/tests/_internal/server/routers/test_projects.py
@@ -21,11 +21,13 @@ from dstack._internal.server.testing.common import (
 
 class TestListProjects:
     @pytest.mark.asyncio
-    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_returns_40x_if_not_authenticated(self, test_db, client: AsyncClient):
         response = await client.post("/api/projects/list")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_empty_list(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session)
         response = await client.post("/api/projects/list", headers=get_auth_headers(user.token))
@@ -33,6 +35,7 @@ class TestListProjects:
         assert response.json() == []
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_projects(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session)
         project = await create_project(session=session, owner=user)
@@ -67,11 +70,13 @@ class TestListProjects:
 
 class TestCreateProject:
     @pytest.mark.asyncio
-    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_returns_40x_if_not_authenticated(self, test_db, client: AsyncClient):
         response = await client.post("/api/projects/create")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_creates_project(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session)
         project_id = UUID("1b0e1b45-2f8c-4ab6-8010-a0d1a3e44e0e")
@@ -120,6 +125,7 @@ class TestCreateProject:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_400_if_project_name_is_taken(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -150,6 +156,7 @@ class TestCreateProject:
         assert len(res.scalars().all()) == 1
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_400_if_user_project_quota_exceeded(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -172,6 +179,7 @@ class TestCreateProject:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_no_project_quota_for_global_admins(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -185,6 +193,7 @@ class TestCreateProject:
             assert response.status_code == 200, response.json()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_forbids_if_no_permission_to_create_projects(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -202,11 +211,13 @@ class TestCreateProject:
 
 class TestDeleteProject:
     @pytest.mark.asyncio
-    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_returns_40x_if_not_authenticated(self, test_db, client: AsyncClient):
         response = await client.post("/api/projects/delete")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_cannot_delete_the_only_project(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -225,6 +236,7 @@ class TestDeleteProject:
         assert not project.deleted
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_deletes_projects(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project1 = await create_project(session=session, owner=user, name="project1")
@@ -247,6 +259,7 @@ class TestDeleteProject:
         assert not project2.deleted
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_project_admin(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -270,6 +283,7 @@ class TestDeleteProject:
         assert len(res.all()) == 2
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_project_member(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -287,11 +301,13 @@ class TestDeleteProject:
 
 class TestGetProject:
     @pytest.mark.asyncio
-    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_returns_40x_if_not_authenticated(self, test_db, client: AsyncClient):
         response = await client.post("/api/projects/test_project/get")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_404_if_project_does_not_exist(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -303,6 +319,7 @@ class TestGetProject:
         assert response.status_code == 404, response.json()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_project(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session)
         project = await create_project(session=session, owner=user)
@@ -351,11 +368,13 @@ class TestGetProject:
 
 class TestSetProjectMembers:
     @pytest.mark.asyncio
-    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_returns_40x_if_not_authenticated(self, test_db, client: AsyncClient):
         response = await client.post("/api/projects/test_project/get")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_sets_project_members(self, test_db, session: AsyncSession, client: AsyncClient):
         project = await create_project(session=session)
         admin = await create_user(session=session)
@@ -443,6 +462,7 @@ class TestSetProjectMembers:
         assert len(members) == 3
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_manager_cannot_set_project_admins(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -474,6 +494,7 @@ class TestSetProjectMembers:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_global_admin_manager_can_set_project_admins(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -508,6 +529,7 @@ class TestSetProjectMembers:
         assert len(members) == 2
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_non_manager_cannot_set_project_members(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):

--- a/src/tests/_internal/server/routers/test_projects.py
+++ b/src/tests/_internal/server/routers/test_projects.py
@@ -2,12 +2,11 @@ from unittest.mock import patch
 from uuid import UUID
 
 import pytest
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dstack._internal.core.models.users import GlobalRole, ProjectRole
-from dstack._internal.server.main import app
 from dstack._internal.server.models import MemberModel, ProjectModel
 from dstack._internal.server.services.permissions import DefaultPermissions
 from dstack._internal.server.services.projects import add_project_member
@@ -19,23 +18,22 @@ from dstack._internal.server.testing.common import (
     get_auth_headers,
 )
 
-client = TestClient(app)
-
 
 class TestListProjects:
-    def test_returns_40x_if_not_authenticated(self):
-        response = client.post("/api/projects/list")
+    @pytest.mark.asyncio
+    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+        response = await client.post("/api/projects/list")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
-    async def test_returns_empty_list(self, test_db, session: AsyncSession):
+    async def test_returns_empty_list(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session)
-        response = client.post("/api/projects/list", headers=get_auth_headers(user.token))
+        response = await client.post("/api/projects/list", headers=get_auth_headers(user.token))
         assert response.status_code in [200]
         assert response.json() == []
 
     @pytest.mark.asyncio
-    async def test_returns_projects(self, test_db, session: AsyncSession):
+    async def test_returns_projects(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session)
         project = await create_project(session=session, owner=user)
         await add_project_member(
@@ -45,7 +43,7 @@ class TestListProjects:
             session=session,
             project_id=project.id,
         )
-        response = client.post("/api/projects/list", headers=get_auth_headers(user.token))
+        response = await client.post("/api/projects/list", headers=get_auth_headers(user.token))
         assert response.status_code in [200]
         assert response.json() == [
             {
@@ -68,19 +66,20 @@ class TestListProjects:
 
 
 class TestCreateProject:
-    def test_returns_40x_if_not_authenticated(self):
-        response = client.post("/api/projects/create")
+    @pytest.mark.asyncio
+    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+        response = await client.post("/api/projects/create")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
-    async def test_creates_project(self, test_db, session: AsyncSession):
+    async def test_creates_project(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session)
         project_id = UUID("1b0e1b45-2f8c-4ab6-8010-a0d1a3e44e0e")
         project_name = "test_project"
         body = {"project_name": project_name}
         with patch("uuid.uuid4") as m:
             m.return_value = project_id
-            response = client.post(
+            response = await client.post(
                 "/api/projects/create",
                 headers=get_auth_headers(user.token),
                 json=body,
@@ -121,11 +120,13 @@ class TestCreateProject:
         }
 
     @pytest.mark.asyncio
-    async def test_returns_400_if_project_name_is_taken(self, test_db, session: AsyncSession):
+    async def test_returns_400_if_project_name_is_taken(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session)
         with patch("uuid.uuid4") as m:
             m.return_value = UUID("1b0e1b45-2f8c-4ab6-8010-a0d1a3e44e0e")
-            response = client.post(
+            response = await client.post(
                 "/api/projects/create",
                 headers=get_auth_headers(user.token),
                 json={"project_name": "TestProject"},
@@ -135,7 +136,7 @@ class TestCreateProject:
         for project_name in ["testproject", "TestProject", "TESTPROJECT"]:
             with patch("uuid.uuid4") as m:
                 m.return_value = UUID("2b0e1b45-2f8c-4ab6-8010-a0d1a3e44e0e")
-                response = client.post(
+                response = await client.post(
                     "/api/projects/create",
                     headers=get_auth_headers(user.token),
                     json={"project_name": project_name},
@@ -150,17 +151,17 @@ class TestCreateProject:
 
     @pytest.mark.asyncio
     async def test_returns_400_if_user_project_quota_exceeded(
-        self, test_db, session: AsyncSession
+        self, test_db, session: AsyncSession, client: AsyncClient
     ):
         user = await create_user(session=session, name="owner", global_role=GlobalRole.USER)
         for i in range(10):
-            response = client.post(
+            response = await client.post(
                 "/api/projects/create",
                 headers=get_auth_headers(user.token),
                 json={"project_name": f"project{i}"},
             )
             assert response.status_code == 200, response.json()
-        response = client.post(
+        response = await client.post(
             "/api/projects/create",
             headers=get_auth_headers(user.token),
             json={"project_name": "project11"},
@@ -171,10 +172,12 @@ class TestCreateProject:
         }
 
     @pytest.mark.asyncio
-    async def test_no_project_quota_for_global_admins(self, test_db, session: AsyncSession):
+    async def test_no_project_quota_for_global_admins(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, name="owner", global_role=GlobalRole.ADMIN)
         for i in range(12):
-            response = client.post(
+            response = await client.post(
                 "/api/projects/create",
                 headers=get_auth_headers(user.token),
                 json={"project_name": f"project{i}"},
@@ -183,13 +186,13 @@ class TestCreateProject:
 
     @pytest.mark.asyncio
     async def test_forbids_if_no_permission_to_create_projects(
-        self, test_db, session: AsyncSession
+        self, test_db, session: AsyncSession, client: AsyncClient
     ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         with default_permissions_context(
             DefaultPermissions(allow_non_admins_create_projects=False)
         ):
-            response = client.post(
+            response = await client.post(
                 "/api/projects/create",
                 headers=get_auth_headers(user.token),
                 json={"project_name": "new_project"},
@@ -198,18 +201,21 @@ class TestCreateProject:
 
 
 class TestDeleteProject:
-    def test_returns_40x_if_not_authenticated(self):
-        response = client.post("/api/projects/delete")
+    @pytest.mark.asyncio
+    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+        response = await client.post("/api/projects/delete")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
-    async def test_cannot_delete_the_only_project(self, test_db, session: AsyncSession):
+    async def test_cannot_delete_the_only_project(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
             session=session, project=project, user=user, project_role=ProjectRole.ADMIN
         )
-        response = client.post(
+        response = await client.post(
             "/api/projects/delete",
             headers=get_auth_headers(user.token),
             json={"projects_names": [project.name]},
@@ -219,7 +225,7 @@ class TestDeleteProject:
         assert not project.deleted
 
     @pytest.mark.asyncio
-    async def test_deletes_projects(self, test_db, session: AsyncSession):
+    async def test_deletes_projects(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project1 = await create_project(session=session, owner=user, name="project1")
         await add_project_member(
@@ -229,7 +235,7 @@ class TestDeleteProject:
         await add_project_member(
             session=session, project=project2, user=user, project_role=ProjectRole.ADMIN
         )
-        response = client.post(
+        response = await client.post(
             "/api/projects/delete",
             headers=get_auth_headers(user.token),
             json={"projects_names": [project1.name]},
@@ -241,7 +247,9 @@ class TestDeleteProject:
         assert not project2.deleted
 
     @pytest.mark.asyncio
-    async def test_returns_403_if_not_project_admin(self, test_db, session: AsyncSession):
+    async def test_returns_403_if_not_project_admin(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         owner = await create_user(session=session, name="owner", global_role=GlobalRole.USER)
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project1 = await create_project(session=session, name="project1", owner=owner)
@@ -252,7 +260,7 @@ class TestDeleteProject:
         await add_project_member(
             session=session, project=project2, user=user, project_role=ProjectRole.USER
         )
-        response = client.post(
+        response = await client.post(
             "/api/projects/delete",
             headers=get_auth_headers(user.token),
             json={"projects_names": [project1.name, project2.name]},
@@ -262,10 +270,12 @@ class TestDeleteProject:
         assert len(res.all()) == 2
 
     @pytest.mark.asyncio
-    async def test_returns_403_if_not_project_member(self, test_db, session: AsyncSession):
+    async def test_returns_403_if_not_project_member(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, name="project")
-        response = client.post(
+        response = await client.post(
             "/api/projects/delete",
             headers=get_auth_headers(user.token),
             json={"projects_names": [project.name]},
@@ -276,27 +286,30 @@ class TestDeleteProject:
 
 
 class TestGetProject:
-    def test_returns_40x_if_not_authenticated(self):
-        response = client.post("/api/projects/test_project/get")
+    @pytest.mark.asyncio
+    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+        response = await client.post("/api/projects/test_project/get")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
-    async def test_returns_404_if_project_does_not_exist(self, test_db, session: AsyncSession):
+    async def test_returns_404_if_project_does_not_exist(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session)
-        response = client.post(
+        response = await client.post(
             "/api/projects/test_project/get",
             headers=get_auth_headers(user.token),
         )
         assert response.status_code == 404, response.json()
 
     @pytest.mark.asyncio
-    async def test_returns_project(self, test_db, session: AsyncSession):
+    async def test_returns_project(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session)
         project = await create_project(session=session, owner=user)
         await add_project_member(
             session=session, project=project, user=user, project_role=ProjectRole.ADMIN
         )
-        response = client.post(
+        response = await client.post(
             "/api/projects/test_project/get",
             headers=get_auth_headers(user.token),
         )
@@ -337,12 +350,13 @@ class TestGetProject:
 
 
 class TestSetProjectMembers:
-    def test_returns_40x_if_not_authenticated(self):
-        response = client.post("/api/projects/test_project/get")
+    @pytest.mark.asyncio
+    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+        response = await client.post("/api/projects/test_project/get")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
-    async def test_sets_project_members(self, test_db, session: AsyncSession):
+    async def test_sets_project_members(self, test_db, session: AsyncSession, client: AsyncClient):
         project = await create_project(session=session)
         admin = await create_user(session=session)
         await add_project_member(
@@ -368,7 +382,7 @@ class TestSetProjectMembers:
             },
         ]
         body = {"members": members}
-        response = client.post(
+        response = await client.post(
             f"/api/projects/{project.name}/set_members",
             headers=get_auth_headers(admin.token),
             json=body,
@@ -429,7 +443,9 @@ class TestSetProjectMembers:
         assert len(members) == 3
 
     @pytest.mark.asyncio
-    async def test_manager_cannot_set_project_admins(self, test_db, session: AsyncSession):
+    async def test_manager_cannot_set_project_admins(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         project = await create_project(session=session)
         user = await create_user(session=session, global_role=GlobalRole.USER)
         await add_project_member(
@@ -450,7 +466,7 @@ class TestSetProjectMembers:
             },
         ]
         body = {"members": members}
-        response = client.post(
+        response = await client.post(
             f"/api/projects/{project.name}/set_members",
             headers=get_auth_headers(user.token),
             json=body,
@@ -459,7 +475,7 @@ class TestSetProjectMembers:
 
     @pytest.mark.asyncio
     async def test_global_admin_manager_can_set_project_admins(
-        self, test_db, session: AsyncSession
+        self, test_db, session: AsyncSession, client: AsyncClient
     ):
         project = await create_project(session=session)
         user = await create_user(session=session, global_role=GlobalRole.ADMIN)
@@ -481,7 +497,7 @@ class TestSetProjectMembers:
             },
         ]
         body = {"members": members}
-        response = client.post(
+        response = await client.post(
             f"/api/projects/{project.name}/set_members",
             headers=get_auth_headers(user.token),
             json=body,
@@ -492,7 +508,9 @@ class TestSetProjectMembers:
         assert len(members) == 2
 
     @pytest.mark.asyncio
-    async def test_non_manager_cannot_set_project_members(self, test_db, session: AsyncSession):
+    async def test_non_manager_cannot_set_project_members(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         project = await create_project(session=session)
         user = await create_user(session=session, global_role=GlobalRole.USER)
         await add_project_member(
@@ -513,7 +531,7 @@ class TestSetProjectMembers:
             },
         ]
         body = {"members": members}
-        response = client.post(
+        response = await client.post(
             f"/api/projects/{project.name}/set_members",
             headers=get_auth_headers(user.token),
             json=body,

--- a/src/tests/_internal/server/routers/test_repos.py
+++ b/src/tests/_internal/server/routers/test_repos.py
@@ -18,6 +18,7 @@ from dstack._internal.server.testing.common import (
 
 class TestListRepos:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_project_member(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -30,6 +31,7 @@ class TestListRepos:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_empty_list(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -44,6 +46,7 @@ class TestListRepos:
         assert response.json() == []
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_repos(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -66,6 +69,7 @@ class TestListRepos:
 
 class TestGetRepo:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_project_member(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -78,6 +82,7 @@ class TestGetRepo:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_400_if_repo_does_not_exist(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -94,6 +99,7 @@ class TestGetRepo:
         assert response.status_code == 400
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_repo(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -114,6 +120,7 @@ class TestGetRepo:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_repo_with_creds(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -138,6 +145,7 @@ class TestGetRepo:
 
 class TestInitRepo:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_project_member(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -150,6 +158,7 @@ class TestInitRepo:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_creates_remote_repo(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -185,6 +194,7 @@ class TestInitRepo:
         assert json.loads(repo.creds) == body["repo_creds"]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_updates_remote_repo(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -241,6 +251,7 @@ class TestInitRepo:
 
 class TestDeleteRepos:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_project_member(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -253,6 +264,7 @@ class TestDeleteRepos:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_deletes_repos(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -273,6 +285,7 @@ class TestDeleteRepos:
 
 class TestUploadCode:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_project_member(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -286,6 +299,7 @@ class TestUploadCode:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_uploads_code(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -307,6 +321,7 @@ class TestUploadCode:
         assert code.blob == file[1]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_uploads_same_code_for_different_repos(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -340,6 +340,7 @@ def get_dev_env_run_dict(
 
 class TestListRuns:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_40x_if_not_authenticated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -347,6 +348,7 @@ class TestListRuns:
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_lists_runs(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -447,6 +449,7 @@ class TestListRuns:
         ]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_lists_runs_pagination(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -509,6 +512,7 @@ class TestListRuns:
 
 class TestGetRunPlan:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_project_member(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -521,6 +525,7 @@ class TestGetRunPlan:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_run_plan(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -565,6 +570,7 @@ class TestGetRunPlan:
 
 class TestSubmitRun:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_project_member(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -577,6 +583,7 @@ class TestSubmitRun:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_submits_run(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -623,6 +630,7 @@ class TestSubmitRun:
         assert job is not None
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_submits_run_without_run_name(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -659,6 +667,7 @@ class TestSubmitRun:
         assert job is not None
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     @pytest.mark.parametrize(
         "run_name",
         [
@@ -696,6 +705,7 @@ class TestSubmitRun:
         assert response.status_code == 400
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_400_if_repo_does_not_exist(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -720,6 +730,7 @@ class TestSubmitRun:
 
 class TestStopRuns:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_project_member(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -732,6 +743,7 @@ class TestStopRuns:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_terminates_submitted_run(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -768,6 +780,7 @@ class TestStopRuns:
         assert job.termination_reason == JobTerminationReason.TERMINATED_BY_USER
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_terminates_running_run(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -809,6 +822,7 @@ class TestStopRuns:
         assert job.termination_reason == JobTerminationReason.TERMINATED_BY_USER
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_leaves_finished_runs_unchanged(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -845,6 +859,7 @@ class TestStopRuns:
 
 class TestDeleteRuns:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_project_member(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -857,6 +872,7 @@ class TestDeleteRuns:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_deletes_runs(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -893,6 +909,7 @@ class TestDeleteRuns:
         assert job.status == JobStatus.FAILED
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_400_if_runs_active(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -929,6 +946,7 @@ class TestDeleteRuns:
 
 class TestCreateInstance:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_not_project_member(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -941,6 +959,7 @@ class TestCreateInstance:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_creates_instance(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -1010,6 +1029,7 @@ class TestCreateInstance:
             assert result == expected
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_error_if_backends_do_not_support_create_instance(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -1049,6 +1069,7 @@ class TestCreateInstance:
             await process_instances()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_backend_does_not_support_create_instance(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 import pytest
 from fastapi.testclient import TestClient
+from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -339,12 +340,14 @@ def get_dev_env_run_dict(
 
 class TestListRuns:
     @pytest.mark.asyncio
-    async def test_returns_40x_if_not_authenticated(self, test_db, session: AsyncSession):
-        response = client.post("/api/runs/list")
+    async def test_returns_40x_if_not_authenticated(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        response = await client.post("/api/runs/list")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
-    async def test_lists_runs(self, test_db, session: AsyncSession):
+    async def test_lists_runs(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
@@ -379,7 +382,7 @@ class TestListRuns:
             submitted_at=run2_submitted_at,
         )
         run2_spec = RunSpec.parse_raw(run2.run_spec)
-        response = client.post(
+        response = await client.post(
             "/api/runs/list",
             headers=get_auth_headers(user.token),
             json={},
@@ -444,7 +447,9 @@ class TestListRuns:
         ]
 
     @pytest.mark.asyncio
-    async def test_lists_runs_pagination(self, test_db, session: AsyncSession):
+    async def test_lists_runs_pagination(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
@@ -477,7 +482,7 @@ class TestListRuns:
             user=user,
             submitted_at=datetime(2023, 1, 2, 5, 15, tzinfo=timezone.utc),
         )
-        response1 = client.post(
+        response1 = await client.post(
             "/api/runs/list",
             headers=get_auth_headers(user.token),
             json={"limit": 2},
@@ -487,7 +492,7 @@ class TestListRuns:
         assert len(response1_json) == 2
         assert response1_json[0]["id"] == str(run3.id)
         assert response1_json[1]["id"] == str(run1.id)
-        response2 = client.post(
+        response2 = await client.post(
             "/api/runs/list",
             headers=get_auth_headers(user.token),
             json={
@@ -504,17 +509,19 @@ class TestListRuns:
 
 class TestGetRunPlan:
     @pytest.mark.asyncio
-    async def test_returns_403_if_not_project_member(self, test_db, session: AsyncSession):
+    async def test_returns_403_if_not_project_member(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/runs/get_plan",
             headers=get_auth_headers(user.token),
         )
         assert response.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_returns_run_plan(self, test_db, session: AsyncSession):
+    async def test_returns_run_plan(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
@@ -547,7 +554,7 @@ class TestGetRunPlan:
             m.return_value = [backend_mock]
             backend_mock.TYPE = BackendType.AWS
             backend_mock.compute.return_value.get_offers.return_value = offers
-            response = client.post(
+            response = await client.post(
                 f"/api/project/{project.name}/runs/get_plan",
                 headers=get_auth_headers(user.token),
                 json=body,
@@ -558,17 +565,19 @@ class TestGetRunPlan:
 
 class TestSubmitRun:
     @pytest.mark.asyncio
-    async def test_returns_403_if_not_project_member(self, test_db, session: AsyncSession):
+    async def test_returns_403_if_not_project_member(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/runs/submit",
             headers=get_auth_headers(user.token),
         )
         assert response.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_submits_run(self, test_db, session: AsyncSession):
+    async def test_submits_run(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
@@ -599,7 +608,7 @@ class TestSubmitRun:
             get_project_backends_mock.return_value = [Mock()]
             uuid_mock.return_value = run_id
             datetime_mock.return_value = submitted_at
-            response = client.post(
+            response = await client.post(
                 f"/api/project/{project.name}/runs/submit",
                 headers=get_auth_headers(user.token),
                 json=body,
@@ -614,7 +623,9 @@ class TestSubmitRun:
         assert job is not None
 
     @pytest.mark.asyncio
-    async def test_submits_run_without_run_name(self, test_db, session: AsyncSession):
+    async def test_submits_run_without_run_name(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
@@ -633,7 +644,7 @@ class TestSubmitRun:
         ) as get_project_backends_mock:
             get_project_backends_mock.return_value = [Mock()]
             uuid_mock.return_value = run_dict["id"]
-            response = client.post(
+            response = await client.post(
                 f"/api/project/{project.name}/runs/submit",
                 headers=get_auth_headers(user.token),
                 json=body,
@@ -657,7 +668,7 @@ class TestSubmitRun:
         ],
     )
     async def test_returns_400_if_bad_run_name(
-        self, test_db, session: AsyncSession, run_name: str
+        self, test_db, session: AsyncSession, client: AsyncClient, run_name: str
     ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -677,7 +688,7 @@ class TestSubmitRun:
         ) as get_project_backends_mock:
             get_project_backends_mock.return_value = [Mock()]
             uuid_mock.return_value = run_dict["id"]
-            response = client.post(
+            response = await client.post(
                 f"/api/project/{project.name}/runs/submit",
                 headers=get_auth_headers(user.token),
                 json=body,
@@ -685,7 +696,9 @@ class TestSubmitRun:
         assert response.status_code == 400
 
     @pytest.mark.asyncio
-    async def test_returns_400_if_repo_does_not_exist(self, test_db, session: AsyncSession):
+    async def test_returns_400_if_repo_does_not_exist(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
@@ -697,7 +710,7 @@ class TestSubmitRun:
             repo_id="repo1234",
         )
         body = {"run_spec": run_dict["run_spec"]}
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/runs/submit",
             headers=get_auth_headers(user.token),
             json=body,
@@ -707,17 +720,21 @@ class TestSubmitRun:
 
 class TestStopRuns:
     @pytest.mark.asyncio
-    async def test_returns_403_if_not_project_member(self, test_db, session: AsyncSession):
+    async def test_returns_403_if_not_project_member(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/runs/stop",
             headers=get_auth_headers(user.token),
         )
         assert response.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_terminates_submitted_run(self, test_db, session: AsyncSession):
+    async def test_terminates_submitted_run(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
@@ -737,7 +754,7 @@ class TestStopRuns:
             session=session,
             run=run,
         )
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/runs/stop",
             headers=get_auth_headers(user.token),
             json={"runs_names": [run.run_name], "abort": False},
@@ -751,7 +768,9 @@ class TestStopRuns:
         assert job.termination_reason == JobTerminationReason.TERMINATED_BY_USER
 
     @pytest.mark.asyncio
-    async def test_terminates_running_run(self, test_db, session: AsyncSession):
+    async def test_terminates_running_run(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session)
         await add_project_member(
@@ -775,7 +794,7 @@ class TestStopRuns:
             status=JobStatus.RUNNING,
         )
         with patch("dstack._internal.server.services.jobs._stop_runner") as stop_runner:
-            response = client.post(
+            response = await client.post(
                 f"/api/project/{project.name}/runs/stop",
                 headers=get_auth_headers(user.token),
                 json={"runs_names": [run.run_name], "abort": False},
@@ -790,7 +809,9 @@ class TestStopRuns:
         assert job.termination_reason == JobTerminationReason.TERMINATED_BY_USER
 
     @pytest.mark.asyncio
-    async def test_leaves_finished_runs_unchanged(self, test_db, session: AsyncSession):
+    async def test_leaves_finished_runs_unchanged(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
@@ -812,7 +833,7 @@ class TestStopRuns:
             run=run,
             status=JobStatus.FAILED,
         )
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/runs/stop",
             headers=get_auth_headers(user.token),
             json={"runs_names": [run.run_name], "abort": False},
@@ -824,17 +845,19 @@ class TestStopRuns:
 
 class TestDeleteRuns:
     @pytest.mark.asyncio
-    async def test_returns_403_if_not_project_member(self, test_db, session: AsyncSession):
+    async def test_returns_403_if_not_project_member(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/runs/delete",
             headers=get_auth_headers(user.token),
         )
         assert response.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_deletes_runs(self, test_db, session: AsyncSession):
+    async def test_deletes_runs(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
@@ -858,7 +881,7 @@ class TestDeleteRuns:
         )
         session.add(run)
         await session.commit()
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/runs/delete",
             headers=get_auth_headers(user.token),
             json={"runs_names": [run.run_name]},
@@ -870,7 +893,9 @@ class TestDeleteRuns:
         assert job.status == JobStatus.FAILED
 
     @pytest.mark.asyncio
-    async def test_returns_400_if_runs_active(self, test_db, session: AsyncSession):
+    async def test_returns_400_if_runs_active(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
@@ -890,7 +915,7 @@ class TestDeleteRuns:
             session=session,
             run=run,
         )
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/runs/delete",
             headers=get_auth_headers(user.token),
             json={"runs_names": [run.run_name]},
@@ -904,17 +929,19 @@ class TestDeleteRuns:
 
 class TestCreateInstance:
     @pytest.mark.asyncio
-    async def test_returns_403_if_not_project_member(self, test_db, session: AsyncSession):
+    async def test_returns_403_if_not_project_member(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
-        response = client.post(
+        response = await client.post(
             f"/api/project/{project.name}/runs/create_instance",
             headers=get_auth_headers(user.token),
         )
         assert response.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_creates_instance(self, test_db, session: AsyncSession):
+    async def test_creates_instance(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
@@ -957,7 +984,7 @@ class TestCreateInstance:
             )
             backend.TYPE = BackendType.AWS
             run_plan_by_req.return_value = [(backend, offer)]
-            response = client.post(
+            response = await client.post(
                 f"/api/project/{project.name}/runs/create_instance",
                 headers=get_auth_headers(user.token),
                 json=request.dict(),
@@ -984,7 +1011,7 @@ class TestCreateInstance:
 
     @pytest.mark.asyncio
     async def test_error_if_backends_do_not_support_create_instance(
-        self, test_db, session: AsyncSession
+        self, test_db, session: AsyncSession, client: AsyncClient
     ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
@@ -1013,7 +1040,7 @@ class TestCreateInstance:
             backend.compute.return_value.get_offers.return_value = [offer]
             backend.compute.return_value.create_instance.side_effect = NotImplementedError()
             run_plan_by_req.return_value = [(backend, offer)]
-            response = client.post(
+            response = await client.post(
                 f"/api/project/{project.name}/runs/create_instance",
                 headers=get_auth_headers(user.token),
                 json=request.dict(),
@@ -1022,7 +1049,9 @@ class TestCreateInstance:
             await process_instances()
 
     @pytest.mark.asyncio
-    async def test_backend_does_not_support_create_instance(self, test_db, session: AsyncSession):
+    async def test_backend_does_not_support_create_instance(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         await add_project_member(
@@ -1053,7 +1082,7 @@ class TestCreateInstance:
             backend.compute.return_value.create_instance.side_effect = NotImplementedError()
             run_plan_by_req.return_value = [(backend, offers)]
 
-            response = client.post(
+            response = await client.post(
                 f"/api/project/{project.name}/runs/create_instance",
                 headers=get_auth_headers(user.token),
                 json=request.dict(),

--- a/src/tests/_internal/server/routers/test_users.py
+++ b/src/tests/_internal/server/routers/test_users.py
@@ -13,11 +13,13 @@ from dstack._internal.server.testing.common import create_user, get_auth_headers
 
 class TestListUsers:
     @pytest.mark.asyncio
-    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_returns_40x_if_not_authenticated(self, test_db, client: AsyncClient):
         response = await client.post("/api/users/list")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_users(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session)
         response = await client.post("/api/users/list", headers=get_auth_headers(user.token))
@@ -38,11 +40,13 @@ class TestListUsers:
 
 class TestGetMyUser:
     @pytest.mark.asyncio
-    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_returns_40x_if_not_authenticated(self, test_db, client: AsyncClient):
         response = await client.post("/api/users/get_my_user")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_40x_if_deactivated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -59,6 +63,7 @@ class TestGetMyUser:
         assert response.status_code == 200
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_logged_in_user(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -81,11 +86,13 @@ class TestGetMyUser:
 
 class TestGetUser:
     @pytest.mark.asyncio
-    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_returns_40x_if_not_authenticated(self, test_db, client: AsyncClient):
         response = await client.post("/api/users/get_user")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_400_if_not_global_admin(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -99,6 +106,7 @@ class TestGetUser:
         assert response.status_code == 400
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_logged_in_user(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -125,11 +133,13 @@ class TestGetUser:
 
 class TestCreateUser:
     @pytest.mark.asyncio
-    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_returns_40x_if_not_authenticated(self, test_db, client: AsyncClient):
         response = await client.post("/api/users/create")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_creates_user(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(name="admin", session=session)
         with patch("uuid.uuid4") as uuid_mock:
@@ -159,6 +169,7 @@ class TestCreateUser:
         assert len(res.scalars().all()) == 1
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_return_400_if_username_taken(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -205,11 +216,13 @@ class TestCreateUser:
 
 class TestDeleteUsers:
     @pytest.mark.asyncio
-    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_returns_40x_if_not_authenticated(self, test_db, client: AsyncClient):
         response = await client.post("/api/users/delete")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_deletes_users(self, test_db, session: AsyncSession, client: AsyncClient):
         admin = await create_user(name="admin", session=session)
         user = await create_user(name="test", session=session)
@@ -225,11 +238,13 @@ class TestDeleteUsers:
 
 class TestRefreshToken:
     @pytest.mark.asyncio
-    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_returns_40x_if_not_authenticated(self, test_db, client: AsyncClient):
         response = await client.post("/api/users/refresh_token")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_refreshes_token(self, test_db, session: AsyncSession, client: AsyncClient):
         user1 = await create_user(name="user1", session=session)
         old_token = user1.token
@@ -244,6 +259,7 @@ class TestRefreshToken:
         assert user1.token != old_token
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_403_if_non_admin_refreshes_for_other_user(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -257,6 +273,7 @@ class TestRefreshToken:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_global_admin_refreshes_token(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):

--- a/src/tests/_internal/server/routers/test_users.py
+++ b/src/tests/_internal/server/routers/test_users.py
@@ -2,27 +2,25 @@ from unittest.mock import patch
 from uuid import UUID
 
 import pytest
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dstack._internal.core.models.users import GlobalRole
-from dstack._internal.server.main import app
 from dstack._internal.server.models import UserModel
 from dstack._internal.server.testing.common import create_user, get_auth_headers
 
-client = TestClient(app)
-
 
 class TestListUsers:
-    def test_returns_40x_if_not_authenticated(self):
-        response = client.post("/api/users/list")
+    @pytest.mark.asyncio
+    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+        response = await client.post("/api/users/list")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
-    async def test_returns_users(self, test_db, session):
+    async def test_returns_users(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session)
-        response = client.post("/api/users/list", headers=get_auth_headers(user.token))
+        response = await client.post("/api/users/list", headers=get_auth_headers(user.token))
         assert response.status_code in [200]
         assert response.json() == [
             {
@@ -39,24 +37,35 @@ class TestListUsers:
 
 
 class TestGetMyUser:
-    def test_returns_40x_if_not_authenticated(self):
-        response = client.post("/api/users/get_my_user")
+    @pytest.mark.asyncio
+    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+        response = await client.post("/api/users/get_my_user")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
-    async def test_returns_40x_if_deactivated(self, test_db, session: AsyncSession):
+    async def test_returns_40x_if_deactivated(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, active=False)
-        response = client.post("/api/users/get_my_user", headers=get_auth_headers(user.token))
+        response = await client.post(
+            "/api/users/get_my_user", headers=get_auth_headers(user.token)
+        )
         assert response.status_code in [401, 403]
         user.active = True
         await session.commit()
-        response = client.post("/api/users/get_my_user", headers=get_auth_headers(user.token))
+        response = await client.post(
+            "/api/users/get_my_user", headers=get_auth_headers(user.token)
+        )
         assert response.status_code == 200
 
     @pytest.mark.asyncio
-    async def test_returns_logged_in_user(self, test_db, session: AsyncSession):
+    async def test_returns_logged_in_user(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session)
-        response = client.post("/api/users/get_my_user", headers=get_auth_headers(user.token))
+        response = await client.post(
+            "/api/users/get_my_user", headers=get_auth_headers(user.token)
+        )
         assert response.status_code == 200
         assert response.json() == {
             "id": str(user.id),
@@ -71,15 +80,18 @@ class TestGetMyUser:
 
 
 class TestGetUser:
-    def test_returns_40x_if_not_authenticated(self):
-        response = client.post("/api/users/get_user")
+    @pytest.mark.asyncio
+    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+        response = await client.post("/api/users/get_user")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
-    async def test_returns_400_if_not_global_admin(self, test_db, session: AsyncSession):
+    async def test_returns_400_if_not_global_admin(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
         other_user = await create_user(session=session, name="other_user", token="1234")
-        response = client.post(
+        response = await client.post(
             "/api/users/get_user",
             headers=get_auth_headers(user.token),
             json={"username": other_user.name},
@@ -87,10 +99,12 @@ class TestGetUser:
         assert response.status_code == 400
 
     @pytest.mark.asyncio
-    async def test_returns_logged_in_user(self, test_db, session: AsyncSession):
+    async def test_returns_logged_in_user(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(session=session, global_role=GlobalRole.ADMIN)
         other_user = await create_user(session=session, name="other_user", token="1234")
-        response = client.post(
+        response = await client.post(
             "/api/users/get_user",
             headers=get_auth_headers(user.token),
             json={"username": other_user.name},
@@ -110,16 +124,17 @@ class TestGetUser:
 
 
 class TestCreateUser:
-    def test_returns_40x_if_not_authenticated(self):
-        response = client.post("/api/users/create")
+    @pytest.mark.asyncio
+    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+        response = await client.post("/api/users/create")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
-    async def test_creates_user(self, test_db, session: AsyncSession):
+    async def test_creates_user(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(name="admin", session=session)
         with patch("uuid.uuid4") as uuid_mock:
             uuid_mock.return_value = UUID("1b0e1b45-2f8c-4ab6-8010-a0d1a3e44e0e")
-            response = client.post(
+            response = await client.post(
                 "/api/users/create",
                 headers=get_auth_headers(user.token),
                 json={
@@ -144,11 +159,13 @@ class TestCreateUser:
         assert len(res.scalars().all()) == 1
 
     @pytest.mark.asyncio
-    async def test_return_400_if_username_taken(self, test_db, session: AsyncSession):
+    async def test_return_400_if_username_taken(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user = await create_user(name="admin", session=session)
         with patch("uuid.uuid4") as uuid_mock:
             uuid_mock.return_value = UUID("1b0e1b45-2f8c-4ab6-8010-a0d1a3e44e0e")
-            response = client.post(
+            response = await client.post(
                 "/api/users/create",
                 headers=get_auth_headers(user.token),
                 json={
@@ -171,7 +188,7 @@ class TestCreateUser:
         for username in ["test", "Test", "TesT"]:
             with patch("uuid.uuid4") as uuid_mock:
                 uuid_mock.return_value = UUID("1b0e1b45-2f8c-4ab6-8010-a0d1a3e44e0e")
-                response = client.post(
+                response = await client.post(
                     "/api/users/create",
                     headers=get_auth_headers(user.token),
                     json={
@@ -187,15 +204,16 @@ class TestCreateUser:
 
 
 class TestDeleteUsers:
-    def test_returns_40x_if_not_authenticated(self):
-        response = client.post("/api/users/delete")
+    @pytest.mark.asyncio
+    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+        response = await client.post("/api/users/delete")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
-    async def test_deletes_users(self, test_db, session: AsyncSession):
+    async def test_deletes_users(self, test_db, session: AsyncSession, client: AsyncClient):
         admin = await create_user(name="admin", session=session)
         user = await create_user(name="test", session=session)
-        response = client.post(
+        response = await client.post(
             "/api/users/delete",
             headers=get_auth_headers(admin.token),
             json={"users": [user.name]},
@@ -206,15 +224,16 @@ class TestDeleteUsers:
 
 
 class TestRefreshToken:
-    def test_returns_40x_if_not_authenticated(self):
-        response = client.post("/api/users/refresh_token")
+    @pytest.mark.asyncio
+    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+        response = await client.post("/api/users/refresh_token")
         assert response.status_code in [401, 403]
 
     @pytest.mark.asyncio
-    async def test_refreshes_token(self, test_db, session: AsyncSession):
+    async def test_refreshes_token(self, test_db, session: AsyncSession, client: AsyncClient):
         user1 = await create_user(name="user1", session=session)
         old_token = user1.token
-        response = client.post(
+        response = await client.post(
             "/api/users/refresh_token",
             headers=get_auth_headers(user1.token),
             json={"username": user1.name},
@@ -226,11 +245,11 @@ class TestRefreshToken:
 
     @pytest.mark.asyncio
     async def test_returns_403_if_non_admin_refreshes_for_other_user(
-        self, test_db, session: AsyncSession
+        self, test_db, session: AsyncSession, client: AsyncClient
     ):
         user1 = await create_user(name="user1", session=session, global_role=GlobalRole.USER)
         user2 = await create_user(name="user2", session=session)
-        response = client.post(
+        response = await client.post(
             "/api/users/refresh_token",
             headers=get_auth_headers(user1.token),
             json={"username": user2.name},
@@ -238,11 +257,13 @@ class TestRefreshToken:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_global_admin_refreshes_token(self, test_db, session: AsyncSession):
+    async def test_global_admin_refreshes_token(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
         user1 = await create_user(name="user1", session=session, global_role=GlobalRole.ADMIN)
         user2 = await create_user(name="user2", session=session)
         old_token = user2.token
-        response = client.post(
+        response = await client.post(
             "/api/users/refresh_token",
             headers=get_auth_headers(user1.token),
             json={"username": user2.name},

--- a/src/tests/_internal/server/routers/test_volumes.py
+++ b/src/tests/_internal/server/routers/test_volumes.py
@@ -27,6 +27,7 @@ from dstack._internal.server.testing.common import (
 
 class TestListVolumes:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_40x_if_not_authenticated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -34,6 +35,7 @@ class TestListVolumes:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_lists_volumes_across_projects(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -115,6 +117,7 @@ class TestListVolumes:
         ]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_non_admin_cannot_see_others_projects(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -166,6 +169,7 @@ class TestListVolumes:
 
 class TestListProjectVolumes:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_40x_if_not_authenticated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -173,6 +177,7 @@ class TestListProjectVolumes:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_lists_volumes(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
@@ -209,6 +214,7 @@ class TestListProjectVolumes:
 
 class TestGetVolume:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_40x_if_not_authenticated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -216,6 +222,7 @@ class TestGetVolume:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_volume(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
@@ -249,6 +256,7 @@ class TestGetVolume:
         }
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_400_if_volume_does_not_exist(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -267,6 +275,7 @@ class TestGetVolume:
 
 class TestCreateVolume:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_40x_if_not_authenticated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -274,6 +283,7 @@ class TestCreateVolume:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     @freeze_time(datetime(2023, 1, 2, 3, 4, tzinfo=timezone.utc))
     async def test_creates_volume(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session, global_role=GlobalRole.USER)
@@ -310,6 +320,7 @@ class TestCreateVolume:
 
 class TestDeleteVolumes:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_40x_if_not_authenticated(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
@@ -317,6 +328,7 @@ class TestDeleteVolumes:
         assert response.status_code == 403
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_deletes_volumes(self, test_db, session: AsyncSession, client: AsyncClient):
         user = await create_user(session, global_role=GlobalRole.USER)
         project = await create_project(session)
@@ -344,6 +356,7 @@ class TestDeleteVolumes:
         assert volume.deleted
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_400_when_volumes_in_use(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):

--- a/src/tests/_internal/server/services/test_config.py
+++ b/src/tests/_internal/server/services/test_config.py
@@ -20,6 +20,7 @@ from dstack._internal.server.testing.common import (
 class TestServerConfigManager:
     class TestInitConfig:
         @pytest.mark.asyncio
+        @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
         async def test_inits_backend(self, test_db, session: AsyncSession, tmp_path: Path):
             await create_project(session=session, name="main")
             config_filepath = tmp_path / "config.yml"
@@ -54,6 +55,7 @@ class TestServerConfigManager:
 
     class TestApplyConfig:
         @pytest.mark.asyncio
+        @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
         async def test_creates_backend(self, test_db, session: AsyncSession, tmp_path: Path):
             owner = await create_user(session=session, name="test_owner")
             await create_project(session=session, owner=owner, name="main")

--- a/src/tests/_internal/server/services/test_logs.py
+++ b/src/tests/_internal/server/services/test_logs.py
@@ -22,6 +22,7 @@ from dstack._internal.server.testing.common import create_project
 
 class TestFileLogStorage:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_writes_logs(self, test_db, session: AsyncSession, tmp_path: Path):
         project = await create_project(session=session)
         log_storage = FileLogStorage(tmp_path)

--- a/src/tests/_internal/server/services/test_pools.py
+++ b/src/tests/_internal/server/services/test_pools.py
@@ -14,6 +14,7 @@ from dstack._internal.utils.common import get_current_datetime
 
 class TestGenerateInstanceName:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_generates_instance_name(self, test_db, session: AsyncSession):
         user = await create_user(session=session)
         project = await create_project(session=session, owner=user)
@@ -43,6 +44,7 @@ class TestGenerateInstanceName:
 
 class TestInstanceModelToInstance:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_converts_instance(self, test_db, session: AsyncSession):
         project = await create_project(
             session=session,

--- a/src/tests/_internal/server/services/test_runs.py
+++ b/src/tests/_internal/server/services/test_runs.py
@@ -81,6 +81,7 @@ async def scale_wrapper(session: AsyncSession, run: RunModel, diff: int):
 
 class TestScaleRunReplicas:
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_no_scale(self, test_db, session: AsyncSession):
         run = await make_run(
             session,
@@ -93,6 +94,7 @@ class TestScaleRunReplicas:
         assert len(run.jobs) == 1
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_downscale_to_zero(self, test_db, session: AsyncSession):
         run = await make_run(
             session,
@@ -107,6 +109,7 @@ class TestScaleRunReplicas:
         assert run.jobs[0].termination_reason == JobTerminationReason.SCALED_DOWN
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_upscale_new(self, test_db, session: AsyncSession):
         run = await make_run(
             session,
@@ -121,6 +124,7 @@ class TestScaleRunReplicas:
         assert run.jobs[1].replica_num == 1
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_upscale_terminated(self, test_db, session: AsyncSession):
         run = await make_run(
             session,
@@ -138,6 +142,7 @@ class TestScaleRunReplicas:
         assert run.jobs[2].replica_num == 1
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_downscale_less_important(self, test_db, session: AsyncSession):
         run = await make_run(
             session,
@@ -154,6 +159,7 @@ class TestScaleRunReplicas:
         assert run.jobs[1].status == JobStatus.RUNNING
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_downscale_greater_replica_num(self, test_db, session: AsyncSession):
         run = await make_run(
             session,
@@ -170,6 +176,7 @@ class TestScaleRunReplicas:
         assert run.jobs[1].termination_reason == JobTerminationReason.SCALED_DOWN
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_no_downscale_below_limit(self, test_db, session: AsyncSession):
         run = await make_run(
             session,
@@ -182,6 +189,7 @@ class TestScaleRunReplicas:
             await scale_wrapper(session, run, -1)
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_no_upscale_above_limit(self, test_db, session: AsyncSession):
         run = await make_run(
             session,
@@ -194,6 +202,7 @@ class TestScaleRunReplicas:
             await scale_wrapper(session, run, 1)
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_upscale_mixed(self, test_db, session: AsyncSession):
         run = await make_run(
             session,

--- a/src/tests/_internal/server/test_app.py
+++ b/src/tests/_internal/server/test_app.py
@@ -11,6 +11,7 @@ client = TestClient(app)
 class TestIndex:
     @pytest.mark.ui
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_returns_html(self, test_db, session: AsyncSession, client: AsyncClient):
         response = await client.get("/")
         assert response.status_code == 200

--- a/src/tests/_internal/server/test_app.py
+++ b/src/tests/_internal/server/test_app.py
@@ -1,5 +1,6 @@
 import pytest
 from fastapi.testclient import TestClient
+from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dstack._internal.server.main import app
@@ -10,7 +11,7 @@ client = TestClient(app)
 class TestIndex:
     @pytest.mark.ui
     @pytest.mark.asyncio
-    async def test_returns_html(self, test_db, session: AsyncSession):
-        response = client.get("/")
+    async def test_returns_html(self, test_db, session: AsyncSession, client: AsyncClient):
+        response = await client.get("/")
         assert response.status_code == 200
         assert response.content.startswith(b'<!doctype html><html lang="en"><')

--- a/src/tests/_internal/server/test_migrations.py
+++ b/src/tests/_internal/server/test_migrations.py
@@ -1,13 +1,15 @@
 from pathlib import Path
 
 import pytest
-from alembic.command import check, upgrade
+from alembic.command import check, downgrade, upgrade
 from alembic.config import Config
 from alembic.util.exc import CommandError
 from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import create_async_engine
+from testcontainers.postgres import PostgresContainer
 
 
-def test_no_database_migration_needs_to_be_added(monkeypatch: pytest.MonkeyPatch):
+def test_sqlite_migrations(monkeypatch: pytest.MonkeyPatch):
     server_dir = Path(__file__).parent.joinpath("../../../dstack/_internal/server").resolve()
     monkeypatch.chdir(server_dir)
 
@@ -17,5 +19,30 @@ def test_no_database_migration_needs_to_be_added(monkeypatch: pytest.MonkeyPatch
     try:
         upgrade(alembic_cfg, "head")
         check(alembic_cfg)
+        downgrade(alembic_cfg, "base")
     except CommandError as e:
         pytest.fail(str(e))
+
+
+@pytest.mark.postgres
+@pytest.mark.asyncio
+async def test_postgres_migrations(monkeypatch: pytest.MonkeyPatch):
+    def f(connection, alembic_cfg):
+        alembic_cfg.attributes["connection"] = connection
+        try:
+            upgrade(alembic_cfg, "head")
+            check(alembic_cfg)
+            downgrade(alembic_cfg, "base")
+        except CommandError as e:
+            pytest.fail(str(e))
+
+    server_dir = Path(__file__).parent.joinpath("../../../dstack/_internal/server").resolve()
+    monkeypatch.chdir(server_dir)
+    alembic_cfg = Config("alembic.ini")
+    with PostgresContainer("postgres:16-alpine", driver="asyncpg") as postgres:
+        db_url = postgres.get_connection_url()
+        # This is needed to run offline(sync) migrations via async driver
+        # https://alembic.sqlalchemy.org/en/latest/cookbook.html#programmatic-api-use-connection-sharing-with-asyncio
+        engine = create_async_engine(db_url)
+        async with engine.connect() as conn:
+            await conn.run_sync(f, alembic_cfg)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -7,12 +7,15 @@ def pytest_configure(config):
 
 def pytest_addoption(parser):
     parser.addoption("--runui", action="store_true", default=False, help="Run UI tests")
+    parser.addoption(
+        "--runpostgres", action="store_true", default=False, help="Run tests with PostgreSQL"
+    )
 
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--runui"):
         return
-    skip_slow = pytest.mark.skip(reason="need --runui option to run")
+    skip_ui = pytest.mark.skip(reason="need --runui option to run")
     for item in items:
         if "ui" in item.keywords:
-            item.add_marker(skip_slow)
+            item.add_marker(skip_ui)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -3,6 +3,9 @@ import pytest
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "ui: mark test as testing UI to run only with --runui")
+    config.addinivalue_line(
+        "markers", "postgres: mark test as testing Postgres to run only with --runpostgres"
+    )
 
 
 def pytest_addoption(parser):
@@ -13,9 +16,10 @@ def pytest_addoption(parser):
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--runui"):
-        return
     skip_ui = pytest.mark.skip(reason="need --runui option to run")
+    skip_postgres = pytest.mark.skip(reason="need --runpostgres option to run")
     for item in items:
-        if "ui" in item.keywords:
+        if not config.getoption("--runui") and "ui" in item.keywords:
             item.add_marker(skip_ui)
+        if not config.getoption("--runpostgres") and "postgres" in item.keywords:
+            item.add_marker(skip_postgres)


### PR DESCRIPTION
This PR:

* Configures pytest to optionally run db tests against Postgres in addition to SQLite.
* Fixes tests to work correctly with Postgres (switches to AsyncClient).
* Enables Postgres tests in CI: Build and Release.