### PR TITLE
Limit azure-mgmt-network>=23.0.0,<28.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ AZURE_DEPS = [
     "azure-identity>=1.12.0",
     "azure-mgmt-subscription>=3.1.1",
     "azure-mgmt-compute>=29.1.0",
-    "azure-mgmt-network>=23.0.0",
+    "azure-mgmt-network>=23.0.0,<28.0.0",
     "azure-mgmt-resource>=22.0.0",
     "azure-mgmt-authorization>=3.0.0",
 ]


### PR DESCRIPTION
Fixed #1987 

The PR places an upper bound on azure-mgmt-network since it's unclear how to make azure-mgmt-network==28.0.0 work. The upper bound can be removed once we get feedback from https://github.com/Azure/azure-sdk-for-python/issues/38507 and update the code accordingly.