### PR TITLE
Expose DSTACK_NODES_IPS env var

### DIFF
--- a/docs/docs/reference/dstack.yml/task.md
+++ b/docs/docs/reference/dstack.yml/task.md
@@ -229,6 +229,7 @@ The following environment variables are available in any run and are passed by `
 | `DSTACK_NODES_NUM`      | The number of nodes in the run          |
 | `DSTACK_NODE_RANK`      | The rank of the node                    |
 | `DSTACK_MASTER_NODE_IP` | The internal IP address the master node |
+| `DSTACK_NODES_IPS`      | The list of internal IP addresses of all nodes delimited by "\n" |
 
 ### Distributed tasks
 

--- a/runner/internal/executor/executor.go
+++ b/runner/internal/executor/executor.go
@@ -200,6 +200,7 @@ func (ex *RunExecutor) execJob(ctx context.Context, jobLogFile io.Writer) error 
 		"REPO_ID":               ex.run.RepoId,  // deprecated, remove in 0.19
 		"DSTACK_RUN_NAME":       ex.run.RunName,
 		"DSTACK_REPO_ID":        ex.run.RepoId,
+		"DSTACK_NODES_IPS":      strings.Join(ex.clusterInfo.JobIPs, "\n"),
 		"DSTACK_MASTER_NODE_IP": ex.clusterInfo.MasterJobIP,
 		"DSTACK_NODE_RANK":      strconv.Itoa(node_rank),
 		"DSTACK_NODES_NUM":      strconv.Itoa(nodes_num),

--- a/runner/internal/schemas/schemas.go
+++ b/runner/internal/schemas/schemas.go
@@ -50,8 +50,9 @@ type JobSpec struct {
 }
 
 type ClusterInfo struct {
-	MasterJobIP string `json:"master_job_ip"`
-	GPUSPerJob  int    `json:"gpus_per_job"`
+	JobIPs      []string `json:"job_ips"`
+	MasterJobIP string   `json:"master_job_ip"`
+	GPUSPerJob  int      `json:"gpus_per_job"`
 }
 
 type RepoCredentials struct {

--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -226,6 +226,7 @@ class JobProvisioningData(CoreModel):
 
 
 class ClusterInfo(CoreModel):
+    job_ips: List[str]
     master_job_ip: str
     gpus_per_job: int
 


### PR DESCRIPTION
Closes #1981 

The PR exposes a new `DSTACK_NODES_IPS` env variable to runs that includes a list of internal ip addresses of all nodes of a multi-node task, e.g. `DSTACK_NODES_IPS="10.128.0.47\n10.128.0.48"`.