### PR TITLE
[shim] Change NVIDIA GPU detection method

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -97,6 +97,7 @@ These are nonexhaustive lists of external dependencies (executables, libraries) 
 * `mountpoint`
 * `lsblk`
 * `mkfs.ext4`
+* (NVIDIA GPU SSH fleet instances only) `nvidia-smi`
 * ...
 
 Debian/Ubuntu packages: `mount` (`mount`, `umount`), `util-linux` (`mountpoint`, `lsblk`), `e2fsprogs` (`mkfs.ext4`)


### PR DESCRIPTION
* Check for `/dev/nvidiactl`, not `nvidia-smi` binary, to detect NVIDIA GPU. Unlike the binary, the devfs file only exists if some conditions are met (the exact way how `/dev/ndivia*` character device files are created is complicated and setup-specific — involving some of: kernel module, udev, modprobe, nvidia-persistenced, X server, and more — but in general, it should be safe to assume that if NVIDIA GPU is available, then `/dev/nvidiactl` does exist.
* Run `nvidia-smi` to get GPU info directly on the host, not inside a container. Using Docker is completely unnecessary, as NVIDIA Container Toolkit mounts libs and executables from the host — dstack-provided Docker image doesn't even contain `nvidia-smi` binary, it's always a bind-mounted file from the host.

Fixes: https://github.com/dstackai/dstack/issues/1942