### PR TITLE
Fix RESERVATIONS display in fleets table

### DIFF
--- a/src/dstack/_internal/cli/utils/fleet.py
+++ b/src/dstack/_internal/cli/utils/fleet.py
@@ -55,6 +55,10 @@ def get_fleets_table(
 
             row = [
                 fleet.name if i == 0 else "",
+            ]
+            if verbose:
+                row.append(fleet.spec.configuration.reservation or "" if i == 0 else "")
+            row += [
                 str(instance.instance_num),
                 backend,
                 resources,
@@ -62,13 +66,6 @@ def get_fleets_table(
                 status,
                 format_date(instance.created),
             ]
-
-            if verbose and i == 0:
-                row.insert(
-                    1,
-                    fleet.spec.configuration.reservation if i == 0 else "",
-                )
-
             if verbose:
                 error = ""
                 if instance.status == InstanceStatus.TERMINATED and instance.termination_reason:


### PR DESCRIPTION
Fixes a bug introduced in #1977 

The RESERVATION column in fleets table wasn't properly filled:

```
Found fleet my-ssh-fleet. Configuration changes detected.
Re-create the fleet? [y/n]: y
 FLEET         RESERV…  INSTAN…  BACKEND  RESOUR…  PRICE   STATUS   CREAT…  ERROR   
 my-ssh-fleet           0        ssh      2xCPU,   $0.0    termin…  16:37   Provis… 
                                 (remot…  0GB,                              timeout 
                                          100.0GB                           expired 
                                          (disk)                                    
               1        ssh      2xCPU,   $0.0     termi…  16:37    Provi…          
                        (remot…  0GB,                               timeo…          
                                 100.0GB                            expir…          
                                 (disk)                                             

```
