### PR TITLE
Support AWS volumes for Xen-based instances

### DIFF
--- a/runner/internal/shim/backends/base.go
+++ b/runner/internal/shim/backends/base.go
@@ -1,6 +1,6 @@
 package backends
 
 type Backend interface {
-	// GetRealDeviceName returns the device name for the given volume ID.
-	GetRealDeviceName(volumeID string) (string, error)
+	// GetRealDeviceName returns the real device name for the given volume ID and virtual device name.
+	GetRealDeviceName(volumeID, deviceName string) (string, error)
 }

--- a/runner/internal/shim/backends/gcp.go
+++ b/runner/internal/shim/backends/gcp.go
@@ -14,20 +14,20 @@ func NewGCPBackend() *GCPBackend {
 	return &GCPBackend{}
 }
 
-// Resolves device names according to https://cloud.google.com/compute/docs/disks/disk-symlinks
+// GetRealDeviceName resolves device names according to https://cloud.google.com/compute/docs/disks/disk-symlinks
 // The server registers device name as pd-{volumeID}
-func (e *GCPBackend) GetRealDeviceName(volumeID string) (string, error) {
+func (e *GCPBackend) GetRealDeviceName(volumeID, deviceName string) (string, error) {
 	// Try resolving first partition or external volumes
-	deviceName, err := os.Readlink(fmt.Sprintf("/dev/disk/by-id/google-pd-%s-part1", volumeID))
+	realDeviceName, err := os.Readlink(fmt.Sprintf("/dev/disk/by-id/google-pd-%s-part1", volumeID))
 	if err != nil {
-		deviceName, err = os.Readlink(fmt.Sprintf("/dev/disk/by-id/google-pd-%s", volumeID))
+		realDeviceName, err = os.Readlink(fmt.Sprintf("/dev/disk/by-id/google-pd-%s", volumeID))
 		if err != nil {
 			return "", fmt.Errorf("failed to resolve symlink for volume %s: %w", volumeID, err)
 		}
 	}
-	deviceName, err = filepath.Abs(filepath.Join("/dev/disk/by-id/", deviceName))
+	realDeviceName, err = filepath.Abs(filepath.Join("/dev/disk/by-id/", realDeviceName))
 	if err != nil {
 		return "", tracerr.Wrap(err)
 	}
-	return deviceName, nil
+	return realDeviceName, nil
 }

--- a/runner/internal/shim/docker.go
+++ b/runner/internal/shim/docker.go
@@ -309,7 +309,7 @@ func formatAndMountVolume(volume VolumeInfo) error {
 	if err != nil {
 		return tracerr.Wrap(err)
 	}
-	deviceName, err := backend.GetRealDeviceName(volume.VolumeId)
+	deviceName, err := backend.GetRealDeviceName(volume.VolumeId, volume.DeviceName)
 	if err != nil {
 		return tracerr.Wrap(err)
 	}

--- a/runner/internal/shim/models.go
+++ b/runner/internal/shim/models.go
@@ -48,10 +48,11 @@ type InstanceMountPoint struct {
 }
 
 type VolumeInfo struct {
-	Backend  string `json:"backend"`
-	Name     string `json:"name"`
-	VolumeId string `json:"volume_id"`
-	InitFs   bool   `json:"init_fs"`
+	Backend    string `json:"backend"`
+	Name       string `json:"name"`
+	VolumeId   string `json:"volume_id"`
+	InitFs     bool   `json:"init_fs"`
+	DeviceName string `json:"device_name"`
 }
 
 type TaskConfig struct {

--- a/src/dstack/_internal/server/schemas/runner.py
+++ b/src/dstack/_internal/server/schemas/runner.py
@@ -91,6 +91,7 @@ class ShimVolumeInfo(CoreModel):
     name: str
     volume_id: str
     init_fs: bool
+    device_name: Optional[str] = None
 
 
 class TaskConfigBody(CoreModel):

--- a/src/dstack/_internal/server/services/runner/client.py
+++ b/src/dstack/_internal/server/services/runner/client.py
@@ -211,9 +211,13 @@ def health_response_to_health_status(data: HealthcheckResponse) -> HealthStatus:
 
 
 def _volume_to_shim_volume_info(volume: Volume) -> ShimVolumeInfo:
+    device_name = None
+    if volume.attachment_data is not None:
+        device_name = volume.attachment_data.device_name
     return ShimVolumeInfo(
         backend=volume.configuration.backend.value,
         name=volume.name,
         volume_id=get_or_error(volume.volume_id),
         init_fs=not volume.external,
+        device_name=device_name,
     )


### PR DESCRIPTION
Closes #2086 

This PR adds support for AWS volumes with Xen-based instances. They differ from Nitro-based instances in that there is no information about volume_id => real device name mapping via `lsblk`. The real device name for Xen-based instances is determined based on virtual device name (specified when attaching the volume):
* Xen-based Ubuntu instances: /dev/sda => /dev/xvda.
* Other legacy systems: /dev/sda => /dev/sda.

Tested on t2.* and p3.* instances.