### PR TITLE
Handle empty user when processing image manifest

### DIFF
--- a/src/dstack/_internal/server/services/docker.py
+++ b/src/dstack/_internal/server/services/docker.py
@@ -47,6 +47,13 @@ class ImageConfig(CoreModel):
     entrypoint: Annotated[Optional[List[str]], Field(alias="Entrypoint")] = None
     cmd: Annotated[Optional[List[str]], Field(alias="Cmd")] = None
 
+    @validator("user")
+    def normalize_user(cls, v: Optional[str]) -> Optional[str]:
+        # If USER is not set, the corresponding field may be missing or set to an empty string
+        if v == "":
+            return None
+        return v
+
 
 class ImageConfigObject(CoreModel):
     config: ImageConfig = ImageConfig()

--- a/src/tests/_internal/server/services/test_docker.py
+++ b/src/tests/_internal/server/services/test_docker.py
@@ -108,6 +108,26 @@ def test_parse_image_config_object_with_config_null(sample_image_config_object):
     assert config_object.config is not None
 
 
+@pytest.mark.parametrize(
+    ["value", "expected"],
+    [
+        [None, None],
+        ["", None],
+        ["1000:1000", "1000:1000"],
+    ],
+)
+def test_parse_image_config_object_user_field(sample_image_config_object, value, expected):
+    sample_image_config_object["config"]["User"] = value
+    config_object = ImageConfigObject.__response__.parse_obj(sample_image_config_object)
+    assert config_object.config.user == expected
+
+
+def test_parse_image_config_object_user_field_missing(sample_image_config_object):
+    del sample_image_config_object["config"]["User"]
+    config_object = ImageConfigObject.__response__.parse_obj(sample_image_config_object)
+    assert config_object.config.user is None
+
+
 class TestIsValidDockerVolumeTarget:
     @pytest.mark.parametrize(
         "path",


### PR DESCRIPTION
Fixes: https://github.com/dstackai/dstack/issues/2089