### PR TITLE
Improve AMD Instinct `asic.market_name` normalization

### DIFF
--- a/src/dstack/_internal/utils/gpu.py
+++ b/src/dstack/_internal/utils/gpu.py
@@ -31,8 +31,14 @@ def convert_nvidia_gpu_name(name: str) -> str:
 
 def convert_amd_gpu_name(name: str) -> str:
     """Convert asic.market_name from amd-smi to short version"""
-    name = name.replace("Instinct ", "")
+    if match := _AMD_INSTINCT_MARKET_NAME_REGEX.search(name):
+        name = match.group("name")
     # https://github.com/ROCm/amdsmi/blob/52b3947/src/amd_smi/amd_smi_utils.cc#L558-L593
     if name == "MI300X-O":
         return "MI300X"
     return name
+
+
+_AMD_INSTINCT_MARKET_NAME_REGEX = re.compile(
+    r"^(?:AMD )?(?:Instinct )?(?P<name>MI\d{1,3}[A-Z]?(?:-\w+)?)(?:\s|$)", flags=re.ASCII | re.I
+)

--- a/src/tests/_internal/utils/test_gpu.py
+++ b/src/tests/_internal/utils/test_gpu.py
@@ -26,9 +26,14 @@ class TestConvertGpuName:
     @pytest.mark.parametrize(
         ["test_input", "expected"],
         [
+            # The following are asic.market_name collected in the wild
             ("MI300X-O", "MI300X"),
             ("Instinct MI210", "MI210"),
+            ("AMD INSTINCT MI250 (MCM) OAM AC MBA", "MI250"),
+            # The following are made-up examples
             ("MI300A", "MI300A"),
+            ("Instinct MI325X", "MI325X"),
+            ("AMD Radeon PRO W7900", "AMD Radeon PRO W7900"),
         ],
     )
     def test_convert_amd_gpu_name(self, test_input, expected):


### PR DESCRIPTION
Normalizes the following `asic.market_name`: 

![image](https://github.com/user-attachments/assets/0095d6a9-c7ce-4e50-a172-2b5a47ee289a)

Should cover more potential Instinct naming schemes