### PR TITLE
Forbid deleting backends with active instances or volumes

### DIFF
--- a/src/dstack/_internal/core/models/instances.py
+++ b/src/dstack/_internal/core/models/instances.py
@@ -154,3 +154,10 @@ class InstanceStatus(str, Enum):
             self.IDLE,
             self.BUSY,
         )
+
+    def is_active(self) -> bool:
+        return self not in self.finished_statuses()
+
+    @classmethod
+    def finished_statuses(cls) -> List["InstanceStatus"]:
+        return [cls.TERMINATING, cls.TERMINATED]

--- a/src/dstack/_internal/core/models/volumes.py
+++ b/src/dstack/_internal/core/models/volumes.py
@@ -19,6 +19,13 @@ class VolumeStatus(str, Enum):
     ACTIVE = "active"
     FAILED = "failed"
 
+    def is_active(self) -> bool:
+        return self not in self.finished_statuses()
+
+    @classmethod
+    def finished_statuses(cls) -> List["VolumeStatus"]:
+        return [cls.FAILED]
+
 
 class VolumeConfiguration(CoreModel):
     type: Literal["volume"] = "volume"

--- a/src/dstack/_internal/server/routers/backends.py
+++ b/src/dstack/_internal/server/routers/backends.py
@@ -21,6 +21,7 @@ from dstack._internal.server.schemas.backends import (
 )
 from dstack._internal.server.security.permissions import Authenticated, ProjectAdmin
 from dstack._internal.server.services import backends
+from dstack._internal.server.services.backends import handlers as backends_handlers
 from dstack._internal.server.services.config import (
     ServerConfigManager,
     create_backend_config_yaml,
@@ -87,8 +88,8 @@ async def delete_backends(
     user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectAdmin()),
 ):
     _, project = user_project
-    await backends.delete_backends(
-        session=session, project=project, backends_types=body.backends_names
+    await backends_handlers.delete_backends_safe(
+        session=session, project=project, backends_types=body.backends_names, error=True
     )
     if settings.SERVER_CONFIG_ENABLED:
         await ServerConfigManager().sync_config(session=session)

--- a/src/dstack/_internal/server/services/backends/__init__.py
+++ b/src/dstack/_internal/server/services/backends/__init__.py
@@ -239,6 +239,9 @@ async def delete_backends(
             BackendModel.project_id == project.id,
         )
     )
+    logger.info(
+        "Deleted backends %s in project %s", [b.value for b in backends_types], project.name
+    )
 
 
 BackendTuple = Tuple[BackendModel, Backend]

--- a/src/dstack/_internal/server/services/backends/__init__.py
+++ b/src/dstack/_internal/server/services/backends/__init__.py
@@ -1,6 +1,6 @@
 import asyncio
 import heapq
-from typing import Callable, Coroutine, Dict, Iterable, List, Optional, Tuple, Type, Union
+from typing import Callable, Coroutine, Dict, List, Optional, Tuple, Type, Union
 from uuid import UUID
 
 from sqlalchemy import delete, update
@@ -229,18 +229,24 @@ async def get_config_info(
 async def delete_backends(
     session: AsyncSession,
     project: ProjectModel,
-    backends_types: Iterable[BackendType],
+    backends_types: List[BackendType],
 ):
     if BackendType.DSTACK in backends_types:
         raise ServerClientError("Cannot delete dstack backend")
+    current_backends_types = set(b.type for b in project.backends)
+    deleted_backends_types = current_backends_types.intersection(backends_types)
+    if len(deleted_backends_types) == 0:
+        return
     await session.execute(
         delete(BackendModel).where(
-            BackendModel.type.in_(backends_types),
+            BackendModel.type.in_(deleted_backends_types),
             BackendModel.project_id == project.id,
         )
     )
     logger.info(
-        "Deleted backends %s in project %s", [b.value for b in backends_types], project.name
+        "Deleted backends %s in project %s",
+        [b.value for b in deleted_backends_types],
+        project.name,
     )
 
 

--- a/src/dstack/_internal/server/services/backends/handlers.py
+++ b/src/dstack/_internal/server/services/backends/handlers.py
@@ -87,12 +87,12 @@ async def _check_active_volumes(
         ):
             if error:
                 msg = (
-                    f"Backend {volume_model.provisioning_data.backend} has active volumes."
+                    f"Backend {volume_model.provisioning_data.backend.value} has active volumes."
                     " Delete volumes before deleting the backend."
                 )
             else:
                 msg = (
-                    f"Backend {volume_model.provisioning_data.backend} has active volumes."
+                    f"Backend {volume_model.provisioning_data.backend.value} has active volumes."
                     " The backend will be deleted but volumes may be left hanging."
                 )
             raise ServerClientError(msg)

--- a/src/dstack/_internal/server/services/backends/handlers.py
+++ b/src/dstack/_internal/server/services/backends/handlers.py
@@ -1,0 +1,98 @@
+from typing import List
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dstack._internal.core.errors import ServerClientError
+from dstack._internal.core.models.backends.base import BackendType
+from dstack._internal.server.models import ProjectModel
+from dstack._internal.server.services.backends import delete_backends
+from dstack._internal.server.services.fleets import list_project_fleet_models
+from dstack._internal.server.services.volumes import list_project_volumes
+from dstack._internal.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+async def delete_backends_safe(
+    session: AsyncSession,
+    project: ProjectModel,
+    backends_types: List[BackendType],
+    error: bool = True,
+):
+    try:
+        await _check_active_instances(
+            session=session,
+            project=project,
+            backends_types=backends_types,
+            error=error,
+        )
+        await _check_active_volumes(
+            session=session,
+            project=project,
+            backends_types=backends_types,
+            error=error,
+        )
+    except ServerClientError as e:
+        if error:
+            raise
+        logger.warning("%s", e.msg)
+    await delete_backends(
+        session=session,
+        project=project,
+        backends_types=backends_types,
+    )
+
+
+async def _check_active_instances(
+    session: AsyncSession,
+    project: ProjectModel,
+    backends_types: List[BackendType],
+    error: bool,
+):
+    fleet_models = await list_project_fleet_models(
+        session=session,
+        project=project,
+    )
+    for fleet_model in fleet_models:
+        for instance in fleet_model.instances:
+            if instance.status.is_active() and instance.backend in backends_types:
+                if error:
+                    msg = (
+                        f"Backend {instance.backend.value} has active instances."
+                        " Delete instances before deleting the backend."
+                    )
+                else:
+                    msg = (
+                        f"Backend {instance.backend.value} has active instances."
+                        " The backend will be deleted but instances may be left hanging."
+                    )
+                raise ServerClientError(msg)
+
+
+async def _check_active_volumes(
+    session: AsyncSession,
+    project: ProjectModel,
+    backends_types: List[BackendType],
+    error: bool,
+):
+    volume_models = await list_project_volumes(
+        session=session,
+        project=project,
+    )
+    for volume_model in volume_models:
+        if (
+            volume_model.status.is_active()
+            and volume_model.provisioning_data is not None
+            and volume_model.provisioning_data.backend in backends_types
+        ):
+            if error:
+                msg = (
+                    f"Backend {volume_model.provisioning_data.backend} has active volumes."
+                    " Delete volumes before deleting the backend."
+                )
+            else:
+                msg = (
+                    f"Backend {volume_model.provisioning_data.backend} has active volumes."
+                    " The backend will be deleted but volumes may be left hanging."
+                )
+            raise ServerClientError(msg)

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -29,6 +29,7 @@ from dstack._internal.server.models import ProjectModel, UserModel
 from dstack._internal.server.services import backends as backends_services
 from dstack._internal.server.services import encryption as encryption_services
 from dstack._internal.server.services import projects as projects_services
+from dstack._internal.server.services.backends.handlers import delete_backends_safe
 from dstack._internal.server.services.encryption import AnyEncryptionKeyConfig
 from dstack._internal.server.services.permissions import (
     DefaultPermissions,
@@ -595,8 +596,11 @@ class ServerConfigManager:
                     )
             except Exception as e:
                 logger.warning("Failed to configure backend %s: %s", config_info.type, e)
-        await backends_services.delete_backends(
-            session=session, project=project, backends_types=backends_to_delete
+        await delete_backends_safe(
+            session=session,
+            project=project,
+            backends_types=list(backends_to_delete),
+            error=False,
         )
 
     async def _init_config(

--- a/src/dstack/_internal/server/services/repos.py
+++ b/src/dstack/_internal/server/services/repos.py
@@ -29,6 +29,9 @@ from dstack._internal.server.models import (
 )
 from dstack._internal.server.services.storage import get_default_storage
 from dstack._internal.utils.common import run_async
+from dstack._internal.utils.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 async def list_repos(
@@ -170,6 +173,7 @@ async def delete_repos(
         delete(RepoModel).where(RepoModel.project_id == project.id, RepoModel.name.in_(repos_ids))
     )
     await session.commit()
+    logger.info("Deleted repos %s in project", repos_ids, project.name)
 
 
 async def get_repo_creds(
@@ -263,6 +267,7 @@ async def delete_repo_creds(
         )
     )
     await session.commit()
+    logger.info("Deleted repo creds for repo %s user %s", repo.name, user.name)
 
 
 async def upload_code(

--- a/src/dstack/_internal/server/services/repos.py
+++ b/src/dstack/_internal/server/services/repos.py
@@ -173,7 +173,7 @@ async def delete_repos(
         delete(RepoModel).where(RepoModel.project_id == project.id, RepoModel.name.in_(repos_ids))
     )
     await session.commit()
-    logger.info("Deleted repos %s in project", repos_ids, project.name)
+    logger.info("Deleted repos %s in project %s", repos_ids, project.name)
 
 
 async def get_repo_creds(

--- a/src/dstack/_internal/server/services/users.py
+++ b/src/dstack/_internal/server/services/users.py
@@ -146,6 +146,7 @@ async def delete_users(
 ):
     await session.execute(delete(UserModel).where(UserModel.name.in_(usernames)))
     await session.commit()
+    logger.info("Deleted users %s by user %s", usernames, user.name)
 
 
 async def get_user_model_by_name(

--- a/src/dstack/_internal/server/testing/common.py
+++ b/src/dstack/_internal/server/testing/common.py
@@ -578,6 +578,7 @@ async def create_volume(
         else None,
         instances=[],
         deleted_at=deleted_at,
+        deleted=True if deleted_at else False,
     )
     session.add(vm)
     await session.commit()
@@ -641,8 +642,10 @@ def get_volume_provisioning_data(
     size_gb: int = 100,
     availability_zone: Optional[str] = None,
     backend_data: Optional[str] = None,
+    backend: Optional[BackendType] = None,
 ) -> VolumeProvisioningData:
     return VolumeProvisioningData(
+        backend=backend,
         volume_id=volume_id,
         size_gb=size_gb,
         availability_zone=availability_zone,


### PR DESCRIPTION
Closes #2114 

* The API returns 400 when deleting a backend if the backend has active instances/volumes.
* The server emits a warning when removing a backend from server/config.yml if the backend has active instances/volumes.
* The delete operations are logged with the INFO level.