### PR TITLE
Fix dstack-proxy dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ BASE_DEPS = [
     "python-json-logger",
     "alembic-postgresql-enum",
     "asyncpg",
+    "jinja2",
 ]
 
 AWS_DEPS = [


### PR DESCRIPTION
`jinja2` is needed for the TGI client.

Part of #1595