### PR TITLE
Restore dstack-proxy state on gateway restarts

### DIFF
--- a/src/dstack/_internal/proxy/gateway/const.py
+++ b/src/dstack/_internal/proxy/gateway/const.py
@@ -2,5 +2,6 @@
 
 from pathlib import Path
 
-SERVER_CONNECTIONS_DIR_ON_GATEWAY = Path("/home/ubuntu/dstack/server-connections/")
+DSTACK_DIR_ON_GATEWAY = Path("/home/ubuntu/dstack")
+SERVER_CONNECTIONS_DIR_ON_GATEWAY = DSTACK_DIR_ON_GATEWAY / "server-connections"
 PROXY_PORT_ON_GATEWAY = 8000

--- a/src/dstack/_internal/proxy/gateway/models.py
+++ b/src/dstack/_internal/proxy/gateway/models.py
@@ -7,6 +7,12 @@ from pydantic import AnyHttpUrl
 from dstack._internal.proxy.lib.models import ImmutableModel
 
 
+class ModelEntrypoint(ImmutableModel):
+    project_name: str
+    domain: str
+    https: bool
+
+
 class ACMESettings(ImmutableModel):
     server: Optional[AnyHttpUrl] = None
     eab_kid: Optional[str] = None

--- a/src/dstack/_internal/proxy/gateway/repo.py
+++ b/src/dstack/_internal/proxy/gateway/repo.py
@@ -1,60 +1,121 @@
+from contextlib import asynccontextmanager
 from itertools import chain
+from pathlib import Path
 from typing import Optional
 
-from dstack._internal.proxy.gateway.models import GlobalProxyConfig
+from aiorwlock import RWLock
+from pydantic import BaseModel
+
+from dstack._internal.proxy.gateway.models import GlobalProxyConfig, ModelEntrypoint
 from dstack._internal.proxy.lib.models import ChatModel, Project, Service
 from dstack._internal.proxy.lib.repo import BaseProxyRepo
+from dstack._internal.utils.common import run_async
+
+
+class State(BaseModel):
+    services: dict[str, dict[str, Service]] = {}
+    models: dict[str, dict[str, ChatModel]] = {}
+    entrypoints: dict[str, ModelEntrypoint] = {}
+    projects: dict[str, Project] = {}
+    config: GlobalProxyConfig = GlobalProxyConfig()
 
 
 class GatewayProxyRepo(BaseProxyRepo):
-    def __init__(self) -> None:
-        self.services: dict[str, dict[str, Service]] = {}
-        self.models: dict[str, dict[str, ChatModel]] = {}
-        self.projects: dict[str, Project] = {}
-        self.config = GlobalProxyConfig()
+    """
+    Repo implementation used on gateways. Stores state in memory and maintains a copy on disk.
+    """
+
+    def __init__(self, state: Optional[State] = None, file: Optional[Path] = None) -> None:
+        self._state = state or State()
+        self._file = file
+        self._lock = RWLock()
 
     async def list_services(self) -> list[Service]:
-        return list(
-            chain(*(project_services.values() for project_services in self.services.values()))
-        )
+        async with self.reader():
+            services_by_project = (
+                project_services.values() for project_services in self._state.services.values()
+            )
+            return list(chain(*services_by_project))
 
     async def get_service(self, project_name: str, run_name: str) -> Optional[Service]:
-        return self.services.get(project_name, {}).get(run_name)
+        async with self.reader():
+            return self._state.services.get(project_name, {}).get(run_name)
 
     async def set_service(self, service: Service) -> None:
-        self.services.setdefault(service.project_name, {})[service.run_name] = service
+        async with self.writer():
+            self._state.services.setdefault(service.project_name, {})[service.run_name] = service
 
     async def delete_service(self, project_name: str, run_name: str) -> None:
-        project_services = self.services.get(project_name, {})
-        project_services.pop(run_name, None)
-        if not project_services:
-            self.services.pop(project_name, None)
+        async with self.writer():
+            project_services = self._state.services.get(project_name, {})
+            project_services.pop(run_name, None)
+            if not project_services:
+                self._state.services.pop(project_name, None)
 
     async def list_models(self, project_name: str) -> list[ChatModel]:
-        return list(self.models.get(project_name, {}).values())
+        async with self.reader():
+            return list(self._state.models.get(project_name, {}).values())
 
     async def get_model(self, project_name: str, name: str) -> Optional[ChatModel]:
-        return self.models.get(project_name, {}).get(name)
+        async with self.reader():
+            return self._state.models.get(project_name, {}).get(name)
 
     async def set_model(self, model: ChatModel) -> None:
-        self.models.setdefault(model.project_name, {})[model.name] = model
+        async with self.writer():
+            self._state.models.setdefault(model.project_name, {})[model.name] = model
 
     async def delete_models_by_run(self, project_name: str, run_name: str) -> None:
-        project_models = self.models.get(project_name, {})
-        models_to_delete = [m for m in project_models.values() if m.run_name == run_name]
-        for model in models_to_delete:
-            project_models.pop(model.name, None)
-        if not project_models:
-            self.models.pop(project_name, None)
+        async with self.writer():
+            project_models = self._state.models.get(project_name, {})
+            models_to_delete = [m for m in project_models.values() if m.run_name == run_name]
+            for model in models_to_delete:
+                project_models.pop(model.name, None)
+            if not project_models:
+                self._state.models.pop(project_name, None)
+
+    async def list_entrypoints(self) -> list[ModelEntrypoint]:
+        async with self.reader():
+            return list(self._state.entrypoints.values())
+
+    async def set_entrypoint(self, entrypoint: ModelEntrypoint) -> None:
+        async with self.writer():
+            self._state.entrypoints[entrypoint.project_name] = entrypoint
 
     async def get_project(self, name: str) -> Optional[Project]:
-        return self.projects.get(name)
+        async with self.reader():
+            return self._state.projects.get(name)
 
     async def set_project(self, project: Project) -> None:
-        self.projects[project.name] = project
+        async with self.writer():
+            self._state.projects[project.name] = project
 
     async def get_config(self) -> GlobalProxyConfig:
-        return self.config
+        async with self.reader():
+            return self._state.config
 
     async def set_config(self, config: GlobalProxyConfig) -> None:
-        self.config = config
+        async with self.writer():
+            self._state.config = config
+
+    @asynccontextmanager
+    async def reader(self):
+        async with self._lock.reader:
+            yield
+
+    @asynccontextmanager
+    async def writer(self):
+        async with self._lock.writer:
+            yield
+            await run_async(self.save)
+
+    @staticmethod
+    def load(state_file: Path) -> "GatewayProxyRepo":
+        if state_file.exists():
+            state = State.parse_file(state_file)
+        else:
+            state = None
+        return GatewayProxyRepo(state=state, file=state_file)
+
+    def save(self) -> None:
+        if self._file is not None:
+            self._file.write_text(self._state.json())

--- a/src/dstack/_internal/proxy/gateway/testing/common.py
+++ b/src/dstack/_internal/proxy/gateway/testing/common.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from typing import Union
+from unittest.mock import AsyncMock, MagicMock
+
+AnyMock = Union[MagicMock, AsyncMock]
+
+
+@dataclass
+class Mocks:
+    reload_nginx: AnyMock
+    run_certbot: AnyMock
+    open_conn: AnyMock
+    close_conn: AnyMock

--- a/src/dstack/_internal/proxy/lib/models.py
+++ b/src/dstack/_internal/proxy/lib/models.py
@@ -1,7 +1,7 @@
 """Things stored in BaseProxyRepo implementations."""
 
 from datetime import datetime
-from typing import Literal, Optional, Union
+from typing import Iterable, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 from typing_extensions import Annotated
@@ -32,29 +32,39 @@ class Service(ImmutableModel):
     https: Optional[bool]  # only used on gateways
     auth: bool
     client_max_body_size: int
-    replicas: frozenset[Replica]
+    replicas: tuple[Replica, ...]
 
     @property
     def domain_safe(self) -> str:
         if self.domain is None:
-            raise UnexpectedProxyError(
-                f"domain is unexpectedly missing for service {self.project_name}/{self.run_name}"
-            )
+            raise UnexpectedProxyError(f"domain unexpectedly missing for service {self.fmt()}")
         return self.domain
 
     @property
     def https_safe(self) -> bool:
         if self.https is None:
-            raise UnexpectedProxyError(
-                f"https is unexpectedly missing for service {self.project_name}/{self.run_name}"
-            )
+            raise UnexpectedProxyError(f"https unexpectedly missing for service {self.fmt()}")
         return self.https
+
+    def with_replicas(self, new_replicas: Iterable[Replica]) -> "Service":
+        return Service(
+            project_name=self.project_name,
+            run_name=self.run_name,
+            domain=self.domain,
+            https=self.https,
+            auth=self.auth,
+            client_max_body_size=self.client_max_body_size,
+            replicas=tuple(new_replicas),
+        )
 
     def find_replica(self, replica_id: str) -> Optional[Replica]:
         for replica in self.replicas:
             if replica.id == replica_id:
                 return replica
         return None
+
+    def fmt(self) -> str:
+        return f"{self.project_name}/{self.run_name}"
 
 
 class Project(ImmutableModel):

--- a/src/dstack/_internal/proxy/lib/testing/common.py
+++ b/src/dstack/_internal/proxy/lib/testing/common.py
@@ -8,24 +8,26 @@ def make_project(name: str) -> Project:
 
 
 def make_service(
-    project_name: str, run_name: str, domain: Optional[str] = None, auth: bool = False
+    project_name: str,
+    run_name: str,
+    domain: Optional[str] = None,
+    https: Optional[bool] = None,
+    auth: bool = False,
 ) -> Service:
     return Service(
         project_name=project_name,
         run_name=run_name,
         domain=domain,
-        https=None,
+        https=https,
         auth=auth,
         client_max_body_size=2**20,
-        replicas=frozenset(
-            [
-                Replica(
-                    id="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-                    app_port=80,
-                    ssh_destination="ubuntu@server",
-                    ssh_port=22,
-                    ssh_proxy=None,
-                )
-            ]
+        replicas=(
+            Replica(
+                id="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                app_port=80,
+                ssh_destination="ubuntu@server",
+                ssh_port=22,
+                ssh_proxy=None,
+            ),
         ),
     )

--- a/src/dstack/_internal/server/services/proxy/repo.py
+++ b/src/dstack/_internal/server/services/proxy/repo.py
@@ -92,7 +92,7 @@ class ServerProxyRepo(BaseProxyRepo):
             https=None,
             auth=run_spec.configuration.auth,
             client_max_body_size=DEFAULT_SERVICE_CLIENT_MAX_BODY_SIZE,
-            replicas=frozenset(replicas),
+            replicas=tuple(replicas),
         )
 
     async def list_models(self, project_name: str) -> List[ChatModel]:

--- a/src/tests/_internal/proxy/gateway/conftest.py
+++ b/src/tests/_internal/proxy/gateway/conftest.py
@@ -1,0 +1,26 @@
+from typing import Generator
+from unittest.mock import patch
+
+import pytest
+
+from dstack._internal.proxy.gateway.testing.common import Mocks
+
+
+@pytest.fixture
+def system_mocks() -> Generator[Mocks, None, None]:
+    nginx = "dstack._internal.proxy.gateway.services.nginx"
+    connection = "dstack._internal.proxy.lib.services.service_connection"
+    with (
+        patch(f"{nginx}.sudo") as sudo,
+        patch(f"{nginx}.Nginx.reload") as reload_nginx,
+        patch(f"{nginx}.Nginx.run_certbot") as run_certbot,
+        patch(f"{connection}.ServiceReplicaConnection.open") as open_conn,
+        patch(f"{connection}.ServiceReplicaConnection.close") as close_conn,
+    ):
+        sudo.return_value = []
+        yield Mocks(
+            reload_nginx=reload_nginx,
+            run_certbot=run_certbot,
+            open_conn=open_conn,
+            close_conn=close_conn,
+        )

--- a/src/tests/_internal/proxy/gateway/test_app.py
+++ b/src/tests/_internal/proxy/gateway/test_app.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import pytest
+
+from dstack._internal.proxy.gateway.app import lifespan, make_app
+from dstack._internal.proxy.gateway.models import ModelEntrypoint
+from dstack._internal.proxy.gateway.repo import GatewayProxyRepo
+from dstack._internal.proxy.gateway.services.nginx import Nginx
+from dstack._internal.proxy.gateway.testing.common import Mocks
+from dstack._internal.proxy.lib.testing.common import make_project, make_service
+
+
+@pytest.mark.asyncio
+async def test_lifespan(tmp_path: Path, system_mocks: Mocks) -> None:
+    repo = GatewayProxyRepo()
+    await repo.set_project(make_project("test-proj"))
+    await repo.set_entrypoint(
+        ModelEntrypoint(project_name="proj-1", domain="gateway.gtw.test", https=True)
+    )
+    await repo.set_service(
+        make_service("test-proj", "test-run", domain="test-run.gtw.test", https=True)
+    )
+    nginx_dir = tmp_path / "nginx"
+    nginx_dir.mkdir()
+    app = make_app(repo=repo, nginx=Nginx(conf_dir=nginx_dir))
+    async with lifespan(app):
+        assert (nginx_dir / "00-log-format.conf").exists()
+        assert (nginx_dir / "443-gateway.gtw.test.conf").exists()
+        assert (nginx_dir / "443-test-run.gtw.test.conf").exists()
+        assert system_mocks.open_conn.call_count == 1
+        assert system_mocks.close_conn.call_count == 0
+    assert system_mocks.close_conn.call_count == 1

--- a/src/tests/_internal/proxy/gateway/test_repo.py
+++ b/src/tests/_internal/proxy/gateway/test_repo.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import pytest
+
+from dstack._internal.proxy.gateway.models import ACMESettings, GlobalProxyConfig, ModelEntrypoint
+from dstack._internal.proxy.gateway.repo import GatewayProxyRepo
+from dstack._internal.proxy.lib.testing.common import make_project, make_service
+from tests._internal.proxy.lib.routers.test_model_proxy import make_model
+
+
+@pytest.mark.asyncio
+async def test_persist_repo(tmp_path: Path) -> None:
+    proj_1 = make_project("proj-1")
+    proj_2 = make_project("proj-2")
+    srv_1 = make_service("proj-1", "run-1", domain="run-1.gtw.test")
+    srv_2 = make_service("proj-2", "run-2", domain="run-2.gtw.test")
+    model_1 = make_model("proj-1", "model-1", run_name="run-1")
+    entrypoint_1 = ModelEntrypoint(project_name="proj-1", domain="gateway.gtw.test", https=True)
+    config = GlobalProxyConfig(acme_settings=ACMESettings(server="https://acme.test"))
+    file = tmp_path / "state-v2.json"
+
+    repo = GatewayProxyRepo.load(file)
+    await repo.set_config(config)
+    await repo.set_project(proj_1)
+    await repo.set_project(proj_2)
+    await repo.set_entrypoint(entrypoint_1)
+    await repo.set_service(srv_1)
+    await repo.set_service(srv_2)
+    await repo.set_model(model_1)
+
+    repo = GatewayProxyRepo.load(file)  # reload from file
+    assert await repo.get_config() == config
+    assert await repo.get_project("proj-1") == proj_1
+    assert await repo.get_project("proj-2") == proj_2
+    assert await repo.list_entrypoints() == [entrypoint_1]
+    assert set(await repo.list_services()) == {srv_1, srv_2}
+    assert await repo.list_models("proj-1") == [model_1]

--- a/src/tests/_internal/proxy/lib/routers/test_model_proxy.py
+++ b/src/tests/_internal/proxy/lib/routers/test_model_proxy.py
@@ -110,7 +110,7 @@ def make_openai_client(
 def mock_chat_client() -> Generator[None, None, None]:
     with (
         patch(
-            "dstack._internal.proxy.lib.services.service_connection.ServiceReplicaConnectionPool.add"
+            "dstack._internal.proxy.lib.services.service_connection.ServiceReplicaConnectionPool.get_or_add"
         ),
         patch("dstack._internal.proxy.lib.routers.model_proxy.get_chat_client") as get_client_mock,
     ):

--- a/src/tests/_internal/server/services/proxy/routers/test_service_proxy.py
+++ b/src/tests/_internal/server/services/proxy/routers/test_service_proxy.py
@@ -23,7 +23,7 @@ ProxyTestRepo = GatewayProxyRepo
 @pytest.fixture
 def mock_replica_client_httpbin(httpbin) -> Generator[None, None, None]:
     with patch(
-        "dstack._internal.proxy.lib.services.service_connection.ServiceReplicaConnectionPool.add"
+        "dstack._internal.proxy.lib.services.service_connection.ServiceReplicaConnectionPool.get_or_add"
     ) as add_connection_mock:
         add_connection_mock.return_value.client.return_value = ServiceReplicaClient(
             base_url=httpbin.url, timeout=MOCK_REPLICA_CLIENT_TIMEOUT


### PR DESCRIPTION
- Persist repo state on disk.
- Reopen tunnels and rewrite Nginx configs on app startup.
- Store model entrypoints in the repo to rewrite their Nginx configs on app startup.
- `registry.py` is refactored so that the same code (`apply_service`) is used both for restoring and modifying services.

Not part of this commit, will come separately: actually running dstack-proxy on gateways, adapter for legacy `state.json`.

Part of #1595