### PR TITLE
[shim] Add old container cleanup routine

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -25,7 +25,7 @@ Here's the steps to build `dstack-shim` and `dstack-runner` and run `dstack` wit
 3. Start the shim:
 
     ```shell
-    ./shim --home $RUNNER_DIR --runner-binary-path $COMPILED_RUNNER_PATH docker --ssh-key $DSTACK_PUBLIC_KEY --keep-container
+    ./shim --home $RUNNER_DIR --runner-binary-path $COMPILED_RUNNER_PATH docker --ssh-key $DSTACK_PUBLIC_KEY
     ```
 
     Notes:

--- a/runner/cmd/shim/main.go
+++ b/runner/cmd/shim/main.go
@@ -93,11 +93,6 @@ func main() {
 				Flags: []cli.Flag{
 					/* Docker Parameters */
 					&cli.BoolFlag{
-						Name:        "keep-container",
-						Usage:       "Do not delete container on exit",
-						Destination: &args.Docker.KeepContainer,
-					},
-					&cli.BoolFlag{
 						Name:        "privileged",
 						Usage:       "Give extended privileges to the container",
 						Destination: &args.Docker.Privileged,

--- a/runner/internal/shim/docker_test.go
+++ b/runner/internal/shim/docker_test.go
@@ -131,10 +131,6 @@ type dockerParametersMock struct {
 	publicSSHKey string
 }
 
-func (c *dockerParametersMock) DockerKeepContainer() bool {
-	return false
-}
-
 func (c *dockerParametersMock) DockerPrivileged() bool {
 	return false
 }

--- a/runner/internal/shim/models.go
+++ b/runner/internal/shim/models.go
@@ -11,7 +11,6 @@ import (
 
 type DockerParameters interface {
 	DockerPrivileged() bool
-	DockerKeepContainer() bool
 	DockerShellCommands([]string) []string
 	DockerMounts(string) ([]mount.Mount, error)
 	DockerPorts() []int
@@ -38,7 +37,6 @@ type CLIArgs struct {
 
 	Docker struct {
 		SSHPort                   int
-		KeepContainer             bool
 		ConcatinatedPublicSSHKeys string
 		Privileged                bool
 		PJRTDevice                string

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -226,7 +226,7 @@ def get_run_shim_script(is_privileged: bool, pjrt_device: Optional[str]) -> List
     pjrt_device_env = f"--pjrt-device={pjrt_device}" if pjrt_device else ""
 
     return [
-        f"nohup dstack-shim {dev_flag} docker --keep-container {privileged_flag} {pjrt_device_env} >{DSTACK_WORKING_DIR}/shim.log 2>&1 &",
+        f"nohup dstack-shim {dev_flag} docker {privileged_flag} {pjrt_device_env} >{DSTACK_WORKING_DIR}/shim.log 2>&1 &",
     ]
 
 

--- a/src/dstack/_internal/core/backends/remote/provisioning.py
+++ b/src/dstack/_internal/core/backends/remote/provisioning.py
@@ -100,7 +100,7 @@ def run_shim_as_systemd_service(client: paramiko.SSHClient, working_dir: str, de
     Restart=always
     WorkingDirectory={working_dir}
     EnvironmentFile={working_dir}/{DSTACK_SHIM_ENV_FILE}
-    ExecStart=/usr/local/bin/dstack-shim {dev_flag} docker --keep-container
+    ExecStart=/usr/local/bin/dstack-shim {dev_flag} docker
     StandardOutput=append:/root/.dstack/shim.log
     StandardError=append:/root/.dstack/shim.log
 


### PR DESCRIPTION
* Remove all containers but the last one when a container exits unless `--keep-container` is used
* Don't use `--keep-container` by default

Fixes: https://github.com/dstackai/dstack/issues/1243