### PR TITLE
Change default spot_policy to on-demand

### DIFF
--- a/src/dstack/_internal/core/models/fleets.py
+++ b/src/dstack/_internal/core/models/fleets.py
@@ -183,7 +183,7 @@ class FleetSpec(CoreModel):
             if conf_val is not None:
                 setattr(merged_profile, key, conf_val)
         if merged_profile.spot_policy is None:
-            merged_profile.spot_policy = SpotPolicy.AUTO
+            merged_profile.spot_policy = SpotPolicy.ONDEMAND
         if merged_profile.retry is None:
             merged_profile.retry = False
         if merged_profile.termination_policy is None:

--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -366,9 +366,8 @@ class PoolInstanceOffers(CoreModel):
 
 
 def get_policy_map(spot_policy: Optional[SpotPolicy], default: SpotPolicy) -> Optional[bool]:
-    """Map profile.spot_policy[SpotPolicy|None] to requirements.spot[bool|None]
-    - SpotPolicy.AUTO by default for `dstack run`
-    - SpotPolicy.ONDEMAND by default for `dstack pool add`
+    """
+    Map profile.spot_policy[SpotPolicy|None] to requirements.spot[bool|None]
     """
     if spot_policy is None:
         spot_policy = default

--- a/src/dstack/_internal/server/services/fleets.py
+++ b/src/dstack/_internal/server/services/fleets.py
@@ -180,7 +180,7 @@ async def create_fleet_instance_model(
     requirements = Requirements(
         resources=spec.configuration.resources or ResourcesSpec(),
         max_price=profile.max_price,
-        spot=get_policy_map(profile.spot_policy, default=SpotPolicy.AUTO),
+        spot=get_policy_map(profile.spot_policy, default=SpotPolicy.ONDEMAND),
     )
     instance_model = await pools_services.create_instance_model(
         session=session,

--- a/src/dstack/_internal/server/services/jobs/configurators/service.py
+++ b/src/dstack/_internal/server/services/jobs/configurators/service.py
@@ -15,7 +15,7 @@ class ServiceJobConfigurator(JobConfigurator):
         return None
 
     def _spot_policy(self) -> SpotPolicy:
-        return self.run_spec.merged_profile.spot_policy or SpotPolicy.AUTO
+        return self.run_spec.merged_profile.spot_policy or SpotPolicy.ONDEMAND
 
     def _ports(self) -> List[PortMapping]:
         return []

--- a/src/dstack/_internal/server/services/jobs/configurators/task.py
+++ b/src/dstack/_internal/server/services/jobs/configurators/task.py
@@ -29,7 +29,7 @@ class TaskJobConfigurator(JobConfigurator):
         return DEFAULT_MAX_DURATION_SECONDS
 
     def _spot_policy(self) -> SpotPolicy:
-        return self.run_spec.merged_profile.spot_policy or SpotPolicy.AUTO
+        return self.run_spec.merged_profile.spot_policy or SpotPolicy.ONDEMAND
 
     def _ports(self) -> List[PortMapping]:
         return self.run_spec.configuration.ports


### PR DESCRIPTION
Closes #1650 

This PR changes default spot policy to `on-demand` for tasks and services to avoid confusing users who do not expect instances being interrupted. Now spots are disabled by default and require spot policy to be specified explicitly.