### PR TITLE
Add `/proxy` prefix to dstack-proxy endpoints

### DIFF
--- a/src/dstack/_internal/server/services/gateways/__init__.py
+++ b/src/dstack/_internal/server/services/gateways/__init__.py
@@ -445,7 +445,7 @@ def _register_service_in_server(run_model: RunModel) -> ServiceSpec:
             "Auto-scaling is not yet supported when running services without a gateway. "
             "Please configure a gateway or set `replicas` to a fixed value in the service configuration"
         )
-    return ServiceSpec(url=f"/services/{run_model.project.name}/{run_model.run_name}/")
+    return ServiceSpec(url=f"/proxy/services/{run_model.project.name}/{run_model.run_name}/")
 
 
 async def register_replica(

--- a/src/tests/_internal/core/models/test_runs.py
+++ b/src/tests/_internal/core/models/test_runs.py
@@ -40,18 +40,18 @@ def test_service_spec_full_url_from_full_url():
     [
         (
             "http://localhost:3000",
-            "/services/main/service/",
-            "http://localhost:3000/services/main/service/",
+            "/proxy/services/main/service/",
+            "http://localhost:3000/proxy/services/main/service/",
         ),
         (
             "http://localhost:3000/",
-            "/services/main/service/",
-            "http://localhost:3000/services/main/service/",
+            "/proxy/services/main/service/",
+            "http://localhost:3000/proxy/services/main/service/",
         ),
         (
             "http://localhost:3000/prefix",
-            "/services/main/service/",
-            "http://localhost:3000/prefix/services/main/service/",
+            "/proxy/services/main/service/",
+            "http://localhost:3000/prefix/proxy/services/main/service/",
         ),
     ],
 )

--- a/src/tests/_internal/core/services/test_logs.py
+++ b/src/tests/_internal/core/services/test_logs.py
@@ -132,10 +132,12 @@ class TestServiceURLReplacer:
             app_specs=[],
             hostname="0.0.0.0",
             secure=False,
-            path_prefix="/services/main/service/",
+            path_prefix="/proxy/services/main/service/",
         )
-        assert replacer(b"http://0.0.0.0:8888") == b"http://0.0.0.0:3000/services/main/service/"
+        assert (
+            replacer(b"http://0.0.0.0:8888") == b"http://0.0.0.0:3000/proxy/services/main/service/"
+        )
         assert (
             replacer(b"http://0.0.0.0:8888/qwerty")
-            == b"http://0.0.0.0:3000/services/main/service/qwerty"
+            == b"http://0.0.0.0:3000/proxy/services/main/service/qwerty"
         )

--- a/src/tests/_internal/proxy/routers/test_service_proxy.py
+++ b/src/tests/_internal/proxy/routers/test_service_proxy.py
@@ -18,7 +18,7 @@ def make_app(repo: BaseProxyRepo) -> FastAPI:
 
     app = FastAPI()
     app.state.proxy_dependency_injector = DependencyInjector()
-    app.include_router(router, prefix="/services")
+    app.include_router(router, prefix="/proxy/services")
     return app
 
 
@@ -78,7 +78,7 @@ async def test_proxy(mock_replica_client_httpbin, method: str) -> None:
     req_body = "." * 20 * 2**20 if method not in methods_without_body else None
     resp = await client.request(
         method,
-        f"http://test-host:8888/services/test-proj/httpbin/{method}?a=b&c=",
+        f"http://test-host:8888/proxy/services/test-proj/httpbin/{method}?a=b&c=",
         headers={"User-Agent": "test-ua", "Connection": "keep-alive"},
         content=req_body,
     )
@@ -100,7 +100,7 @@ async def test_proxy_method_head(mock_replica_client_httpbin) -> None:
     await repo.add_project(make_project("test-proj"))
     await repo.add_service(project_name="test-proj", service=make_service("httpbin"))
     _, client = make_app_client(repo)
-    url = "http://test-host/services/test-proj/httpbin/"
+    url = "http://test-host/proxy/services/test-proj/httpbin/"
     get_resp = await client.get(url)
     head_resp = await client.head(url)
     assert get_resp.status_code == head_resp.status_code == 200
@@ -115,7 +115,7 @@ async def test_proxy_method_options(mock_replica_client_httpbin) -> None:
     await repo.add_project(make_project("test-proj"))
     await repo.add_service(project_name="test-proj", service=make_service("httpbin"))
     _, client = make_app_client(repo)
-    resp = await client.options("http://test-host/services/test-proj/httpbin/get")
+    resp = await client.options("http://test-host/proxy/services/test-proj/httpbin/get")
     assert resp.status_code == 200
     assert set(resp.headers["Allow"].split(", ")) == {"HEAD", "GET", "OPTIONS"}
     assert resp.content == b""
@@ -128,7 +128,7 @@ async def test_proxy_status_codes(mock_replica_client_httpbin, code: int) -> Non
     await repo.add_project(make_project("test-proj"))
     await repo.add_service(project_name="test-proj", service=make_service("httpbin"))
     _, client = make_app_client(repo)
-    resp = await client.get(f"http://test-host/services/test-proj/httpbin/status/{code}")
+    resp = await client.get(f"http://test-host/proxy/services/test-proj/httpbin/status/{code}")
     assert resp.status_code == code
 
 
@@ -140,7 +140,7 @@ async def test_proxy_not_leaks_cookies(mock_replica_client_httpbin) -> None:
     app = make_app(repo)
     client1 = make_client(app)
     client2 = make_client(app)
-    cookies_url = "http://test-host/services/test-proj/httpbin/cookies"
+    cookies_url = "http://test-host/proxy/services/test-proj/httpbin/cookies"
     await client1.get(cookies_url + "/set?a=1")
     await client1.get(cookies_url + "/set?b=2")
     await client2.get(cookies_url + "/set?a=3")
@@ -157,7 +157,7 @@ async def test_proxy_gateway_timeout(mock_replica_client_httpbin) -> None:
     await repo.add_service(project_name="test-proj", service=make_service("httpbin"))
     _, client = make_app_client(repo)
     assert MOCK_REPLICA_CLIENT_TIMEOUT < 10
-    resp = await client.get("http://test-host/services/test-proj/httpbin/delay/10")
+    resp = await client.get("http://test-host/proxy/services/test-proj/httpbin/delay/10")
     assert resp.status_code == 504
     assert resp.json()["detail"] == "Gateway Timeout"
 
@@ -168,7 +168,7 @@ async def test_proxy_run_not_found(mock_replica_client_httpbin) -> None:
     await repo.add_project(make_project("test-proj"))
     await repo.add_service(project_name="test-proj", service=make_service("test-run"))
     _, client = make_app_client(repo)
-    resp = await client.get("http://test-host/services/test-proj/unknown/")
+    resp = await client.get("http://test-host/proxy/services/test-proj/unknown/")
     assert resp.status_code == 404
     assert resp.json()["detail"] == "Service test-proj/unknown not found"
 
@@ -176,7 +176,7 @@ async def test_proxy_run_not_found(mock_replica_client_httpbin) -> None:
 @pytest.mark.asyncio
 async def test_proxy_project_not_found(mock_replica_client_httpbin) -> None:
     _, client = make_app_client(ProxyTestRepo())
-    resp = await client.get("http://test-host/services/unknown/test-run/")
+    resp = await client.get("http://test-host/proxy/services/unknown/test-run/")
     assert resp.status_code == 404
     assert resp.json()["detail"] == "Service unknown/test-run not found"
 
@@ -187,7 +187,7 @@ async def test_redirect_to_service_root(mock_replica_client_httpbin) -> None:
     await repo.add_project(make_project("test-proj"))
     await repo.add_service(project_name="test-proj", service=make_service("httpbin"))
     _, client = make_app_client(repo)
-    url = "http://test-host/services/test-proj/httpbin"
+    url = "http://test-host/proxy/services/test-proj/httpbin"
     resp = await client.get(url, follow_redirects=False)
     assert resp.status_code == 308
     assert resp.headers["Location"] == url + "/"
@@ -205,7 +205,7 @@ async def test_auth(mock_replica_client_httpbin, token: str, status: int) -> Non
     await repo.add_project(make_project("test-proj"))
     await repo.add_service(project_name="test-proj", service=make_service("httpbin", auth=True))
     _, client = make_app_client(repo)
-    url = "http://test-host/services/test-proj/httpbin/"
+    url = "http://test-host/proxy/services/test-proj/httpbin/"
     headers = {}
     if token is not None:
         headers["Authorization"] = f"Bearer {token}"


### PR DESCRIPTION
This is a preparation for supporting the OpenAI
endpoint that will be named `/models`. Since we
already have `/models` in the UI, we decided to
add a prefix to both dstack-proxy endpoints -
`/proxy/services` and `/proxy/models`.

Behind the `PROXY` feature flag.

Part of #1595