### PR TITLE
Implement dstack attach command

### DIFF
--- a/docs/docs/guides/protips.md
+++ b/docs/docs/guides/protips.md
@@ -180,13 +180,13 @@ This means it streams the logs as they come in and, in the case of a task, forwa
 
 To run in detached mode, use `-d` with `dstack apply`.
 
-> If you detached the CLI, you can always re-attach to a run via `dstack logs -a RUN_NAME`.
+> If you detached the CLI, you can always re-attach to a run via `dstack attach RUN_NAME`.
 
 ## GPU
 
 `dstack` natively supports NVIDIA GPU, AMD GPU, and Google Cloud TPU accelerator chips.
 
-The `gpu` property withing `resources` (or the `--gpu` option with `dstack apply`)
+The `gpu` property within `resources` (or the `--gpu` option with `dstack apply`)
 allows specifying not only memory size but also GPU vendor, names, their memory, and quantity.
 
 Examples:

--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -105,7 +105,7 @@ If you attempt to run a service on an SSH fleet, it won't work due to a [known i
 
 When running a dev environment or task with configured ports, `dstack apply` 
 automatically forwards remote ports to `localhost` via SSH for easy and secure access.
-If you interrupt the command, the port forwarding will be disconnected. To reattach, use `dstack logs --attach <run name`.
+If you interrupt the command, the port forwarding will be disconnected. To reattach, use `dstack attach <run name`.
 
 #### Windows
 

--- a/docs/docs/reference/cli/index.md
+++ b/docs/docs/reference/cli/index.md
@@ -87,7 +87,7 @@ $ dstack ps --help
 
 ### dstack stop
 
-This command stops run(s) within the current repository.
+This command stops run(s).
 
 <div class="termy">
 
@@ -98,9 +98,22 @@ $ dstack stop --help
 
 </div>
 
+### dstack attach
+
+This command attaches to a given run. It establishes the SSH tunnel, forwards ports, and shows real-time run logs.
+
+<div class="termy">
+
+```shell
+$ dstack attach --help
+#GENERATE#
+```
+
+</div>
+
 ### dstack logs
 
-This command shows the output of a given run within the current repository.
+This command shows the output of a given run.
 
 <div class="termy">
 

--- a/src/dstack/_internal/cli/commands/apply.py
+++ b/src/dstack/_internal/cli/commands/apply.py
@@ -14,7 +14,7 @@ NOTSET = object()
 
 class ApplyCommand(APIBaseCommand):
     NAME = "apply"
-    DESCRIPTION = "Apply dstack configuration"
+    DESCRIPTION = "Apply a configuration"
     DEFAULT_HELP = False
 
     def _register(self):

--- a/src/dstack/_internal/cli/commands/attach.py
+++ b/src/dstack/_internal/cli/commands/attach.py
@@ -100,13 +100,16 @@ def _print_attached_message(
         bind_address = "localhost"
 
     output = f"Attached to run [code]{run.name}[/] (replica={replica_num} job={job_num})\n"
-    # job = get_or_error(run._find_job(replica_num=replica_num, job_num=job_num))
+    job = get_or_error(run._find_job(replica_num=replica_num, job_num=job_num))
+    name = run.name
+    if replica_num != 0 or job_num != 0:
+        name = job.job_spec.job_name
     ports = get_or_error(run.ports)
     ports = {k: v for k, v in ports.items() if k not in _IGNORED_PORTS}
     if len(ports) > 0:
         output += "Forwarded ports (local -> remote):\n"
         for remote_port, local_port in ports.items():
             output += f"  - {bind_address}:{local_port} -> {remote_port}\n"
-    output += f"To connect to the run container via SSH, use `ssh {run.name}`.\n"
+    output += f"To connect to the run via SSH, use `ssh {name}`.\n"
     output += "Press Ctrl+C to detach..."
     console.print(output)

--- a/src/dstack/_internal/cli/commands/attach.py
+++ b/src/dstack/_internal/cli/commands/attach.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Optional
 
 from dstack._internal.cli.commands import APIBaseCommand
+from dstack._internal.cli.services.args import port_mapping
 from dstack._internal.cli.utils.common import console
 from dstack._internal.core.errors import CLIError
 from dstack._internal.utils.common import get_or_error
@@ -31,8 +32,17 @@ class AttachCommand(APIBaseCommand):
         )
         self._parser.add_argument(
             "--host",
-            help="Local address to bind. Defaults to [code]localhost[/]",
+            help="Local address to bind. Defaults to [code]localhost[/].",
             metavar="HOST",
+        )
+        self._parser.add_argument(
+            "-p",
+            "--port",
+            type=port_mapping,
+            action="append",
+            help="Port mapping overrides",
+            dest="ports",
+            metavar="MAPPING",
         )
         self._parser.add_argument(
             "--replica",
@@ -57,6 +67,7 @@ class AttachCommand(APIBaseCommand):
             run.attach(
                 ssh_identity_file=args.ssh_identity_file,
                 bind_address=args.host,
+                ports_overrides=args.ports,
                 replica_num=args.replica,
                 job_num=args.job,
             )

--- a/src/dstack/_internal/cli/commands/attach.py
+++ b/src/dstack/_internal/cli/commands/attach.py
@@ -1,0 +1,112 @@
+import argparse
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+from dstack._internal.cli.commands import APIBaseCommand
+from dstack._internal.cli.utils.common import console
+from dstack._internal.core.errors import CLIError
+from dstack._internal.utils.common import get_or_error
+from dstack.api._public.runs import Run
+
+
+class AttachCommand(APIBaseCommand):
+    NAME = "attach"
+    DESCRIPTION = "Attach to the run"
+
+    def _register(self):
+        super()._register()
+        self._parser.add_argument(
+            "--ssh-identity",
+            metavar="SSH_PRIVATE_KEY",
+            help="The private SSH key path for SSH tunneling",
+            type=Path,
+            dest="ssh_identity_file",
+        )
+        self._parser.add_argument(
+            "--logs",
+            action="store_true",
+            help="Print run logs as they follow",
+        )
+        self._parser.add_argument(
+            "--host",
+            help="Local address to bind. Defaults to [code]localhost[/]",
+            metavar="HOST",
+        )
+        self._parser.add_argument(
+            "--replica",
+            help="The relica number. Defaults to 0.",
+            type=int,
+            default=0,
+        )
+        self._parser.add_argument(
+            "--job",
+            help="The job number inside the replica. Defaults to 0.",
+            type=int,
+            default=0,
+        )
+        self._parser.add_argument("run_name")
+
+    def _command(self, args: argparse.Namespace):
+        super()._command(args)
+        run = self.api.runs.get(args.run_name)
+        if run is None:
+            raise CLIError(f"Run {args.run_name} not found")
+        try:
+            run.attach(
+                ssh_identity_file=args.ssh_identity_file,
+                bind_address=args.host,
+                replica_num=args.replica,
+                job_num=args.job,
+            )
+            _print_attached_message(
+                run=run,
+                bind_address=args.host,
+                replica_num=args.replica,
+                job_num=args.job,
+            )
+            if args.logs:
+                logs = run.logs(
+                    replica_num=args.replica,
+                    job_num=args.job,
+                )
+                try:
+                    for log in logs:
+                        sys.stdout.buffer.write(log)
+                        sys.stdout.buffer.flush()
+                except KeyboardInterrupt:
+                    pass
+            else:
+                try:
+                    while True:
+                        time.sleep(10)
+                except KeyboardInterrupt:
+                    pass
+        finally:
+            run.detach()
+
+
+_IGNORED_PORTS = [10999]
+
+
+def _print_attached_message(
+    run: Run,
+    bind_address: Optional[str],
+    replica_num: int,
+    job_num: int,
+):
+    if bind_address is None:
+        bind_address = "localhost"
+
+    output = f"Attached to run [code]{run.name}[/] (replica={replica_num} job={job_num})\n"
+    # job = get_or_error(run._find_job(replica_num=replica_num, job_num=job_num))
+    ports = get_or_error(run.ports)
+    ports = {k: v for k, v in ports.items() if k not in _IGNORED_PORTS}
+    if len(ports) > 0:
+        output += "Forwarded ports (local -> remote):\n"
+        for remote_port, local_port in ports.items():
+            output += f"  - {bind_address}:{local_port} -> {remote_port}\n"
+    output += f"To connect to the run container via SSH, use `ssh {run.name}`.\n"
+    output += "Press Ctrl+C to detach..."
+    console.print(output)

--- a/src/dstack/_internal/cli/commands/attach.py
+++ b/src/dstack/_internal/cli/commands/attach.py
@@ -64,13 +64,15 @@ class AttachCommand(APIBaseCommand):
         if run is None:
             raise CLIError(f"Run {args.run_name} not found")
         try:
-            run.attach(
+            attached = run.attach(
                 ssh_identity_file=args.ssh_identity_file,
                 bind_address=args.host,
                 ports_overrides=args.ports,
                 replica_num=args.replica,
                 job_num=args.job,
             )
+            if not attached:
+                raise CLIError(f"Failed to attach to run {args.run_name}")
             _print_attached_message(
                 run=run,
                 bind_address=args.host,

--- a/src/dstack/_internal/cli/commands/config.py
+++ b/src/dstack/_internal/cli/commands/config.py
@@ -14,7 +14,7 @@ logger = get_logger(__name__)
 
 class ConfigCommand(BaseCommand):
     NAME = "config"
-    DESCRIPTION = "Configure projects"
+    DESCRIPTION = "Configure CLI"
 
     def _register(self):
         super()._register()

--- a/src/dstack/_internal/cli/commands/delete.py
+++ b/src/dstack/_internal/cli/commands/delete.py
@@ -10,7 +10,7 @@ from dstack._internal.cli.services.configurators import (
 
 class DeleteCommand(APIBaseCommand):
     NAME = "delete"
-    DESCRIPTION = "Delete resources defined by dstack configuration"
+    DESCRIPTION = "Delete resources"
     ALIASES = ["destroy"]
 
     def _register(self):

--- a/src/dstack/_internal/cli/commands/logs.py
+++ b/src/dstack/_internal/cli/commands/logs.py
@@ -4,6 +4,9 @@ from pathlib import Path
 
 from dstack._internal.cli.commands import APIBaseCommand
 from dstack._internal.core.errors import CLIError
+from dstack._internal.utils.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class LogsCommand(APIBaseCommand):
@@ -51,6 +54,9 @@ class LogsCommand(APIBaseCommand):
             if run.status.is_finished():
                 raise CLIError(f"Run {args.run_name} is finished")
             else:
+                logger.warning(
+                    "`dstack logs --attach` is deprecated in favor of `dstack attach --logs`"
+                )
                 run.attach(args.ssh_identity_file)
         logs = run.logs(
             diagnose=args.diagnose,

--- a/src/dstack/_internal/cli/commands/pool.py
+++ b/src/dstack/_internal/cli/commands/pool.py
@@ -42,7 +42,7 @@ logger = get_logger(__name__)
 
 class PoolCommand(APIBaseCommand):
     NAME = "pool"
-    DESCRIPTION = "Pool management"
+    DESCRIPTION = "Manage pools"
 
     def _register(self) -> None:
         super()._register()

--- a/src/dstack/_internal/cli/main.py
+++ b/src/dstack/_internal/cli/main.py
@@ -4,6 +4,7 @@ from rich.markup import escape
 from rich_argparse import RichHelpFormatter
 
 from dstack._internal.cli.commands.apply import ApplyCommand
+from dstack._internal.cli.commands.attach import AttachCommand
 from dstack._internal.cli.commands.config import ConfigCommand
 from dstack._internal.cli.commands.delete import DeleteCommand
 from dstack._internal.cli.commands.fleet import FleetCommand
@@ -56,6 +57,7 @@ def main():
 
     subparsers = parser.add_subparsers(metavar="COMMAND")
     ApplyCommand.register(subparsers)
+    AttachCommand.register(subparsers)
     ConfigCommand.register(subparsers)
     DeleteCommand.register(subparsers)
     FleetCommand.register(subparsers)


### PR DESCRIPTION
Closes #1533 

This PR adds the `dstack attach` command. The command works like `dstack logs --attach` except:

* It prints the message with an ssh command and forwarded ports:

```
✗ dstack attach shaggy-crab-1    
Attached to run shaggy-crab-1 (replica=0 job=0)
Forwarded ports (local -> remote):
  - localhost:7860 -> 7860
To connect to the run via SSH, use `ssh shaggy-crab-1`.
Press Ctrl+C to detach...
```

* It shows no logs by default. To see logs, you run `dstack attach --logs`.
* It supports `--host` and `--port` to override local bind address and ports mapping.
* It supports attaching to multiple jobs of the same run, which can also be done simultaneously.