### PR TITLE
Fix Handle KeyboardInterrupt in CLI when getting run plan #1626

### DIFF
--- a/src/dstack/_internal/cli/commands/apply.py
+++ b/src/dstack/_internal/cli/commands/apply.py
@@ -50,27 +50,31 @@ class ApplyCommand(APIBaseCommand):
         )
 
     def _command(self, args: argparse.Namespace):
-        if args.help is not NOTSET:
-            if args.help is not None:
-                configurator_class = get_apply_configurator_class(
-                    ApplyConfigurationType(args.help)
-                )
-            else:
-                configurator_class = BaseApplyConfigurator
-            configurator_class.register_args(self._parser)
-            self._parser.print_help()
-            return
+        try:
+            if args.help is not NOTSET:
+                if args.help is not None:
+                    configurator_class = get_apply_configurator_class(
+                        ApplyConfigurationType(args.help)
+                    )
+                else:
+                    configurator_class = BaseApplyConfigurator
+                configurator_class.register_args(self._parser)
+                self._parser.print_help()
+                return
 
-        super()._command(args)
-        configuration_path, configuration = load_apply_configuration(args.configuration_file)
-        configurator_class = get_apply_configurator_class(configuration.type)
-        configurator = configurator_class(api_client=self.api)
-        configurator_parser = configurator.get_parser()
-        known, unknown = configurator_parser.parse_known_args(args.unknown)
-        configurator.apply_configuration(
-            conf=configuration,
-            configuration_path=configuration_path,
-            command_args=args,
-            configurator_args=known,
-            unknown_args=unknown,
-        )
+            super()._command(args)
+            configuration_path, configuration = load_apply_configuration(args.configuration_file)
+            configurator_class = get_apply_configurator_class(configuration.type)
+            configurator = configurator_class(api_client=self.api)
+            configurator_parser = configurator.get_parser()
+            known, unknown = configurator_parser.parse_known_args(args.unknown)
+            configurator.apply_configuration(
+                conf=configuration,
+                configuration_path=configuration_path,
+                command_args=args,
+                configurator_args=known,
+                unknown_args=unknown,
+            )
+        except KeyboardInterrupt:
+            print("\nOperation interrupted by user. Exiting...")
+            exit(0)


### PR DESCRIPTION
This PR improve error handling in the `apply` command of the CLI to handle user interruptions.

![image](https://github.com/user-attachments/assets/dabfa5d5-85cf-47b9-afcc-ffa48a4ca7a6)

I have followed [CONTRIBUTING.md](CONTRIBUTING.md) Guidelines.

Please informed me, if I have to make any changes #1626 .