### PR TITLE
Set minimum paramiko version to 3.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ BASE_DEPS = [
     "python-dateutil",
     "gitpython",
     "jsonschema",
-    "paramiko",
+    "paramiko>=3.2.0,<4",
     "cursor",
     "rich",
     "rich-argparse",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ BASE_DEPS = [
     "python-dateutil",
     "gitpython",
     "jsonschema",
-    "paramiko>=3.2.0,<4",
+    "paramiko>=3.2.0",
     "cursor",
     "rich",
     "rich-argparse",


### PR DESCRIPTION
`dstack` uses `PKey.fingerprint` property, which was added in 3.2.0:

https://www.paramiko.org/changelog.html

> 3.2.0 2023-05-25
> * [Feature]: `PKey` grew a new `.fingerprint` property [...]

Fixes: https://github.com/dstackai/dstack/issues/1982