### PR TITLE
Mitigate concurrent `dstack attach` issues

### DIFF
--- a/src/dstack/_internal/core/services/ssh/attach.py
+++ b/src/dstack/_internal/core/services/ssh/attach.py
@@ -105,7 +105,9 @@ class SSHAttach:
             ),
             control_sock_path=control_sock_path,
             ssh_config_path=self.ssh_config_path,
-            options={},
+            options={
+                "ExitOnForwardFailure": "yes",
+            },
         )
         self.ssh_proxy = ssh_proxy
         if ssh_proxy is None:

--- a/src/dstack/_internal/core/services/ssh/ports.py
+++ b/src/dstack/_internal/core/services/ssh/ports.py
@@ -75,8 +75,6 @@ class PortsLock:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             if IS_WINDOWS:
                 sock.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
-            else:
-                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             sock.bind(("", port))
             return sock
         except socket.error as e:


### PR DESCRIPTION
1. Don't use SO_REUSEADDR. Although it might be helpful, as it allows to bind a socket in TIME_WAIT state (this is the reason it was added in the first place), unfortunately it has some other (unwanted) effects:
    * On Linux, it allows to bind to the same address-port pair (including wildcard), as long as this option is set before each bind().
    * On BSD, it allows to bind to a wildcard address and a specific address, or vice versa (but not the same specific address, as on Linux). 
   
   These other effects increase discrepancy between Linux and BSD (incl. macOS).

2. Run ssh with ExitOnForwardFailure=yes. With this option, ssh exits with error if it cannot bind() to requested ports.

This is not an ideal solution. the way Run.attach() works, it's still possible to PortsLock.acquire() the same local port due to race condition (if one client just released the lock, but ssh hasn't yet established the tunnel, another client can acquire the same port in between, but with the second fix applied it will eventually fail, as it will not be able to establish ssh tunnel in 10 attempts.

It would be better to acquire PortsLock as soon as possible (don't wait for RunStatus.RUNNING), but it requires refactoring, including the public Python API.

Fixes: https://github.com/dstackai/dstack/issues/1814