### PR TITLE
Document run diagnostic logs

### DIFF
--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -58,8 +58,12 @@ requirements specified in `resources`.
 There could be several reasons for a run failing after successful provisioning. 
 
 !!! info "Termination reason"
-    To find out why, use `-v` (stands for `--verbose`) with `dstack ps`.
+    To find out why a run terminated, use `--verbose/-v` with `dstack ps`.
     This will show the run's status and any failure reasons.
+
+!!! info "Diagnostic logs"
+    You can get more information on why a run fails with diagnostic logs.
+    Pass `--diagnose/-v` to `dstack logs` and you'll see logs of the run executor.
 
 #### Spot interruption
 

--- a/src/dstack/_internal/cli/commands/logs.py
+++ b/src/dstack/_internal/cli/commands/logs.py
@@ -12,12 +12,14 @@ class LogsCommand(APIBaseCommand):
 
     def _register(self):
         super()._register()
-        self._parser.add_argument("-d", "--diagnose", action="store_true")
+        self._parser.add_argument(
+            "-d", "--diagnose", action="store_true", help="Show run diagnostic logs"
+        )
         self._parser.add_argument(
             "-a",
             "--attach",
             action="store_true",
-            help="Set up an SSH tunnel, and print logs as they follow.",
+            help="Set up an SSH tunnel and print logs as they follow",
         )
         self._parser.add_argument(
             "--ssh-identity",


### PR DESCRIPTION
`dstack logs --diagnose` may often be helpful to debug run failure reasons (e.g. #1701) but users are generally unaware of it due to poor documentation. The PR documents `dstack logs --diagnose` in Troubleshooting. 