### PR TITLE
Return server_version in /api/server/get_info

### DIFF
--- a/src/dstack/_internal/core/models/server.py
+++ b/src/dstack/_internal/core/models/server.py
@@ -1,0 +1,7 @@
+from typing import Optional
+
+from dstack._internal.core.models.common import CoreModel
+
+
+class ServerInfo(CoreModel):
+    server_version: Optional[str]

--- a/src/dstack/_internal/server/app.py
+++ b/src/dstack/_internal/server/app.py
@@ -26,6 +26,7 @@ from dstack._internal.server.routers import (
     repos,
     runs,
     secrets,
+    server,
     users,
     volumes,
 )
@@ -149,6 +150,7 @@ def add_no_api_version_check_routes(paths: List[str]):
 
 
 def register_routes(app: FastAPI, ui: bool = True):
+    app.include_router(server.router)
     app.include_router(users.router)
     app.include_router(projects.router)
     app.include_router(backends.root_router)

--- a/src/dstack/_internal/server/routers/server.py
+++ b/src/dstack/_internal/server/routers/server.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+
+from dstack._internal import settings
+from dstack._internal.core.models.server import ServerInfo
+
+router = APIRouter(prefix="/api/server", tags=["server"])
+
+
+@router.post("/get_info")
+async def get_server_info() -> ServerInfo:
+    return ServerInfo(
+        server_version=settings.DSTACK_VERSION,
+    )

--- a/src/tests/_internal/server/routers/test_server.py
+++ b/src/tests/_internal/server/routers/test_server.py
@@ -1,0 +1,15 @@
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+
+from dstack._internal import settings
+
+
+class TestGetInfo:
+    @pytest.mark.asyncio
+    async def test_returns_40x_if_not_authenticated(self, test_db, client: AsyncClient):
+        with patch.object(settings, "DSTACK_VERSION", "0.18.10"):
+            response = await client.post("/api/server/get_info")
+        assert response.status_code == 200
+        assert response.json() == {"server_version": "0.18.10"}


### PR DESCRIPTION
Needed for #1620.

This PR adds a new server endpoint /api/server/get_info that returns server version.

Note that server version can be null (in case of dev setup).

