### PR TITLE
Add nat_check option to GCP config

### DIFF
--- a/src/dstack/_internal/core/backends/gcp/resources.py
+++ b/src/dstack/_internal/core/backends/gcp/resources.py
@@ -63,6 +63,7 @@ def check_vpc(
     allocate_public_ip: bool,
     vpc_name: Optional[str] = None,
     shared_vpc_project_id: Optional[str] = None,
+    nat_check: bool = True,
 ):
     if vpc_name is None:
         vpc_name = "default"
@@ -77,15 +78,19 @@ def check_vpc(
     if allocate_public_ip:
         return
 
-    regions_without_nat = []
-    for region in regions:
-        if not has_vpc_nat_access(routers_client, vpc_project_id, vpc_name, region):
-            regions_without_nat.append(region)
+    if nat_check:
+        regions_without_nat = []
+        for region in regions:
+            if not has_vpc_nat_access(routers_client, vpc_project_id, vpc_name, region):
+                regions_without_nat.append(region)
 
-    if regions_without_nat:
-        raise ComputeError(
-            f"VPC {vpc_name} in project {vpc_project_id} does not have Cloud NAT configured for external internet access in regions: {regions_without_nat}"
-        )
+        if regions_without_nat:
+            raise ComputeError(
+                f"VPC {vpc_name} in project {vpc_project_id} does not have Cloud NAT configured"
+                f" for outbound internet connectivity in regions: {regions_without_nat}."
+                " Specify `nat_check: false` if you use a different mechanism"
+                " for outbound internet connectivity such as a third-part NAT appliance."
+            )
 
 
 def has_vpc_nat_access(

--- a/src/dstack/_internal/core/backends/gcp/resources.py
+++ b/src/dstack/_internal/core/backends/gcp/resources.py
@@ -89,7 +89,7 @@ def check_vpc(
                 f"VPC {vpc_name} in project {vpc_project_id} does not have Cloud NAT configured"
                 f" for outbound internet connectivity in regions: {regions_without_nat}."
                 " Specify `nat_check: false` if you use a different mechanism"
-                " for outbound internet connectivity such as a third-part NAT appliance."
+                " for outbound internet connectivity such as a third-party NAT appliance."
             )
 
 

--- a/src/dstack/_internal/core/models/backends/gcp.py
+++ b/src/dstack/_internal/core/models/backends/gcp.py
@@ -14,6 +14,7 @@ class GCPConfigInfo(CoreModel):
     vpc_name: Optional[str] = None
     vpc_project_id: Optional[str] = None
     public_ips: Optional[bool] = None
+    nat_check: Optional[bool] = None
     tags: Optional[Dict[str, str]] = None
 
 
@@ -49,6 +50,7 @@ class GCPConfigInfoWithCredsPartial(CoreModel):
     vpc_name: Optional[str] = None
     vpc_project_id: Optional[str] = None
     public_ips: Optional[bool]
+    nat_check: Optional[bool] = None
     tags: Optional[Dict[str, str]] = None
 
 

--- a/src/dstack/_internal/server/services/backends/configurators/gcp.py
+++ b/src/dstack/_internal/server/services/backends/configurators/gcp.py
@@ -249,6 +249,7 @@ class GCPConfigurator(Configurator):
         routers_client: compute_v1.RoutersClient,
     ):
         allocate_public_ip = config.public_ips if config.public_ips is not None else True
+        nat_check = config.nat_check if config.nat_check is not None else True
         try:
             resources.check_vpc(
                 network_client=network_client,
@@ -258,6 +259,7 @@ class GCPConfigurator(Configurator):
                 vpc_name=config.vpc_name,
                 shared_vpc_project_id=config.vpc_project_id,
                 allocate_public_ip=allocate_public_ip,
+                nat_check=nat_check,
             )
         except BackendError as e:
             raise ServerClientError(e.args[0])

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -212,6 +212,17 @@ class GCPConfig(CoreModel):
             description="A flag to enable/disable public IP assigning on instances. Defaults to `true`"
         ),
     ] = None
+    nat_check: Annotated[
+        Optional[bool],
+        Field(
+            description=(
+                "A flag to enable/disable a check that Cloud NAT is configured for the VPC."
+                " This should be set to `false` when `public_ips: false` and outbound internet connectivity"
+                " is provided by a mechanism other than Cloud NAT such as a third-part NAT appliance."
+                " Defaults to `true`"
+            )
+        ),
+    ] = None
     tags: Annotated[
         Optional[Dict[str, str]],
         Field(
@@ -234,6 +245,17 @@ class GCPAPIConfig(CoreModel):
         Optional[bool],
         Field(
             description="A flag to enable/disable public IP assigning on instances. Defaults to `true`"
+        ),
+    ] = None
+    nat_check: Annotated[
+        Optional[bool],
+        Field(
+            description=(
+                "A flag to enable/disable a check that Cloud NAT is configured for the VPC."
+                " This should be set to `false` when `public_ips: false` and outbound internet connectivity"
+                " is provided by a mechanism other than Cloud NAT such as a third-part NAT appliance."
+                " Defaults to `true`"
+            )
         ),
     ] = None
     tags: Annotated[

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -218,7 +218,7 @@ class GCPConfig(CoreModel):
             description=(
                 "A flag to enable/disable a check that Cloud NAT is configured for the VPC."
                 " This should be set to `false` when `public_ips: false` and outbound internet connectivity"
-                " is provided by a mechanism other than Cloud NAT such as a third-part NAT appliance."
+                " is provided by a mechanism other than Cloud NAT such as a third-party NAT appliance."
                 " Defaults to `true`"
             )
         ),
@@ -253,7 +253,7 @@ class GCPAPIConfig(CoreModel):
             description=(
                 "A flag to enable/disable a check that Cloud NAT is configured for the VPC."
                 " This should be set to `false` when `public_ips: false` and outbound internet connectivity"
-                " is provided by a mechanism other than Cloud NAT such as a third-part NAT appliance."
+                " is provided by a mechanism other than Cloud NAT such as a third-party NAT appliance."
                 " Defaults to `true`"
             )
         ),


### PR DESCRIPTION
Closes #1903 

This PR adds `nat_check` option for GCP config that allows to disable Cloud NAT check when `public_ips: false`. This will allow for setups that provide outbound internet connectivity via a third-party NAT appliance or other mechanisms.