### PR TITLE
[Internal]: Fix building docs in CI

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,9 +17,9 @@ jobs:
       - name: Install dstack
         run: |
           if [ -n "${{ inputs.release_tag }}" ]; then
-            pip install "dstack==${{ inputs.release_tag }}"
+            pip install "dstack[server]==${{ inputs.release_tag }}"
           else
-            pip install -e .
+            pip install -e .[server]
           fi
       - name: Build
         run: |


### PR DESCRIPTION
Building docs requires `dstack[server]` dependencies to generate the OpenAPI schema.

Example of a failed GitHub Actions run: https://github.com/dstackai/dstack/actions/runs/12183817886/job/33986173826

#2002