### PR TITLE
Increase time waiting for OCI Bare Metal instances

### DIFF
--- a/src/dstack/_internal/server/background/tasks/process_running_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_running_jobs.py
@@ -578,6 +578,7 @@ def _submit_job_to_runner(
 
 
 def _get_runner_timeout_interval(backend_type: BackendType, instance_type_name: str) -> timedelta:
+    # when changing timeouts, also consider process_instances._get_instance_timeout_interval
     if backend_type == BackendType.LAMBDA:
         return timedelta(seconds=1200)
     if backend_type == BackendType.KUBERNETES:


### PR DESCRIPTION
Some bare metal instances such as BM.GPU4.8 did not have enough time to start, so `dstack` terminated them as failed prematurely.