### PR TITLE
Support custom and private networks for Azure

### DIFF
--- a/docs/docs/reference/server/config.yml.md
+++ b/docs/docs/reference/server/config.yml.md
@@ -162,8 +162,8 @@ There are two ways to configure AWS: using an access key or using the default cr
         For the regions without configured `vpc_ids`, enable default VPCs by setting `default_vpcs` to `true`.
 
 ??? info "Private subnets"
-    By default, `dstack` utilizes public subnets and permits inbound SSH traffic exclusively for any provisioned instances.
-    If you want `dstack` to use private subnets, set `public_ips` to `false`.
+    By default, `dstack` provisions instances with public IPs and permits inbound SSH traffic.
+    If you want `dstack` to use private subnets and provision instances without public IPs, set `public_ips` to `false`.
 
     ```yaml
     projects:
@@ -176,8 +176,8 @@ There are two ways to configure AWS: using an access key or using the default cr
             public_ips: false
     ```
     
-    Using private subnets assumes that both the `dstack` server and users can access the configured VPC's private subnets 
-    (e.g., through VPC peering).
+    Using private subnets assumes that both the `dstack` server and users can access the configured VPC's private subnets.
+    Additionally, private subnets must have outbound internet connectivity provided by NAT Gateway, Transit Gateway, or other mechanism.
 
 #### Azure
 
@@ -286,6 +286,44 @@ There are two ways to configure Azure: using a client secret or using the defaul
         }
     }
     ```
+
+??? info "VPC"
+    By default, `dstack` creates new Azure networks and subnets for every configured region.
+    It's possible to use custom networks by specifying `vpc_ids`:
+
+    ```yaml
+    projects:
+      - name: main
+        backends:
+          - type: azure
+            creds:
+              type: default
+        regions: [westeurope]
+        vpc_ids:
+          westeurope: myNetworkResourceGroup/myNetworkName
+    ```
+
+
+??? info "Private subnets"
+    By default, `dstack` provisions instances with public IPs and permits inbound SSH traffic.
+    If you want `dstack` to use private subnets and provision instances without public IPs,
+    specify custom networks using `vpc_ids` and set `public_ips` to `false`.
+
+    ```yaml
+    projects:
+      - name: main
+        backends:
+          - type: azure
+            creds:
+              type: default
+            regions: [westeurope]
+            vpc_ids:
+              westeurope: myNetworkResourceGroup/myNetworkName
+            public_ips: false
+    ```
+    
+    Using private subnets assumes that both the `dstack` server and users can access the configured VPC's private subnets.
+    Additionally, private subnets must have outbound internet connectivity provided by [NAT Gateway or other mechanism](https://learn.microsoft.com/en-us/azure/nat-gateway/nat-overview).
 
 #### GCP
 
@@ -441,8 +479,8 @@ gcloud projects list --format="json(projectId)"
         * Allow `INGRESS` traffic on ports `22`, `80`, `443`, with the target tag `dstack-gateway-instance`
 
 ??? info "Private subnets"
-    By default, `dstack` utilizes public subnets and permits inbound SSH traffic exclusively for any provisioned instances.
-    If you want `dstack` to use private subnets, set `public_ips` to `false`.
+    By default, `dstack` provisions instances with public IPs and permits inbound SSH traffic.
+    If you want `dstack` to use private subnets and provision instances without public IPs, set `public_ips` to `false`.
 
     ```yaml
     projects:
@@ -455,7 +493,8 @@ gcloud projects list --format="json(projectId)"
             public_ips: false
     ```
     
-    Using private subnets assumes that both the `dstack` server and users can access the configured VPC's private subnets (e.g., through VPC peering). Additionally, [Cloud NAT](https://cloud.google.com/nat/docs/overview) must be configured to provide access to external resources for provisioned instances.
+    Using private subnets assumes that both the `dstack` server and users can access the configured VPC's private subnets.
+    Additionally, [Cloud NAT](https://cloud.google.com/nat/docs/overview) must be configured to provide access to external resources for provisioned instances.
 
 #### Lambda
 

--- a/src/dstack/_internal/core/backends/aws/resources.py
+++ b/src/dstack/_internal/core/backends/aws/resources.py
@@ -5,7 +5,7 @@ import botocore.client
 import botocore.exceptions
 
 import dstack.version as version
-from dstack._internal.core.errors import ComputeError, ComputeResourceNotFoundError
+from dstack._internal.core.errors import BackendError, ComputeError, ComputeResourceNotFoundError
 
 
 def get_image_id(ec2_client: botocore.client.BaseClient, cuda: bool) -> str:
@@ -408,7 +408,7 @@ def make_tags(tags: Dict[str, str]) -> List[Dict[str, str]]:
 def validate_tags(tags: Dict[str, str]):
     for k, v in tags.items():
         if not _is_valid_tag(k, v):
-            raise ComputeError(
+            raise BackendError(
                 "Invalid resource tags. "
                 "See tags restrictions: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions"
             )

--- a/src/dstack/_internal/core/backends/azure/compute.py
+++ b/src/dstack/_internal/core/backends/azure/compute.py
@@ -226,7 +226,7 @@ class AzureCompute(Compute):
             resource_group=self.config.resource_group,
             vpc_ids=self.config.vpc_ids,
             location=configuration.region,
-            allocate_public_ip=self.config.allocate_public_ips,
+            allocate_public_ip=True,
         )
         network_security_group = azure_utils.get_default_network_security_group_name(
             resource_group=self.config.resource_group,
@@ -252,7 +252,7 @@ class AzureCompute(Compute):
             subnet=subnet,
             managed_identity=None,
             image_reference=_get_gateway_image_ref(),
-            vm_size="Standard_B1s",
+            vm_size="Standard_B1ms",
             instance_name=configuration.instance_name,
             user_data=get_gateway_user_data(configuration.ssh_key_pub),
             ssh_pub_keys=[configuration.ssh_key_pub],

--- a/src/dstack/_internal/core/backends/azure/config.py
+++ b/src/dstack/_internal/core/backends/azure/config.py
@@ -4,3 +4,9 @@ from dstack._internal.core.models.backends.azure import AnyAzureCreds, AzureStor
 
 class AzureConfig(AzureStoredConfig, BackendConfig):
     creds: AnyAzureCreds
+
+    @property
+    def allocate_public_ips(self) -> bool:
+        if self.public_ips is not None:
+            return self.public_ips
+        return True

--- a/src/dstack/_internal/core/backends/azure/resources.py
+++ b/src/dstack/_internal/core/backends/azure/resources.py
@@ -4,7 +4,7 @@ from typing import Dict, List
 from azure.mgmt import network as network_mgmt
 from azure.mgmt.network.models import Subnet
 
-from dstack._internal.core.errors import ComputeError
+from dstack._internal.core.errors import BackendError
 
 
 def get_network_subnets(
@@ -78,7 +78,7 @@ def _is_eligible_private_subnet(
 def validate_tags(tags: Dict[str, str]):
     for k, v in tags.items():
         if not _is_valid_tag(k, v):
-            raise ComputeError(
+            raise BackendError(
                 "Invalid Azure resource tags. "
                 "See tags restrictions: https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/tag-resources#limitations"
             )

--- a/src/dstack/_internal/core/backends/gcp/resources.py
+++ b/src/dstack/_internal/core/backends/gcp/resources.py
@@ -11,7 +11,7 @@ from google.api_core.operation import Operation
 from google.cloud import tpu_v2
 
 import dstack.version as version
-from dstack._internal.core.errors import ComputeError
+from dstack._internal.core.errors import BackendError, ComputeError
 from dstack._internal.core.models.instances import Gpu
 from dstack._internal.utils.common import remove_prefix
 from dstack._internal.utils.logging import get_logger
@@ -314,7 +314,7 @@ def get_accelerators(
 def validate_labels(labels: Dict[str, str]):
     for k, v in labels.items():
         if not _is_valid_label(k, v):
-            raise ComputeError(
+            raise BackendError(
                 "Invalid resource labels. "
                 "See labels restrictions: https://cloud.google.com/compute/docs/labeling-resources#requirements"
             )

--- a/src/dstack/_internal/core/models/backends/azure.py
+++ b/src/dstack/_internal/core/models/backends/azure.py
@@ -12,6 +12,8 @@ class AzureConfigInfo(CoreModel):
     tenant_id: str
     subscription_id: str
     locations: Optional[List[str]] = None
+    vpc_ids: Optional[Dict[str, str]] = None
+    public_ips: Optional[bool] = None
     tags: Optional[Dict[str, str]] = None
 
 
@@ -47,6 +49,8 @@ class AzureConfigInfoWithCredsPartial(CoreModel):
     tenant_id: Optional[str]
     subscription_id: Optional[str]
     locations: Optional[List[str]]
+    vpc_ids: Optional[Dict[str, str]]
+    public_ips: Optional[bool]
     tags: Optional[Dict[str, str]]
 
 

--- a/src/dstack/_internal/server/services/backends/configurators/aws.py
+++ b/src/dstack/_internal/server/services/backends/configurators/aws.py
@@ -6,7 +6,11 @@ from boto3.session import Session
 
 from dstack._internal.core.backends.aws import AWSBackend, auth, compute, resources
 from dstack._internal.core.backends.aws.config import AWSConfig
-from dstack._internal.core.errors import BackendAuthError, ComputeError, ServerClientError
+from dstack._internal.core.errors import (
+    BackendAuthError,
+    BackendError,
+    ServerClientError,
+)
 from dstack._internal.core.models.backends.aws import (
     AnyAWSConfigInfo,
     AWSAccessKeyCreds,
@@ -144,7 +148,7 @@ class AWSConfigurator(Configurator):
             )
         try:
             resources.validate_tags(config.tags)
-        except ComputeError as e:
+        except BackendError as e:
             raise ServerClientError(e.args[0])
 
     def _check_vpc_config(self, session: Session, config: AWSConfigInfoWithCredsPartial):
@@ -188,5 +192,5 @@ class AWSConfigurator(Configurator):
             for future in concurrent.futures.as_completed(futures):
                 try:
                     future.result()
-                except ComputeError as e:
+                except BackendError as e:
                     raise ServerClientError(e.args[0])

--- a/src/dstack/_internal/server/services/backends/configurators/azure.py
+++ b/src/dstack/_internal/server/services/backends/configurators/azure.py
@@ -165,6 +165,7 @@ class AzureConfigurator(Configurator):
             subscription_id=config.subscription_id,
             resource_group=resource_group,
             locations=config.locations,
+            create_default_network=config.vpc_ids is None,
         )
         return BackendModel(
             project_id=project.id,
@@ -289,17 +290,19 @@ class AzureConfigurator(Configurator):
         subscription_id: str,
         resource_group: str,
         locations: List[str],
+        create_default_network: bool,
     ):
         def func(location: str):
             network_manager = NetworkManager(
                 credential=credential, subscription_id=subscription_id
             )
-            network_manager.create_virtual_network(
-                resource_group=resource_group,
-                location=location,
-                name=azure_utils.get_default_network_name(resource_group, location),
-                subnet_name=azure_utils.get_default_subnet_name(resource_group, location),
-            )
+            if create_default_network:
+                network_manager.create_virtual_network(
+                    resource_group=resource_group,
+                    location=location,
+                    name=azure_utils.get_default_network_name(resource_group, location),
+                    subnet_name=azure_utils.get_default_subnet_name(resource_group, location),
+                )
             network_manager.create_network_security_group(
                 resource_group=resource_group,
                 location=location,

--- a/src/dstack/_internal/server/services/backends/configurators/azure.py
+++ b/src/dstack/_internal/server/services/backends/configurators/azure.py
@@ -54,7 +54,6 @@ from dstack._internal.server.services.backends.configurators.base import (
     Configurator,
     raise_invalid_credentials_error,
 )
-from dstack._internal.utils.common import get_or_error
 
 LOCATIONS = [
     ("(US) Central US", "centralus"),
@@ -338,7 +337,8 @@ class AzureConfigurator(Configurator):
     def _check_vpc_config(
         self, config: AzureConfigInfoWithCredsPartial, credential: AzureCredential
     ):
-        subscription_id = get_or_error(config.subscription_id)
+        if config.subscription_id is None:
+            return None
         allocate_public_ip = config.public_ips if config.public_ips is not None else True
         if config.public_ips is False and config.vpc_ids is None:
             raise ServerClientError(msg="`vpc_ids` must be specified if `public_ips: false`.")
@@ -360,7 +360,7 @@ class AzureConfigurator(Configurator):
                 )
             network_client = network_mgmt.NetworkManagementClient(
                 credential=credential,
-                subscription_id=subscription_id,
+                subscription_id=config.subscription_id,
             )
             with ThreadPoolExecutor(max_workers=8) as executor:
                 futures = []

--- a/src/dstack/_internal/server/services/backends/configurators/gcp.py
+++ b/src/dstack/_internal/server/services/backends/configurators/gcp.py
@@ -6,7 +6,7 @@ from google.auth.credentials import Credentials
 
 from dstack._internal.core.backends.gcp import GCPBackend, auth, resources
 from dstack._internal.core.backends.gcp.config import GCPConfig
-from dstack._internal.core.errors import BackendAuthError, ComputeError, ServerClientError
+from dstack._internal.core.errors import BackendAuthError, BackendError, ServerClientError
 from dstack._internal.core.models.backends.base import (
     BackendType,
     ConfigElement,
@@ -239,7 +239,7 @@ class GCPConfigurator(Configurator):
             )
         try:
             resources.validate_labels(config.tags)
-        except ComputeError as e:
+        except BackendError as e:
             raise ServerClientError(e.args[0])
 
     def _check_vpc_config(
@@ -259,5 +259,5 @@ class GCPConfigurator(Configurator):
                 shared_vpc_project_id=config.vpc_project_id,
                 allocate_public_ip=allocate_public_ip,
             )
-        except ComputeError as e:
+        except BackendError as e:
             raise ServerClientError(e.args[0])

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -70,7 +70,10 @@ class AWSConfig(CoreModel):
     vpc_ids: Annotated[
         Optional[Dict[str, str]],
         Field(
-            description="The mapping from AWS regions to VPC IDs. If `default_vpcs: true`, omitted regions will use default VPCs"
+            description=(
+                "The mapping from AWS regions to VPC IDs."
+                " If `default_vpcs: true`, omitted regions will use default VPCs"
+            )
         ),
     ] = None
     default_vpcs: Annotated[
@@ -86,7 +89,12 @@ class AWSConfig(CoreModel):
     public_ips: Annotated[
         Optional[bool],
         Field(
-            description="A flag to enable/disable public IP assigning on instances. Defaults to `true`"
+            description=(
+                "A flag to enable/disable public IP assigning on instances."
+                " `public_ips: false` requires at least one private subnet with outbound internet connection"
+                " provided by a NAT Gateway or a Transit Gateway."
+                " Defaults to `true`"
+            )
         ),
     ] = None
     tags: Annotated[
@@ -101,7 +109,28 @@ class AzureConfig(CoreModel):
     tenant_id: Annotated[str, Field(description="The tenant ID")]
     subscription_id: Annotated[str, Field(description="The subscription ID")]
     regions: Annotated[
-        Optional[List[str]], Field(description="The list of Azure regions (locations)")
+        Optional[List[str]],
+        Field(description="The list of Azure regions (locations)"),
+    ] = None
+    vpc_ids: Annotated[
+        Optional[Dict[str, str]],
+        Field(
+            description=(
+                "The mapping from configured Azure locations to network IDs."
+                " A network ID must have a format `networkResourceGroup/networkName`"
+                " If not specified, `dstack` will create a new network for every configured region"
+            )
+        ),
+    ] = None
+    public_ips: Annotated[
+        Optional[bool],
+        Field(
+            description=(
+                "A flag to enable/disable public IP assigning on instances."
+                " `public_ips: false` requires `vpc_ids` that specifies custom networks with NAT gateway."
+                " Defaults to `true`"
+            )
+        ),
     ] = None
     tags: Annotated[
         Optional[Dict[str, str]],
@@ -132,9 +161,9 @@ class GCPServiceAccountCreds(CoreModel):
         Optional[str],
         Field(
             description=(
-                "The contents of the service account file. "
-                "When configuring via `server/config.yml`, it's automatically filled from `filename`. "
-                "When configuring via UI, it has to be specified explicitly"
+                "The contents of the service account file."
+                " When configuring via `server/config.yml`, it's automatically filled from `filename`."
+                " When configuring via UI, it has to be specified explicitly"
             )
         ),
     ] = None
@@ -216,9 +245,9 @@ class KubeconfigConfig(CoreModel):
         Optional[str],
         Field(
             description=(
-                "The contents of the kubeconfig file. "
-                "When configuring via `server/config.yml`, it's automatically filled from `filename`. "
-                "When configuring via UI, it has to be specified explicitly"
+                "The contents of the kubeconfig file."
+                " When configuring via `server/config.yml`, it's automatically filled from `filename`."
+                " When configuring via UI, it has to be specified explicitly"
             )
         ),
     ] = None
@@ -312,8 +341,8 @@ class OCIConfig(CoreModel):
         Optional[str],
         Field(
             description=(
-                "Compartment where `dstack` will create all resources. "
-                "Omit to instruct `dstack` to create a new compartment"
+                "Compartment where `dstack` will create all resources."
+                " Omit to instruct `dstack` to create a new compartment"
             )
         ),
     ] = None

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -65,7 +65,12 @@ class AWSConfig(CoreModel):
     regions: Annotated[Optional[List[str]], Field(description="The list of AWS regions")] = None
     vpc_name: Annotated[
         Optional[str],
-        Field(description="The VPC name. All configured regions must have a VPC with this name"),
+        Field(
+            description=(
+                "The name of custom VPCs. All configured regions must have a VPC with this name."
+                " If your custom VPCs don't have names or have different names in different regions, use `vpc_ids` instead."
+            )
+        ),
     ] = None
     vpc_ids: Annotated[
         Optional[Dict[str, str]],
@@ -91,7 +96,7 @@ class AWSConfig(CoreModel):
         Field(
             description=(
                 "A flag to enable/disable public IP assigning on instances."
-                " `public_ips: false` requires at least one private subnet with outbound internet connection"
+                " `public_ips: false` requires at least one private subnet with outbound internet connectivity"
                 " provided by a NAT Gateway or a Transit Gateway."
                 " Defaults to `true`"
             )
@@ -127,7 +132,8 @@ class AzureConfig(CoreModel):
         Field(
             description=(
                 "A flag to enable/disable public IP assigning on instances."
-                " `public_ips: false` requires `vpc_ids` that specifies custom networks with NAT gateway."
+                " `public_ips: false` requires `vpc_ids` that specifies custom networks with outbound internet connectivity"
+                " provided by NAT Gateway or other mechanism."
                 " Defaults to `true`"
             )
         ),
@@ -195,7 +201,7 @@ class GCPConfig(CoreModel):
     type: Annotated[Literal["gcp"], Field(description="The type of backend")] = "gcp"
     project_id: Annotated[str, Field(description="The project ID")]
     regions: Optional[List[str]] = None
-    vpc_name: Annotated[Optional[str], Field(description="The VPC name")] = None
+    vpc_name: Annotated[Optional[str], Field(description="The name of a custom VPC")] = None
     vpc_project_id: Annotated[
         Optional[str],
         Field(description="The shared VPC hosted project ID. Required for shared VPC only"),
@@ -219,7 +225,7 @@ class GCPAPIConfig(CoreModel):
     type: Annotated[Literal["gcp"], Field(description="The type of backend")] = "gcp"
     project_id: Annotated[str, Field(description="The project ID")]
     regions: Optional[List[str]] = None
-    vpc_name: Annotated[Optional[str], Field(description="The VPC name")] = None
+    vpc_name: Annotated[Optional[str], Field(description="The name of a custom VPC")] = None
     vpc_project_id: Annotated[
         Optional[str],
         Field(description="The shared VPC hosted project ID. Required for shared VPC only"),

--- a/src/tests/_internal/core/backends/aws/test_resources.py
+++ b/src/tests/_internal/core/backends/aws/test_resources.py
@@ -5,7 +5,7 @@ from dstack._internal.core.backends.aws.resources import (
     _is_valid_tag_value,
     validate_tags,
 )
-from dstack._internal.core.errors import ComputeError
+from dstack._internal.core.errors import BackendError
 
 
 class TestIsValidTagKey:
@@ -69,5 +69,5 @@ class TestValidateTags:
 
     def test_validate_invalid_tags(self):
         tags = {"aws:ReservedKey": "SomeValue", "ValidKey": "Invalid#Value"}
-        with pytest.raises(ComputeError, match="Invalid resource tags"):
+        with pytest.raises(BackendError, match="Invalid resource tags"):
             validate_tags(tags)

--- a/src/tests/_internal/core/backends/azure/test_resources.py
+++ b/src/tests/_internal/core/backends/azure/test_resources.py
@@ -5,7 +5,7 @@ from dstack._internal.core.backends.azure.resources import (
     _is_valid_tag_value,
     validate_tags,
 )
-from dstack._internal.core.errors import ComputeError
+from dstack._internal.core.errors import BackendError
 
 
 class TestValidateTags:
@@ -15,7 +15,7 @@ class TestValidateTags:
 
     def test_invalid_tags(self):
         tags = {"Invalid<key": "SomeValue"}
-        with pytest.raises(ComputeError, match="Invalid Azure resource tags"):
+        with pytest.raises(BackendError, match="Invalid Azure resource tags"):
             validate_tags(tags)
 
 

--- a/src/tests/_internal/core/backends/gcp/test_resources.py
+++ b/src/tests/_internal/core/backends/gcp/test_resources.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dstack._internal.core.backends.gcp import resources as gcp_resources
-from dstack._internal.core.errors import ComputeError
+from dstack._internal.core.errors import BackendError
 
 
 class TestValidateLabels:
@@ -17,7 +17,7 @@ class TestValidateLabels:
             "InvalidName": "validvalue",
             "valid-name": "invalid_value!",
         }
-        with pytest.raises(ComputeError, match="Invalid resource label"):
+        with pytest.raises(BackendError, match="Invalid resource label"):
             gcp_resources.validate_labels(labels)
 
 

--- a/src/tests/_internal/server/routers/test_backends.py
+++ b/src/tests/_internal/server/routers/test_backends.py
@@ -309,7 +309,9 @@ class TestGetBackendConfigValuesAzure:
             "dstack._internal.core.backends.azure.auth.authenticate"
         ) as authenticate_mock, patch(
             "azure.mgmt.subscription.SubscriptionClient"
-        ) as SubscriptionClientMock:
+        ) as SubscriptionClientMock, patch(
+            "dstack._internal.core.backends.azure.compute.get_resource_group_network_subnet_or_error"
+        ):
             default_creds_available_mock.return_value = False
             authenticate_mock.return_value = None, "test_tenant"
             client_mock = SubscriptionClientMock.return_value


### PR DESCRIPTION
Closes #1672

This PR adds support for custom Azure networks specified via the `vpc_ids` mapping and instances without public IPs specified via `public_ips: false`:

```yaml
type: azure
  ...
  regions: [westeurope]
  public_ips: false
  vpc_ids:
    westeurope: test-networks-rg/test-network
  creds:
    type: default
 ```
 
`public_ips: false` requires a NAT Gateway or a VNet peering.