### PR TITLE
Add `DSTACK_{RUNNER,SHIM}_DOWNLOAD_URL` env vars

### DIFF
--- a/docs/docs/reference/cli/index.md
+++ b/docs/docs/reference/cli/index.md
@@ -426,6 +426,8 @@ $ dstack pool delete --help
      * `DSTACK_SERVER_UVICORN_LOG_LEVEL` – (Optional) Sets uvicorn logger log level. Defaults to `ERROR`.
      * `DSTACK_PROFILE` – (Optional) Has the same effect as `--profile`. Defaults to `None`.
      * `DSTACK_PROJECT` – (Optional) Has the same effect as `--project`. Defaults to `None`.
-     * `DSTACK_RUNNER_VERSION` – (Optional) Sets exact runner version for debug. Defaults to `latest`.
+     * `DSTACK_RUNNER_VERSION` – (Optional) Sets exact runner version for debug. Defaults to `latest`. Ignored if `DSTACK_RUNNER_DOWNLOAD_URL` is set.
+     * `DSTACK_RUNNER_DOWNLOAD_URL` – (Optional) Overrides `dstack-runner` binary download URL.
+     * `DSTACK_SHIM_DOWNLOAD_URL` – (Optional) Overrides `dstack-shim` binary download URL.
      * `DSTACK_DEFAULT_CREDS_DISABLED` – (Optional) Disables default credentials detection if set. Defaults to `None`.
      * `DSTACK_LOCAL_BACKEND_ENABLED` – (Optional) Enables local backend for debug if set. Defaults to `None`.

--- a/runner/cmd/shim/main.go
+++ b/runner/cmd/shim/main.go
@@ -65,16 +65,10 @@ func main() {
 				EnvVars:     []string{"DSTACK_RUNNER_LOG_LEVEL"},
 			},
 			&cli.StringFlag{
-				Name:        "runner-version",
-				Usage:       "Set runner's version",
-				Value:       "latest",
-				Destination: &args.Runner.Version,
-				EnvVars:     []string{"DSTACK_RUNNER_VERSION"},
-			},
-			&cli.BoolFlag{
-				Name:        "dev",
-				Usage:       "Use stgn channel",
-				Destination: &args.Runner.DevChannel,
+				Name:        "runner-download-url",
+				Usage:       "Set runner's download URL",
+				Destination: &args.Runner.DownloadURL,
+				EnvVars:     []string{"DSTACK_RUNNER_DOWNLOAD_URL"},
 			},
 			&cli.PathFlag{
 				Name:        "runner-binary-path",

--- a/runner/internal/shim/models.go
+++ b/runner/internal/shim/models.go
@@ -25,14 +25,13 @@ type CLIArgs struct {
 	}
 
 	Runner struct {
-		HTTPPort   int
-		LogLevel   int
-		Version    string
-		DevChannel bool
-		BinaryPath string
-		TempDir    string
-		HomeDir    string
-		WorkingDir string
+		HTTPPort    int
+		LogLevel    int
+		DownloadURL string
+		BinaryPath  string
+		TempDir     string
+		HomeDir     string
+		WorkingDir  string
 	}
 
 	Docker struct {

--- a/runner/internal/shim/runner.go
+++ b/runner/internal/shim/runner.go
@@ -15,12 +15,7 @@ import (
 	"github.com/dstackai/dstack/runner/internal/gerrors"
 )
 
-const (
-	DstackRunnerURL        = "https://%s.s3.eu-west-1.amazonaws.com/%s/binaries/dstack-runner-%s-%s"
-	DstackReleaseBucket    = "dstack-runner-downloads"
-	DstackStagingBucket    = "dstack-runner-downloads-stgn"
-	DstackRunnerBinaryName = "/usr/local/bin/dstack-runner"
-)
+const DstackRunnerBinaryName = "/usr/local/bin/dstack-runner"
 
 func (c *CLIArgs) GetDockerCommands() []string {
 	return []string{
@@ -30,9 +25,7 @@ func (c *CLIArgs) GetDockerCommands() []string {
 }
 
 func (c *CLIArgs) DownloadRunner() error {
-	url := makeDownloadRunnerURL(c.Runner.Version, c.Runner.DevChannel)
-
-	runnerBinaryPath, err := downloadRunner(url)
+	runnerBinaryPath, err := downloadRunner(c.Runner.DownloadURL)
 	if err != nil {
 		return gerrors.Wrap(err)
 	}
@@ -51,19 +44,6 @@ func (c *CLIArgs) getRunnerArgs() []string {
 		"--home-dir", c.Runner.HomeDir,
 		"--working-dir", c.Runner.WorkingDir,
 	}
-}
-
-func makeDownloadRunnerURL(version string, staging bool) string {
-	bucket := DstackReleaseBucket
-	if staging {
-		bucket = DstackStagingBucket
-	}
-
-	osName := "linux"
-	archName := "amd64"
-
-	url := fmt.Sprintf(DstackRunnerURL, bucket, version, osName, archName)
-	return url
 }
 
 func downloadRunner(url string) (string, error) {

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -173,6 +173,10 @@ def get_instance_name(run: Run, job: Job) -> str:
     return f"{run.project_name.lower()}-{job.job_spec.job_name}"
 
 
+def get_cloud_config(**config) -> str:
+    return "#cloud-config\n" + yaml.dump(config, default_flow_style=False)
+
+
 def get_user_data(
     authorized_keys: List[str], backend_specific_commands: Optional[List[str]] = None
 ) -> str:
@@ -184,11 +188,10 @@ def get_user_data(
     )
 
 
-def get_shim_env(build: str, authorized_keys: List[str]) -> Dict[str, str]:
-    build = get_dstack_runner_version()
+def get_shim_env(authorized_keys: List[str]) -> Dict[str, str]:
     envs = {
         "DSTACK_RUNNER_LOG_LEVEL": "6",
-        "DSTACK_RUNNER_VERSION": build,
+        "DSTACK_RUNNER_DOWNLOAD_URL": get_dstack_runner_download_url(),
         "DSTACK_PUBLIC_SSH_KEY": "\n".join(authorized_keys),
         "DSTACK_HOME": DSTACK_WORKING_DIR,
     }
@@ -198,11 +201,8 @@ def get_shim_env(build: str, authorized_keys: List[str]) -> Dict[str, str]:
 def get_shim_commands(
     authorized_keys: List[str], *, is_privileged: bool = False, pjrt_device: Optional[str] = None
 ) -> List[str]:
-    build = get_dstack_runner_version()
-    commands = get_shim_pre_start_commands(
-        build,
-    )
-    for k, v in get_shim_env(build, authorized_keys).items():
+    commands = get_shim_pre_start_commands()
+    for k, v in get_shim_env(authorized_keys).items():
         commands += [f'export "{k}={v}"']
     commands += get_run_shim_script(is_privileged, pjrt_device)
     return commands
@@ -217,17 +217,32 @@ def get_dstack_runner_version() -> str:
     return version or "latest"
 
 
-def get_cloud_config(**config) -> str:
-    return "#cloud-config\n" + yaml.dump(config, default_flow_style=False)
-
-
-def get_shim_pre_start_commands(build: str) -> List[str]:
-    bucket = "dstack-runner-downloads-stgn"
+def get_dstack_runner_download_url() -> str:
+    if url := os.environ.get("DSTACK_RUNNER_DOWNLOAD_URL"):
+        return url
+    build = get_dstack_runner_version()
     if settings.DSTACK_VERSION is not None:
         bucket = "dstack-runner-downloads"
+    else:
+        bucket = "dstack-runner-downloads-stgn"
+    return (
+        f"https://{bucket}.s3.eu-west-1.amazonaws.com/{build}/binaries/dstack-runner-linux-amd64"
+    )
 
-    url = f"https://{bucket}.s3.eu-west-1.amazonaws.com/{build}/binaries/dstack-shim-linux-amd64"
 
+def get_dstack_shim_download_url() -> str:
+    if url := os.environ.get("DSTACK_SHIM_DOWNLOAD_URL"):
+        return url
+    build = get_dstack_runner_version()
+    if settings.DSTACK_VERSION is not None:
+        bucket = "dstack-runner-downloads"
+    else:
+        bucket = "dstack-runner-downloads-stgn"
+    return f"https://{bucket}.s3.eu-west-1.amazonaws.com/{build}/binaries/dstack-shim-linux-amd64"
+
+
+def get_shim_pre_start_commands() -> List[str]:
+    url = get_dstack_shim_download_url()
     dstack_shim_binary_name = "dstack-shim"
     dstack_shim_binary_path = f"/usr/local/bin/{dstack_shim_binary_name}"
 
@@ -242,12 +257,11 @@ def get_shim_pre_start_commands(build: str) -> List[str]:
 
 
 def get_run_shim_script(is_privileged: bool, pjrt_device: Optional[str]) -> List[str]:
-    dev_flag = "" if settings.DSTACK_VERSION is not None else "--dev"
     privileged_flag = "--privileged" if is_privileged else ""
     pjrt_device_env = f"--pjrt-device={pjrt_device}" if pjrt_device else ""
 
     return [
-        f"nohup dstack-shim {dev_flag} docker {privileged_flag} {pjrt_device_env} >{DSTACK_WORKING_DIR}/shim.log 2>&1 &",
+        f"nohup dstack-shim docker {privileged_flag} {pjrt_device_env} >{DSTACK_WORKING_DIR}/shim.log 2>&1 &",
     ]
 
 

--- a/src/dstack/_internal/core/backends/remote/provisioning.py
+++ b/src/dstack/_internal/core/backends/remote/provisioning.py
@@ -89,7 +89,6 @@ def run_pre_start_commands(
 
 
 def run_shim_as_systemd_service(client: paramiko.SSHClient, working_dir: str, dev: bool) -> None:
-    dev_flag = "--dev" if dev else ""
     shim_service = f"""\
     [Unit]
     Description=dstack-shim
@@ -101,7 +100,7 @@ def run_shim_as_systemd_service(client: paramiko.SSHClient, working_dir: str, de
     Restart=always
     WorkingDirectory={working_dir}
     EnvironmentFile={working_dir}/{DSTACK_SHIM_ENV_FILE}
-    ExecStart=/usr/local/bin/dstack-shim {dev_flag} docker
+    ExecStart=/usr/local/bin/dstack-shim docker
     StandardOutput=append:/root/.dstack/shim.log
     StandardError=append:/root/.dstack/shim.log
 

--- a/src/dstack/_internal/server/background/tasks/process_instances.py
+++ b/src/dstack/_internal/server/background/tasks/process_instances.py
@@ -18,7 +18,6 @@ from dstack._internal.core.backends import (
 )
 from dstack._internal.core.backends.base.compute import (
     DSTACK_WORKING_DIR,
-    get_dstack_runner_version,
     get_shim_env,
     get_shim_pre_start_commands,
 )
@@ -356,15 +355,13 @@ def _deploy_instance(
     ) as client:
         logger.info(f"Connected to {remote_details.ssh_user} {remote_details.host}")
 
-        runner_build = get_dstack_runner_version()
-
         # Execute pre start commands
-        shim_pre_start_commands = get_shim_pre_start_commands(runner_build)
+        shim_pre_start_commands = get_shim_pre_start_commands()
         run_pre_start_commands(client, shim_pre_start_commands, authorized_keys)
         logger.debug("The script for installing dstack has been executed")
 
         # Upload envs
-        shim_envs = get_shim_env(runner_build, authorized_keys)
+        shim_envs = get_shim_env(authorized_keys)
         try:
             fleet_configuration_envs = remote_details.env.as_dict()
         except ValueError as e:


### PR DESCRIPTION
Useful for:

* Development — allows to deploy locally built and served binaries
* Self-hosted dstack deployments — removes yet another hardcoded dependency on dstack-provided blobs