### PR TITLE
Adjust gateway management for multiple server replicas

### DIFF
--- a/src/dstack/_internal/server/background/tasks/process_gateways.py
+++ b/src/dstack/_internal/server/background/tasks/process_gateways.py
@@ -6,8 +6,8 @@ from sqlalchemy.orm import joinedload, lazyload
 
 from dstack._internal.core.errors import BackendError, BackendNotAvailable, SSHError
 from dstack._internal.core.models.gateways import GatewayStatus
-from dstack._internal.server.db import get_session_ctx
-from dstack._internal.server.models import GatewayModel, ProjectModel
+from dstack._internal.server.db import get_db, get_session_ctx
+from dstack._internal.server.models import GatewayComputeModel, GatewayModel, ProjectModel
 from dstack._internal.server.services import backends as backends_services
 from dstack._internal.server.services import gateways as gateways_services
 from dstack._internal.server.services.gateways import (
@@ -15,7 +15,7 @@ from dstack._internal.server.services.gateways import (
     create_gateway_compute,
     gateway_connections_pool,
 )
-from dstack._internal.server.services.locking import get_locker
+from dstack._internal.server.services.locking import advisory_lock_ctx, get_locker
 from dstack._internal.utils.common import get_current_datetime
 from dstack._internal.utils.logging import get_logger
 
@@ -23,9 +23,8 @@ logger = get_logger(__name__)
 
 
 async def process_gateways_connections():
-    # TODO(egor-s): distribute the load evenly
-    connections = await gateway_connections_pool.all()
-    await asyncio.gather(*(_process_connection(conn) for conn in connections))
+    await _remove_inactive_connections()
+    await _process_active_connections()
 
 
 async def process_submitted_gateways():
@@ -54,12 +53,43 @@ async def process_submitted_gateways():
             lockset.difference_update([gateway_model_id])
 
 
+async def _remove_inactive_connections():
+    connections = await gateway_connections_pool.all()
+    ip_addresses = [c.ip_address for c in connections]
+    async with get_session_ctx() as session:
+        res = await session.execute(
+            select(GatewayComputeModel).where(
+                GatewayComputeModel.ip_address.in_(ip_addresses),
+                GatewayComputeModel.active == False,
+            )
+        )
+        removed_connections = res.scalars().all()
+        for conn in removed_connections:
+            await gateway_connections_pool.remove(conn.ip_address)
+
+
+async def _process_active_connections():
+    connections = await gateway_connections_pool.all()
+    # Two server processes on a single host cannot process
+    # gateway connections and init gateway connections concurrently:
+    # Race conditions cause conflicting tunnels being opened.
+    async with get_session_ctx() as session:
+        async with advisory_lock_ctx(
+            bind=session,
+            dialect_name=get_db().dialect_name,
+            resource="gateway_tunnels",
+        ):
+            await asyncio.gather(*(_process_connection(conn) for conn in connections))
+
+
 async def _process_connection(conn: GatewayConnection):
     try:
         await conn.check_or_restart()
-        await conn.try_collect_stats()
     except SSHError as e:
         logger.error("Connection to gateway %s failed: %s", conn.ip_address, e)
+        return
+
+    await conn.try_collect_stats()
 
 
 async def _process_submitted_gateway(session: AsyncSession, gateway_model: GatewayModel):

--- a/src/dstack/_internal/server/background/tasks/process_runs.py
+++ b/src/dstack/_internal/server/background/tasks/process_runs.py
@@ -135,7 +135,7 @@ async def _process_pending_run(session: AsyncSession, run_model: RunModel):
         replicas = run.run_spec.configuration.replicas.min or 0  # new default
         scaler = autoscalers.get_service_autoscaler(run.run_spec.configuration)
         if scaler is not None:
-            conn = await gateways.get_gateway_connection(session, run_model.gateway_id)
+            conn = await gateways.get_or_add_gateway_connection(session, run_model.gateway_id)
             stats = await conn.get_stats(run_model.id)
             if stats:
                 # replicas info doesn't matter for now
@@ -316,7 +316,7 @@ async def _process_active_run(session: AsyncSession, run_model: RunModel):
         if run_spec.configuration.type == "service":
             scaler = autoscalers.get_service_autoscaler(run_spec.configuration)
             if scaler is not None:
-                conn = await gateways.get_gateway_connection(session, run_model.gateway_id)
+                conn = await gateways.get_or_add_gateway_connection(session, run_model.gateway_id)
                 stats = await conn.get_stats(run_model.id)
                 if stats:
                     # use replicas_info from before retrying

--- a/src/tests/_internal/server/background/tasks/test_process_gateways.py
+++ b/src/tests/_internal/server/background/tasks/test_process_gateways.py
@@ -28,7 +28,7 @@ class TestProcessSubmittedGateways:
         with patch(
             "dstack._internal.server.services.backends.get_project_backend_with_model_by_type_or_error"
         ) as m, patch(
-            "dstack._internal.server.services.gateways.gateway_connections_pool.add"
+            "dstack._internal.server.services.gateways.gateway_connections_pool.get_or_add"
         ) as pool_add:
             aws = Mock()
             m.return_value = (backend, aws)


### PR DESCRIPTION
Closes #1633

This PR ensures multiple server replicas can work with gateways (including multi-worker server on one host):

* Replaces `gateway_connections_pool.get()` with `gateway_connections_pool.get_or_add()` so that a new gateway connection can be established if gateway submission was processed by another replica.
* Extends `process_gateways_connections()` to remove inactive connections (gateways deleted by other replicas).
* Adds locking to gateway initialization/processing to prevent race conditions with tunnel re-creation.

Notes:
* `GatewayConnection.open()` is called by every server replica during init and closes tunnel connections left by process died w/o graceful shutdown. However, it cannot differentiate between tunnels left by died processes and active workers on the same host. Therefore, in multi-worker server setup, every worker will be re-creating tunnels on init. It should not interfere with gateway processing due to locking.

TODO:
* Since every server replicas initializes gateways sequentially, it takes a lot of time and is actually unnecessary. This can be optimized, e.g. do not update/configure gateway too often.