### PR TITLE
Show warning on missing backend deps

### DIFF
--- a/src/dstack/_internal/server/services/backends/__init__.py
+++ b/src/dstack/_internal/server/services/backends/__init__.py
@@ -1,6 +1,6 @@
 import asyncio
 import heapq
-from typing import Callable, Coroutine, Dict, List, Optional, Tuple, Type, Union
+from typing import Callable, Coroutine, Dict, Iterable, List, Optional, Tuple, Type, Union
 from uuid import UUID
 
 from sqlalchemy import delete, update
@@ -229,7 +229,7 @@ async def get_config_info(
 async def delete_backends(
     session: AsyncSession,
     project: ProjectModel,
-    backends_types: List[BackendType],
+    backends_types: Iterable[BackendType],
 ):
     if BackendType.DSTACK in backends_types:
         raise ServerClientError("Cannot delete dstack backend")


### PR DESCRIPTION
Fixes #1609 

Now you see a warning if trying to configure a backend without backend deps installed:

```
[09:44:04] INFO     Applying ~/.dstack/server/config.yml...            
           WARNING  dstack._internal.server.services.config:542 Backend
                    aws not available and won't be configured. Check   
                    that backend dependencies are installed.
```