### PR TITLE
Support --repo, --no-repo, and autoinit in dstack apply

### DIFF
--- a/docs/docs/reference/cli/index.md
+++ b/docs/docs/reference/cli/index.md
@@ -19,7 +19,10 @@ $ dstack server --help
 
 ### dstack init
 
-This command must be called inside a folder before you can run `dstack apply`.
+This command initializes the current directory as a `dstack` repo.
+Runs started with `dstack apply` will have all the repo files inside the `/workflow` directory.
+The repo can be a regular local directory or a Git repo directory.
+Using Git repos can be more efficient since `dstack` does not need to transfer all the local files but only a diff of local changes.
 
 **Git credentials**
 
@@ -45,6 +48,9 @@ It is possible to override this key via the `--ssh-identity` argument.
 
 This command applies a given configuration. If a resource does not exist, `dstack apply` creates the resource.
 If a resource exists, `dstack apply` updates the resource in-place or re-creates the resource if the update is not possible.
+
+When applying run configurations, `dstack apply` requires that you run `dstack init` first,
+or specify a repo to work with via `--repo`, or specify `--no-repo` if you don't need any repo for the run.
 
 <div class="termy">
 

--- a/src/dstack/_internal/cli/commands/apply.py
+++ b/src/dstack/_internal/cli/commands/apply.py
@@ -59,6 +59,7 @@ class ApplyCommand(APIBaseCommand):
         )
         repo_group = self._parser.add_argument_group("Repo Options")
         repo_group.add_argument(
+            "-P",
             "--repo",
             help=("The repo to use for the run. Can be a local path or a Git repo URL."),
             dest="repo",

--- a/src/dstack/_internal/cli/commands/init.py
+++ b/src/dstack/_internal/cli/commands/init.py
@@ -3,9 +3,8 @@ import os
 from pathlib import Path
 
 from dstack._internal.cli.commands import BaseCommand
+from dstack._internal.cli.services.repos import init_repo, register_init_repo_args
 from dstack._internal.cli.utils.common import configure_logging, console
-from dstack._internal.core.models.repos.base import RepoType
-from dstack._internal.core.services.configs import ConfigManager
 from dstack.api import Client
 
 
@@ -19,51 +18,21 @@ class InitCommand(BaseCommand):
             help="The name of the project",
             default=os.getenv("DSTACK_PROJECT"),
         )
-        self._parser.add_argument(
-            "-t",
-            "--token",
-            metavar="OAUTH_TOKEN",
-            help="An authentication token for Git",
-            type=str,
-            dest="gh_token",
-        )
-        self._parser.add_argument(
-            "--git-identity",
-            metavar="SSH_PRIVATE_KEY",
-            help="The private SSH key path to access the remote repo",
-            type=str,
-            dest="git_identity_file",
-        )
-        self._parser.add_argument(
-            "--ssh-identity",
-            metavar="SSH_PRIVATE_KEY",
-            help="The private SSH key path for SSH tunneling",
-            type=Path,
-            dest="ssh_identity_file",
-        )
-        self._parser.add_argument(
-            "--local",
-            action="store_true",
-            help="Do not use git",
-        )
+        register_init_repo_args(self._parser)
 
     def _command(self, args: argparse.Namespace):
         configure_logging()
         api = Client.from_config(
             project_name=args.project, ssh_identity_file=args.ssh_identity_file
         )
-        repo = api.repos.load(
-            Path.cwd(),
+        init_repo(
+            api=api,
+            repo_path=Path.cwd(),
+            repo_branch=None,
+            repo_hash=None,
             local=args.local,
-            init=True,
             git_identity_file=args.git_identity_file,
             oauth_token=args.gh_token,
+            ssh_identity_file=args.ssh_identity_file,
         )
-        if args.ssh_identity_file:
-            ConfigManager().save_repo_config(
-                repo.get_repo_dir_or_error(),
-                repo.repo_id,
-                RepoType(repo.run_repo_data.repo_type),
-                args.ssh_identity_file,
-            )
         console.print("OK")

--- a/src/dstack/_internal/cli/services/configurators/base.py
+++ b/src/dstack/_internal/cli/services/configurators/base.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 from abc import ABC, abstractmethod
-from typing import List, cast
+from typing import List, Optional, cast
 
 from dstack._internal.cli.services.args import env_var
 from dstack._internal.core.errors import ConfigurationError
@@ -11,6 +11,7 @@ from dstack._internal.core.models.configurations import (
     ApplyConfigurationType,
 )
 from dstack._internal.core.models.envs import Env, EnvSentinel, EnvVarTuple
+from dstack._internal.core.models.repos.base import Repo
 from dstack.api._public import Client
 
 
@@ -28,6 +29,7 @@ class BaseApplyConfigurator(ABC):
         command_args: argparse.Namespace,
         configurator_args: argparse.Namespace,
         unknown_args: List[str],
+        repo: Optional[Repo] = None,
     ):
         """
         Implements `dstack apply` for a given configuration type.
@@ -37,7 +39,8 @@ class BaseApplyConfigurator(ABC):
             configuration_path: The path to the configuration file.
             command_args: The args parsed by `dstack apply`.
             configurator_args: The known args parsed by `cls.get_parser()`.
-            unknown_args: The unknown args after parsing by `cls.get_parser()`
+            unknown_args: The unknown args after parsing by `cls.get_parser()`.
+            repo: The repo to use with apply.
         """
         pass
 

--- a/src/dstack/_internal/cli/services/configurators/fleet.py
+++ b/src/dstack/_internal/cli/services/configurators/fleet.py
@@ -27,6 +27,7 @@ from dstack._internal.core.models.fleets import (
     InstanceGroupPlacement,
 )
 from dstack._internal.core.models.instances import InstanceAvailability, InstanceStatus, SSHKey
+from dstack._internal.core.models.repos.base import Repo
 from dstack._internal.utils.common import local_time
 from dstack._internal.utils.logging import get_logger
 from dstack._internal.utils.ssh import convert_ssh_key_to_pem, generate_public_key, pkey_from_str
@@ -50,6 +51,7 @@ class FleetConfigurator(ApplyEnvVarsConfiguratorMixin, BaseApplyConfigurator):
         command_args: argparse.Namespace,
         configurator_args: argparse.Namespace,
         unknown_args: List[str],
+        repo: Optional[Repo] = None,
     ):
         self.apply_args(conf, configurator_args, unknown_args)
         profile = load_profile(Path.cwd(), None)

--- a/src/dstack/_internal/cli/services/configurators/gateway.py
+++ b/src/dstack/_internal/cli/services/configurators/gateway.py
@@ -1,6 +1,6 @@
 import argparse
 import time
-from typing import List
+from typing import List, Optional
 
 from rich.table import Table
 
@@ -21,6 +21,7 @@ from dstack._internal.core.models.gateways import (
     GatewaySpec,
     GatewayStatus,
 )
+from dstack._internal.core.models.repos.base import Repo
 from dstack._internal.utils.common import local_time
 from dstack.api._public import Client
 
@@ -35,6 +36,7 @@ class GatewayConfigurator(BaseApplyConfigurator):
         command_args: argparse.Namespace,
         configurator_args: argparse.Namespace,
         unknown_args: List[str],
+        repo: Optional[Repo] = None,
     ):
         spec = GatewaySpec(
             configuration=conf,

--- a/src/dstack/_internal/cli/services/configurators/volume.py
+++ b/src/dstack/_internal/cli/services/configurators/volume.py
@@ -1,6 +1,6 @@
 import argparse
 import time
-from typing import List
+from typing import List, Optional
 
 from rich.table import Table
 
@@ -14,6 +14,7 @@ from dstack._internal.cli.utils.rich import MultiItemStatus
 from dstack._internal.cli.utils.volume import get_volumes_table
 from dstack._internal.core.errors import ResourceNotExistsError
 from dstack._internal.core.models.configurations import ApplyConfigurationType
+from dstack._internal.core.models.repos.base import Repo
 from dstack._internal.core.models.volumes import (
     Volume,
     VolumeConfiguration,
@@ -35,6 +36,7 @@ class VolumeConfigurator(BaseApplyConfigurator):
         command_args: argparse.Namespace,
         configurator_args: argparse.Namespace,
         unknown_args: List[str],
+        repo: Optional[Repo] = None,
     ):
         spec = VolumeSpec(
             configuration=conf,

--- a/src/dstack/_internal/cli/services/repos.py
+++ b/src/dstack/_internal/cli/services/repos.py
@@ -1,0 +1,97 @@
+from argparse import ArgumentParser, _ArgumentGroup
+from pathlib import Path
+from typing import Optional, Union
+
+from dstack._internal.core.errors import CLIError
+from dstack._internal.core.models.repos.base import Repo, RepoType
+from dstack._internal.core.models.repos.remote import GitRepoURL, RemoteRepo, RepoError
+from dstack._internal.core.services.configs import ConfigManager
+from dstack._internal.core.services.repos import get_default_branch
+from dstack._internal.utils.path import PathLike
+from dstack.api._public import Client
+
+
+def register_init_repo_args(parser: Union[ArgumentParser, _ArgumentGroup]):
+    parser.add_argument(
+        "-t",
+        "--token",
+        metavar="OAUTH_TOKEN",
+        help="An authentication token to access a private Git repo",
+        type=str,
+        dest="gh_token",
+    )
+    parser.add_argument(
+        "--git-identity",
+        metavar="SSH_PRIVATE_KEY",
+        help="The private SSH key path to access a private Git repo",
+        type=str,
+        dest="git_identity_file",
+    )
+    parser.add_argument(
+        "--ssh-identity",
+        metavar="SSH_PRIVATE_KEY",
+        help="The private SSH key path for SSH tunneling",
+        type=Path,
+        dest="ssh_identity_file",
+    )
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        help="Do not use Git",
+    )
+
+
+def init_repo(
+    api: Client,
+    repo_path: Optional[PathLike],
+    repo_branch: Optional[str],
+    repo_hash: Optional[str],
+    local: bool,
+    git_identity_file: Optional[PathLike],
+    oauth_token: Optional[str],
+    ssh_identity_file: Optional[PathLike],
+) -> Repo:
+    init = True
+    if repo_path is None:
+        init = False
+        repo_path = Path.cwd()
+    if Path(repo_path).exists():
+        repo = api.repos.load(
+            repo_dir=repo_path,
+            local=local,
+            init=init,
+            git_identity_file=git_identity_file,
+            oauth_token=oauth_token,
+        )
+        if ssh_identity_file:
+            ConfigManager().save_repo_config(
+                repo_path=repo.get_repo_dir_or_error(),
+                repo_id=repo.repo_id,
+                repo_type=RepoType(repo.run_repo_data.repo_type),
+                ssh_key_path=ssh_identity_file,
+            )
+    elif isinstance(repo_path, str):
+        try:
+            GitRepoURL.parse(repo_path)
+        except RepoError as e:
+            raise CLIError("Invalid repo path") from e
+        if repo_branch is None and repo_hash is None:
+            repo_branch = get_default_branch(repo_path)
+            if repo_branch is None:
+                raise CLIError(
+                    "Failed to automatically detect remote repo branch."
+                    " Specify --repo-branch or --repo-hash."
+                )
+        repo = RemoteRepo.from_url(
+            repo_url=repo_path,
+            repo_branch=repo_branch,
+            repo_hash=repo_hash,
+        )
+        api.repos.init(
+            repo=repo,
+            git_identity_file=git_identity_file,
+            oauth_token=oauth_token,
+        )
+    else:
+        raise CLIError("Invalid repo path")
+    return repo

--- a/src/dstack/api/_public/repos.py
+++ b/src/dstack/api/_public/repos.py
@@ -127,21 +127,23 @@ class RepoCollection:
             repo_config = config.get_repo_config(repo_dir)
             if repo_config is None:
                 raise ConfigurationError(
-                    "The repo is not initialized. Run `dstack init` to initialize the repo."
+                    "The repo is not initialized."
+                    " Run `dstack init` to initialize the current directory as a repo or specify `--repo`."
                 )
             repo = load_repo(repo_config)
             try:
                 self._api_client.repos.get(self._project, repo.repo_id, include_creds=False)
             except ResourceNotExistsError:
                 raise ConfigurationError(
-                    "The repo is not initialized. Run `dstack init` to initialize the repo."
+                    "The repo is not initialized."
+                    " Run `dstack init` to initialize the current directory as a repo or specify `--repo`."
                 )
         else:
             logger.debug("Initializing repo")
             repo = LocalRepo(repo_dir=repo_dir)  # default
             if not local:
                 try:
-                    repo = RemoteRepo(local_repo_dir=repo_dir)
+                    repo = RemoteRepo.from_dir(repo_dir)
                 except InvalidGitRepositoryError:
                     pass  # use default
             self.init(repo, git_identity_file, oauth_token)


### PR DESCRIPTION
Closes #2072

This PR improves the repos and `dstack apply` UX:
* Allows specifying a repo for the run via `-P`/`--repo`. The repo can be a local path or a remote Git repo URL. Previously, dstack always used the current directory as a repo and required it to be initialized.
* If the repo is specified but not initialized, `dstack apply` will init the repo. `dstack apply` accepts the same parameters as `dstack init` to init the repo. This is primarily useful when working with remote repos without cloning them locally.
* Allows specifying `--no-repo` if no repo is needed for the run. In this case, the run repo directory (`/workflow`) will be empty.

If the repo is not specified, `dstack apply` requires the directory to be initialized as before.