### PR TITLE
Update pydantic-duality to fix the infinite recursion bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,7 @@ BASE_DEPS = [
     "starlette>=0.26.0",
     "uvicorn",
     "pydantic>=1.10.10,<2.0.0",
-    # https://github.com/zmievsa/pydantic-duality/issues/21
-    "pydantic-duality<=1.2.2",
+    "pydantic-duality>=1.2.4",
     "sqlalchemy[asyncio]>=2.0.0",
     "sqlalchemy_utils>=0.40.0",
     "alembic>=1.10.2",


### PR DESCRIPTION
It was a long one. Here's the entire process for the fix:

Resolves https://github.com/zmievsa/pydantic-duality/issues/21

1. Here's the minimal reproducible example:

```python
import abc

from pydantic import BaseModel
from pydantic_duality import DualBaseModel


class AzureStoredConfig(DualBaseModel):
    resource_group: str


# from cryptography.hazmat.primitives.hashes import HashContext

# Which actually contains the code below:

# ```


class HashContext(metaclass=abc.ABCMeta):
    pass


from cryptography.hazmat.bindings._rust import openssl as rust_openssl

HashContext.register(rust_openssl.hashes.Hash)


# ```


class AzureConfig(AzureStoredConfig, BaseModel):
    pass


class GCPVolumeDiskBackendData(DualBaseModel):
    disk_type: str
```

2. [Here's the fix in pydantic-duality](https://github.com/zmievsa/pydantic-duality/pull/23)
3. [Here's an alternative fix within dstack](https://github.com/dstackai/dstack/pull/1901)

I am still not sure what exactly is causing the bug but here's what happens:

1. Because pydantic-duality now uses `DualBaseModel.__response__` in subclass checks, the response model gets generated (exactly once though) during the very first subclass check
2. In one of those checks, we have `issubclass(annotation, pydantic.BaseModel)`. The specific class that caused the issue here is `str` so `issubclass(str, pydantic.BaseModel)`
3. For some unknown and weird reason, it calls `DualBaseModel.__subclasshook__` instead of using `BaseModel`'s or `type`'s default subclass check. Not sure how it is possible but I verified that everything from the code block above is absolutely necessary for this situation to happen