### PR TITLE
Run container as --privileged if DSTACK_DOCKER_PRIVILEGED

### DIFF
--- a/runner/cmd/shim/main.go
+++ b/runner/cmd/shim/main.go
@@ -93,6 +93,7 @@ func main() {
 						Name:        "privileged",
 						Usage:       "Give extended privileges to the container",
 						Destination: &args.Docker.Privileged,
+						EnvVars:     []string{"DSTACK_DOCKER_PRIVILEGED"},
 					},
 					&cli.StringFlag{
 						Name:        "ssh-key",


### PR DESCRIPTION
This is needed to run Docker-in-Docker.

I'm *guessing* the env vars passed from the `env:` section at the root of the task yaml make it to the initialization of `dstack-shim`, but please let me know if not!

Fixes #1820