### PR TITLE
Fix returning metrics from deleted runs

### DIFF
--- a/src/dstack/_internal/server/services/metrics.py
+++ b/src/dstack/_internal/server/services/metrics.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from dstack._internal.core.errors import ResourceNotExistsError
 from dstack._internal.core.models.metrics import JobMetrics, Metric
 from dstack._internal.server.models import JobMetricsPoint, JobModel, ProjectModel
-from dstack._internal.server.services.jobs import list_run_job_models
+from dstack._internal.server.services.jobs import get_run_job_model
 
 
 async def get_job_metrics(
@@ -17,16 +17,15 @@ async def get_job_metrics(
     replica_num: int,
     job_num: int,
 ) -> JobMetrics:
-    job_models = await list_run_job_models(
+    job_model = await get_run_job_model(
         session=session,
         project=project,
         run_name=run_name,
         replica_num=replica_num,
         job_num=job_num,
     )
-    if len(job_models) == 0:
+    if job_model is None:
         raise ResourceNotExistsError("Found no job with given parameters")
-    job_model = job_models[-1]
     job_metrics = await _get_job_metrics(
         session=session,
         job_model=job_model,

--- a/src/dstack/_internal/server/testing/common.py
+++ b/src/dstack/_internal/server/testing/common.py
@@ -240,6 +240,7 @@ async def create_run(
     submitted_at: datetime = datetime(2023, 1, 2, 3, 4, tzinfo=timezone.utc),
     run_spec: Optional[RunSpec] = None,
     run_id: Optional[UUID] = None,
+    deleted: bool = False,
 ) -> RunModel:
     if run_spec is None:
         run_spec = get_run_spec(
@@ -250,6 +251,7 @@ async def create_run(
         run_id = uuid.uuid4()
     run = RunModel(
         id=run_id,
+        deleted=deleted,
         project_id=project.id,
         repo_id=repo.id,
         user_id=user.id,


### PR DESCRIPTION
This commit fixes the bug when
`/api/metrics/job/{run_name}` would randomly
return metrics from a deleted run instead of the
active run with the same name.

It also includes a small optimization to only
fetch the latest job submission from the database
instead of filtering in runtime.

Fixes #2037