### PR TITLE
Fix Trl example

### DIFF
--- a/examples/fine-tuning/trl/train.dstack.yml
+++ b/examples/fine-tuning/trl/train.dstack.yml
@@ -12,7 +12,7 @@ env:
 # Commands of the task
 commands:
   - conda install cuda
-  - pip install "transformers>=4.43.2"
+  - pip install git+https://github.com/huggingface/transformers.git
   - pip install bitsandbytes
   - pip install flash-attn --no-build-isolation
   - pip install peft


### PR DESCRIPTION
### Issue
Fine-tuning with TRL  example produced below error with below command:

`dstack apply -f examples/fine-tuning/trl/train.dstack.yml`

```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/workflow/trl/examples/scripts/sft.py", line 95, in <module>
[rank0]:     trainer = SFTTrainer(
[rank0]:   File "/opt/conda/envs/workflow/lib/python3.10/site-packages/huggingface_hub/utils/_deprecation.py", line 101, in inner_f
[rank0]:     return f(*args, **kwargs)
[rank0]:   File "/opt/conda/envs/workflow/lib/python3.10/site-packages/transformers/utils/deprecation.py", line 165, in wrapped_func
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/opt/conda/envs/workflow/lib/python3.10/site-packages/trl/trainer/sft_trainer.py", line 409, in __init__
[rank0]:     super().__init__(
[rank0]: TypeError: Trainer.__init__() got an unexpected keyword argument 'processing_class'
E1016 09:00:27.142000 139836130027328 torch/distributed/elastic/multiprocessing/api.py:833] failed (exitcode: 1) local_rank: 0 (pid: 1564) of binary: /opt/conda/envs/workflow/bin/python3.10
Traceback (most recent call last):
  File "/opt/conda/envs/workflow/bin/accelerate", line 8, in <module>
    sys.exit(main())
  File "/opt/conda/envs/workflow/lib/python3.10/site-packages/accelerate/commands/accelerate_cli.py", line 48, in main
    args.func(args)
  File "/opt/conda/envs/workflow/lib/python3.10/site-packages/accelerate/commands/launch.py", line 1159, in launch_command
    multi_gpu_launcher(args)
  File "/opt/conda/envs/workflow/lib/python3.10/site-packages/accelerate/commands/launch.py", line 793, in multi_gpu_launcher
    distrib_run.run(args)
  File "/opt/conda/envs/workflow/lib/python3.10/site-packages/torch/distributed/run.py", line 892, in run
    elastic_launch(
  File "/opt/conda/envs/workflow/lib/python3.10/site-packages/torch/distributed/launcher/api.py", line 133, in __call__
    return launch_agent(self._config, self._entrypoint, list(args))
  File "/opt/conda/envs/workflow/lib/python3.10/site-packages/torch/distributed/launcher/api.py", line 264, in launch_agent
    raise ChildFailedError(
torch.distributed.elastic.multiprocessing.errors.ChildFailedError:
============================================================
examples/scripts/sft.py FAILED
------------------------------------------------------------
Failures:
  <NO_OTHER_FAILURES>
------------------------------------------------------------
Root Cause (first observed failure):
[0]:
  time      : 2024-10-16_09:00:27
  host      : 8cb5684fc1d5
  rank      : 0 (local_rank: 0)
  exitcode  : 1 (pid: 1564)
  error_file: <N/A>
  traceback : To enable traceback see: https://pytorch.org/docs/stable/elastic/errors.html
```

### Fix

Use `pip install git+https://github.com/huggingface/transformers.git` instead of `pip install "transformers>=4.43.2"` as solved [here]( https://github.com/huggingface/trl/issues/2226#issuecomment-2408465017)