### PR TITLE
Support specifying multiple volumes per mount point

### DIFF
--- a/docs/docs/concepts/volumes.md
+++ b/docs/docs/concepts/volumes.md
@@ -93,6 +93,22 @@ volumes:
 Once you run this configuration, the contents of the volume will be attached to `/volume_data` inside the dev environment, 
 and its contents will persist across runs.
 
+!!! Info "Different volumes at the same path"
+    You can specify a list of volumes for the same mount path:
+
+    <div editor-title=".dstack.yml">
+
+    ```yaml
+    volumes:
+      - name: [my-aws-eu-west-1-volume, my-aws-us-east-1-volume]
+        path: /volume_data
+    ```
+
+    </div>
+
+    `dstack` will choose and mount one volume from the list.
+    This can be used to increase GPU availability by specifying different volumes for different regions.
+
 !!! info "Limitations"
     When you're running a dev environment, task, or service with `dstack`, it automatically mounts the project folder contents
     to `/workflow` (and sets that as the current working directory). Right now, `dstack` doesn't allow you to 
@@ -213,6 +229,9 @@ data across different backends, you should either use object storage or replicat
 Typically, network volumes are associated with specific regions, so you can't use them in other regions. Often,
 volumes are also linked to availability zones, but some providers support volumes that can be used across different
 availability zones within the same region.
+
+If you don't want to limit a run to one particular region, you can create different volumes for different regions
+and specify them for the same mount point as [documented above](#attach-network-volume).
 
 ##### Can I attach network volumes to multiple runs or instances?
 

--- a/src/dstack/_internal/core/models/volumes.py
+++ b/src/dstack/_internal/core/models/volumes.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from enum import Enum
 from pathlib import PurePosixPath
-from typing import Literal, Optional, Tuple, Union
+from typing import List, Literal, Optional, Tuple, Union
 
 from pydantic import Field, validator
 from typing_extensions import Annotated, Self
@@ -106,7 +106,16 @@ def _validate_mount_point_path(path: str) -> str:
 
 
 class VolumeMountPoint(CoreModel):
-    name: Annotated[str, Field(description="The name of the network volume to mount")]
+    name: Annotated[
+        Union[str, List[str]],
+        Field(
+            description=(
+                "The network volume name or the list of network volume names to mount."
+                " If a list is specified, one of the volumes in the list will be mounted."
+                " Specify volumes from different backends/regions to increase availability."
+            )
+        ),
+    ]
     path: Annotated[str, Field(description="The absolute container path to mount the volume at")]
 
     _validate_path = validator("path", allow_reuse=True)(_validate_mount_point_path)

--- a/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
@@ -58,6 +58,7 @@ from dstack._internal.server.services.pools import (
 from dstack._internal.server.services.runs import (
     check_can_attach_run_volumes,
     check_run_spec_has_instance_mounts,
+    get_offer_volumes,
     get_run_volume_models,
     get_run_volumes,
     run_model_to_run,
@@ -403,6 +404,7 @@ async def _run_job_on_new_instance(
             offer.region,
             offer.price,
         )
+        offer_volumes = get_offer_volumes(volumes, offer)
         try:
             job_provisioning_data = await run_async(
                 backend.compute().run_job,
@@ -411,7 +413,7 @@ async def _run_job_on_new_instance(
                 offer,
                 project_ssh_public_key,
                 project_ssh_private_key,
-                volumes,
+                offer_volumes,
             )
             return job_provisioning_data, offer
         except BackendError as e:

--- a/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
@@ -53,11 +53,13 @@ from dstack._internal.server.services.logging import fmt
 from dstack._internal.server.services.offers import get_offers_by_requirements
 from dstack._internal.server.services.pools import (
     filter_pool_instances,
+    get_instance_provisioning_data,
 )
 from dstack._internal.server.services.runs import (
     check_can_attach_run_volumes,
     check_run_spec_has_instance_mounts,
     get_run_volume_models,
+    get_run_volumes,
     run_model_to_run,
 )
 from dstack._internal.server.services.volumes import (
@@ -141,7 +143,11 @@ async def _process_submitted_job(session: AsyncSession, job_model: JobModel):
             project=project,
             run_spec=run_spec,
         )
-        volumes = [volume_model_to_volume(v) for v in volume_models]
+        volumes = await get_run_volumes(
+            session=session,
+            project=project,
+            run_spec=run_spec,
+        )
         check_can_attach_run_volumes(run_spec=run_spec, volumes=volumes)
     except ServerClientError as e:
         logger.warning("%s: failed to prepare run volumes: %s", fmt(job_model), repr(e))
@@ -206,7 +212,6 @@ async def _process_submitted_job(session: AsyncSession, job_model: JobModel):
             await session.commit()
             return
 
-    instance: InstanceModel
     if job_model.instance is not None:
         res = await session.execute(
             select(InstanceModel)
@@ -285,7 +290,7 @@ async def _process_submitted_job(session: AsyncSession, job_model: JobModel):
         await session.flush()  # to get im.id
         job_model.used_instance_id = instance.id
 
-    volumes_ids = sorted([v.id for v in volume_models])
+    volumes_ids = sorted([v.id for vs in volume_models for v in vs])
     # TODO: lock instances for attaching volumes?
     # Take lock to prevent attaching volumes that are to be deleted.
     # If the volume was deleted before the lock, the volume will fail to attach and the job will fail.
@@ -316,7 +321,7 @@ async def _assign_job_to_pool_instance(
     job: Job,
     fleet_model: Optional[FleetModel],
     master_job_provisioning_data: Optional[JobProvisioningData] = None,
-    volumes: Optional[List[Volume]] = None,
+    volumes: Optional[List[List[Volume]]] = None,
 ) -> Optional[InstanceModel]:
     profile = run_spec.merged_profile
     relevant_instances = filter_pool_instances(
@@ -365,7 +370,7 @@ async def _run_job_on_new_instance(
     project_ssh_public_key: str,
     project_ssh_private_key: str,
     master_job_provisioning_data: Optional[JobProvisioningData] = None,
-    volumes: Optional[List[Volume]] = None,
+    volumes: Optional[List[List[Volume]]] = None,
     fleet_model: Optional[FleetModel] = None,
 ) -> Optional[Tuple[JobProvisioningData, InstanceOfferWithAvailability]]:
     if volumes is None:
@@ -526,42 +531,47 @@ async def _attach_volumes(
     project: ProjectModel,
     job_model: JobModel,
     instance: InstanceModel,
-    volume_models: List[VolumeModel],
+    volume_models: List[List[VolumeModel]],
 ):
-    job_provisioning_data = JobProvisioningData.__response__.parse_raw(
-        instance.job_provisioning_data
-    )
+    job_provisioning_data = common_utils.get_or_error(get_instance_provisioning_data(instance))
     backend = await get_project_backend_by_type_or_error(
         project=project,
         backend_type=job_provisioning_data.backend,
     )
-    logger.info("Attaching volumes: %s", [v.name for v in volume_models])
-    for volume_model in volume_models:
-        volume = volume_model_to_volume(volume_model)
-        try:
-            if volume.provisioning_data is not None and volume.provisioning_data.attachable:
-                await _attach_volume(
-                    session=session,
-                    backend=backend,
-                    volume_model=volume_model,
-                    instance=instance,
-                    instance_id=job_provisioning_data.instance_id,
+    logger.info("Attaching volumes: %s", [[v.name for v in vs] for vs in volume_models])
+    for mount_point_volume_models in volume_models:
+        for volume_model in mount_point_volume_models:
+            volume = volume_model_to_volume(volume_model)
+            try:
+                if (
+                    job_provisioning_data.backend != volume.configuration.backend
+                    or job_provisioning_data.region != volume.configuration.region
+                ):
+                    continue
+                if volume.provisioning_data is not None and volume.provisioning_data.attachable:
+                    await _attach_volume(
+                        session=session,
+                        backend=backend,
+                        volume_model=volume_model,
+                        instance=instance,
+                        instance_id=job_provisioning_data.instance_id,
+                    )
+                    break  # attach next mount point
+            except (ServerClientError, BackendError) as e:
+                logger.warning("%s: failed to attached volume: %s", fmt(job_model), repr(e))
+                job_model.status = JobStatus.TERMINATING
+                # TODO: Replace with JobTerminationReason.VOLUME_ERROR in 0.19
+                job_model.termination_reason = JobTerminationReason.TERMINATED_BY_SERVER
+                job_model.termination_reason_message = "Failed to attach volume"
+            except Exception:
+                logger.exception(
+                    "%s: got exception when attaching volume",
+                    fmt(job_model),
                 )
-        except (ServerClientError, BackendError) as e:
-            logger.warning("%s: failed to attached volume: %s", fmt(job_model), repr(e))
-            job_model.status = JobStatus.TERMINATING
-            # TODO: Replace with JobTerminationReason.VOLUME_ERROR in 0.19
-            job_model.termination_reason = JobTerminationReason.TERMINATED_BY_SERVER
-            job_model.termination_reason_message = "Failed to attach volume"
-        except Exception:
-            logger.exception(
-                "%s: got exception when attaching volume",
-                fmt(job_model),
-            )
-            job_model.status = JobStatus.TERMINATING
-            # TODO: Replace with JobTerminationReason.VOLUME_ERROR in 0.19
-            job_model.termination_reason = JobTerminationReason.TERMINATED_BY_SERVER
-            job_model.termination_reason_message = "Failed to attach volume"
+                job_model.status = JobStatus.TERMINATING
+                # TODO: Replace with JobTerminationReason.VOLUME_ERROR in 0.19
+                job_model.termination_reason = JobTerminationReason.TERMINATED_BY_SERVER
+                job_model.termination_reason_message = "Failed to attach volume"
 
 
 async def _attach_volume(

--- a/src/dstack/_internal/server/services/offers.py
+++ b/src/dstack/_internal/server/services/offers.py
@@ -21,7 +21,7 @@ async def get_offers_by_requirements(
     exclude_not_available=False,
     multinode: bool = False,
     master_job_provisioning_data: Optional[JobProvisioningData] = None,
-    volumes: Optional[List[Volume]] = None,
+    volumes: Optional[List[List[Volume]]] = None,
     privileged: bool = False,
     instance_mounts: bool = False,
 ) -> List[Tuple[Backend, InstanceOfferWithAvailability]]:
@@ -39,9 +39,9 @@ async def get_offers_by_requirements(
     regions = profile.regions
 
     if volumes:
-        volume = volumes[0]
-        backend_types = [volume.configuration.backend]
-        regions = [volume.configuration.region]
+        mount_point_volumes = volumes[0]
+        backend_types = [v.configuration.backend for v in mount_point_volumes]
+        regions = [v.configuration.region for v in mount_point_volumes]
 
     if multinode:
         if not backend_types:

--- a/src/dstack/_internal/server/services/runs.py
+++ b/src/dstack/_internal/server/services/runs.py
@@ -741,11 +741,13 @@ def check_can_attach_run_volumes(
     run_spec: RunSpec,
     volumes: List[List[Volume]],
 ):
+    """
+    Performs basic checks if volumes can be attached.
+    This is useful to show error ASAP (when user submits the run).
+    If the attachment is to fail anyway, the error will be handled when proccessing submitted jobs.
+    """
     if len(volumes) == 0:
         return
-    # Perform basic checks if volumes can be attached.
-    # This is useful to show error ASAP (when user submits the run).
-    # If the attachment is to fail anyway, the error will be handled when proccessing submitted jobs.
     expected_backends = {v.configuration.backend for v in volumes[0]}
     expected_regions = {v.configuration.region for v in volumes[0]}
     for mount_point_volumes in volumes:
@@ -762,6 +764,9 @@ def check_can_attach_run_volumes(
         for volume in mount_point_volumes:
             if volume.status != VolumeStatus.ACTIVE:
                 raise ServerClientError(f"Cannot mount volumes that are not active: {volume.name}")
+    volumes_names = [v.name for vs in volumes for v in vs]
+    if len(volumes_names) != len(set(volumes_names)):
+        raise ServerClientError("Cannot attach the same volume at different mount points")
 
 
 async def get_job_volumes(

--- a/src/dstack/_internal/server/testing/common.py
+++ b/src/dstack/_internal/server/testing/common.py
@@ -44,6 +44,8 @@ from dstack._internal.core.models.runs import (
 )
 from dstack._internal.core.models.users import GlobalRole
 from dstack._internal.core.models.volumes import (
+    Volume,
+    VolumeAttachmentData,
     VolumeConfiguration,
     VolumeProvisioningData,
     VolumeStatus,
@@ -553,6 +555,42 @@ async def create_volume(
     session.add(vm)
     await session.commit()
     return vm
+
+
+def get_volume(
+    id_: Optional[UUID] = None,
+    name: str = "test_volume",
+    user: str = "test_user",
+    project_name: str = "test_project",
+    configuration: Optional[VolumeConfiguration] = None,
+    external: bool = False,
+    created_at: datetime = datetime(2023, 1, 2, 3, 4, tzinfo=timezone.utc),
+    status: VolumeStatus = VolumeStatus.ACTIVE,
+    status_message: Optional[str] = None,
+    deleted: bool = False,
+    volume_id: Optional[str] = None,
+    provisioning_data: Optional[VolumeProvisioningData] = None,
+    attachment_data: Optional[VolumeAttachmentData] = None,
+) -> Volume:
+    if id_ is None:
+        id_ = uuid.uuid4()
+    if configuration is None:
+        configuration = get_volume_configuration()
+    return Volume(
+        id=id_,
+        name=name,
+        user=user,
+        project_name=project_name,
+        configuration=configuration,
+        external=external,
+        created_at=created_at,
+        status=status,
+        status_message=status_message,
+        deleted=deleted,
+        volume_id=volume_id,
+        provisioning_data=provisioning_data,
+        attachment_data=attachment_data,
+    )
 
 
 def get_volume_configuration(

--- a/src/tests/_internal/server/services/test_runs.py
+++ b/src/tests/_internal/server/services/test_runs.py
@@ -4,13 +4,15 @@ import pytest
 from pydantic import parse_obj_as
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from dstack._internal.core.errors import ServerError
+from dstack._internal.core.errors import ServerClientError, ServerError
+from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.configurations import ScalingSpec, ServiceConfiguration
 from dstack._internal.core.models.profiles import Profile
 from dstack._internal.core.models.resources import Range
 from dstack._internal.core.models.runs import JobStatus, JobTerminationReason, RunStatus
+from dstack._internal.core.models.volumes import VolumeMountPoint
 from dstack._internal.server.models import RunModel
-from dstack._internal.server.services.runs import scale_run_replicas
+from dstack._internal.server.services.runs import check_can_attach_run_volumes, scale_run_replicas
 from dstack._internal.server.testing.common import (
     create_job,
     create_pool,
@@ -19,6 +21,7 @@ from dstack._internal.server.testing.common import (
     create_run,
     create_user,
     get_run_spec,
+    get_volume,
 )
 
 
@@ -218,3 +221,79 @@ class TestScaleRunReplicas:
         assert run.jobs[1].replica_num == 0
         assert run.jobs[2].status == JobStatus.SUBMITTED
         assert run.jobs[2].replica_num == 1
+
+
+class TestCanAttachRunVolumes:
+    @pytest.mark.asyncio
+    async def test_can_attach(self):
+        vol11 = get_volume(name="vol11")
+        vol11.configuration.backend = BackendType.AWS
+        vol11.configuration.region = "eu-west-1"
+        vol12 = get_volume(name="vol12")
+        vol12.configuration.backend = BackendType.AWS
+        vol12.configuration.region = "eu-west-2"
+        vol21 = get_volume(name="vol21")
+        vol21.configuration.backend = BackendType.AWS
+        vol21.configuration.region = "eu-west-1"
+        vol22 = get_volume(name="vol22")
+        vol22.configuration.backend = BackendType.AWS
+        vol22.configuration.region = "eu-west-2"
+        volumes = [[vol11, vol12], [vol21, vol22]]
+        run_spec = get_run_spec(
+            run_name="test_run",
+            repo_id="test_repo",
+            configuration=ServiceConfiguration(
+                port=80,
+                commands=[""],
+                volumes=[
+                    VolumeMountPoint(name=["vol11", "vol12"], path="/vol1"),
+                    VolumeMountPoint(name=["vol21", "vol22"], path="/vol2"),
+                ],
+            ),
+        )
+        check_can_attach_run_volumes(run_spec, volumes)
+
+    @pytest.mark.asyncio
+    async def test_cannot_attach_different_mount_points_with_different_backends_regions(self):
+        vol1 = get_volume(name="vol11")
+        vol1.configuration.backend = BackendType.AWS
+        vol1.configuration.region = "eu-west-1"
+        vol2 = get_volume(name="vol12")
+        vol2.configuration.backend = BackendType.AWS
+        vol2.configuration.region = "eu-west-2"
+        volumes = [[vol1], [vol2]]
+        run_spec = get_run_spec(
+            run_name="test_run",
+            repo_id="test_repo",
+            configuration=ServiceConfiguration(
+                port=80,
+                commands=[""],
+                volumes=[
+                    VolumeMountPoint(name=["vol1"], path="/vol1"),
+                    VolumeMountPoint(name=["vol2"], path="/vol2"),
+                ],
+            ),
+        )
+        with pytest.raises(ServerClientError):
+            check_can_attach_run_volumes(run_spec, volumes)
+
+    @pytest.mark.asyncio
+    async def test_cannot_attach_same_volume_at_different_mount_points(self):
+        vol1 = get_volume(name="vol11")
+        vol1.configuration.backend = BackendType.AWS
+        vol1.configuration.region = "eu-west-1"
+        volumes = [[vol1], [vol1]]
+        run_spec = get_run_spec(
+            run_name="test_run",
+            repo_id="test_repo",
+            configuration=ServiceConfiguration(
+                port=80,
+                commands=[""],
+                volumes=[
+                    VolumeMountPoint(name=["vol1"], path="/vol1"),
+                    VolumeMountPoint(name=["vol1"], path="/vol2"),
+                ],
+            ),
+        )
+        with pytest.raises(ServerClientError):
+            check_can_attach_run_volumes(run_spec, volumes)


### PR DESCRIPTION
Closes #1949

* Allow specifying a list of network volumes for the same mount point.
* Suggest offers that are eligible for any specified volume (increases availability).
* When attaching volumes, choose a volume that works with the provisioned offer (same backend/region).