### PR TITLE
Allow gateway to connect to replicated server

### DIFF
--- a/gateway/src/dstack/gateway/core/auth.py
+++ b/gateway/src/dstack/gateway/core/auth.py
@@ -6,22 +6,18 @@ from aiocache import cached
 from fastapi import Depends, HTTPException, Security, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
-from dstack.gateway.common import AsyncClientWrapper
+from dstack.gateway.core.multi_client import dstack_server_client
 
-DSTACK_SERVER_TUNNEL_PORT = 8001
 logger = logging.getLogger(__name__)
 
 
 class AuthProvider:
-    def __init__(self):
-        self.client = AsyncClientWrapper(base_url=f"http://localhost:{DSTACK_SERVER_TUNNEL_PORT}")
-
     @cached(ttl=60, noself=True, skip_cache_func=lambda r: r is None)
     async def has_access(self, project: str, token: str) -> bool | None:
         """True - yes, False - no, None - failed checking"""
 
         try:
-            resp = await self.client.post(
+            resp = await dstack_server_client.post(
                 f"/api/projects/{project}/get",
                 headers={"Authorization": f"Bearer {token}"},
             )

--- a/gateway/src/dstack/gateway/core/multi_client.py
+++ b/gateway/src/dstack/gateway/core/multi_client.py
@@ -1,0 +1,95 @@
+import datetime
+import logging
+import random
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Container, Dict, Generator, List
+
+import httpx
+
+from dstack.gateway.common import AsyncClientWrapper
+
+logger = logging.getLogger(__name__)
+BASE_URL = "http://dstack/"  # any hostname will work
+
+
+@dataclass
+class CachedClientInfo:
+    client: AsyncClientWrapper
+    socket: Path
+    connect_errors: List[datetime.datetime] = field(default_factory=lambda: [])
+
+    def seems_disconnected(self) -> bool:
+        if len(self.connect_errors) < 2:
+            return False
+        return self.connect_errors[-1] - self.connect_errors[0] >= datetime.timedelta(minutes=2)
+
+
+class HTTPMultiClient(AsyncClientWrapper):
+    """
+    An HTTP client that sends requests to randomly chosen Unix sockets from a specified
+    directory. This allows to balance the load between multiple HTTP server replicas.
+    """
+
+    def __init__(self, sockets_dir: Path):
+        super().__init__(base_url=BASE_URL)
+        self._sockets_dir = sockets_dir.expanduser()
+        self._clients_cache: Dict[str, CachedClientInfo] = {}
+
+    async def send(self, request: httpx.Request, *args, **kwargs) -> httpx.Response:
+        errors: List[httpx.RequestError] = []
+        clients_count = 0
+
+        for clients_count, client in enumerate(self._iter_clients_rand(), start=1):
+            try:
+                resp = await client.client.send(request, *args, **kwargs)
+                client.connect_errors = []
+                return resp
+            except httpx.ConnectError:
+                client.connect_errors.append(datetime.datetime.now())
+                if client.seems_disconnected():
+                    logging.debug("Removing socket %s after several failed connection attempts")
+                    client.socket.unlink()
+            except httpx.RequestError as e:
+                errors.append(e)
+                logger.warning("Request failed with socket %s: %r", client.socket, e)
+
+        msg = f"Cannot request {request.url.path}: "
+        if not clients_count:
+            msg += f"no sockets found in {self._sockets_dir}"
+        elif not errors:
+            msg += f"all {clients_count} socket(s) in {self._sockets_dir} are disconnected"
+        else:
+            msg += f"{len(errors)} socket(s) failed. Last error: {errors[-1]!r}"
+        raise httpx.RequestError(msg, request=request)
+
+    def _iter_clients_rand(self) -> Generator[CachedClientInfo, None, None]:
+        sockets = list(self._sockets_dir.glob("*.sock"))
+        self._evict_clients(stems_to_keep={s.stem for s in sockets})
+        random.shuffle(sockets)
+
+        for socket in sockets:
+            if socket.stem in self._clients_cache:
+                cached_client = self._clients_cache[socket.stem]
+            else:
+                cached_client = self._clients_cache[socket.stem] = self._make_client(socket)
+            yield cached_client
+
+    @staticmethod
+    def _make_client(socket: Path) -> CachedClientInfo:
+        client = AsyncClientWrapper(
+            transport=httpx.AsyncHTTPTransport(uds=str(socket.absolute())),
+            base_url=BASE_URL,
+        )
+        return CachedClientInfo(
+            client=client,
+            socket=socket,
+        )
+
+    def _evict_clients(self, stems_to_keep: Container[str]) -> None:
+        self._clients_cache = {
+            stem: client for stem, client in self._clients_cache.items() if stem in stems_to_keep
+        }
+
+
+dstack_server_client = HTTPMultiClient(Path("/home/ubuntu/dstack/server-connections/"))

--- a/src/dstack/_internal/core/models/gateways.py
+++ b/src/dstack/_internal/core/models/gateways.py
@@ -91,7 +91,7 @@ class GatewayComputeConfiguration(CoreModel):
 
 class GatewayProvisioningData(CoreModel):
     instance_id: str
-    ip_address: str
+    ip_address: str  # TODO: rename, Kubernetes uses domain names
     region: str
     availability_zone: Optional[str] = None
     hostname: Optional[str] = None

--- a/src/dstack/_internal/server/services/gateways/connection.py
+++ b/src/dstack/_internal/server/services/gateways/connection.py
@@ -1,8 +1,9 @@
 import contextlib
-import os
+import shutil
 import uuid
+from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import AsyncIterator, Dict, Optional
+from typing import AsyncIterator, Dict, Optional, Tuple
 
 import aiorwlock
 
@@ -18,13 +19,13 @@ from dstack._internal.server.services.gateways.client import (
     GatewayClient,
     Stat,
 )
+from dstack._internal.server.settings import SERVER_DIR_PATH
 from dstack._internal.utils.logging import get_logger
 from dstack._internal.utils.path import FileContent
 
 logger = get_logger(__name__)
-
-
-SERVER_PORT_ON_GATEWAY = 8001
+CONNECTIONS_DIR = SERVER_DIR_PATH / "gateway-connections"
+CONNECTIONS_DIR_ON_GATEWAY = "/home/ubuntu/dstack/server-connections"
 
 
 class GatewayConnection:
@@ -40,11 +41,18 @@ class GatewayConnection:
         self._lock = aiorwlock.RWLock()
         self.stats: Dict[str, Dict[int, Stat]] = {}
         self.ip_address = ip_address
-        self.temp_dir = TemporaryDirectory()
-        self.gateway_socket_path = os.path.join(self.temp_dir.name, "gateway")
+        self.server_port = server_port
+        # a persistent connection_dir is needed to discover and close leftover connections
+        # in case of server restarts w/o graceful shutdown
+        self.connection_dir = CONNECTIONS_DIR / ip_address
+        # connection_dir can have a long path that won't be accepted by the ssh command,
+        # so we create a short temporary symlink
+        self.temp_dir, self.connection_symlink_dir = self._init_symlink_dir(self.connection_dir)
+        self.gateway_socket_path = self.connection_symlink_dir / "gateway.sock"
         self.tunnel = SSHTunnel(
             destination=f"ubuntu@{ip_address}",
             identity=FileContent(id_rsa),
+            control_sock_path=self.connection_symlink_dir / "control.sock",
             options={
                 **SSH_DEFAULT_OPTIONS,
                 "ConnectTimeout": "1",
@@ -56,14 +64,16 @@ class GatewayConnection:
                     remote=IPSocket(host="localhost", port=GATEWAY_MANAGEMENT_PORT),
                 ),
             ],
-            reverse_forwarded_sockets=[
-                SocketPair(
-                    local=IPSocket(host="localhost", port=server_port),
-                    remote=IPSocket(host="localhost", port=SERVER_PORT_ON_GATEWAY),
-                ),
-            ],
+            # reverse_forwarded_sockets are added later in .open()
         )
         self._client = GatewayClient(uds=self.gateway_socket_path)
+
+    @staticmethod
+    def _init_symlink_dir(connection_dir: Path) -> Tuple[TemporaryDirectory, Path]:
+        temp_dir = TemporaryDirectory()
+        symlink_dir = Path(temp_dir.name) / "connection"
+        symlink_dir.symlink_to(connection_dir, target_is_directory=True)
+        return temp_dir, symlink_dir
 
     async def check_or_restart(self):
         async with self._lock.writer_lock:
@@ -71,6 +81,29 @@ class GatewayConnection:
                 logger.info("Connection to gateway %s is down, restarting", self.ip_address)
                 await self.tunnel.aopen()
         return
+
+    async def open(self) -> None:
+        async with self._lock.writer_lock:
+            # Close remaining tunnel if previous server process died w/o graceful shutdown
+            if await self.tunnel.acheck():
+                await self.tunnel.aclose()
+
+            self.connection_dir.mkdir(parents=True, exist_ok=True)
+            await self.tunnel.aopen()
+            await self.tunnel.aexec(f"mkdir -p {CONNECTIONS_DIR_ON_GATEWAY}")
+
+            self.tunnel.reverse_forwarded_sockets = [
+                SocketPair(
+                    local=IPSocket(host="localhost", port=self.server_port),
+                    remote=UnixSocket(path=f"{CONNECTIONS_DIR_ON_GATEWAY}/{uuid.uuid4()}.sock"),
+                ),
+            ]
+            await self.tunnel.aopen()  # apply reverse forwarding
+
+    async def close(self) -> None:
+        async with self._lock.writer_lock:
+            await self.tunnel.aclose()
+            shutil.rmtree(self.connection_dir)
 
     async def try_collect_stats(self) -> None:
         if not self._client.is_server_ready:

--- a/src/dstack/_internal/server/services/gateways/pool.py
+++ b/src/dstack/_internal/server/services/gateways/pool.py
@@ -19,7 +19,7 @@ class GatewayConnectionsPool:
                 logger.warning(f"Gateway connection for {hostname} already exists")
                 return self._connections[hostname]
             self._connections[hostname] = GatewayConnection(hostname, id_rsa, SERVER_PORT)
-            open_task = self._connections[hostname].tunnel.aopen()
+            open_task = self._connections[hostname].open()
         try:
             await open_task
             return self._connections[hostname]
@@ -33,14 +33,14 @@ class GatewayConnectionsPool:
             if hostname not in self._connections:
                 logger.warning(f"Gateway connection for {hostname} does not exist")
                 return False
-            close_task = self._connections.pop(hostname).tunnel.aclose()
+            close_task = self._connections.pop(hostname).close()
         await close_task
         return True
 
     async def remove_all(self) -> None:
         async with self._lock:
             await asyncio.gather(
-                *(conn.tunnel.aclose() for conn in self._connections.values()),
+                *(conn.close() for conn in self._connections.values()),
                 return_exceptions=True,
             )
             self._connections = {}


### PR DESCRIPTION
Make dstack-server's API available as a unix
domain socket on dstack-gateway instead of TCP
port 8001. Multiple server replicas can have a
unix socket each and dstack-gateway will choose a
random server for each API request.

Part of #1633. Fixes #1213 