### PR TITLE
Support chat models in `dstack-proxy`

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,6 +4,7 @@ httpx>=0.23
 pytest~=7.2
 pytest-asyncio>=0.21
 pytest-httpbin==2.1.0
+openai>=1.53.0,<2.0.0
 freezegun>=1.2.0
 ruff==0.5.3  # Should match .pre-commit-config.yaml
 testcontainers # testcontainers<4 may not work with asyncpg

--- a/src/dstack/_internal/core/models/gateways.py
+++ b/src/dstack/_internal/core/models/gateways.py
@@ -8,6 +8,8 @@ from typing_extensions import Annotated, Literal
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.common import CoreModel
 
+# TODO(#1595): refactor into different modules: gateway-specific and proxy-specific
+
 
 class GatewayStatus(str, Enum):
     SUBMITTED = "submitted"
@@ -111,6 +113,8 @@ class GatewayProvisioningData(CoreModel):
 
 
 class BaseChatModel(CoreModel):
+    # Adding more model types might require rethinking this class,
+    # since pydantic doesn't work with two discriminators (type and format) at once
     type: Annotated[Literal["chat"], Field(description="The type of the model")]
     name: Annotated[str, Field(description="The name of the model")]
     format: Annotated[
@@ -151,4 +155,4 @@ class OpenAIChatModel(BaseChatModel):
 
 
 ChatModel = Annotated[Union[TGIChatModel, OpenAIChatModel], Field(discriminator="format")]
-AnyModel = Annotated[Union[ChatModel], Field(discriminator="type")]  # embeddings and etc.
+AnyModel = Union[ChatModel]  # embeddings and etc.

--- a/src/dstack/_internal/core/models/gateways.py
+++ b/src/dstack/_internal/core/models/gateways.py
@@ -113,8 +113,6 @@ class GatewayProvisioningData(CoreModel):
 
 
 class BaseChatModel(CoreModel):
-    # Adding more model types might require rethinking this class,
-    # since pydantic doesn't work with two discriminators (type and format) at once
     type: Annotated[Literal["chat"], Field(description="The type of the model")]
     name: Annotated[str, Field(description="The name of the model")]
     format: Annotated[

--- a/src/dstack/_internal/proxy/errors.py
+++ b/src/dstack/_internal/proxy/errors.py
@@ -1,0 +1,14 @@
+from fastapi import HTTPException, status
+
+
+class ProxyError(HTTPException):
+    """Errors in dstack-proxy that are caused by and should be reported to the user"""
+
+    def __init__(self, detail: str, code: int = status.HTTP_400_BAD_REQUEST) -> None:
+        super().__init__(detail=detail, status_code=code)
+
+
+class UnexpectedProxyError(RuntimeError):
+    """Internal errors in dstack-proxy that should have never happened"""
+
+    pass

--- a/src/dstack/_internal/proxy/repos/memory.py
+++ b/src/dstack/_internal/proxy/repos/memory.py
@@ -1,11 +1,12 @@
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
-from dstack._internal.proxy.repos.base import BaseProxyRepo, Project, Service
+from dstack._internal.proxy.repos.base import BaseProxyRepo, ChatModel, Project, Service
 
 
 class InMemoryProxyRepo(BaseProxyRepo):
     def __init__(self) -> None:
         self.services: Dict[str, Dict[str, Service]] = {}
+        self.models: Dict[str, Dict[str, ChatModel]] = {}
         self.projects: Dict[str, Project] = {}
 
     async def get_service(self, project_name: str, run_name: str) -> Optional[Service]:
@@ -13,6 +14,15 @@ class InMemoryProxyRepo(BaseProxyRepo):
 
     async def add_service(self, project_name: str, service: Service) -> None:
         self.services.setdefault(project_name, {})[service.run_name] = service
+
+    async def list_models(self, project_name: str) -> List[ChatModel]:
+        return list(self.models.get(project_name, {}).values())
+
+    async def get_model(self, project_name: str, name: str) -> Optional[ChatModel]:
+        return self.models.get(project_name, {}).get(name)
+
+    async def add_model(self, project_name: str, model: ChatModel) -> None:
+        self.models.setdefault(project_name, {})[model.name] = model
 
     async def get_project(self, name: str) -> Optional[Project]:
         return self.projects.get(name)

--- a/src/dstack/_internal/proxy/routers/model_proxy.py
+++ b/src/dstack/_internal/proxy/routers/model_proxy.py
@@ -1,0 +1,67 @@
+from typing import AsyncIterator
+
+from fastapi import APIRouter, Depends, status
+from fastapi.responses import StreamingResponse
+from typing_extensions import Annotated
+
+from dstack._internal.proxy.deps import ProxyAuth, get_proxy_repo
+from dstack._internal.proxy.errors import ProxyError, UnexpectedProxyError
+from dstack._internal.proxy.repos.base import BaseProxyRepo
+from dstack._internal.proxy.schemas.model_proxy import (
+    ChatCompletionsChunk,
+    ChatCompletionsRequest,
+    ChatCompletionsResponse,
+    Model,
+    ModelsResponse,
+)
+from dstack._internal.proxy.services.model_proxy import get_chat_client
+from dstack._internal.proxy.services.service_connection import get_service_replica_client
+
+router = APIRouter(dependencies=[Depends(ProxyAuth(auto_enforce=True))])
+
+
+@router.get("/{project_name}/models")
+async def get_models(
+    project_name: str, repo: Annotated[BaseProxyRepo, Depends(get_proxy_repo)]
+) -> ModelsResponse:
+    models = await repo.list_models(project_name)
+    data = [
+        Model(id=m.name, created=int(m.created_at.timestamp()), owned_by=project_name)
+        for m in models
+    ]
+    return ModelsResponse(data=data)
+
+
+@router.post("/{project_name}/chat/completions", response_model=ChatCompletionsResponse)
+async def post_chat_completions(
+    project_name: str,
+    body: ChatCompletionsRequest,
+    repo: Annotated[BaseProxyRepo, Depends(get_proxy_repo)],
+):
+    model = await repo.get_model(project_name, body.model)
+    if model is None:
+        raise ProxyError(
+            f"Model {body.model} not found in project {project_name}", status.HTTP_404_NOT_FOUND
+        )
+    service = await repo.get_service(project_name, model.run_name)
+    if service is None or not service.replicas:
+        raise UnexpectedProxyError(
+            f"Model {model.name} in project {project_name} references run {model.run_name}"
+            " that does not exist or has no replicas"
+        )
+    http_client = await get_service_replica_client(project_name, service, repo)
+    client = get_chat_client(model, http_client)
+    if not body.stream:
+        return await client.generate(body)
+    else:
+        return StreamingResponse(
+            stream_chunks(client.stream(body)),
+            media_type="text/event-stream",
+            headers={"X-Accel-Buffering": "no"},
+        )
+
+
+async def stream_chunks(chunks: AsyncIterator[ChatCompletionsChunk]) -> AsyncIterator[bytes]:
+    async for chunk in chunks:
+        yield f"data:{chunk.json()}\n\n".encode()
+    yield "data: [DONE]\n\n".encode()

--- a/src/dstack/_internal/proxy/schemas/model_proxy.py
+++ b/src/dstack/_internal/proxy/schemas/model_proxy.py
@@ -1,0 +1,79 @@
+from typing import Any, Dict, List, Literal, Optional, Union
+
+from dstack._internal.core.models.common import CoreModel
+
+FinishReason = Literal["stop", "length", "tool_calls", "eos_token"]
+
+
+class ChatMessage(CoreModel):
+    role: str  # TODO(egor-s) types
+    content: str
+
+
+class ChatCompletionsRequest(CoreModel):
+    messages: List[ChatMessage]
+    model: str
+    frequency_penalty: Optional[float] = 0.0
+    logit_bias: Dict[str, float] = {}
+    max_tokens: Optional[int] = None
+    n: int = 1
+    presence_penalty: float = 0.0
+    response_format: Optional[Dict] = None
+    seed: Optional[int] = None
+    stop: Optional[Union[str, List[str]]] = None
+    stream: bool = False
+    temperature: Optional[float] = 1.0
+    top_p: Optional[float] = 1.0
+    tools: List[Any] = []
+    tool_choice: Union[Literal["none", "auto"], Dict] = {}
+    user: Optional[str] = None
+
+
+class ChatCompletionsChoice(CoreModel):
+    finish_reason: FinishReason
+    index: int
+    message: ChatMessage
+
+
+class ChatCompletionsChunkChoice(CoreModel):
+    delta: object
+    logprobs: object = {}
+    finish_reason: Optional[FinishReason]
+    index: int
+
+
+class ChatCompletionsUsage(CoreModel):
+    completion_tokens: int
+    prompt_tokens: int
+    total_tokens: int
+
+
+class ChatCompletionsResponse(CoreModel):
+    id: str
+    choices: List[ChatCompletionsChoice]
+    created: int
+    model: str
+    system_fingerprint: str = ""
+    object: Literal["chat.completion"] = "chat.completion"
+    usage: ChatCompletionsUsage
+
+
+class ChatCompletionsChunk(CoreModel):
+    id: str
+    choices: List[ChatCompletionsChunkChoice]
+    created: int
+    model: str
+    system_fingerprint: str = ""
+    object: Literal["chat.completion.chunk"] = "chat.completion.chunk"
+
+
+class Model(CoreModel):
+    object: Literal["model"] = "model"
+    id: str
+    created: int
+    owned_by: str
+
+
+class ModelsResponse(CoreModel):
+    object: Literal["list"] = "list"
+    data: List[Model]

--- a/src/dstack/_internal/proxy/services/model_proxy/__init__.py
+++ b/src/dstack/_internal/proxy/services/model_proxy/__init__.py
@@ -1,0 +1,23 @@
+import httpx
+
+from dstack._internal.proxy.errors import UnexpectedProxyError
+from dstack._internal.proxy.repos.base import ChatModel
+from dstack._internal.proxy.services.model_proxy.clients import ChatCompletionsClient
+from dstack._internal.proxy.services.model_proxy.clients.openai import OpenAIChatCompletions
+from dstack._internal.proxy.services.model_proxy.clients.tgi import TGIChatCompletions
+
+
+def get_chat_client(model: ChatModel, http_client: httpx.AsyncClient) -> ChatCompletionsClient:
+    if model.format_spec.format == "tgi":
+        return TGIChatCompletions(
+            http_client=http_client,
+            chat_template=model.format_spec.chat_template,
+            eos_token=model.format_spec.eos_token,
+        )
+    elif model.format_spec.format == "openai":
+        return OpenAIChatCompletions(
+            http_client=http_client,
+            prefix=model.format_spec.prefix,
+        )
+    else:
+        raise UnexpectedProxyError(f"Unsupported model format {model.format_spec.format}")

--- a/src/dstack/_internal/proxy/services/model_proxy/clients/__init__.py
+++ b/src/dstack/_internal/proxy/services/model_proxy/clients/__init__.py
@@ -1,0 +1,18 @@
+from abc import ABC, abstractmethod
+from typing import AsyncIterator
+
+from dstack._internal.proxy.schemas.model_proxy import (
+    ChatCompletionsChunk,
+    ChatCompletionsRequest,
+    ChatCompletionsResponse,
+)
+
+
+class ChatCompletionsClient(ABC):
+    @abstractmethod
+    async def generate(self, request: ChatCompletionsRequest) -> ChatCompletionsResponse:
+        pass
+
+    @abstractmethod
+    async def stream(self, request: ChatCompletionsRequest) -> AsyncIterator[ChatCompletionsChunk]:
+        yield

--- a/src/dstack/_internal/proxy/services/model_proxy/clients/openai.py
+++ b/src/dstack/_internal/proxy/services/model_proxy/clients/openai.py
@@ -1,0 +1,37 @@
+from typing import AsyncIterator
+
+import httpx
+
+from dstack._internal.proxy.errors import ProxyError
+from dstack._internal.proxy.schemas.model_proxy import (
+    ChatCompletionsChunk,
+    ChatCompletionsRequest,
+    ChatCompletionsResponse,
+)
+from dstack._internal.proxy.services.model_proxy.clients import ChatCompletionsClient
+
+
+class OpenAIChatCompletions(ChatCompletionsClient):
+    def __init__(self, http_client: httpx.AsyncClient, prefix: str):
+        self._http = http_client
+        self._prefix = prefix
+
+    async def generate(self, request: ChatCompletionsRequest) -> ChatCompletionsResponse:
+        resp = await self._http.post(
+            f"{self._prefix}/chat/completions", json=request.dict(exclude_unset=True)
+        )
+        if resp.status_code != 200:
+            raise ProxyError(resp.text)
+        return ChatCompletionsResponse.__response__.parse_raw(resp.content)
+
+    async def stream(self, request: ChatCompletionsRequest) -> AsyncIterator[ChatCompletionsChunk]:
+        async with self._http.stream(
+            "POST", f"{self._prefix}/chat/completions", json=request.dict(exclude_unset=True)
+        ) as resp:
+            async for line in resp.aiter_lines():
+                if not line.startswith("data:"):
+                    continue
+                data = line[len("data:") :].strip()
+                if data == "[DONE]":
+                    break
+                yield ChatCompletionsChunk.__response__.parse_raw(data)

--- a/src/dstack/_internal/proxy/services/model_proxy/clients/tgi.py
+++ b/src/dstack/_internal/proxy/services/model_proxy/clients/tgi.py
@@ -1,0 +1,182 @@
+import datetime
+import json
+import uuid
+from typing import AsyncIterator, Dict, List
+
+import httpx
+import jinja2
+import jinja2.sandbox
+
+from dstack._internal.proxy.errors import ProxyError
+from dstack._internal.proxy.schemas.model_proxy import (
+    ChatCompletionsChoice,
+    ChatCompletionsChunk,
+    ChatCompletionsChunkChoice,
+    ChatCompletionsRequest,
+    ChatCompletionsResponse,
+    ChatCompletionsUsage,
+    ChatMessage,
+    FinishReason,
+)
+from dstack._internal.proxy.services.model_proxy.clients import ChatCompletionsClient
+
+
+class TGIChatCompletions(ChatCompletionsClient):
+    # https://huggingface.github.io/text-generation-inference/
+    def __init__(self, http_client: httpx.AsyncClient, chat_template: str, eos_token: str):
+        self.client = http_client
+        self.eos_token = eos_token
+
+        try:
+            jinja_env = jinja2.sandbox.ImmutableSandboxedEnvironment(
+                trim_blocks=True, lstrip_blocks=True
+            )
+            jinja_env.globals["raise_exception"] = raise_exception
+            self.chat_template = jinja_env.from_string(chat_template)
+        except jinja2.TemplateError as e:
+            raise ProxyError(f"Failed to compile chat template: {e}")
+
+    async def generate(self, request: ChatCompletionsRequest) -> ChatCompletionsResponse:
+        payload = self.get_payload(request)
+        resp = await self.client.post("/generate", json=payload)
+        if resp.status_code != 200:
+            raise ProxyError(resp.text)  # TODO(egor-s)
+        data = resp.json()
+
+        choices = [
+            ChatCompletionsChoice(
+                finish_reason=self.finish_reason(data["details"]["finish_reason"]),
+                index=0,
+                message=ChatMessage(
+                    role="assistant",
+                    content=self.trim_stop_tokens(
+                        data["generated_text"], payload["parameters"]["stop"]
+                    ),
+                ),
+            )
+        ]
+        completion_tokens = data["details"]["generated_tokens"]
+        prompt_tokens = len(data["details"]["prefill"])
+
+        for i, sequence in enumerate(data["details"].get("best_of_sequences", []), start=1):
+            choices.append(
+                ChatCompletionsChoice(
+                    finish_reason=self.finish_reason(sequence["finish_reason"]),
+                    index=i,
+                    message=ChatMessage(
+                        role="assistant",
+                        content=self.trim_stop_tokens(
+                            sequence["generated_text"], payload["parameters"]["stop"]
+                        ),
+                    ),
+                )
+            )
+            completion_tokens += sequence["generated_tokens"]
+
+        return ChatCompletionsResponse(
+            id=uuid.uuid4().hex,
+            choices=choices,
+            created=int(datetime.datetime.utcnow().timestamp()),
+            model=request.model,
+            system_fingerprint=f"fp_{data['details']['seed']}",
+            usage=ChatCompletionsUsage(
+                completion_tokens=completion_tokens,
+                prompt_tokens=prompt_tokens,  # TODO(egor-s): do we need to multiply by number of sequences?
+                total_tokens=completion_tokens + prompt_tokens,
+            ),
+        )
+
+    async def stream(self, request: ChatCompletionsRequest) -> AsyncIterator[ChatCompletionsChunk]:
+        completion_id = uuid.uuid4().hex
+        created = int(datetime.datetime.utcnow().timestamp())
+
+        payload = self.get_payload(request)
+        async with self.client.stream("POST", "/generate_stream", json=payload) as resp:
+            async for line in resp.aiter_lines():
+                if line.startswith("data:"):
+                    data = json.loads(line[len("data:") :].strip("\n"))
+                    if "error" in data:
+                        raise ProxyError(data["error"])
+                    chunk = ChatCompletionsChunk(
+                        id=completion_id,
+                        choices=[],
+                        created=created,
+                        model=request.model,
+                        system_fingerprint="",
+                    )
+                    if data["details"] is not None:
+                        chunk.choices = [
+                            ChatCompletionsChunkChoice(
+                                delta={},
+                                logprobs=None,
+                                finish_reason=self.finish_reason(data["details"]["finish_reason"]),
+                                index=0,
+                            )
+                        ]
+                    else:
+                        chunk.choices = [
+                            ChatCompletionsChunkChoice(
+                                delta={"content": data["token"]["text"], "role": "assistant"},
+                                logprobs=None,
+                                finish_reason=None,
+                                index=0,
+                            )
+                        ]
+                    yield chunk
+
+    def get_payload(self, request: ChatCompletionsRequest) -> Dict:
+        try:
+            inputs = self.chat_template.render(
+                messages=request.messages,
+                add_generation_prompt=True,
+            )
+        except jinja2.TemplateError as e:
+            raise ProxyError(f"Failed to render chat template: {e}")
+
+        stop = ([request.stop] if isinstance(request.stop, str) else request.stop) or []
+        if self.eos_token not in stop:
+            stop.append(self.eos_token)
+
+        parameters = {
+            "do_sample": True,  # activate logits sampling
+            "max_new_tokens": request.max_tokens,
+            # TODO(egor-s): OpenAI parameters do not convert to `repetition_penalty`
+            # "repetition_penalty": None,
+            # "return_full_text": False,
+            "stop": stop,
+            "seed": request.seed,
+            "temperature": request.temperature,
+            # OpenAI doesn't specify `top_k` parameter
+            # "top_k": None,
+            # "truncate": None,
+            # "typical_p": None,
+            "best_of": request.n,
+            # "watermark": False,
+            "details": True,  # to get best_of_sequences
+            "decoder_input_details": not request.stream,
+        }
+        if request.top_p < 1.0:
+            parameters["top_p"] = request.top_p
+        return {
+            "inputs": inputs,
+            "parameters": parameters,
+        }
+
+    @staticmethod
+    def finish_reason(reason: str) -> FinishReason:
+        if reason == "stop_sequence" or reason == "eos_token":
+            return "stop"
+        if reason == "length":
+            return "length"
+        raise ProxyError(f"Unknown finish reason: {reason}")
+
+    @staticmethod
+    def trim_stop_tokens(text: str, stop_tokens: List[str]) -> str:
+        for stop_token in stop_tokens:
+            if text.endswith(stop_token):
+                return text[: -len(stop_token)]
+        return text
+
+
+def raise_exception(message: str):
+    raise jinja2.TemplateError(message)

--- a/src/dstack/_internal/proxy/testing/common.py
+++ b/src/dstack/_internal/proxy/testing/common.py
@@ -1,0 +1,57 @@
+from typing import AsyncGenerator, Optional, Tuple
+
+import httpx
+from fastapi import FastAPI
+
+from dstack._internal.proxy.deps import BaseProxyDependencyInjector
+from dstack._internal.proxy.repos.base import BaseProxyRepo, Project, Replica, Service
+from dstack._internal.proxy.routers.model_proxy import router as model_router
+from dstack._internal.proxy.routers.service_proxy import router as service_router
+
+
+def make_app(repo: BaseProxyRepo) -> FastAPI:
+    class DependencyInjector(BaseProxyDependencyInjector):
+        async def get_repo(self) -> AsyncGenerator[BaseProxyRepo, None]:
+            yield repo
+
+    app = FastAPI()
+    app.state.proxy_dependency_injector = DependencyInjector()
+    app.include_router(service_router, prefix="/proxy/services")
+    app.include_router(model_router, prefix="/proxy/models")
+    return app
+
+
+def make_client(app: FastAPI, auth_token: Optional[str] = None) -> httpx.AsyncClient:
+    headers = None
+    if auth_token is not None:
+        headers = {"Authorization": f"Bearer {auth_token}"}
+    return httpx.AsyncClient(transport=httpx.ASGITransport(app=app), headers=headers)
+
+
+def make_app_client(
+    repo: BaseProxyRepo, auth_token: Optional[str] = None
+) -> Tuple[FastAPI, httpx.AsyncClient]:
+    app = make_app(repo)
+    client = make_client(app, auth_token)
+    return app, client
+
+
+def make_project(name: str) -> Project:
+    return Project(name=name, ssh_private_key="secret")
+
+
+def make_service(run_name: str, auth: bool = False) -> Service:
+    return Service(
+        id="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        run_name=run_name,
+        auth=auth,
+        app_port=80,
+        replicas=[
+            Replica(
+                id="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                ssh_destination="ubuntu@server",
+                ssh_port=22,
+                ssh_proxy=None,
+            )
+        ],
+    )

--- a/src/dstack/_internal/server/app.py
+++ b/src/dstack/_internal/server/app.py
@@ -14,7 +14,7 @@ from fastapi.staticfiles import StaticFiles
 from dstack._internal.cli.utils.common import console
 from dstack._internal.core.errors import ForbiddenError, ServerClientError
 from dstack._internal.core.services.configs import update_default_project
-from dstack._internal.proxy.routers import service_proxy
+from dstack._internal.proxy.routers import model_proxy, service_proxy
 from dstack._internal.proxy.services.service_connection import service_replica_connection_pool
 from dstack._internal.server import settings
 from dstack._internal.server.background import start_background_tasks
@@ -178,6 +178,7 @@ def register_routes(app: FastAPI, ui: bool = True):
     app.include_router(volumes.project_router)
     if FeatureFlags.PROXY:
         app.include_router(service_proxy.router, prefix="/proxy/services", tags=["service-proxy"])
+        app.include_router(model_proxy.router, prefix="/proxy/models", tags=["model-proxy"])
 
     @app.exception_handler(ForbiddenError)
     async def forbidden_error_handler(request: Request, exc: ForbiddenError):

--- a/src/dstack/_internal/server/services/proxy/repo.py
+++ b/src/dstack/_internal/server/services/proxy/repo.py
@@ -1,14 +1,31 @@
-from typing import Optional
+from typing import List, Optional
 
+import pydantic
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from dstack._internal.core.models.common import is_core_model_instance
 from dstack._internal.core.models.configurations import ServiceConfiguration
+from dstack._internal.core.models.gateways import AnyModel
 from dstack._internal.core.models.instances import SSHConnectionParams
-from dstack._internal.core.models.runs import JobProvisioningData, JobStatus, RunSpec
-from dstack._internal.proxy.repos.base import BaseProxyRepo, Project, Replica, Service
+from dstack._internal.core.models.runs import (
+    JobProvisioningData,
+    JobStatus,
+    RunSpec,
+    RunStatus,
+    ServiceSpec,
+)
+from dstack._internal.proxy.repos.base import (
+    AnyModelFormat,
+    BaseProxyRepo,
+    ChatModel,
+    OpenAIChatModelFormat,
+    Project,
+    Replica,
+    Service,
+    TGIChatModelFormat,
+)
 from dstack._internal.server.models import JobModel, ProjectModel, RunModel
 from dstack._internal.server.security.permissions import is_project_member
 
@@ -80,6 +97,45 @@ class DBProxyRepo(BaseProxyRepo):
     async def add_service(self, project_name: str, service: Service) -> None:
         pass
 
+    async def list_models(self, project_name: str) -> List[ChatModel]:
+        res = await self.session.execute(
+            select(RunModel)
+            .join(RunModel.project)
+            .where(
+                ProjectModel.name == project_name,
+                RunModel.gateway_id.is_(None),
+                RunModel.service_spec.is_not(None),
+                RunModel.status == RunStatus.RUNNING,
+            )
+        )
+        models = []
+        for run in res.scalars().all():
+            service_spec: ServiceSpec = ServiceSpec.__response__.parse_raw(run.service_spec)
+            model_spec = service_spec.model
+            model_options_obj = service_spec.options.get("openai", {}).get("model")
+            if model_spec is None or model_options_obj is None:
+                continue
+            model_options = pydantic.parse_obj_as(AnyModel, model_options_obj)
+            model = ChatModel(
+                name=model_spec.name,
+                created_at=run.submitted_at,
+                run_name=run.run_name,
+                format_spec=_model_options_to_format_spec(model_options),
+            )
+            models.append(model)
+        return models
+
+    async def get_model(self, project_name: str, name: str) -> Optional[ChatModel]:
+        models = await self.list_models(project_name)
+        models = [m for m in models if m.name == name]
+        if not models:
+            return None
+        # If there are many models with the same name, choose the most recent
+        return max(models, key=lambda m: m.created_at)
+
+    async def add_model(self, project_name: str, model: ChatModel) -> None:
+        pass
+
     async def get_project(self, name: str) -> Optional[Project]:
         res = await self.session.execute(select(ProjectModel).where(ProjectModel.name == name))
         project = res.scalar_one_or_none()
@@ -95,3 +151,22 @@ class DBProxyRepo(BaseProxyRepo):
 
     async def is_project_member(self, project_name: str, token: str) -> bool:
         return await is_project_member(self.session, project_name, token)
+
+
+def _model_options_to_format_spec(model: AnyModel) -> AnyModelFormat:
+    if model.type == "chat":
+        if model.format == "openai":
+            return OpenAIChatModelFormat(
+                format="openai",
+                prefix=model.prefix,
+            )
+        elif model.format == "tgi":
+            return TGIChatModelFormat(
+                format="tgi",
+                chat_template=model.chat_template,
+                eos_token=model.eos_token,
+            )
+        else:
+            raise RuntimeError(f"Unexpected model format {model.format}")
+    else:
+        raise RuntimeError(f"Unexpected model type {model.type}")

--- a/src/tests/_internal/proxy/routers/test_model_proxy.py
+++ b/src/tests/_internal/proxy/routers/test_model_proxy.py
@@ -1,0 +1,217 @@
+from datetime import datetime
+from typing import AsyncIterator, Generator, Optional
+from unittest.mock import patch
+
+import openai
+import pytest
+
+from dstack._internal.proxy.repos.base import BaseProxyRepo, ChatModel, OpenAIChatModelFormat
+from dstack._internal.proxy.schemas.model_proxy import (
+    ChatCompletionsChoice,
+    ChatCompletionsChunk,
+    ChatCompletionsChunkChoice,
+    ChatCompletionsRequest,
+    ChatCompletionsResponse,
+    ChatCompletionsUsage,
+    ChatMessage,
+)
+from dstack._internal.proxy.services.model_proxy.clients import ChatCompletionsClient
+from dstack._internal.proxy.testing.common import make_app_client, make_project, make_service
+from dstack._internal.proxy.testing.repo import ProxyTestRepo
+
+SAMPLE_RESPONSE = "Hello there, how may I assist you today?"
+
+
+class ChatClientStub(ChatCompletionsClient):
+    async def generate(self, request: ChatCompletionsRequest) -> ChatCompletionsResponse:
+        return ChatCompletionsResponse(
+            id="chatcmpl-123",
+            choices=[
+                ChatCompletionsChoice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatMessage(
+                        role="assistant",
+                        content=SAMPLE_RESPONSE,
+                    ),
+                )
+            ],
+            created=int(datetime.now().timestamp()),
+            model=request.model,
+            usage=ChatCompletionsUsage(
+                completion_tokens=12,
+                prompt_tokens=9,
+                total_tokens=21,
+            ),
+        )
+
+    async def stream(self, request: ChatCompletionsRequest) -> AsyncIterator[ChatCompletionsChunk]:
+        for i, word in enumerate(SAMPLE_RESPONSE.split(" ")):
+            if i > 0:
+                word = " " + word
+            yield ChatCompletionsChunk(
+                id="chatcmpl-123",
+                choices=[
+                    ChatCompletionsChunkChoice(
+                        finish_reason=None,
+                        index=0,
+                        delta=dict(
+                            role="assistant",
+                            content=word,
+                        ),
+                    )
+                ],
+                created=int(datetime.now().timestamp()),
+                model=request.model,
+            )
+
+
+def make_model(
+    name: str, run_name: str, created_at: datetime = datetime.fromtimestamp(0)
+) -> ChatModel:
+    return ChatModel(
+        name=name,
+        created_at=created_at,
+        run_name=run_name,
+        format_spec=OpenAIChatModelFormat(format="openai", prefix="/v1"),
+    )
+
+
+def make_openai_client(
+    repo: BaseProxyRepo, project_name: str, auth_token: Optional[str] = None
+) -> openai.AsyncOpenAI:
+    _, http_client = make_app_client(repo, auth_token="token")
+    return openai.AsyncOpenAI(
+        api_key=auth_token,
+        base_url=f"http://test-host/proxy/models/{project_name}",
+        http_client=http_client,
+    )
+
+
+@pytest.fixture
+def mock_chat_client() -> Generator[None, None, None]:
+    with (
+        patch(
+            "dstack._internal.proxy.services.service_connection.ServiceReplicaConnectionPool.add"
+        ),
+        patch("dstack._internal.proxy.routers.model_proxy.get_chat_client") as get_client_mock,
+    ):
+        get_client_mock.return_value = ChatClientStub()
+        yield
+
+
+@pytest.mark.asyncio
+async def test_list_models() -> None:
+    repo = ProxyTestRepo(project_to_tokens={"test-proj": {"token"}})
+    await repo.add_project(make_project("test-proj"))
+    await repo.add_service(project_name="test-proj", service=make_service("test-service-1"))
+    await repo.add_service(project_name="test-proj", service=make_service("test-service-2"))
+    await repo.add_model(
+        project_name="test-proj",
+        model=make_model("test-model-1", "test-service-1", created_at=datetime.fromtimestamp(123)),
+    )
+    await repo.add_model(
+        project_name="test-proj",
+        model=make_model("test-model-2", "test-service-2", created_at=datetime.fromtimestamp(321)),
+    )
+    _, client = make_app_client(repo, auth_token="token")
+
+    client = make_openai_client(repo, "test-proj", auth_token="token")
+    models = [model async for model in client.models.list()]
+
+    assert models[0].id == "test-model-1"
+    assert models[0].created == 123
+    assert models[0].owned_by == "test-proj"
+    assert models[1].id == "test-model-2"
+    assert models[1].created == 321
+    assert models[1].owned_by == "test-proj"
+
+
+@pytest.mark.asyncio
+async def test_list_models_empty() -> None:
+    repo = ProxyTestRepo(project_to_tokens={"test-proj": {"token"}, "test-proj-empty": {"token"}})
+    await repo.add_project(make_project("test-proj"))
+    await repo.add_project(make_project("test-proj-empty"))
+    await repo.add_service(project_name="test-proj", service=make_service("test-service"))
+    await repo.add_model(project_name="test-proj", model=make_model("test-model", "test-service"))
+    _, client = make_app_client(repo, auth_token="token")
+
+    client = make_openai_client(repo, "test-proj-empty", auth_token="token")
+    models = [model async for model in client.models.list()]
+    assert not models
+
+
+@pytest.mark.asyncio
+async def test_chat_completions(mock_chat_client) -> None:
+    repo = ProxyTestRepo(project_to_tokens={"test-proj": {"token"}})
+    await repo.add_project(make_project("test-proj"))
+    await repo.add_service(project_name="test-proj", service=make_service("test-service"))
+    await repo.add_model(project_name="test-proj", model=make_model("test-model", "test-service"))
+    client = make_openai_client(repo, "test-proj", auth_token="token")
+    completion = await client.chat.completions.create(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hi"}],
+    )
+    assert completion.choices[0].message.content == SAMPLE_RESPONSE
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_stream(mock_chat_client) -> None:
+    repo = ProxyTestRepo(project_to_tokens={"test-proj": {"token"}})
+    await repo.add_project(make_project("test-proj"))
+    await repo.add_service(project_name="test-proj", service=make_service("test-service"))
+    await repo.add_model(project_name="test-proj", model=make_model("test-model", "test-service"))
+    client = make_openai_client(repo, "test-proj", auth_token="token")
+    response = await client.chat.completions.create(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hi"}],
+        stream=True,
+    )
+    completion = ""
+    async for chunk in response:
+        completion += chunk.choices[0].delta.content
+    assert completion == SAMPLE_RESPONSE
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_model_not_found() -> None:
+    repo = ProxyTestRepo(project_to_tokens={"test-proj": {"token"}})
+    await repo.add_project(make_project("test-proj"))
+    client = make_openai_client(repo, "test-proj", auth_token="token")
+    with pytest.raises(openai.NotFoundError):
+        await client.chat.completions.create(
+            model="unknown-model",
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("token", ["wrong-token", ""])
+async def test_unauthorized(token: str) -> None:
+    repo = ProxyTestRepo(project_to_tokens={"test-proj": {"correct-token"}})
+    await repo.add_project(make_project("test-proj"))
+    client = make_openai_client(repo, "test-proj", auth_token=token)
+
+    with pytest.raises(openai.PermissionDeniedError):
+        await client.models.list()
+    with pytest.raises(openai.PermissionDeniedError):
+        await client.chat.completions.create(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hi"}],
+        )
+
+
+@pytest.mark.asyncio
+async def test_no_token() -> None:
+    repo = ProxyTestRepo(project_to_tokens={"test-proj": {"correct-token"}})
+    await repo.add_project(make_project("test-proj"))
+    _, client = make_app_client(repo, auth_token=None)
+
+    resp = await client.get("http://test-host/proxy/models/test-proj/models")
+    assert resp.status_code == 403
+
+    resp = await client.post(
+        "http://test-host/proxy/models/test-proj/chat/completions",
+        json={"model": "test-model", "messages": [{"role": "user", "content": "Hi"}]},
+    )
+    assert resp.status_code == 403


### PR DESCRIPTION
This commit adds the OpenAI-compatible endpoint
to `dstack-proxy`, which effectively allows running
services with model mappings without a gateway.

Most of the OpenAI- and TGI-specific code is
copied from `dstack-gateway`. This code
duplication will be eliminated later, once
`dstack-proxy` supports running on gateways.

The commit also contains some refactoring in
`dstack-proxy`: introduces `ProxyError` and
`UnexpectedProxyError` exceptions and simplifies
error logging in `service_proxy.py`.

Behind the `PROXY` feature flag.

Part of #1595