### PR TITLE
Recover unreachable instances

### DIFF
--- a/src/dstack/_internal/server/testing/common.py
+++ b/src/dstack/_internal/server/testing/common.py
@@ -30,6 +30,7 @@ from dstack._internal.core.models.profiles import (
     DEFAULT_POOL_NAME,
     DEFAULT_POOL_TERMINATION_IDLE_TIME,
     Profile,
+    TerminationPolicy,
 )
 from dstack._internal.core.models.repos.base import RepoType
 from dstack._internal.core.models.repos.local import LocalRunRepoData
@@ -443,6 +444,7 @@ async def create_instance(
     pool: PoolModel,
     fleet: Optional[FleetModel] = None,
     status: InstanceStatus = InstanceStatus.IDLE,
+    unreachable: bool = False,
     created_at: datetime = datetime(2023, 1, 2, 3, 4, tzinfo=timezone.utc),
     finished_at: Optional[datetime] = None,
     spot: bool = False,
@@ -453,6 +455,8 @@ async def create_instance(
     job: Optional[JobModel] = None,
     instance_num: int = 0,
     backend: BackendType = BackendType.DATACRUNCH,
+    termination_policy: Optional[TerminationPolicy] = None,
+    termination_idle_time: int = DEFAULT_POOL_TERMINATION_IDLE_TIME,
     region: str = "eu-west",
     remote_connection_info: Optional[RemoteConnectionInfo] = None,
 ) -> InstanceModel:
@@ -523,7 +527,7 @@ async def create_instance(
         fleet=fleet,
         project=project,
         status=status,
-        unreachable=False,
+        unreachable=unreachable,
         created_at=created_at,
         started_at=created_at,
         finished_at=finished_at,
@@ -532,7 +536,8 @@ async def create_instance(
         price=1,
         region=region,
         backend=backend,
-        termination_idle_time=DEFAULT_POOL_TERMINATION_IDLE_TIME,
+        termination_policy=termination_policy,
+        termination_idle_time=termination_idle_time,
         profile=profile.json(),
         requirements=requirements.json(),
         instance_configuration=instance_configuration.json(),

--- a/src/tests/_internal/server/background/tasks/test_process_running_jobs.py
+++ b/src/tests/_internal/server/background/tasks/test_process_running_jobs.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -36,6 +36,7 @@ from dstack._internal.server.testing.common import (
     get_run_spec,
     get_volume_configuration,
 )
+from dstack._internal.utils.common import get_current_datetime
 
 
 def get_job_provisioning_data(dockerized: bool) -> JobProvisioningData:
@@ -371,3 +372,52 @@ class TestProcessRunningJobs:
         assert job.status == JobStatus.TERMINATING
         assert job.termination_reason == JobTerminationReason.INTERRUPTED_BY_NO_CAPACITY
         assert job.remove_at is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_provisioning_shim_force_stop_if_already_running(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        test_db,
+        session: AsyncSession,
+    ):
+        project = await create_project(session=session)
+        user = await create_user(session=session)
+        repo = await create_repo(session=session, project_id=project.id)
+        run_spec = get_run_spec(run_name="test-run", repo_id=repo.name)
+        run_spec.configuration.image = "debian"
+        run = await create_run(
+            session=session,
+            project=project,
+            repo=repo,
+            user=user,
+            run_name="test-run",
+            run_spec=run_spec,
+        )
+        job = await create_job(
+            session=session,
+            run=run,
+            status=JobStatus.PROVISIONING,
+            job_provisioning_data=get_job_provisioning_data(dockerized=True),
+            submitted_at=get_current_datetime(),
+        )
+        monkeypatch.setattr(
+            "dstack._internal.server.services.runner.ssh.SSHTunnel", Mock(return_value=MagicMock())
+        )
+        shim_client_mock = Mock()
+        monkeypatch.setattr(
+            "dstack._internal.server.services.runner.client.ShimClient",
+            Mock(return_value=shim_client_mock),
+        )
+        shim_client_mock.healthcheck.return_value = HealthcheckResponse(
+            service="dstack-shim", version="0.0.1.dev2"
+        )
+        shim_client_mock.submit.return_value = False
+
+        await process_running_jobs()
+
+        shim_client_mock.healthcheck.assert_called_once()
+        shim_client_mock.submit.assert_called_once()
+        shim_client_mock.stop.assert_called_once_with(force=True)
+        await session.refresh(job)
+        assert job.status == JobStatus.PROVISIONING


### PR DESCRIPTION
* Check instances regardless of termination_policy -- gives unreachable instances a chance to become reachable again
* Stop a previous job container possibly still running on the insance when submitting a new one

Fixes: https://github.com/dstackai/dstack/issues/2041