### PR TITLE
Allow underscores in custom GCP tags

### DIFF
--- a/src/dstack/_internal/core/backends/gcp/resources.py
+++ b/src/dstack/_internal/core/backends/gcp/resources.py
@@ -337,8 +337,8 @@ def _is_valid_label(key: str, value: str) -> bool:
     return is_valid_resource_name(key) and is_valid_label_value(value)
 
 
-NAME_PATTERN = re.compile(r"^[a-z]([-a-z0-9]*[a-z0-9])?$")
-LABEL_VALUE_PATTERN = re.compile(r"^[-a-z0-9]{0,63}$")
+NAME_PATTERN = re.compile(r"^[a-z][_\-a-z0-9]{0,62}$")
+LABEL_VALUE_PATTERN = re.compile(r"^[_\-a-z0-9]{0,63}$")
 
 
 def is_valid_resource_name(name: str) -> bool:

--- a/src/tests/_internal/core/backends/aws/test_resources.py
+++ b/src/tests/_internal/core/backends/aws/test_resources.py
@@ -19,7 +19,7 @@ class TestIsValidTagKey:
         [
             "Environment",
             "Project123",
-            "special-chars-+/@=:",
+            "special-chars-+/@=:_",
             "a" * 128,
         ],
     )

--- a/src/tests/_internal/core/backends/gcp/test_resources.py
+++ b/src/tests/_internal/core/backends/gcp/test_resources.py
@@ -30,14 +30,13 @@ class TestIsValidResourceName:
             "a" * 64,
             "-startswithdash",
             "1startswithdigit",
-            "asd_asd",
             "Uppercase",
         ],
     )
     def test_invalid_name(self, name):
         assert not gcp_resources.is_valid_resource_name(name)
 
-    @pytest.mark.parametrize("name", ["a", "some-name-with-dashes-123"])
+    @pytest.mark.parametrize("name", ["a", "some-name-with-dashes-123", "asd_asd"])
     def test_valid_name(self, name):
         assert gcp_resources.is_valid_resource_name(name)
 
@@ -47,7 +46,6 @@ class TestIsValidLabelValue:
         "name",
         [
             "a" * 64,
-            "asd_asd",
             "Uppercase",
         ],
     )


### PR DESCRIPTION
The PR fixes an overly restrictive GCP tags check that did not allow underscores although underscores are allowed in GCP labels.