### PR TITLE
Short model mapping syntax

### DIFF
--- a/docs/blog/posts/amd-on-runpod.md
+++ b/docs/blog/posts/amd-on-runpod.md
@@ -64,10 +64,7 @@ you can now specify an AMD GPU under `resources`. Below are a few examples.
     
     spot_policy: auto
 
-    model:
-      type: chat
-      name: meta-llama/Meta-Llama-3.1-70B-Instruct
-      format: openai
+    model: meta-llama/Meta-Llama-3.1-70B-Instruct
     ```
     
     </div>

--- a/docs/blog/posts/dstack-sky.md
+++ b/docs/blog/posts/dstack-sky.md
@@ -115,10 +115,7 @@ resources:
   gpu: 48GB..80GB
 
 # Enable OpenAI compatible endpoint
-model:
-  type: chat
-  name: mixtral
-  format: openai
+model: mixtral
 ```
 </div>
 

--- a/docs/blog/posts/tpu-on-gcp.md
+++ b/docs/blog/posts/tpu-on-gcp.md
@@ -115,10 +115,7 @@ and [vLLM :material-arrow-top-right-thin:{ .external }](https://github.com/vllm-
     resources:
       gpu: v5litepod-4
 
-    model:
-      format: openai
-      type: chat
-      name: meta-llama/Meta-Llama-3.1-8B-Instruct
+    model: meta-llama/Meta-Llama-3.1-8B-Instruct
     ```
     </div>
 

--- a/docs/blog/posts/volumes-on-runpod.md
+++ b/docs/blog/posts/volumes-on-runpod.md
@@ -46,10 +46,7 @@ spot_policy: auto
 resources:
   gpu: 24GB
 
-model:
-  format: openai
-  type: chat
-  name: meta-llama/Meta-Llama-3.1-8B-Instruct
+model: meta-llama/Meta-Llama-3.1-8B-Instruct
 ```
 
 </div>
@@ -123,10 +120,7 @@ spot_policy: auto
 resources:
   gpu: 24GB
   
-model:
-  format: openai
-  type: chat
-  name: meta-llama/Meta-Llama-3.1-8B-Instruct
+model: meta-llama/Meta-Llama-3.1-8B-Instruct
 ```
 
 </div>

--- a/docs/docs/reference/dstack.yml/service.md
+++ b/docs/docs/reference/dstack.yml/service.md
@@ -112,8 +112,9 @@ If you want, you can specify your own Docker image via `image`.
 
 By default, if you run a service, its endpoint is accessible at `https://<run name>.<gateway domain>`.
 
-If you run a model, you can optionally configure the mapping to make it accessible via the 
-OpenAI-compatible interface.
+If you are running a chat model with an OpenAI-compatible interface,
+you can optionally set the [`model`](#model) property to make the model accessible via
+the model gateway provided by `dstack`.
 
 <div editor-title="service.dstack.yml"> 
 
@@ -124,7 +125,9 @@ name: llama31-service
 
 python: "3.10"
 
-# Commands of the service
+# Required environment variables
+env:
+  - HF_TOKEN
 commands:
   - pip install vllm
   - vllm serve meta-llama/Meta-Llama-3.1-8B-Instruct --max-model-len 4096
@@ -135,57 +138,21 @@ resources:
   # Change to what is required
   gpu: 24GB
 
-# Comment if you don't want to access the model via https://gateway.<gateway domain>
-model:
-  type: chat
-  name: meta-llama/Meta-Llama-3.1-8B-Instruct
-  format: openai
+# Make the model accessible at https://gateway.<gateway domain>
+model: meta-llama/Meta-Llama-3.1-8B-Instruct
+
+# Alternatively, use this syntax to set more model settings:
+# model:
+#   type: chat
+#   name: meta-llama/Meta-Llama-3.1-8B-Instruct
+#   format: openai
+#   prefix: /v1
 ```
 
 </div>
 
-In this case, with such a configuration, once the service is up, you'll be able to access the model at
+With such a configuration, once the service is up, you'll be able to access the model at
 `https://gateway.<gateway domain>` via the OpenAI-compatible interface.
-
-The `format` supports only `tgi` (Text Generation Inference)
-and `openai` (if you are using Text Generation Inference or vLLM with OpenAI-compatible mode).
-
-??? info "Chat template"
-
-    By default, `dstack` loads the [chat template](https://huggingface.co/docs/transformers/main/en/chat_templating)
-    from the model's repository. If it is not present there, manual configuration is required.
-
-    ```yaml
-    type: service
-
-    image: ghcr.io/huggingface/text-generation-inference:latest
-    env:
-      - MODEL_ID=TheBloke/Llama-2-13B-chat-GPTQ
-    commands:
-      - text-generation-launcher --port 8000 --trust-remote-code --quantize gptq
-    port: 8000
-
-    resources:
-      gpu: 80GB
-
-    # Enable the OpenAI-compatible endpoint
-    model:
-      type: chat
-      name: TheBloke/Llama-2-13B-chat-GPTQ
-      format: tgi
-      chat_template: "{% if messages[0]['role'] == 'system' %}{% set loop_messages = messages[1:] %}{% set system_message = messages[0]['content'] %}{% else %}{% set loop_messages = messages %}{% set system_message = false %}{% endif %}{% for message in loop_messages %}{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}{% endif %}{% if loop.index0 == 0 and system_message != false %}{% set content = '<<SYS>>\\n' + system_message + '\\n<</SYS>>\\n\\n' + message['content'] %}{% else %}{% set content = message['content'] %}{% endif %}{% if message['role'] == 'user' %}{{ '<s>[INST] ' + content.strip() + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ ' '  + content.strip() + ' </s>' }}{% endif %}{% endfor %}"
-      eos_token: "</s>"
-    ```
-
-    ##### Limitations
-
-    Please note that model mapping is an experimental feature with the following limitations:
-
-    1. Doesn't work if your `chat_template` uses `bos_token`. As a workaround, replace `bos_token` inside `chat_template` with the token content itself.
-    2. Doesn't work if `eos_token` is defined in the model repository as a dictionary. As a workaround, set `eos_token` manually, as shown in the example above (see Chat template).
-
-    If you encounter any other issues, please make sure to file a [GitHub issue](https://github.com/dstackai/dstack/issues/new/choose).
-
 
 ### Auto-scaling
 
@@ -201,7 +168,9 @@ name: llama31-service
 
 python: "3.10"
 
-# Commands of the service
+# Required environment variables
+env:
+  - HF_TOKEN
 commands:
   - pip install vllm
   - vllm serve meta-llama/Meta-Llama-3.1-8B-Instruct --max-model-len 4096
@@ -461,13 +430,60 @@ The `service` configuration type supports many other options. See below.
       type:
         required: true
 
-## `model`
+## `model[format=openai]`
 
-#SCHEMA# dstack._internal.core.models.gateways.BaseChatModel
+#SCHEMA# dstack._internal.core.models.gateways.OpenAIChatModel
     overrides:
       show_root_heading: false
       type:
         required: true
+
+## `model[format=tgi]`
+
+> TGI provides an OpenAI-compatible API starting with version 1.4.0,
+so models served by TGI can be defined with `format: openai` too.
+
+#SCHEMA# dstack._internal.core.models.gateways.TGIChatModel
+    overrides:
+      show_root_heading: false
+      type:
+        required: true
+
+??? info "Chat template"
+
+    By default, `dstack` loads the [chat template](https://huggingface.co/docs/transformers/main/en/chat_templating)
+    from the model's repository. If it is not present there, manual configuration is required.
+
+    ```yaml
+    type: service
+
+    image: ghcr.io/huggingface/text-generation-inference:latest
+    env:
+      - MODEL_ID=TheBloke/Llama-2-13B-chat-GPTQ
+    commands:
+      - text-generation-launcher --port 8000 --trust-remote-code --quantize gptq
+    port: 8000
+
+    resources:
+      gpu: 80GB
+
+    # Enable the OpenAI-compatible endpoint
+    model:
+      type: chat
+      name: TheBloke/Llama-2-13B-chat-GPTQ
+      format: tgi
+      chat_template: "{% if messages[0]['role'] == 'system' %}{% set loop_messages = messages[1:] %}{% set system_message = messages[0]['content'] %}{% else %}{% set loop_messages = messages %}{% set system_message = false %}{% endif %}{% for message in loop_messages %}{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}{% endif %}{% if loop.index0 == 0 and system_message != false %}{% set content = '<<SYS>>\\n' + system_message + '\\n<</SYS>>\\n\\n' + message['content'] %}{% else %}{% set content = message['content'] %}{% endif %}{% if message['role'] == 'user' %}{{ '<s>[INST] ' + content.strip() + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ ' '  + content.strip() + ' </s>' }}{% endif %}{% endfor %}"
+      eos_token: "</s>"
+    ```
+
+    ##### Limitations
+
+    Please note that model mapping is an experimental feature with the following limitations:
+
+    1. Doesn't work if your `chat_template` uses `bos_token`. As a workaround, replace `bos_token` inside `chat_template` with the token content itself.
+    2. Doesn't work if `eos_token` is defined in the model repository as a dictionary. As a workaround, set `eos_token` manually, as shown in the example above (see Chat template).
+
+    If you encounter any other issues, please make sure to file a [GitHub issue](https://github.com/dstackai/dstack/issues/new/choose).
 
 ## `scaling`
 
@@ -486,7 +502,7 @@ The `service` configuration type supports many other options. See below.
         required: true
       item_id_prefix: resources-
 
-## `resouces.gpu` { #resources-gpu data-toc-label="resources.gpu" } 
+## `resouces.gpu` { #resources-gpu data-toc-label="resources.gpu" }
 
 #SCHEMA# dstack._internal.core.models.resources.GPUSpecSchema
     overrides:

--- a/docs/docs/services.md
+++ b/docs/docs/services.md
@@ -44,11 +44,8 @@ resources:
   # Change to what is required
   gpu: 24GB
 
-# Comment if you don't to access the model via https://gateway.<gateway domain>
-model:
-  type: chat
-  name: meta-llama/Meta-Llama-3.1-8B-Instruct
-  format: openai
+# Comment out if you won't access the model via https://gateway.<gateway domain>
+model: meta-llama/Meta-Llama-3.1-8B-Instruct
 ```
 
 </div>

--- a/examples/accelerators/amd/README.md
+++ b/examples/accelerators/amd/README.md
@@ -39,10 +39,7 @@ Llama 3.1 70B in FP16 using [TGI :material-arrow-top-right-thin:{ .external }](h
     spot_policy: auto
 
     # Register the model    
-    model:
-      type: chat
-      name: meta-llama/Meta-Llama-3.1-70B-Instruct
-      format: openai
+    model: meta-llama/Meta-Llama-3.1-70B-Instruct
     ```
     
     </div>
@@ -98,10 +95,7 @@ Llama 3.1 70B in FP16 using [TGI :material-arrow-top-right-thin:{ .external }](h
       disk: 200GB
     
     # Register the model
-    model:
-      format: openai
-      type: chat
-      name: meta-llama/Meta-Llama-3.1-70B-Instruct
+    model: meta-llama/Meta-Llama-3.1-70B-Instruct
     ```
     </div>
 

--- a/examples/accelerators/tpu/README.md
+++ b/examples/accelerators/tpu/README.md
@@ -87,10 +87,7 @@ and [vLLM :material-arrow-top-right-thin:{ .external }](https://github.com/vllm-
     resources:
       gpu: v5litepod-4
 
-    model:
-      format: openai
-      type: chat
-      name: meta-llama/Meta-Llama-3.1-8B-Instruct
+    model: meta-llama/Meta-Llama-3.1-8B-Instruct
     ```
     </div>
 

--- a/examples/deployment/ollama/serve.dstack.yml
+++ b/examples/deployment/ollama/serve.dstack.yml
@@ -13,7 +13,4 @@ resources:
   gpu: 48GB..80GB
 
 # (Optional) Enable the OpenAI-compatible endpoint
-model:
-  type: chat
-  name: mixtral
-  format: openai
+model: mixtral

--- a/examples/deployment/tgi/amd/service.dstack.yml
+++ b/examples/deployment/tgi/amd/service.dstack.yml
@@ -17,7 +17,4 @@ resources:
 
 spot_policy: auto
 
-model:
-  type: chat
-  name: meta-llama/Meta-Llama-3.1-70B-Instruct
-  format: openai
+model: meta-llama/Meta-Llama-3.1-70B-Instruct

--- a/examples/deployment/vllm/amd/service.dstack.yml
+++ b/examples/deployment/vllm/amd/service.dstack.yml
@@ -43,7 +43,4 @@ resources:
   disk: 200GB
 
 # (Optional) Enable the OpenAI-compatible endpoint
-model:
-  format: openai
-  type: chat
-  name: meta-llama/Meta-Llama-3.1-70B-Instruct
+model: meta-llama/Meta-Llama-3.1-70B-Instruct

--- a/examples/deployment/vllm/serve.dstack.yml
+++ b/examples/deployment/vllm/serve.dstack.yml
@@ -13,7 +13,4 @@ resources:
   gpu: 24GB
 
 # (Optional) Enable the OpenAI-compatible endpoint
-model:
-  format: openai
-  type: chat
-  name: NousResearch/Llama-2-7b-chat-hf
+model: NousResearch/Llama-2-7b-chat-hf

--- a/examples/deployment/vllm/service-tpu.dstack.yml
+++ b/examples/deployment/vllm/service-tpu.dstack.yml
@@ -34,7 +34,4 @@ resources:
   gpu: v5litepod-4
 
 # (Optional) Enable the OpenAI-compatible endpoint
-model:
-  format: openai
-  type: chat
-  name: meta-llama/Meta-Llama-3.1-8B-Instruct
+model: meta-llama/Meta-Llama-3.1-8B-Instruct

--- a/examples/llms/mixtral/vllm.dstack.yml
+++ b/examples/llms/mixtral/vllm.dstack.yml
@@ -17,7 +17,4 @@ resources:
   disk: 200GB
 
 # (Optional) Enable the OpenAI-compatible endpoint
-model:
-  type: chat
-  name: TheBloke/Mixtral-8x7B-Instruct-v0.1-GPTQ
-  format: openai
+model: TheBloke/Mixtral-8x7B-Instruct-v0.1-GPTQ

--- a/src/dstack/_internal/core/models/gateways.py
+++ b/src/dstack/_internal/core/models/gateways.py
@@ -113,7 +113,7 @@ class GatewayProvisioningData(CoreModel):
 
 
 class BaseChatModel(CoreModel):
-    type: Annotated[Literal["chat"], Field(description="The type of the model")]
+    type: Annotated[Literal["chat"], Field(description="The type of the model")] = "chat"
     name: Annotated[str, Field(description="The name of the model")]
     format: Annotated[
         str, Field(description="The serving format. Supported values include `openai` and `tgi`")
@@ -128,13 +128,31 @@ class TGIChatModel(BaseChatModel):
         type (str): The type of the model, e.g. "chat"
         name (str): The name of the model. This name will be used both to load model configuration from the HuggingFace Hub and in the OpenAI-compatible endpoint.
         format (str): The format of the model, e.g. "tgi" if the model is served with HuggingFace's Text Generation Inference.
-        chat_template (Optional[str]): The custom prompt template for the model. If not specified, the default prompt template the HuggingFace Hub configuration will be used.
-        eos_token (Optional[str]): The custom end of sentence token. If not specified, the default custom end of sentence token from the HuggingFace Hub configuration will be used.
+        chat_template (Optional[str]): The custom prompt template for the model. If not specified, the default prompt template from the HuggingFace Hub configuration will be used.
+        eos_token (Optional[str]): The custom end of sentence token. If not specified, the default end of sentence token from the HuggingFace Hub configuration will be used.
     """
 
-    format: Literal["tgi"]
-    chat_template: Optional[str] = None  # will be set before registering the service
-    eos_token: Optional[str] = None
+    format: Annotated[Literal["tgi"], Field(description="The serving format")]
+    chat_template: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "The custom prompt template for the model."
+                " If not specified, the default prompt template"
+                " from the HuggingFace Hub configuration will be used"
+            )
+        ),
+    ] = None  # will be set before registering the service
+    eos_token: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "The custom end of sentence token."
+                " If not specified, the default end of sentence token"
+                " from the HuggingFace Hub configuration will be used"
+            )
+        ),
+    ] = None
 
 
 class OpenAIChatModel(BaseChatModel):
@@ -148,7 +166,7 @@ class OpenAIChatModel(BaseChatModel):
         prefix (str): The `base_url` prefix: `http://hostname/{prefix}/chat/completions`. Defaults to `/v1`.
     """
 
-    format: Literal["openai"]
+    format: Annotated[Literal["openai"], Field(description="The serving format")]
     prefix: Annotated[str, Field(description="The `base_url` prefix (after hostname)")] = "/v1"
 
 


### PR DESCRIPTION
- Allow to define models in service configurations with a shorter `model: <name>` syntax.
- Upgrade docs and examples to the new syntax.
- Make everything related to `format: tgi` less visible in the docs, since the default and recommended format is now OpenAI.
- Show all model mapping fields in the reference, not just those from `BaseChatModel`.

Closes #1590