### PR TITLE
Fix errors exit codes in dstack apply

### DIFF
--- a/src/dstack/_internal/cli/services/configurators/fleet.py
+++ b/src/dstack/_internal/cli/services/configurators/fleet.py
@@ -144,6 +144,7 @@ class FleetConfigurator(ApplyEnvVarsConfiguratorMixin, BaseApplyConfigurator):
         )
         if _failed_provisioning(fleet):
             console.print("\n[error]Some instances failed. Check the table above for errors.[/]")
+            exit(1)
 
     def delete_configuration(
         self,

--- a/src/dstack/_internal/cli/services/configurators/gateway.py
+++ b/src/dstack/_internal/cli/services/configurators/gateway.py
@@ -130,6 +130,7 @@ class GatewayConfigurator(BaseApplyConfigurator):
             console.print(
                 f"\n[error]Provisioning failed. Error: {gateway.status_message or 'unknown'}[/]"
             )
+            exit(1)
 
     def delete_configuration(
         self,

--- a/src/dstack/_internal/cli/services/configurators/volume.py
+++ b/src/dstack/_internal/cli/services/configurators/volume.py
@@ -126,6 +126,7 @@ class VolumeConfigurator(BaseApplyConfigurator):
             console.print(
                 f"\n[error]Provisioning failed. Error: {volume.status_message or 'unknown'}[/]"
             )
+            exit(1)
 
     def delete_configuration(
         self,


### PR DESCRIPTION
The CLI should always return non-zero exit codes when exiting with errors.