### PR TITLE
Fix shim tests binding to 0 port

### DIFF
--- a/runner/internal/shim/docker_test.go
+++ b/runner/internal/shim/docker_test.go
@@ -154,7 +154,9 @@ func (c *dockerParametersMock) DockerShellCommands(publicKeys []string) []string
 
 func (c *dockerParametersMock) DockerPorts() []int {
 	ports := make([]int, 0)
-	ports = append(ports, c.sshPort)
+	if c.sshPort != 0 {
+		ports = append(ports, c.sshPort)
+	}
 	return ports
 }
 


### PR DESCRIPTION
Some shim integration tests run Docker with a `0` port bind on the host. 

This led to the following error (macOS Ventura 13.4, Docker version 24.0.5):

```
--- FAIL: TestDocker_ShmExecIfSizeSpecified (12.56s)
    docker_test.go:122: 
                Error Trace:    /Users/r4victor/Projects/dstack/dstack/runner/internal/shim/docker_test.go:122
                Error:          Received unexpected error:
                                Error response from daemon: driver failed programming external connectivity on endpoint practical_proskuriakova (818079840b3ffaec8873b5383e5bcff358c80a5cd55e7518ffc0c45b29b30083):  (iptables failed: iptables --wait -t nat -A DOCKER -p tcp -d 0/0 --dport 32787 -j DNAT --to-destination 172.17.0.3:0: iptables v1.8.7 (legacy): Port `0' not valid
                            
                                Try `iptables -h' or 'iptables --help' for more information.
                                 (exit status 2))
                Test:           TestDocker_ShmExecIfSizeSpecified
```