### PR TITLE
Handle deleted volumes in attach_volume()

### DIFF
--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -561,9 +561,9 @@ class AWSCompute(Compute):
                 if e.response["Error"]["Code"] == "VolumeInUse":
                     raise ComputeError(f"Failed to attach volume in use: {volume.volume_id}")
                 if e.response["Error"]["Code"] == "InvalidVolume.ZoneMismatch":
-                    raise ComputeError(
-                        f"Failed to attach volume {volume.volume_id}. Volume zone is different from instance zone."
-                    )
+                    raise ComputeError("Volume zone is different from instance zone")
+                if e.response["Error"]["Code"] == "InvalidVolume.NotFound":
+                    raise ComputeError("Volume not found")
                 if (
                     e.response["Error"]["Code"] == "InvalidParameterValue"
                     and f"Invalid value '{device_name}' for unixDevice"

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -158,6 +158,7 @@ class Compute(ABC):
     def attach_volume(self, volume: Volume, instance_id: str) -> VolumeAttachmentData:
         """
         Attaches a volume to the instance.
+        If the volume is not found, it should raise `ComputeError()` instead of a thrid-party exception.
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
This PR adds explicit handling of missing volumes in attach_volume() to return ComputeError. Previously, it was possible to delete the volume while provisioning a run, and cause unnecessary error logs.