### PR TITLE
Implement custom backend tags

### DIFF
--- a/docs/docs/reference/server/config.yml.md
+++ b/docs/docs/reference/server/config.yml.md
@@ -350,6 +350,7 @@ gcloud projects list --format="json(projectId)"
     compute.disks.delete
     compute.disks.get
     compute.disks.list
+    compute.disks.setLabels
     compute.disks.use
     compute.firewalls.create
     compute.images.useReadOnly

--- a/src/dstack/_internal/core/backends/aws/resources.py
+++ b/src/dstack/_internal/core/backends/aws/resources.py
@@ -417,8 +417,8 @@ def _is_valid_tag(key: str, value: str) -> bool:
     return _is_valid_tag_key(key) and _is_valid_tag_value(value)
 
 
-TAG_KEY_PATTERN = re.compile(r"^[\w\s.:/=\-+@]{1,128}$")
-TAG_VALUE_PATTERN = re.compile(r"^[\w\s.:/=\-+@]{0,256}$")
+TAG_KEY_PATTERN = re.compile(r"^[\w .:/=\-+@]{1,128}$")
+TAG_VALUE_PATTERN = re.compile(r"^[\w .:/=\-+@]{0,256}$")
 
 
 def _is_valid_tag_key(key: str) -> bool:

--- a/src/dstack/_internal/core/backends/aws/resources.py
+++ b/src/dstack/_internal/core/backends/aws/resources.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any, Dict, List, Optional
 
 import botocore.client
@@ -394,6 +395,42 @@ def list_instance_device_names(
     for mapping in block_device_mappings:
         device_names.append(mapping["DeviceName"])
     return device_names
+
+
+def make_tags(tags: Dict[str, str]) -> List[Dict[str, str]]:
+    tags_list = []
+    for k, v in tags.items():
+        tags_list.append({"Key": k, "Value": v})
+    return tags_list
+
+
+def validate_tags(tags: Dict[str, str]):
+    for k, v in tags.items():
+        if not _is_valid_tag(k, v):
+            raise ComputeError(
+                "Invalid resource tags. "
+                "See tags restrictions: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions"
+            )
+
+
+def _is_valid_tag(key: str, value: str) -> bool:
+    return _is_valid_tag_key(key) and _is_valid_tag_value(value)
+
+
+TAG_KEY_PATTERN = re.compile(r"^[\w\s.:/=\-+@]{1,128}$")
+TAG_VALUE_PATTERN = re.compile(r"^[\w\s.:/=\-+@]{0,256}$")
+
+
+def _is_valid_tag_key(key: str) -> bool:
+    if key.startswith("aws:"):
+        return False
+    match = re.match(TAG_KEY_PATTERN, key)
+    return match is not None
+
+
+def _is_valid_tag_value(value: str) -> bool:
+    match = re.match(TAG_VALUE_PATTERN, value)
+    return match is not None
 
 
 def _list_possible_device_names() -> List[str]:

--- a/src/dstack/_internal/core/backends/azure/resources.py
+++ b/src/dstack/_internal/core/backends/azure/resources.py
@@ -1,0 +1,29 @@
+import re
+from typing import Dict
+
+from dstack._internal.core.errors import ComputeError
+
+
+def validate_tags(tags: Dict[str, str]):
+    for k, v in tags.items():
+        if not _is_valid_tag(k, v):
+            raise ComputeError(
+                "Invalid Azure resource tags. "
+                "See tags restrictions: https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources#limitations"
+            )
+
+
+def _is_valid_tag(key: str, value: str) -> bool:
+    return _is_valid_tag_key(key) and _is_valid_tag_value(value)
+
+
+TAG_KEY_PATTERN = re.compile(r"^(?!.*[<>&\\%?\/]).{1,512}$")
+TAG_VALUE_PATTERN = re.compile(r".{0,256}$")
+
+
+def _is_valid_tag_key(key: str) -> bool:
+    return TAG_KEY_PATTERN.match(key) is not None
+
+
+def _is_valid_tag_value(value: str) -> bool:
+    return TAG_VALUE_PATTERN.match(value) is not None

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -393,3 +393,11 @@ def get_dstack_gateway_commands() -> List[str]:
         f"/home/ubuntu/dstack/blue/bin/pip install {get_dstack_gateway_wheel(build)}",
         "sudo /home/ubuntu/dstack/blue/bin/python -m dstack.gateway.systemd install --run",
     ]
+
+
+def merge_tags(tags: Dict[str, str], backend_tags: Optional[Dict[str, str]]) -> Dict[str, str]:
+    res = tags.copy()
+    if backend_tags is not None:
+        for k, v in backend_tags.items():
+            res.setdefault(k, v)
+    return res

--- a/src/dstack/_internal/core/backends/gcp/resources.py
+++ b/src/dstack/_internal/core/backends/gcp/resources.py
@@ -311,8 +311,20 @@ def get_accelerators(
     return [accelerator_config]
 
 
-NAME_PATTERN = re.compile(r"^[a-z]([-a-z0-9]*[a-z0-9])?$")
+def validate_labels(labels: Dict[str, str]):
+    for k, v in labels.items():
+        if not _is_valid_label(k, v):
+            raise ComputeError(
+                "Invalid resource labels. "
+                "See labels restrictions: https://cloud.google.com/compute/docs/labeling-resources#requirements"
+            )
 
+
+def _is_valid_label(key: str, value: str) -> bool:
+    return is_valid_resource_name(key) and is_valid_label_value(value)
+
+
+NAME_PATTERN = re.compile(r"^[a-z]([-a-z0-9]*[a-z0-9])?$")
 LABEL_VALUE_PATTERN = re.compile(r"^[-a-z0-9]{0,63}$")
 
 

--- a/src/dstack/_internal/core/models/backends/aws.py
+++ b/src/dstack/_internal/core/models/backends/aws.py
@@ -14,6 +14,7 @@ class AWSConfigInfo(CoreModel):
     vpc_ids: Optional[Dict[str, str]] = None
     default_vpcs: Optional[bool] = None
     public_ips: Optional[bool] = None
+    tags: Optional[Dict[str, str]] = None
 
 
 class AWSAccessKeyCreds(CoreModel):
@@ -50,6 +51,7 @@ class AWSConfigInfoWithCredsPartial(CoreModel):
     vpc_ids: Optional[Dict[str, str]]
     default_vpcs: Optional[bool]
     public_ips: Optional[bool]
+    tags: Optional[Dict[str, str]]
 
 
 class AWSConfigValues(CoreModel):

--- a/src/dstack/_internal/core/models/backends/azure.py
+++ b/src/dstack/_internal/core/models/backends/azure.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from pydantic import Field
 from typing_extensions import Annotated, List, Literal, Optional, Union
 
@@ -10,6 +12,7 @@ class AzureConfigInfo(CoreModel):
     tenant_id: str
     subscription_id: str
     locations: Optional[List[str]] = None
+    tags: Optional[Dict[str, str]] = None
 
 
 class AzureClientCreds(CoreModel):
@@ -44,6 +47,7 @@ class AzureConfigInfoWithCredsPartial(CoreModel):
     tenant_id: Optional[str]
     subscription_id: Optional[str]
     locations: Optional[List[str]]
+    tags: Optional[Dict[str, str]]
 
 
 class AzureConfigValues(CoreModel):

--- a/src/dstack/_internal/core/models/backends/gcp.py
+++ b/src/dstack/_internal/core/models/backends/gcp.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from pydantic import Field
 from typing_extensions import Literal
@@ -14,6 +14,7 @@ class GCPConfigInfo(CoreModel):
     vpc_name: Optional[str] = None
     vpc_project_id: Optional[str] = None
     public_ips: Optional[bool] = None
+    tags: Optional[Dict[str, str]] = None
 
 
 class GCPServiceAccountCreds(CoreModel):
@@ -48,6 +49,7 @@ class GCPConfigInfoWithCredsPartial(CoreModel):
     vpc_name: Optional[str] = None
     vpc_project_id: Optional[str] = None
     public_ips: Optional[bool]
+    tags: Optional[Dict[str, str]] = None
 
 
 class GCPConfigValues(CoreModel):

--- a/src/dstack/_internal/server/services/backends/configurators/aws.py
+++ b/src/dstack/_internal/server/services/backends/configurators/aws.py
@@ -140,7 +140,7 @@ class AWSConfigurator(Configurator):
             return
         if len(config.tags) > TAGS_MAX_NUM:
             raise ServerClientError(
-                f"Exceed maximum number of tags. Up to {TAGS_MAX_NUM} tags is allowed."
+                f"Maximum number of tags exceeded. Up to {TAGS_MAX_NUM} tags is allowed."
             )
         try:
             resources.validate_tags(config.tags)

--- a/src/dstack/_internal/server/services/backends/configurators/azure.py
+++ b/src/dstack/_internal/server/services/backends/configurators/azure.py
@@ -312,6 +312,9 @@ class AzureConfigurator(Configurator):
                 executor.submit(func, location)
 
     def _check_config(self, config: AzureConfigInfoWithCredsPartial):
+        self._check_tags_config(config)
+
+    def _check_tags_config(self, config: AzureConfigInfoWithCredsPartial):
         if not config.tags:
             return
         if len(config.tags) > TAGS_MAX_NUM:

--- a/src/dstack/_internal/server/services/backends/configurators/base.py
+++ b/src/dstack/_internal/server/services/backends/configurators/base.py
@@ -12,6 +12,10 @@ from dstack._internal.core.models.backends import (
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.server.models import BackendModel, ProjectModel
 
+# Most clouds allow ~ 40-60 tags/labels per resource.
+# We'll introduce our own base limit that can be customized per backend if required.
+TAGS_MAX_NUM = 25
+
 
 class Configurator(ABC):
     TYPE: BackendType

--- a/src/dstack/_internal/server/services/backends/configurators/gcp.py
+++ b/src/dstack/_internal/server/services/backends/configurators/gcp.py
@@ -235,7 +235,7 @@ class GCPConfigurator(Configurator):
             return
         if len(config.tags) > TAGS_MAX_NUM:
             raise ServerClientError(
-                f"Exceed maximum number of tags. Up to {TAGS_MAX_NUM} tags is allowed."
+                f"Maximum number of tags exceeded. Up to {TAGS_MAX_NUM} tags is allowed."
             )
         try:
             resources.validate_labels(config.tags)

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -171,6 +171,12 @@ class GCPConfig(CoreModel):
             description="A flag to enable/disable public IP assigning on instances. Defaults to `true`"
         ),
     ] = None
+    tags: Annotated[
+        Optional[Dict[str, str]],
+        Field(
+            description="The tags (labels) that will be assigned to resources created by `dstack`"
+        ),
+    ] = None
     creds: AnyGCPCreds = Field(..., description="The credentials", discriminator="type")
 
 
@@ -187,6 +193,12 @@ class GCPAPIConfig(CoreModel):
         Optional[bool],
         Field(
             description="A flag to enable/disable public IP assigning on instances. Defaults to `true`"
+        ),
+    ] = None
+    tags: Annotated[
+        Optional[Dict[str, str]],
+        Field(
+            description="The tags (labels) that will be assigned to resources created by `dstack`"
         ),
     ] = None
     creds: AnyGCPAPICreds = Field(..., description="The credentials", discriminator="type")

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -89,6 +89,10 @@ class AWSConfig(CoreModel):
             description="A flag to enable/disable public IP assigning on instances. Defaults to `true`"
         ),
     ] = None
+    tags: Annotated[
+        Optional[Dict[str, str]],
+        Field(description="The tags that will be assigned to resources created by `dstack`"),
+    ] = None
     creds: AnyAWSCreds = Field(..., description="The credentials", discriminator="type")
 
 

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -100,7 +100,13 @@ class AzureConfig(CoreModel):
     type: Annotated[Literal["azure"], Field(description="The type of the backend")] = "azure"
     tenant_id: Annotated[str, Field(description="The tenant ID")]
     subscription_id: Annotated[str, Field(description="The subscription ID")]
-    regions: Optional[List[str]] = None
+    regions: Annotated[
+        Optional[List[str]], Field(description="The list of Azure regions (locations)")
+    ] = None
+    tags: Annotated[
+        Optional[Dict[str, str]],
+        Field(description="The tags that will be assigned to resources created by `dstack`"),
+    ] = None
     creds: AnyAzureCreds = Field(..., description="The credentials", discriminator="type")
 
 

--- a/src/tests/_internal/core/backends/aws/test_resources.py
+++ b/src/tests/_internal/core/backends/aws/test_resources.py
@@ -1,0 +1,72 @@
+import pytest
+
+from dstack._internal.core.backends.aws.resources import (
+    _is_valid_tag_key,
+    _is_valid_tag_value,
+    validate_tags,
+)
+from dstack._internal.core.errors import ComputeError
+
+
+class TestIsValidTagKey:
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "Environment",
+            "Project123",
+            "service-name@123",
+            "a" * 128,
+        ],
+    )
+    def test_valid_tag_key(self, key):
+        assert _is_valid_tag_key(key)
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "aws:reserved",
+            "",
+            "a" * 129,
+            "Invalid#Char",
+        ],
+    )
+    def test_invalid_tag_key(self, key):
+        assert not _is_valid_tag_key(key)
+
+
+class TestIsValidTagValue:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "Production",
+            "v1.0",
+            "",
+            "a" * 256,
+        ],
+    )
+    def test_valid_tag_value(self, value):
+        assert _is_valid_tag_value(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "a" * 257,
+            "Invalid#Value",
+        ],
+    )
+    def test_invalid_tag_value(self, value):
+        assert _is_valid_tag_value(value) is False
+
+
+class TestValidateTags:
+    def test_validate_valid_tags(self):
+        tags = {
+            "Environment": "Production",
+            "Project": "AWS_Tag_Validator",
+        }
+        assert validate_tags(tags) is None
+
+    def test_validate_invalid_tags(self):
+        tags = {"aws:ReservedKey": "SomeValue", "ValidKey": "Invalid#Value"}
+        with pytest.raises(ComputeError, match="Invalid resource tags"):
+            validate_tags(tags)

--- a/src/tests/_internal/core/backends/aws/test_resources.py
+++ b/src/tests/_internal/core/backends/aws/test_resources.py
@@ -14,7 +14,7 @@ class TestIsValidTagKey:
         [
             "Environment",
             "Project123",
-            "service-name@123",
+            "special-chars-+/@=:",
             "a" * 128,
         ],
     )
@@ -25,6 +25,7 @@ class TestIsValidTagKey:
         "key",
         [
             "aws:reserved",
+            "key\twith\nweird\nspaces",
             "",
             "a" * 129,
             "Invalid#Char",

--- a/src/tests/_internal/core/backends/azure/test_resources.py
+++ b/src/tests/_internal/core/backends/azure/test_resources.py
@@ -1,0 +1,74 @@
+import pytest
+
+from dstack._internal.core.backends.azure.resources import (
+    _is_valid_tag_key,
+    _is_valid_tag_value,
+    validate_tags,
+)
+from dstack._internal.core.errors import ComputeError
+
+
+class TestValidateTags:
+    def test_valid_tags(self):
+        tags = {"ValidTag": "SomeValue"}
+        assert validate_tags(tags) is None
+
+    def test_invalid_tags(self):
+        tags = {"Invalid<key": "SomeValue"}
+        with pytest.raises(ComputeError, match="Invalid Azure resource tags"):
+            validate_tags(tags)
+
+
+class TestIsValidTagKey:
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "ValidTagName",
+            "Tag-Name_with.123",
+            "🧬",
+            "a" * 512,
+            "Tag With Spaces",
+        ],
+    )
+    def test_valid_tag_keys(self, key):
+        assert _is_valid_tag_key(key)
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "",
+            "A" * 513,
+            "Invalid<key>",
+            "Invalid>key",
+            "Invalid%key",
+            "Invalid&key",
+            "Invalid\\key",
+            "Invalid?key",
+            "Invalid/key",
+        ],
+    )
+    def test_invalid_tag_keys(self, key):
+        assert not _is_valid_tag_key(key)
+
+
+class TestIsValidTagValue:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "ValidValue",
+            "Value_with_special_chars!@#",
+            "a" * 256,
+            "",
+        ],
+    )
+    def test_valid_tag_values(self, value):
+        assert _is_valid_tag_value(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "a" * 257,
+        ],
+    )
+    def test_invalid_tag_values(self, value):
+        assert not _is_valid_tag_value(value)

--- a/src/tests/_internal/core/backends/gcp/test_resources.py
+++ b/src/tests/_internal/core/backends/gcp/test_resources.py
@@ -1,6 +1,24 @@
 import pytest
 
 from dstack._internal.core.backends.gcp import resources as gcp_resources
+from dstack._internal.core.errors import ComputeError
+
+
+class TestValidateLabels:
+    def test_validate_valid_labels(self):
+        labels = {
+            "env": "production",
+            "project": "gcp-label-validator",
+        }
+        assert gcp_resources.validate_labels(labels) is None
+
+    def test_validate_invalid_labels(self):
+        labels = {
+            "InvalidName": "validvalue",
+            "valid-name": "invalid_value!",
+        }
+        with pytest.raises(ComputeError, match="Invalid resource label"):
+            gcp_resources.validate_labels(labels)
 
 
 class TestIsValidResourceName:

--- a/src/tests/_internal/server/routers/test_backends.py
+++ b/src/tests/_internal/server/routers/test_backends.py
@@ -1209,6 +1209,7 @@ class TestGetConfigInfo:
             "vpc_ids": None,
             "default_vpcs": None,
             "public_ips": None,
+            "tags": None,
             "creds": json.loads(backend.auth.plaintext),
         }
 


### PR DESCRIPTION
Closes #1838 

This PR adds support for custom backend tags for AWS, GCP, and Azure that are applied to all resources (instances, gateways, volumes) created by dstack:

```
type: aws
tags:
  company_project: dstack
  company_user: victor
creds:
  type: default
```

Also, some resources were not tagged previously (e.g. GCP volumes and all Azure resources). The PR fixes that.