### PR TITLE
[Docs] Use correct discord server invite in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![Last commit](https://img.shields.io/github/last-commit/dstackai/dstack?style=flat-square)](https://github.com/dstackai/dstack/commits/)
 [![PyPI - License](https://img.shields.io/pypi/l/dstack?style=flat-square&color=blue)](https://github.com/dstackai/dstack/blob/master/LICENSE.md)
-[![Discord](https://dcbadge.vercel.app/api/server/u8SmfwPpMd?style=flat-square)](https://discord.gg/CBgdrGnZjy)
+[![Discord](https://dcbadge.vercel.app/api/server/u8SmfwPpMd?style=flat-square)](https://discord.gg/u8SmfwPpMd)
 
 </div>
 


### PR DESCRIPTION
The discord invite in readme was pointing to a random server which was not the server linked in the docs.
![image](https://github.com/user-attachments/assets/6a600c77-f727-4e58-8b19-b9bba32b5a87)
I have edited the link to use same invite as from the docs.
