### PR TITLE
Add missing backends docs reference

### DIFF
--- a/docs/docs/reference/server/config.yml.md
+++ b/docs/docs/reference/server/config.yml.md
@@ -1000,23 +1000,6 @@ See the [reference table](#default-permissions) for all configurable permissions
             type:
                 required: true
 
-## `projects[n].backends[type=datacrunch]` { #_datacrunch data-toc-label="backends[type=datacrunch]" }
-
-#SCHEMA# dstack._internal.server.services.config.DataCrunchConfig
-    overrides:
-        show_root_heading: false
-        type:
-            required: true
-        item_id_prefix: datacrunch-
-
-## `projects[n].backends[type=datacrunch].creds` { #_datacrunch-creds data-toc-label="backends[type=datacrunch].creds" }
-
-#SCHEMA# dstack._internal.core.models.backends.datacrunch.DataCrunchAPIKeyCreds
-    overrides:
-        show_root_heading: false
-        type:
-            required: true
-
 ## `projects[n].backends[type=gcp]` { #_gcp data-toc-label="backends[type=gcp]" }
 
 #SCHEMA# dstack._internal.server.services.config.GCPConfig
@@ -1066,6 +1049,57 @@ See the [reference table](#default-permissions) for all configurable permissions
         type:
             required: true
 
+## `projects[n].backends[type=runpod]` { #_runpod data-toc-label="backends[type=runpod]" }
+
+#SCHEMA# dstack._internal.server.services.config.RunpodConfig
+    overrides:
+        show_root_heading: false
+        type:
+            required: true
+        item_id_prefix: runpod-
+
+## `projects[n].backends[type=runpod].creds` { #_runpod-creds data-toc-label="backends[type=runpod].creds" }
+
+#SCHEMA# dstack._internal.core.models.backends.runpod.RunpodAPIKeyCreds
+    overrides:
+        show_root_heading: false
+        type:
+            required: true
+
+## `projects[n].backends[type=vastai]` { #_vastai data-toc-label="backends[type=vastai]" }
+
+#SCHEMA# dstack._internal.server.services.config.VastAIConfig
+    overrides:
+        show_root_heading: false
+        type:
+            required: true
+        item_id_prefix: vastai-
+
+## `projects[n].backends[type=vastai].creds` { #_vastai-creds data-toc-label="backends[type=vastai].creds" }
+
+#SCHEMA# dstack._internal.core.models.backends.vastai.VastAIAPIKeyCreds
+    overrides:
+        show_root_heading: false
+        type:
+            required: true
+
+## `projects[n].backends[type=tensordock]` { #_tensordock data-toc-label="backends[type=tensordock]" }
+
+#SCHEMA# dstack._internal.server.services.config.TensorDockConfig
+    overrides:
+        show_root_heading: false
+        type:
+            required: true
+        item_id_prefix: tensordock-
+
+## `projects[n].backends[type=tensordock].creds` { #_tensordock-creds data-toc-label="backends[type=tensordock].creds" }
+
+#SCHEMA# dstack._internal.core.models.backends.tensordock.TensorDockAPIKeyCreds
+    overrides:
+        show_root_heading: false
+        type:
+            required: true
+
 ## `projects[n].backends[type=oci]` { #_oci data-toc-label="backends[type=oci]" }
 
 #SCHEMA# dstack._internal.server.services.config.OCIConfig
@@ -1091,40 +1125,6 @@ See the [reference table](#default-permissions) for all configurable permissions
             type:
                 required: true
 
-## `projects[n].backends[type=tensordock]` { #_tensordock data-toc-label="backends[type=tensordock]" }
-
-#SCHEMA# dstack._internal.server.services.config.TensorDockConfig
-    overrides:
-        show_root_heading: false
-        type:
-            required: true
-        item_id_prefix: tensordock-
-
-## `projects[n].backends[type=tensordock].creds` { #_tensordock-creds data-toc-label="backends[type=tensordock].creds" }
-
-#SCHEMA# dstack._internal.core.models.backends.tensordock.TensorDockAPIKeyCreds
-    overrides:
-        show_root_heading: false
-        type:
-            required: true
-
-## `projects[n].backends[type=vastai]` { #_vastai data-toc-label="backends[type=vastai]" }
-
-#SCHEMA# dstack._internal.server.services.config.VastAIConfig
-    overrides:
-        show_root_heading: false
-        type:
-            required: true
-        item_id_prefix: vastai-
-
-## `projects[n].backends[type=vastai].creds` { #_vastai-creds data-toc-label="backends[type=vastai].creds" }
-
-#SCHEMA# dstack._internal.core.models.backends.vastai.VastAIAPIKeyCreds
-    overrides:
-        show_root_heading: false
-        type:
-            required: true
-
 ## `projects[n].backends[type=cudo]` { #_cudo data-toc-label="backends[type=cudo]" }
 
 #SCHEMA# dstack._internal.server.services.config.CudoConfig
@@ -1137,6 +1137,23 @@ See the [reference table](#default-permissions) for all configurable permissions
 ## `projects[n].backends[type=cudo].creds` { #_cudo-creds data-toc-label="backends[type=cudo].creds" }
 
 #SCHEMA# dstack._internal.core.models.backends.cudo.CudoAPIKeyCreds
+    overrides:
+        show_root_heading: false
+        type:
+            required: true
+
+## `projects[n].backends[type=datacrunch]` { #_datacrunch data-toc-label="backends[type=datacrunch]" }
+
+#SCHEMA# dstack._internal.server.services.config.DataCrunchConfig
+    overrides:
+        show_root_heading: false
+        type:
+            required: true
+        item_id_prefix: datacrunch-
+
+## `projects[n].backends[type=datacrunch].creds` { #_datacrunch-creds data-toc-label="backends[type=datacrunch].creds" }
+
+#SCHEMA# dstack._internal.core.models.backends.datacrunch.DataCrunchAPIKeyCreds
     overrides:
         show_root_heading: false
         type:

--- a/src/dstack/_internal/core/models/backends/aws.py
+++ b/src/dstack/_internal/core/models/backends/aws.py
@@ -8,18 +8,20 @@ from dstack._internal.core.models.common import CoreModel
 
 
 class AWSOSImage(CoreModel):
-    name: Annotated[str, Field(description="AMI name")]
+    name: Annotated[str, Field(description="The AMI name")]
     owner: Annotated[
         str,
-        Field(regex=r"^(\d{12}|self)$", description="AMI owner, account ID or `self`"),
+        Field(regex=r"^(\d{12}|self)$", description="The AMI owner, account ID or `self`"),
     ] = "self"
-    user: Annotated[str, Field(description="OS user for provisioning")]
+    user: Annotated[str, Field(description="The OS user for provisioning")]
 
 
 class AWSOSImageConfig(CoreModel):
-    cpu: Annotated[Optional[AWSOSImage], Field(description="AMI used for CPU instances")] = None
+    cpu: Annotated[Optional[AWSOSImage], Field(description="The AMI used for CPU instances")] = (
+        None
+    )
     nvidia: Annotated[
-        Optional[AWSOSImage], Field(description="AMI used for NVIDIA GPU instances")
+        Optional[AWSOSImage], Field(description="The AMI used for NVIDIA GPU instances")
     ] = None
 
 

--- a/src/dstack/_internal/core/models/backends/runpod.py
+++ b/src/dstack/_internal/core/models/backends/runpod.py
@@ -1,5 +1,6 @@
-from typing import List, Optional
+from typing import Annotated, List, Optional
 
+from pydantic import Field
 from typing_extensions import Literal
 
 from dstack._internal.core.models.backends.base import ConfigMultiElement
@@ -17,7 +18,7 @@ class RunpodStoredConfig(RunpodConfigInfo):
 
 class RunpodAPIKeyCreds(CoreModel):
     type: Literal["api_key"] = "api_key"
-    api_key: str
+    api_key: Annotated[str, Field(description="The API key")]
 
 
 AnyRunpodCreds = RunpodAPIKeyCreds

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -63,7 +63,9 @@ yaml.add_representer(list, seq_representer)
 
 class AWSConfig(CoreModel):
     type: Annotated[Literal["aws"], Field(description="The type of the backend")] = "aws"
-    regions: Annotated[Optional[List[str]], Field(description="The list of AWS regions")] = None
+    regions: Annotated[
+        Optional[List[str]], Field(description="The list of AWS regions. Omit to use all regions")
+    ] = None
     vpc_name: Annotated[
         Optional[str],
         Field(
@@ -122,7 +124,7 @@ class AzureConfig(CoreModel):
     subscription_id: Annotated[str, Field(description="The subscription ID")]
     regions: Annotated[
         Optional[List[str]],
-        Field(description="The list of Azure regions (locations)"),
+        Field(description="The list of Azure regions (locations). Omit to use all regions"),
     ] = None
     vpc_ids: Annotated[
         Optional[Dict[str, str]],
@@ -154,14 +156,19 @@ class AzureConfig(CoreModel):
 
 class CudoConfig(CoreModel):
     type: Annotated[Literal["cudo"], Field(description="The type of backend")] = "cudo"
-    regions: Optional[List[str]] = None
+    regions: Annotated[
+        Optional[List[str]], Field(description="The list of Cudo regions. Omit to use all regions")
+    ] = None
     project_id: Annotated[str, Field(description="The project ID")]
     creds: Annotated[AnyCudoCreds, Field(description="The credentials")]
 
 
 class DataCrunchConfig(CoreModel):
     type: Annotated[Literal["datacrunch"], Field(description="The type of backend")] = "datacrunch"
-    regions: Optional[List[str]] = None
+    regions: Annotated[
+        Optional[List[str]],
+        Field(description="The list of DataCrunch regions. Omit to use all regions"),
+    ] = None
     creds: Annotated[AnyDataCrunchCreds, Field(description="The credentials")]
 
 
@@ -207,7 +214,9 @@ AnyGCPAPICreds = Union[GCPServiceAccountAPICreds, GCPDefaultCreds]
 class GCPConfig(CoreModel):
     type: Annotated[Literal["gcp"], Field(description="The type of backend")] = "gcp"
     project_id: Annotated[str, Field(description="The project ID")]
-    regions: Optional[List[str]] = None
+    regions: Annotated[
+        Optional[List[str]], Field(description="The list of GCP regions. Omit to use all regions")
+    ] = None
     vpc_name: Annotated[Optional[str], Field(description="The name of a custom VPC")] = None
     vpc_project_id: Annotated[
         Optional[str],
@@ -242,7 +251,9 @@ class GCPConfig(CoreModel):
 class GCPAPIConfig(CoreModel):
     type: Annotated[Literal["gcp"], Field(description="The type of backend")] = "gcp"
     project_id: Annotated[str, Field(description="The project ID")]
-    regions: Optional[List[str]] = None
+    regions: Annotated[
+        Optional[List[str]], Field(description="The list of GCP regions. Omit to use all regions")
+    ] = None
     vpc_name: Annotated[Optional[str], Field(description="The name of a custom VPC")] = None
     vpc_project_id: Annotated[
         Optional[str],
@@ -315,7 +326,10 @@ class KubernetesAPIConfig(CoreModel):
 
 class LambdaConfig(CoreModel):
     type: Annotated[Literal["lambda"], Field(description="The type of backend")] = "lambda"
-    regions: Optional[List[str]] = None
+    regions: Annotated[
+        Optional[List[str]],
+        Field(description="The list of Lambda regions. Omit to use all regions"),
+    ] = None
     creds: Annotated[AnyLambdaCreds, Field(description="The credentials")]
 
 
@@ -368,9 +382,7 @@ class OCIConfig(CoreModel):
     creds: Annotated[AnyOCICreds, Field(description="The credentials", discriminator="type")]
     regions: Annotated[
         Optional[List[str]],
-        Field(
-            description="List of region names for running `dstack` jobs. Omit to use all regions"
-        ),
+        Field(description="The list of OCI regions. Omit to use all regions"),
     ] = None
     compartment_id: Annotated[
         Optional[str],
@@ -385,19 +397,28 @@ class OCIConfig(CoreModel):
 
 class RunpodConfig(CoreModel):
     type: Literal["runpod"] = "runpod"
-    regions: Optional[List[str]] = None
-    creds: AnyRunpodCreds
+    regions: Annotated[
+        Optional[List[str]],
+        Field(description="The list of RunPod regions. Omit to use all regions"),
+    ] = None
+    creds: Annotated[AnyRunpodCreds, Field(description="The credentials")]
 
 
 class TensorDockConfig(CoreModel):
     type: Annotated[Literal["tensordock"], Field(description="The type of backend")] = "tensordock"
-    regions: Optional[List[str]] = None
+    regions: Annotated[
+        Optional[List[str]],
+        Field(description="The list of TensorDock regions. Omit to use all regions"),
+    ] = None
     creds: Annotated[AnyTensorDockCreds, Field(description="The credentials")]
 
 
 class VastAIConfig(CoreModel):
     type: Annotated[Literal["vastai"], Field(description="The type of backend")] = "vastai"
-    regions: Optional[List[str]] = None
+    regions: Annotated[
+        Optional[List[str]],
+        Field(description="The list of VastAI regions. Omit to use all regions"),
+    ] = None
     creds: Annotated[AnyVastAICreds, Field(description="The credentials")]
 
 


### PR DESCRIPTION
Fixes #2095

The PR documents `regions` property for GCP and other backends. It also adds missing RunPod config reference.