### PR TITLE
UX enhancements for `dstack apply`

### DIFF
--- a/src/dstack/_internal/cli/utils/fleet.py
+++ b/src/dstack/_internal/cli/utils/fleet.py
@@ -6,7 +6,7 @@ from dstack._internal.cli.utils.common import console
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.fleets import Fleet, FleetStatus
 from dstack._internal.core.models.instances import InstanceStatus
-from dstack._internal.utils.common import pretty_date
+from dstack._internal.utils.common import DateFormatter, pretty_date
 
 
 def print_fleets_table(fleets: List[Fleet], verbose: bool = False) -> None:
@@ -14,7 +14,9 @@ def print_fleets_table(fleets: List[Fleet], verbose: bool = False) -> None:
     console.print()
 
 
-def get_fleets_table(fleets: List[Fleet], verbose: bool = False) -> Table:
+def get_fleets_table(
+    fleets: List[Fleet], verbose: bool = False, format_date: DateFormatter = pretty_date
+) -> Table:
     table = Table(box=None)
     table.add_column("FLEET", no_wrap=True)
     table.add_column("INSTANCE")
@@ -56,7 +58,7 @@ def get_fleets_table(fleets: List[Fleet], verbose: bool = False) -> Table:
                 resources,
                 f"${instance.price:.4}" if instance.price is not None else "",
                 status,
-                pretty_date(instance.created),
+                format_date(instance.created),
             ]
 
             if verbose:
@@ -75,7 +77,7 @@ def get_fleets_table(fleets: List[Fleet], verbose: bool = False) -> Table:
                 "-",
                 "-",
                 "-",
-                pretty_date(fleet.created_at),
+                format_date(fleet.created_at),
             ]
             table.add_row(*row)
 

--- a/src/dstack/_internal/cli/utils/run.py
+++ b/src/dstack/_internal/cli/utils/run.py
@@ -10,7 +10,7 @@ from dstack._internal.core.models.runs import (
     Job,
     RunPlan,
 )
-from dstack._internal.utils.common import format_pretty_duration, pretty_date
+from dstack._internal.utils.common import DateFormatter, format_pretty_duration, pretty_date
 from dstack.api import Run
 
 
@@ -113,18 +113,14 @@ def print_run_plan(run_plan: RunPlan, offers_limit: int = 3):
 
 
 def get_runs_table(
-    runs: List[Run], include_configuration: bool = False, verbose: bool = False
+    runs: List[Run], verbose: bool = False, format_date: DateFormatter = pretty_date
 ) -> Table:
     table = Table(box=None)
     table.add_column("NAME", style="bold", no_wrap=True)
-    if include_configuration:
-        table.add_column("CONFIGURATION", style="grey58")
-    table.add_column("BACKEND", style="grey58", no_wrap=True, max_width=16)
-    table.add_column("REGION", style="grey58")
+    table.add_column("BACKEND", style="grey58")
     if verbose:
         table.add_column("INSTANCE", no_wrap=True)
     table.add_column("RESOURCES")
-    table.add_column("SPOT")
     table.add_column("PRICE", no_wrap=True)
     table.add_column("STATUS", no_wrap=True)
     table.add_column("SUBMITTED", style="grey58", no_wrap=True)
@@ -137,30 +133,27 @@ def get_runs_table(
 
         run_row: Dict[Union[str, int], Any] = {
             "NAME": run.run_spec.run_name,
-            "CONFIGURATION": run.run_spec.configuration_path,
-            "STATUS": run.status,
-            "SUBMITTED": pretty_date(run.submitted_at),
+            "SUBMITTED": format_date(run.submitted_at),
             "ERROR": run_error,
         }
         if len(run.jobs) != 1:
+            run_row["STATUS"] = run.status
             add_row_from_dict(table, run_row)
 
         for job in run.jobs:
             job_row: Dict[Union[str, int], Any] = {
-                "NAME": f"  replica {job.job_spec.replica_num}\n  job_num {job.job_spec.job_num}",
+                "NAME": f"  replica={job.job_spec.replica_num} job={job.job_spec.job_num}",
                 "STATUS": job.job_submissions[-1].status,
-                "SUBMITTED": pretty_date(job.job_submissions[-1].submitted_at),
+                "SUBMITTED": format_date(job.job_submissions[-1].submitted_at),
                 "ERROR": _get_job_error(job),
             }
             jpd = job.job_submissions[-1].job_provisioning_data
             if jpd is not None:
                 job_row.update(
                     {
-                        "BACKEND": jpd.backend.value.replace("remote", "ssh"),
-                        "REGION": jpd.region,
+                        "BACKEND": f"{jpd.backend.value.replace('remote', 'ssh')} ({jpd.region})",
                         "INSTANCE": jpd.instance_type.name,
-                        "RESOURCES": jpd.instance_type.resources.pretty_format(),
-                        "SPOT": "yes" if jpd.instance_type.resources.spot else "no",
+                        "RESOURCES": jpd.instance_type.resources.pretty_format(include_spot=True),
                         "PRICE": f"${jpd.price:.4}",
                     }
                 )

--- a/src/dstack/_internal/cli/utils/volume.py
+++ b/src/dstack/_internal/cli/utils/volume.py
@@ -4,7 +4,7 @@ from rich.table import Table
 
 from dstack._internal.cli.utils.common import console
 from dstack._internal.core.models.volumes import Volume
-from dstack._internal.utils.common import pretty_date
+from dstack._internal.utils.common import DateFormatter, pretty_date
 
 
 def print_volumes_table(volumes: List[Volume], verbose: bool = False):
@@ -13,7 +13,9 @@ def print_volumes_table(volumes: List[Volume], verbose: bool = False):
     console.print()
 
 
-def get_volumes_table(volumes: List[Volume], verbose: bool = False) -> Table:
+def get_volumes_table(
+    volumes: List[Volume], verbose: bool = False, format_date: DateFormatter = pretty_date
+) -> Table:
     table = Table(box=None)
     table.add_column("NAME", no_wrap=True)
     table.add_column("BACKEND")
@@ -27,7 +29,7 @@ def get_volumes_table(volumes: List[Volume], verbose: bool = False) -> Table:
             volume.name,
             f"{volume.configuration.backend.value} ({volume.configuration.region})",
             volume.status,
-            pretty_date(volume.created_at),
+            format_date(volume.created_at),
         ]
         if verbose:
             renderables.append(volume.status_message)

--- a/src/dstack/_internal/utils/common.py
+++ b/src/dstack/_internal/utils/common.py
@@ -1,9 +1,10 @@
 import itertools
 import re
 import time
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Iterable, List, Optional, TypeVar, Union
+from typing import Any, Iterable, List, Optional, TypeVar
 from urllib.parse import urlparse
 
 
@@ -19,14 +20,18 @@ def get_milliseconds_since_epoch() -> int:
     return int(round(time.time() * 1000))
 
 
-def pretty_date(time: Union[datetime, int] = False) -> str:
+DateFormatter = Callable[[datetime], str]
+
+
+def local_time(time: datetime) -> str:
+    """Return HH:MM in local timezone"""
+    return time.astimezone().strftime("%H:%M")
+
+
+def pretty_date(time: datetime) -> str:
     """
-    Get a datetime object or an epoch timestamp and return a
-    pretty string like 'an hour ago', 'Yesterday', '3 months ago',
-    'just now', etc
+    Return a pretty string like 'an hour ago', 'Yesterday', '3 months ago', 'just now', etc
     """
-    if isinstance(time, int):
-        time = datetime.fromtimestamp(time, tz=timezone.utc)
     now = get_current_datetime()
     diff = now - time
     if diff.days < 0:

--- a/src/tests/_internal/utils/test_common.py
+++ b/src/tests/_internal/utils/test_common.py
@@ -6,11 +6,23 @@ from freezegun import freeze_time
 
 from dstack._internal.utils.common import (
     concat_url_path,
+    local_time,
     make_proxy_url,
     parse_memory,
     pretty_date,
     split_chunks,
 )
+
+
+@pytest.mark.parametrize(
+    ("dt", "result"),
+    [
+        (datetime.fromisoformat("1970-01-01T12:34"), "12:34"),
+        (datetime.fromisoformat("2024-12-01T01:02:03"), "01:02"),
+    ],
+)
+def test_local_time(dt: datetime, result: str) -> None:
+    assert local_time(dt) == result
 
 
 @freeze_time(datetime(2023, 10, 4, 12, 0, tzinfo=timezone.utc))
@@ -73,10 +85,6 @@ class TestPrettyDate:
         now = datetime.now(tz=timezone.utc)
         future_time = now + timedelta(hours=1)
         assert pretty_date(future_time) == ""
-
-    def test_epoch_timestamp(self):
-        epoch_time = 1609459200  # January 1, 2021
-        assert pretty_date(epoch_time) == "3 years ago"
 
 
 class TestParseMemory:


### PR DESCRIPTION
For all configuration types:
- Show a spinner while provisioning.
- Show a non-verbose live table to save screen space.
- After provisioning, show a final render of the table with absolute times, not relative. This allows the table to stay relevant if the user looks at it later.
- In case of errors, show a verbose table in the final render to provide more details for troubleshooting.
- In case of errors, show a highlighted error description.

For runs:
- Merge the backend+region and resources+spot columns to save screen space and for consistency with other configuration types.
- Show the replica and job number on the same line for better readability and consistency with `dstack stats`.
- For single-job runs, show the status of the job, not the run. This allows the `pulling` status to be visible.

For fleets:
- Wait for the `terminating`->`terminated` transition before quitting so that the table shows a relevant final status.

Misc:
- Remove unused code: the `configuration` column in the runs table and timestamp arguments to `pretty_date`.

This PR is not part of an issue, but it follows the changes from #1951 and is based on feedback from the team.