### PR TITLE
Fix instances stuck in busy status

### DIFF
--- a/src/dstack/_internal/server/services/fleets.py
+++ b/src/dstack/_internal/server/services/fleets.py
@@ -516,7 +516,7 @@ async def generate_fleet_name(session: AsyncSession, project: ProjectModel) -> s
 
 
 def is_fleet_in_use(fleet_model: FleetModel, instance_nums: Optional[List[int]] = None) -> bool:
-    instances_in_use = [i for i in fleet_model.instances if i.job_id is not None]
+    instances_in_use = [i for i in fleet_model.instances if i.job_id is not None and not i.deleted]
     selected_instance_in_use = instances_in_use
     if instance_nums is not None:
         selected_instance_in_use = [i for i in instances_in_use if i.instance_num in instance_nums]

--- a/src/dstack/_internal/server/services/runs.py
+++ b/src/dstack/_internal/server/services/runs.py
@@ -506,11 +506,17 @@ async def stop_runs(
 
 async def stop_run(session: AsyncSession, run_model: RunModel, abort: bool):
     res = await session.execute(
-        select(RunModel).where(RunModel.id == run_model.id).with_for_update()
+        select(RunModel)
+        .where(RunModel.id == run_model.id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
     )
     run_model = res.scalar_one()
     await session.execute(
-        select(JobModel).where(JobModel.run_id == run_model.id).with_for_update()
+        select(JobModel)
+        .where(JobModel.run_id == run_model.id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
     )
     if run_model.status.is_finished():
         return


### PR DESCRIPTION
Fixes #2068 

The bug was caused by a missing `.execution_options(populate_existing=True)` when `stop_runs` loads runs and jobs after locking them. Without this option, the jobs attributes are loaded from the sqlalchemy cache, which leads to `job.used_instance_id` being `None`, even though the instance was assigned to the job.

The PR:
* Fixes the bug.
* Ensures existing busy instance with finished jobs are terminated.
* Ensures fleets with such "stuck" instances are autodeleted.