### PR TITLE
Support AWS private subnets with Transit Gateway

### DIFF
--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -630,7 +630,11 @@ def get_vpc_id_subnet_id_or_error(
                 return vpc_id, subnets_ids
             if allocate_public_ip:
                 raise ComputeError(f"Failed to find public subnets for VPC {vpc_id}")
-            raise ComputeError(f"Failed to find private subnets for VPC {vpc_id}")
+            raise ComputeError(
+                f"Failed to find private subnets for VPC {vpc_id} with outbound internet access. "
+                "Ensure you've setup NAT Gateway, Transit Gateway, or other mechanism "
+                "to provide outbound internet access from private subnets."
+            )
         if not config.use_default_vpcs:
             raise ComputeError(f"No VPC ID configured for region {region}")
 

--- a/src/dstack/_internal/core/backends/aws/resources.py
+++ b/src/dstack/_internal/core/backends/aws/resources.py
@@ -554,7 +554,8 @@ def _is_private_subnet_with_internet_egress(
                 if any(route.get(k) for k in _PRIVATE_SUBNET_EGRESS_ROUTE_KEYS):
                     return True
 
-    # If no explicitly associated route tables, check the main route table
+    # Main route table controls the routing of all subnetes
+    # that are not explicitly associated with any other route table.
     if len(response["RouteTables"]) > 0:
         return False
 

--- a/src/dstack/_internal/core/backends/aws/resources.py
+++ b/src/dstack/_internal/core/backends/aws/resources.py
@@ -326,13 +326,14 @@ def get_subnets_ids_for_vpc(
             if is_public_subnet:
                 subnets_ids.append(subnet_id)
         else:
-            subnet_behind_nat = _is_subnet_behind_nat(
+            is_eligible_private_subnet = _is_private_subnet_with_internet_egress(
                 ec2_client=ec2_client,
                 vpc_id=vpc_id,
                 subnet_id=subnet_id,
             )
-            if subnet_behind_nat:
+            if is_eligible_private_subnet:
                 subnets_ids.append(subnet_id)
+
     return subnets_ids
 
 
@@ -535,7 +536,10 @@ def _is_public_subnet(
     return False
 
 
-def _is_subnet_behind_nat(
+_PRIVATE_SUBNET_EGRESS_ROUTE_KEYS = ["NatGatewayId", "TransitGatewayId", "VpcPeeringConnectionId"]
+
+
+def _is_private_subnet_with_internet_egress(
     ec2_client: botocore.client.BaseClient,
     vpc_id: str,
     subnet_id: str,
@@ -546,11 +550,11 @@ def _is_subnet_behind_nat(
     )
     for route_table in response["RouteTables"]:
         for route in route_table["Routes"]:
-            if "NatGatewayId" in route and route["NatGatewayId"].startswith("nat-"):
-                return True
+            if route.get("DestinationCidrBlock") == "0.0.0.0/0":
+                if any(route.get(k) for k in _PRIVATE_SUBNET_EGRESS_ROUTE_KEYS):
+                    return True
 
-    # Main route table controls the routing of all subnetes
-    # that are not explicitly associated with any other route table.
+    # If no explicitly associated route tables, check the main route table
     if len(response["RouteTables"]) > 0:
         return False
 
@@ -563,7 +567,8 @@ def _is_subnet_behind_nat(
     )
     for route_table in response["RouteTables"]:
         for route in route_table["Routes"]:
-            if "NatGatewayId" in route and route["NatGatewayId"].startswith("nat-"):
-                return True
+            if route.get("DestinationCidrBlock") == "0.0.0.0/0":
+                if any(route.get(k) for k in _PRIVATE_SUBNET_EGRESS_ROUTE_KEYS):
+                    return True
 
     return False


### PR DESCRIPTION
Closes #1879 

This PR adds support for AWS configuration when outbound access to the internet is provided via Transit Gateway. Previously, only setup with direct NAT Gateway was supported.

It's not an option simply checking for a 0.0.0.0/0 route anywhere since it includes a popular case of a 0.0.0.0/0 being routed to IGW (public subnet). So we explicitly list which types of routing can provide internet access for instances without public IPs. Currently, it includes NAT Gateway, Transit Gateway, and VPC Peering Connection.