### PR TITLE
Support tests that access db from a new thread

### DIFF
--- a/src/dstack/_internal/server/testing/common.py
+++ b/src/dstack/_internal/server/testing/common.py
@@ -459,32 +459,36 @@ async def create_instance(
     termination_idle_time: int = DEFAULT_POOL_TERMINATION_IDLE_TIME,
     region: str = "eu-west",
     remote_connection_info: Optional[RemoteConnectionInfo] = None,
+    job_provisioning_data: Optional[JobProvisioningData] = None,
 ) -> InstanceModel:
     if instance_id is None:
         instance_id = uuid.uuid4()
-    job_provisioning_data = {
-        "backend": backend.value,
-        "instance_type": {
-            "name": "instance",
-            "resources": {
-                "cpus": 1,
-                "memory_mib": 512,
-                "gpus": [],
-                "spot": spot,
-                "disk": {"size_mib": 102400},
-                "description": "",
+    if job_provisioning_data is None:
+        job_provisioning_data_dict = {
+            "backend": backend.value,
+            "instance_type": {
+                "name": "instance",
+                "resources": {
+                    "cpus": 1,
+                    "memory_mib": 512,
+                    "gpus": [],
+                    "spot": spot,
+                    "disk": {"size_mib": 102400},
+                    "description": "",
+                },
             },
-        },
-        "instance_id": "running_instance.id",
-        "ssh_proxy": None,
-        "hostname": "running_instance.ip",
-        "region": region,
-        "price": 0.1,
-        "username": "root",
-        "ssh_port": 22,
-        "dockerized": True,
-        "backend_data": None,
-    }
+            "instance_id": "running_instance.id",
+            "ssh_proxy": None,
+            "hostname": "running_instance.ip",
+            "region": region,
+            "price": 0.1,
+            "username": "root",
+            "ssh_port": 22,
+            "dockerized": True,
+            "backend_data": None,
+        }
+    else:
+        job_provisioning_data_dict = job_provisioning_data.dict()
     offer = {
         "backend": backend.value,
         "instance": {
@@ -530,7 +534,7 @@ async def create_instance(
         created_at=created_at,
         started_at=created_at,
         finished_at=finished_at,
-        job_provisioning_data=json.dumps(job_provisioning_data),
+        job_provisioning_data=json.dumps(job_provisioning_data_dict),
         offer=json.dumps(offer),
         price=1,
         region=region,

--- a/src/dstack/_internal/server/testing/conf.py
+++ b/src/dstack/_internal/server/testing/conf.py
@@ -1,7 +1,10 @@
 import pytest
 import pytest_asyncio
+from sqlalchemy import StaticPool
+from sqlalchemy.ext.asyncio import create_async_engine
 from testcontainers.postgres import PostgresContainer
 
+from dstack._internal.server import settings
 from dstack._internal.server.db import Database, override_db
 from dstack._internal.server.models import BaseModel
 
@@ -15,15 +18,24 @@ def postgres_container():
 @pytest_asyncio.fixture
 async def test_db(request):
     db_type = getattr(request, "param", "sqlite")
+    engine = None
     if db_type == "sqlite":
         db_url = "sqlite+aiosqlite://"
+        # For SQLite, allow accessing the in-memory DB from multiple threads:
+        # https://docs.sqlalchemy.org/en/13/dialects/sqlite.html#using-a-memory-database-in-multiple-threads
+        engine = create_async_engine(
+            db_url,
+            echo=settings.SQL_ECHO_ENABLED,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
     elif db_type == "postgres":
         if not request.config.getoption("--runpostgres"):
             pytest.skip("Skipping Postgres tests as --runpostgres was not provided")
         db_url = request.getfixturevalue("postgres_container")
     else:
         raise ValueError(f"Unknown db_type {db_type}")
-    db = Database(db_url)
+    db = Database(db_url, engine=engine)
     override_db(db)
     async with db.engine.begin() as conn:
         await conn.run_sync(BaseModel.metadata.drop_all)


### PR DESCRIPTION
The PR makes it possible to test sync code that needs to access the db. Such code must create a new db engine. Now `get_new_db()` can be monkey-patch with sqlite test_db so that the same db is safe to use from different threads.