### PR TITLE
Make repo optional when submitting runs via HTTP API

### DIFF
--- a/docs/docs/reference/api/rest/index.md
+++ b/docs/docs/reference/api/rest/index.md
@@ -19,18 +19,6 @@ token = os.environ["DSTACK_TOKEN"]
 project = os.environ["DSTACK_PROJECT"]
 ssh_public_key = Path(os.environ["SSH_PUBLIC_KEY_PATH"]).read_text()
 
-print("Initializing repo")
-resp = requests.post(
-    url=f"{url}/api/project/{project}/repos/init",
-    headers={"Authorization": f"Bearer {token}"},
-    json={
-        "repo_id": "my_virtual_repo",
-        "repo_info": {
-            "repo_type": "virtual"
-        }
-    },
-)
-
 print("Submitting task")
 resp = requests.post(
     url=f"{url}/api/project/{project}/runs/apply",
@@ -38,10 +26,6 @@ resp = requests.post(
     json={
         "plan":{
             "run_spec": {
-                "repo_id": "my_virtual_repo",
-                "repo_data": {
-                    "repo_type": "virtual"
-                },
                 "configuration": {
                     "type": "task",
                     "commands": [

--- a/src/dstack/_internal/core/models/configurations.py
+++ b/src/dstack/_internal/core/models/configurations.py
@@ -168,7 +168,7 @@ class BaseRunConfiguration(CoreModel):
         return v
 
     def get_repo(self) -> Repo:
-        return VirtualRepo(repo_id="none")
+        return VirtualRepo()
 
 
 class BaseRunConfigurationWithPorts(BaseRunConfiguration):

--- a/src/dstack/_internal/core/models/repos/virtual.py
+++ b/src/dstack/_internal/core/models/repos/virtual.py
@@ -8,6 +8,8 @@ from dstack._internal.core.models.repos.base import BaseRepoInfo, Repo
 from dstack._internal.utils.hash import get_sha256
 from dstack._internal.utils.path import resolve_relative_path
 
+DEFAULT_VIRTUAL_REPO_ID = "none"
+
 
 class VirtualRepoInfo(BaseRepoInfo):
     repo_type: Literal["virtual"] = "virtual"
@@ -41,8 +43,7 @@ class VirtualRepo(Repo):
 
     run_repo_data: VirtualRunRepoData
 
-    # TODO: Make repo_id optional
-    def __init__(self, repo_id: str):
+    def __init__(self, repo_id: str = DEFAULT_VIRTUAL_REPO_ID):
         self.repo_id = repo_id
         self.repo_dir = None
         self.files: Dict[str, bytes] = {}

--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -262,21 +262,27 @@ class Job(CoreModel):
 
 class RunSpec(CoreModel):
     # TODO: run_name, working_dir are redundant here since they already passed in configuration
-    # TODO: Consider auto-creating virtual repos to make repo fields optional
     run_name: Annotated[
         Optional[str],
         Field(description="The run name. If not set, the run name is generated automatically."),
     ]
     repo_id: Annotated[
-        str,
+        Optional[str],
         Field(
             description=(
                 "Same `repo_id` that is specified when initializing the repo"
                 " by calling the `/api/project/{project_name}/repos/init` endpoint."
+                " If not specified, a default virtual repo is used."
             )
         ),
     ]
-    repo_data: Annotated[AnyRunRepoData, Field(discriminator="repo_type")]
+    repo_data: Annotated[
+        Optional[AnyRunRepoData],
+        Field(
+            discriminator="repo_type",
+            description="The repo data such as the current branch and commit.",
+        ),
+    ]
     repo_code_hash: Annotated[Optional[str], Field(description="The hash of the repo diff")]
     working_dir: Annotated[
         Optional[str],

--- a/src/dstack/_internal/server/routers/runs.py
+++ b/src/dstack/_internal/server/routers/runs.py
@@ -117,9 +117,6 @@ async def apply_plan(
     Errors if the expected current resource from the plan does not match the current resource.
     Use `force: true` to apply even if the current resource does not match.
     If the existing run is active and cannot be updated, it must be stopped first.
-
-    Before calling this endpoint, you need to init a repo using
-    the `/api/project/{project_name}/repos/init` endpoint.
     """
     user, project = user_project
     return await runs.apply_plan(


### PR DESCRIPTION
Follows #2059 

The PR simplifies usage of the HTTP API by making repo optional. This means users no longer required to init the repo, and then pass repo info when submitting run configurations. This is implemented by re-using existing virtual repo functionality – if repo is not specified, a default virtual repo is used for the run.

Note that the CLI users still need to init the repo, but this PR can be a step towards making `dstack init` optional as well.