### PR TITLE
Support calling RunCollection.get_plan() without repo

### DIFF
--- a/src/dstack/api/_public/runs.py
+++ b/src/dstack/api/_public/runs.py
@@ -418,7 +418,7 @@ class RunCollection:
     def get_plan(
         self,
         configuration: AnyRunConfiguration,
-        repo: Repo,
+        repo: Optional[Repo] = None,
         configuration_path: Optional[str] = None,
         backends: Optional[List[BackendType]] = None,
         regions: Optional[List[str]] = None,
@@ -442,6 +442,12 @@ class RunCollection:
         # Returns:
         #     run plan
         # """
+
+        if repo is None:
+            repo = configuration.get_repo()
+            if repo is None:
+                raise ConfigurationError("Repo is required for this type of configuration")
+
         if working_dir is None:
             working_dir = "."
         elif repo.repo_dir is not None:


### PR DESCRIPTION
Closes #1737 

This PR makes it possible to call `RunCollection.get_plan()` without passing a repo to simplify Python API usage (similar to `RunCollection.submit()`).