### PR TITLE
Implement fleet apply plan

### DIFF
--- a/src/dstack/_internal/cli/commands/apply.py
+++ b/src/dstack/_internal/cli/commands/apply.py
@@ -48,6 +48,12 @@ class ApplyCommand(APIBaseCommand):
             help="Force apply when no changes detected",
             action="store_true",
         )
+        self._parser.add_argument(
+            "-d",
+            "--detach",
+            help="Exit immediately after sumbitting configuration",
+            action="store_true",
+        )
 
     def _command(self, args: argparse.Namespace):
         if args.help is not NOTSET:

--- a/src/dstack/_internal/cli/commands/apply.py
+++ b/src/dstack/_internal/cli/commands/apply.py
@@ -38,14 +38,14 @@ class ApplyCommand(APIBaseCommand):
             dest="configuration_file",
         )
         self._parser.add_argument(
-            "--force",
-            help="Force apply when no changes detected",
-            action="store_true",
-        )
-        self._parser.add_argument(
             "-y",
             "--yes",
             help="Do not ask for confirmation",
+            action="store_true",
+        )
+        self._parser.add_argument(
+            "--force",
+            help="Force apply when no changes detected",
             action="store_true",
         )
 

--- a/src/dstack/_internal/cli/services/configurators/fleet.py
+++ b/src/dstack/_internal/cli/services/configurators/fleet.py
@@ -115,6 +115,9 @@ class FleetConfigurator(ApplyEnvVarsConfiguratorMixin, BaseApplyConfigurator):
                 project_name=self.api.project,
                 spec=spec,
             )
+        if command_args.detach:
+            console.print("Fleet configuration submitted. Exiting...")
+            return
         console.print()
         try:
             with Live(console=console, refresh_per_second=LIVE_TABLE_REFRESH_RATE_PER_SEC) as live:

--- a/src/dstack/_internal/cli/services/configurators/run.py
+++ b/src/dstack/_internal/cli/services/configurators/run.py
@@ -102,12 +102,12 @@ class BaseRunConfigurator(ApplyEnvVarsConfiguratorMixin, BaseApplyConfigurator):
         try:
             with console.status("Submitting run..."):
                 run = self.api.runs.exec_plan(
-                    run_plan, repo, reserve_ports=not configurator_args.detach
+                    run_plan, repo, reserve_ports=not command_args.detach
                 )
         except ServerClientError as e:
             raise CLIError(e.msg)
 
-        if configurator_args.detach:
+        if command_args.detach:
             console.print(f"Run [code]{run.name}[/] submitted, detaching...")
             return
 
@@ -229,12 +229,6 @@ class BaseRunConfigurator(ApplyEnvVarsConfiguratorMixin, BaseApplyConfigurator):
             "--name",
             dest="run_name",
             help="The name of the run. If not specified, a random name is assigned",
-        )
-        parser.add_argument(
-            "-d",
-            "--detach",
-            help="Do not poll logs and run status",
-            action="store_true",
         )
         parser.add_argument(
             "--max-offers",

--- a/src/dstack/_internal/cli/services/configurators/run.py
+++ b/src/dstack/_internal/cli/services/configurators/run.py
@@ -64,7 +64,7 @@ class BaseRunConfigurator(ApplyEnvVarsConfiguratorMixin, BaseApplyConfigurator):
         repo_config = ConfigManager().get_repo_config_or_error(repo.get_repo_dir_or_error())
         self.api.ssh_identity_file = repo_config.ssh_key_path
         profile = load_profile(Path.cwd(), configurator_args.profile)
-        with console.status("Getting run plan..."):
+        with console.status("Getting apply plan..."):
             run_plan = self.api.runs.get_plan(
                 configuration=conf,
                 repo=repo,

--- a/src/dstack/_internal/cli/utils/run.py
+++ b/src/dstack/_internal/cli/utils/run.py
@@ -50,11 +50,11 @@ def print_run_plan(run_plan: RunPlan, offers_limit: int = 3):
     def th(s: str) -> str:
         return f"[bold]{s}[/bold]"
 
-    props.add_row(th("Configuration"), run_plan.run_spec.configuration_path)
     props.add_row(th("Project"), run_plan.project_name)
     props.add_row(th("User"), run_plan.user)
-    props.add_row(th("Pool"), profile.pool_name)
-    props.add_row(th("Min resources"), pretty_req)
+    props.add_row(th("Configuration"), run_plan.run_spec.configuration_path)
+    props.add_row(th("Type"), run_plan.run_spec.configuration.type)
+    props.add_row(th("Resources"), pretty_req)
     props.add_row(th("Max price"), max_price)
     props.add_row(th("Max duration"), max_duration)
     props.add_row(th("Spot policy"), spot_policy)

--- a/src/dstack/_internal/core/models/fleets.py
+++ b/src/dstack/_internal/core/models/fleets.py
@@ -9,7 +9,7 @@ from typing_extensions import Annotated, Literal
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.common import CoreModel
 from dstack._internal.core.models.envs import Env
-from dstack._internal.core.models.instances import SSHKey
+from dstack._internal.core.models.instances import InstanceOfferWithAvailability, SSHKey
 from dstack._internal.core.models.pools import Instance
 from dstack._internal.core.models.profiles import (
     DEFAULT_POOL_TERMINATION_IDLE_TIME,
@@ -160,6 +160,7 @@ class FleetConfiguration(InstanceGroupParams, FleetProps):
 
 class FleetSpec(CoreModel):
     configuration: FleetConfiguration
+    configuration_path: Optional[str] = None
     profile: Profile
     autocreated: bool = False
     # TODO: make merged_profile a computed field after migrating to pydanticV2
@@ -202,3 +203,13 @@ class Fleet(CoreModel):
     status: FleetStatus
     status_message: Optional[str] = None
     instances: List[Instance]
+
+
+class FleetPlan(CoreModel):
+    project_name: str
+    user: str
+    spec: FleetSpec
+    current_resource: Optional[Fleet]
+    offers: List[InstanceOfferWithAvailability]
+    total_offers: int
+    max_offer_price: Optional[float]

--- a/src/dstack/_internal/core/models/resources.py
+++ b/src/dstack/_internal/core/models/resources.py
@@ -7,6 +7,7 @@ from pydantic.generics import GenericModel
 from typing_extensions import Annotated
 
 from dstack._internal.core.models.common import CoreModel
+from dstack._internal.utils.common import pretty_resources
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -270,6 +271,22 @@ class ResourcesSpec(CoreModel):
     ] = None
     gpu: Annotated[Optional[GPUSpec], Field(description="The GPU requirements")] = None
     disk: Annotated[Optional[DiskSpec], Field(description="The disk resources")] = DEFAULT_DISK
+
+    def pretty_format(self) -> str:
+        resources: Dict[str, Any] = dict(cpus=self.cpu, memory=self.memory)
+        if self.gpu:
+            gpu = self.gpu
+            resources.update(
+                gpu_name=",".join(gpu.name) if gpu.name else None,
+                gpu_count=gpu.count,
+                gpu_memory=gpu.memory,
+                total_gpu_memory=gpu.total_memory,
+                compute_capability=gpu.compute_capability,
+            )
+        if self.disk:
+            resources.update(disk_size=self.disk.size)
+        res = pretty_resources(**resources)
+        return res
 
 
 IntRangeLike = Union[Range[Union[int, str]], int, str]

--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -29,7 +29,7 @@ from dstack._internal.core.models.profiles import (
 from dstack._internal.core.models.repos import AnyRunRepoData
 from dstack._internal.core.models.resources import ResourcesSpec
 from dstack._internal.utils import common as common_utils
-from dstack._internal.utils.common import format_pretty_duration, pretty_resources
+from dstack._internal.utils.common import format_pretty_duration
 
 
 class AppSpec(CoreModel):
@@ -150,19 +150,7 @@ class Requirements(CoreModel):
     spot: Optional[bool]
 
     def pretty_format(self, resources_only: bool = False):
-        resources = dict(cpus=self.resources.cpu, memory=self.resources.memory)
-        if self.resources.gpu:
-            gpu = self.resources.gpu
-            resources.update(
-                gpu_name=",".join(gpu.name) if gpu.name else None,
-                gpu_count=gpu.count,
-                gpu_memory=gpu.memory,
-                total_gpu_memory=gpu.total_memory,
-                compute_capability=gpu.compute_capability,
-            )
-        if self.resources.disk:
-            resources.update(disk_size=self.resources.disk.size)
-        res = pretty_resources(**resources)
+        res = self.resources.pretty_format()
         if not resources_only:
             if self.spot is not None:
                 res += f", {'spot' if self.spot else 'on-demand'}"

--- a/src/dstack/_internal/server/background/tasks/process_instances.py
+++ b/src/dstack/_internal/server/background/tasks/process_instances.py
@@ -69,7 +69,10 @@ from dstack._internal.server.models import (
 )
 from dstack._internal.server.schemas.runner import HealthcheckResponse
 from dstack._internal.server.services import backends as backends_services
-from dstack._internal.server.services.fleets import fleet_model_to_fleet
+from dstack._internal.server.services.fleets import (
+    fleet_model_to_fleet,
+    get_create_instance_offers,
+)
 from dstack._internal.server.services.jobs import (
     terminate_job_provisioning_data_instance,
 )
@@ -87,7 +90,6 @@ from dstack._internal.server.services.pools import (
 from dstack._internal.server.services.runner import client as runner_client
 from dstack._internal.server.services.runner.client import HealthStatus
 from dstack._internal.server.services.runner.ssh import runner_ssh_tunnel
-from dstack._internal.server.services.runs import get_create_instance_offers
 from dstack._internal.server.utils.common import run_async
 from dstack._internal.utils.common import get_current_datetime
 from dstack._internal.utils.logging import get_logger

--- a/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
@@ -50,12 +50,12 @@ from dstack._internal.server.services.jobs import (
 )
 from dstack._internal.server.services.locking import get_locker
 from dstack._internal.server.services.logging import fmt
+from dstack._internal.server.services.offers import get_offers_by_requirements
 from dstack._internal.server.services.pools import (
     filter_pool_instances,
 )
 from dstack._internal.server.services.runs import (
     check_can_attach_run_volumes,
-    get_offers_by_requirements,
     get_run_volume_models,
     run_model_to_run,
 )

--- a/src/dstack/_internal/server/routers/fleets.py
+++ b/src/dstack/_internal/server/routers/fleets.py
@@ -5,13 +5,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 import dstack._internal.server.services.fleets as fleets_services
 from dstack._internal.core.errors import ResourceNotExistsError
-from dstack._internal.core.models.fleets import Fleet
+from dstack._internal.core.models.fleets import Fleet, FleetPlan
 from dstack._internal.server.db import get_session
 from dstack._internal.server.models import ProjectModel, UserModel
 from dstack._internal.server.schemas.fleets import (
     CreateFleetRequest,
     DeleteFleetInstancesRequest,
     DeleteFleetsRequest,
+    GetFleetPlanRequest,
     GetFleetRequest,
 )
 from dstack._internal.server.security.permissions import ProjectMember
@@ -41,6 +42,22 @@ async def get_fleet(
     if fleet is None:
         raise ResourceNotExistsError()
     return fleet
+
+
+@router.post("/get_plan")
+async def get_plan(
+    body: GetFleetPlanRequest,
+    session: AsyncSession = Depends(get_session),
+    user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectMember()),
+) -> FleetPlan:
+    user, project = user_project
+    plan = await fleets_services.get_plan(
+        session=session,
+        project=project,
+        user=user,
+        spec=body.spec,
+    )
+    return plan
 
 
 @router.post("/create")

--- a/src/dstack/_internal/server/routers/runs.py
+++ b/src/dstack/_internal/server/routers/runs.py
@@ -19,7 +19,7 @@ from dstack._internal.server.schemas.runs import (
     SubmitRunRequest,
 )
 from dstack._internal.server.security.permissions import Authenticated, ProjectMember
-from dstack._internal.server.services import runs
+from dstack._internal.server.services import fleets, runs
 from dstack._internal.server.services.pools import (
     get_or_create_pool_by_name,
 )
@@ -144,7 +144,7 @@ async def get_offers(
 ) -> PoolInstanceOffers:
     _, project = user_project
     pool = await get_or_create_pool_by_name(session, project, body.profile.pool_name)
-    offers = await runs.get_create_instance_offers(
+    offers = await fleets.get_create_instance_offers(
         project=project,
         profile=body.profile,
         requirements=body.requirements,
@@ -162,7 +162,7 @@ async def create_instance(
 ) -> Instance:
     user, project = user_project
     try:
-        instance = await runs.create_instance(
+        instance = await fleets.create_instance(
             session=session,
             project=project,
             user=user,

--- a/src/dstack/_internal/server/schemas/fleets.py
+++ b/src/dstack/_internal/server/schemas/fleets.py
@@ -8,6 +8,10 @@ class GetFleetRequest(CoreModel):
     name: str
 
 
+class GetFleetPlanRequest(CoreModel):
+    spec: FleetSpec
+
+
 class CreateFleetRequest(CoreModel):
     spec: FleetSpec
 

--- a/src/dstack/_internal/server/services/fleets.py
+++ b/src/dstack/_internal/server/services/fleets.py
@@ -117,12 +117,14 @@ async def get_plan(
     # TODO: refactor offers logic into a separate module to avoid depending on runs
     from dstack._internal.server.services.runs import get_create_instance_offers
 
-    offers_with_backends = await get_create_instance_offers(
-        project=project,
-        profile=spec.merged_profile,
-        requirements=_get_fleet_requirements(spec),
-    )
-    offers = [offer for _, offer in offers_with_backends]
+    offers = []
+    if spec.configuration.ssh_config is None:
+        offers_with_backends = await get_create_instance_offers(
+            project=project,
+            profile=spec.merged_profile,
+            requirements=_get_fleet_requirements(spec),
+        )
+        offers = [offer for _, offer in offers_with_backends]
     current_fleet = None
     if spec.configuration.name is not None:
         current_fleet = await get_fleet_by_name(

--- a/src/dstack/_internal/server/services/offers.py
+++ b/src/dstack/_internal/server/services/offers.py
@@ -1,0 +1,79 @@
+from typing import List, Optional, Tuple
+
+from dstack._internal.core.backends import BACKENDS_WITH_MULTINODE_SUPPORT
+from dstack._internal.core.backends.base import Backend
+from dstack._internal.core.models.backends.base import BackendType
+from dstack._internal.core.models.instances import InstanceOfferWithAvailability
+from dstack._internal.core.models.profiles import Profile
+from dstack._internal.core.models.runs import JobProvisioningData, Requirements
+from dstack._internal.core.models.volumes import Volume
+from dstack._internal.server.models import ProjectModel
+from dstack._internal.server.services import backends as backends_services
+
+
+async def get_offers_by_requirements(
+    project: ProjectModel,
+    profile: Profile,
+    requirements: Requirements,
+    exclude_not_available=False,
+    multinode: bool = False,
+    master_job_provisioning_data: Optional[JobProvisioningData] = None,
+    volumes: Optional[List[Volume]] = None,
+) -> List[Tuple[Backend, InstanceOfferWithAvailability]]:
+    backends: List[Backend] = await backends_services.get_project_backends(project=project)
+
+    # For backward-compatibility to show offers if users set `backends: [dstack]`
+    if (
+        profile.backends is not None
+        and len(profile.backends) == 1
+        and BackendType.DSTACK in profile.backends
+    ):
+        profile.backends = None
+
+    backend_types = profile.backends
+    regions = profile.regions
+
+    if volumes:
+        volume = volumes[0]
+        backend_types = [volume.configuration.backend]
+        regions = [volume.configuration.region]
+
+    if multinode:
+        if not backend_types:
+            backend_types = BACKENDS_WITH_MULTINODE_SUPPORT
+        backend_types = [b for b in backend_types if b in BACKENDS_WITH_MULTINODE_SUPPORT]
+
+    # For multi-node, restrict backend and region.
+    # The default behavior is to provision all nodes in the same backend and region.
+    if master_job_provisioning_data is not None:
+        if not backend_types:
+            backend_types = [master_job_provisioning_data.get_base_backend()]
+        if not regions:
+            regions = [master_job_provisioning_data.region]
+        backend_types = [
+            b for b in backend_types if b == master_job_provisioning_data.get_base_backend()
+        ]
+        regions = [r for r in regions if r == master_job_provisioning_data.region]
+
+    if backend_types is not None:
+        backends = [b for b in backends if b.TYPE in backend_types or b.TYPE == BackendType.DSTACK]
+
+    offers = await backends_services.get_instance_offers(
+        backends=backends,
+        requirements=requirements,
+        exclude_not_available=exclude_not_available,
+    )
+
+    # Filter offers again for backends since a backend
+    # can return offers of different backend types (e.g. BackendType.DSTACK).
+    # The first filter should remain as an optimization.
+    if backend_types is not None:
+        offers = [(b, o) for b, o in offers if o.backend in backend_types]
+
+    if regions is not None:
+        offers = [(b, o) for b, o in offers if o.region in regions]
+
+    if profile.instance_types is not None:
+        offers = [(b, o) for b, o in offers if o.instance.name in profile.instance_types]
+
+    return offers

--- a/src/dstack/_internal/server/testing/common.py
+++ b/src/dstack/_internal/server/testing/common.py
@@ -394,6 +394,7 @@ def get_fleet_spec(conf: Optional[FleetConfiguration] = None) -> FleetSpec:
         conf = get_fleet_configuration()
     return FleetSpec(
         configuration=conf,
+        configuration_path="fleet.dstack.yml",
         profile=Profile(name=""),
     )
 

--- a/src/dstack/api/server/_fleets.py
+++ b/src/dstack/api/server/_fleets.py
@@ -29,7 +29,12 @@ class FleetsAPIClient(APIClientGroup):
         spec: FleetSpec,
     ) -> FleetPlan:
         body = GetFleetPlanRequest(spec=spec)
-        resp = self._request(f"/api/project/{project_name}/fleets/get_plan", body=body.json())
+        body_json = body.json()
+        if spec.configuration_path is None:
+            # Handle old server versions that do not accept configuration_path
+            # TODO: Can be removed in 0.19
+            body_json = body.json(exclude={"spec": {"configuration_path"}})
+        resp = self._request(f"/api/project/{project_name}/fleets/get_plan", body=body_json)
         return parse_obj_as(FleetPlan.__response__, resp.json())
 
     def create(
@@ -38,7 +43,12 @@ class FleetsAPIClient(APIClientGroup):
         spec: FleetSpec,
     ) -> Fleet:
         body = CreateFleetRequest(spec=spec)
-        resp = self._request(f"/api/project/{project_name}/fleets/create", body=body.json())
+        body_json = body.json()
+        if spec.configuration_path is None:
+            # Handle old server versions that do not accept configuration_path
+            # TODO: Can be removed in 0.19
+            body_json = body.json(exclude={"spec": {"configuration_path"}})
+        resp = self._request(f"/api/project/{project_name}/fleets/create", body=body_json)
         return parse_obj_as(Fleet.__response__, resp.json())
 
     def delete(self, project_name: str, names: List[str]) -> None:

--- a/src/dstack/api/server/_fleets.py
+++ b/src/dstack/api/server/_fleets.py
@@ -2,11 +2,12 @@ from typing import List
 
 from pydantic import parse_obj_as
 
-from dstack._internal.core.models.fleets import Fleet, FleetSpec
+from dstack._internal.core.models.fleets import Fleet, FleetPlan, FleetSpec
 from dstack._internal.server.schemas.fleets import (
     CreateFleetRequest,
     DeleteFleetInstancesRequest,
     DeleteFleetsRequest,
+    GetFleetPlanRequest,
     GetFleetRequest,
 )
 from dstack.api.server._group import APIClientGroup
@@ -21,6 +22,15 @@ class FleetsAPIClient(APIClientGroup):
         body = GetFleetRequest(name=name)
         resp = self._request(f"/api/project/{project_name}/fleets/get", body=body.json())
         return parse_obj_as(Fleet.__response__, resp.json())
+
+    def get_plan(
+        self,
+        project_name: str,
+        spec: FleetSpec,
+    ) -> FleetPlan:
+        body = GetFleetPlanRequest(spec=spec)
+        resp = self._request(f"/api/project/{project_name}/fleets/get_plan", body=body.json())
+        return parse_obj_as(FleetPlan.__response__, resp.json())
 
     def create(
         self,

--- a/src/tests/_internal/server/background/tasks/test_process_instances.py
+++ b/src/tests/_internal/server/background/tasks/test_process_instances.py
@@ -285,9 +285,7 @@ class TestTerminate:
             backend = Mock()
             backend.TYPE = BackendType.DATACRUNCH
             backend.compute.return_value.terminate_instance.return_value = Mock()
-
             get_backends.return_value = [backend]
-
             await process_instances()
 
         await session.refresh(instance)

--- a/src/tests/_internal/server/routers/test_fleets.py
+++ b/src/tests/_internal/server/routers/test_fleets.py
@@ -159,6 +159,7 @@ class TestCreateFleet:
             "name": spec.configuration.name,
             "project_name": project.name,
             "spec": {
+                "configuration_path": None,
                 "configuration": {
                     "nodes": {"min": 1, "max": 1},
                     "placement": None,
@@ -261,6 +262,7 @@ class TestCreateFleet:
             "name": spec.configuration.name,
             "project_name": project.name,
             "spec": {
+                "configuration_path": None,
                 "configuration": {
                     "env": {},
                     "ssh_config": {

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -975,7 +975,7 @@ class TestCreateInstance:
         )
         instance_id = UUID("1b0e1b45-2f8c-4ab6-8010-a0d1a3e44e0e")
         with patch(
-            "dstack._internal.server.services.runs.get_offers_by_requirements"
+            "dstack._internal.server.services.offers.get_offers_by_requirements"
         ) as run_plan_by_req, patch("uuid.uuid4") as uuid_mock:
             uuid_mock.return_value = instance_id
             offer = InstanceOfferWithAvailability(
@@ -1047,7 +1047,7 @@ class TestCreateInstance:
             requirements=Requirements(resources=ResourcesSpec(cpu=1)),
         )
         with patch(
-            "dstack._internal.server.services.runs.get_offers_by_requirements"
+            "dstack._internal.server.services.offers.get_offers_by_requirements"
         ) as run_plan_by_req:
             offer = InstanceOfferWithAvailability(
                 backend=BackendType.AZURE,
@@ -1088,7 +1088,7 @@ class TestCreateInstance:
         )
 
         with patch(
-            "dstack._internal.server.services.runs.get_offers_by_requirements"
+            "dstack._internal.server.services.offers.get_offers_by_requirements"
         ) as run_plan_by_req:
             offers = InstanceOfferWithAvailability(
                 backend=BackendType.VASTAI,


### PR DESCRIPTION
Closes #1472 

This PR adds a fleet apply plan similar to the run plan:

```
✗ dstack apply -f .dstack/confs/fleet.yaml
 Project        main                           
 User           admin                          
 Configuration  .dstack/confs/fleet.yaml       
 Type           fleet                          
 Fleet type     cloud                          
 Nodes          2                              
 Placement      cluster                        
 Backends       aws                            
 Resources      2..xCPU, 8GB.., 100GB.. (disk) 
 Spot policy    on-demand                      

 #  BACKEND  REGION        INSTANCE   RESOURCES                   SPOT  PRICE    
 1  aws      eu-west-1     m5.large   2xCPU, 8GB, 100.0GB (disk)  no    $0.107   
 2  aws      eu-central-1  m5.large   2xCPU, 8GB, 100.0GB (disk)  no    $0.115   
 3  aws      eu-west-1     c5.xlarge  4xCPU, 8GB, 100.0GB (disk)  no    $0.192   
    ...                                                                          
 Shown 3 of 82 offers, $40.9447 max

Fleet my-cluster-fleet does not exist yet.
Create the fleet? [y/n]: 
```

For older servers (<=0.18.16), the plan is shown without offers (since they don't implement the necessary /get_plan API).

It also implements "attach" for fleet apply so that dstack apply does not exit until the fleet is provisioned with the fleet table shown in watch mode. (addresses #1571).

