### PR TITLE
[shim] Implement Future API

### DIFF
--- a/runner/cmd/shim/main.go
+++ b/runner/cmd/shim/main.go
@@ -110,7 +110,6 @@ func main() {
 						}
 					}
 
-					args.Runner.TempDir = "/tmp/runner"
 					args.Runner.HomeDir = "/root"
 					args.Runner.WorkingDir = "/workflow"
 

--- a/runner/consts/consts.go
+++ b/runner/consts/consts.go
@@ -11,3 +11,6 @@ const (
 
 // Error-containing messages will be identified by this signature
 const ExecutorFailedSignature = "Executor failed"
+
+// A directory inside the container where runner stores its files (logs, etc.)
+const RunnerDir = "/tmp/runner"

--- a/runner/docs/shim.openapi.yaml
+++ b/runner/docs/shim.openapi.yaml
@@ -2,20 +2,165 @@ openapi: 3.1.1
 
 info:
   title: dstack-shim API
-  version: &shim-version 0.18.30
+  version: &api-version 0.18.31
+  x-logo:
+    url: https://avatars.githubusercontent.com/u/54146142?s=260
 
 servers:
   - url: http://localhost:10998/api
 
+tags:
+  - name: &stable-api Stable API
+    description: >
+      Stable API should always stay backward (or future, depending on which point of view we are
+      talking about) compatible, meaning that newer versions of dstack server should be able
+      to use Stable API of older versions of shim without additional API version negotiation
+  - name: &future-api Future API
+    description: >
+      As of the current version of API, Future API is an upcoming "task-oriented" API, able to
+      handle more than one task at a time managing machine resources. It is not yet supported
+      by dstack server
+  - name: &legacy-api Legacy API
+    description: >
+      As of the current version of API, Legacy API is the only API (apart from Stable one) used by
+      dstack server. It can only process one task at a time and cannot manage (that is, limit)
+      machine resources consumed by the task
+
 paths:
-  /submit:
-    post:
+  /healthcheck:
+    get:
+      tags:
+        - *stable-api
+      summary: Ping and API version negotiation
+      description: >
+        Serves two roles:
+
+        * as the path implies, it's a healthcheck, although there is no field in the response that
+        indicate if shim is healthy. Basically, it not is a proper healthcheck but
+          a basic "ping" method
+        * API version negotiation. Server inspects `version` field to figure out which API features
+          it should use
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthcheckResponse"
+
+  /tasks:
+    get:
+      tags:
+        - *future-api
+      summary: Get task list
+      description: Returns a list of all tasks known to shim, including terminated ones
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskListResponse"
+    put:
+      tags:
+        - *future-api
+      summary: Submit and run new task
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TaskConfigBody"
+              $ref: "#/components/schemas/TaskSubmitRequest"
+      responses:
+        "200":
+          description: Pending task info
+          $ref: "#/components/responses/TaskInfo"
+        "409":
+          description: Task with the same ID already submitted
+          $ref: "#/components/responses/PlainTextConflict"
+        "500":
+          description: Internal error
+          $ref: "#/components/responses/PlainTextInternalError"
+
+  /tasks/{id}:
+    get:
+      tags:
+        - *future-api
+      summary: Get task info
+      parameters:
+        - $ref: "#/parameters/taskId"
+      responses:
+        "200":
+          $ref: "#/components/responses/TaskInfo"
+
+    delete:
+      tags:
+        - *future-api
+      summary: Remove task
+      description: >
+        Removes the task from in-memory storage and destroys its associated
+        resources: a container, logs, etc.
+      parameters:
+        - $ref: "#/parameters/taskId"
+      responses:
+        "200":
+          description: Task removed
+          $ref: "#/components/responses/PlainTextOk"
+        "404":
+          description: Task not found
+          $ref: "#/components/responses/PlainTextNotFound"
+        "409":
+          description: Task is not terminated, cannot remove
+          $ref: "#/components/responses/PlainTextConflict"
+        "500":
+          description: Internal error, e.g., failed to remove a container
+          $ref: "#/components/responses/PlainTextInternalError"
+
+  /tasks/{id}/terminate:
+    post:
+      tags:
+        - *future-api
+      summary: Terminate task
+      description: >
+        Stops the task, that is, cancels image pulling if in progress,
+        stops the container if running, and sets the status to `terminated`.
+        No-op if the task is already terminated
+      parameters:
+        - in: path
+          name: id
+          schema:
+            $ref: "#/components/schemas/TaskID"
+          required: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TaskTerminateRequest"
+      responses:
+        "200":
+          description: Updated task info
+          $ref: "#/components/responses/TaskInfo"
+        "404":
+          description: Task not found
+          $ref: "#/components/responses/PlainTextNotFound"
+        "409":
+          description: Task is not terminated, cannot remove
+          $ref: "#/components/responses/PlainTextConflict"
+        "500":
+          description: Internal error, e.g., failed to remove a container
+          $ref: "#/components/responses/PlainTextInternalError"
+
+  /submit:
+    post:
+      tags:
+        - *legacy-api
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LegacySubmitBody"
       responses:
         "200":
           description: ""
@@ -36,42 +181,71 @@ paths:
 
   /pull:
     get:
+      tags:
+        - *legacy-api
       responses:
         "200":
           description: ""
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PullResponse"
+                $ref: "#/components/schemas/LegacyPullResponse"
 
   /stop:
     post:
+      tags:
+        - *legacy-api
       requestBody:
         required: false
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/StopBody"
+              $ref: "#/components/schemas/LegacyStopBody"
       responses:
         "200":
           description: ""
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/StopResponse"
+                $ref: "#/components/schemas/LegacyStopResponse"
 
-  /healthcheck:
-    get:
-      responses:
-        "200":
-          description: ""
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/HealthcheckResponse"
+parameters:
+  taskId:
+    name: id
+    in: path
+    schema:
+      $ref: "#/components/schemas/TaskID"
+    required: true
 
 components:
   schemas:
+    TaskID:
+      description: Unique task ID assigned by dstack server
+      type: string
+      examples:
+        - 23a2c7a0-6c88-48ee-8028-b9ad9f6f5c24
+
+    TaskStatus:
+      title: shim.TaskStatus
+      type: string
+      enum:
+        - pending
+        - preparing
+        - pulling
+        - creating
+        - running
+        - terminated
+
+    TerminationReason:
+      type: string
+      enum:
+        - EXECUTOR_ERROR
+        - CREATING_CONTAINER_ERROR
+        - CONTAINER_EXITED_WITH_ERROR
+        - DONE_BY_RUNNER
+        - TERMINATED_BY_USER
+        - TERMINATED_BY_SERVER
+
     RunnerStatus:
       title: shim.RunnerStatus
       type: string
@@ -86,12 +260,7 @@ components:
       type: object
       properties:
         reason:
-          type: string
-          enum:
-            - EXECUTOR_ERROR
-            - CREATING_CONTAINER_ERROR
-            - CONTAINER_EXITED_WITH_ERROR
-            - DONE_BY_RUNNER
+          $ref: "#/components/schemas/TerminationReason"
         reason_message:
           type: string
           default: ""
@@ -103,19 +272,16 @@ components:
         - reason_message
       additionalProperties: false
 
-    VolumeMountPoint:
-      title: shim.VolumeMountPoint
-      type: object
-      properties:
-        name:
-          type: string
-          default: ""
-          description: >
-            `dstack` volume [name](https://dstack.ai/docs/reference/dstack.yml/volume/#name)
-        path:
-          type: string
-          default: ""
-          description: Mount point inside container
+    GpuID:
+      description: >
+        A vendor-specific unique identifier of GPU:
+          * NVIDIA: "globally unique immutable alphanumeric identifier of the GPU",
+            in the form of `GPU-<UUID>`
+          * AMD: `/dev/dri/renderD<N>` path
+      type: string
+      examples:
+        - GPU-2b79666e-d81f-f3f8-fd47-9903f118c3f5
+        - /dev/dri/renderD128
 
     VolumeInfo:
       title: shim.VolumeInfo
@@ -138,6 +304,20 @@ components:
           description: >
             Create a filesystem when it doesn't exist if `true`, fail with error if `false`
 
+    VolumeMountPoint:
+      title: shim.VolumeMountPoint
+      type: object
+      properties:
+        name:
+          type: string
+          default: ""
+          description: >
+            `dstack` volume [name](https://dstack.ai/docs/reference/dstack.yml/volume/#name)
+        path:
+          type: string
+          default: ""
+          description: Mount point inside container
+
     InstanceMountPoint:
       title: shim.InstanceMountPoint
       type: object
@@ -151,9 +331,211 @@ components:
           default: ""
           description: Mount point inside container
 
-    TaskConfigBody:
-      title: shim.api.TaskConfigBody
+    HealthcheckResponse:
+      title: shim.api.HealthcheckResponse
+      type: object
+      properties:
+        service:
+          const: dstack-shim
+        version:
+          type: string
+          examples:
+            - *api-version
+      required:
+        - service
+        - version
+      additionalProperties: false
+
+    TaskListResponse:
+      title: shim.api.TaskListResponse
+      type: object
+      properties:
+        ids:
+          type: array
+          items:
+            $ref: "#/components/schemas/TaskID"
+          description: A list of all task IDs tracked by shim
+      required:
+        - ids
+      additionalProperties: false
+
+    TaskInfoResponse:
+      title: shim.api.TaskInfoResponse
+      description: Same as `shim.TaskInfo`
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/TaskID"
+        status:
+          allOf:
+            - $ref: "#/components/schemas/TaskStatus"
+            - examples:
+                - terminated
+        termination_reason:
+          $ref: "#/components/schemas/TerminationReason"
+        termination_message:
+          type: string
+          description: A shim-generated message or N last lines from the container logs
+        container_name:
+          type: string
+          examples:
+            - horrible-mule-1-0-0-44f7cb95
+        container_id:
+          type: string
+          examples:
+            - a6bb8d4bb8af8ec72482ecd194ff92fac9974521aa5ad8a46abfc4f0ba858775
+        gpu_ids:
+          type: array
+          items:
+            $ref: "#/components/schemas/GpuID"
+      required:
+        - id
+        - status
+        - termination_reason
+        - termination_message
+        - container_name
+        - container_id
+        - gpu_ids
+      additionalProperties: false
+
+    TaskSubmitRequest:
+      title: shim.api.TaskSubmitRequest
       description: Same as `shim.TaskConfig`
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/TaskID"
+        name:
+          type: string
+          description: Task name. Used to construct unique container name
+          examples:
+            - horrible-mule-1-0-0
+        registry_username:
+          type: string
+          default: ""
+          description: Private container registry username
+          examples:
+            - registry-user
+        registry_password:
+          type: string
+          default: ""
+          description: Private container registry password
+          examples:
+            - registry-token
+        image_name:
+          type: string
+          default: ""
+          examples:
+            - ubuntu:22.04
+        container_user:
+          type: string
+          default: ""
+          description: >
+            If not set, the default image user is used. As of 0.18.24, `dstack` always uses `root`
+          examples:
+            - root
+        privileged:
+          type: boolean
+          default: false
+          description: Start container in privileged mode
+        gpu:
+          type: integer
+          minimum: -1
+          default: 0
+          description: >
+            Number of GPUs allocated for the container. A special value `-1` means "all available,
+            even if none", `0` means "zero GPUs"
+        cpu:
+          type: number
+          minimum: 0
+          default: 0
+          description: >
+            Amount of CPU resources available to the container. A special value `0` means "all".
+            Fractional values are allowed, e.g., `1.5` — one and a half CPUs
+        memory:
+          type: number
+          minimum: 0
+          default: 0
+          description: >
+            Amount of memory available to the container, in bytes. A special value `0` means "all"
+        shm_size:
+          type: integer
+          minimum: 0
+          default: 0
+          description: >
+            POSIX shared memory, bytes. A special value `0` means "use the default value (64MiB)".
+            If > 0, tmpfs is mounted with the `exec` option, unlike the default mount options
+          examples:
+            - 1073741824
+        volumes:
+          type: array
+          items:
+            $ref: "#/components/schemas/VolumeInfo"
+          default: []
+        volume_mounts:
+          type: array
+          items:
+            $ref: "#/components/schemas/VolumeMountPoint"
+          default: []
+        instance_mounts:
+          type: array
+          items:
+            $ref: "#/components/schemas/InstanceMountPoint"
+          default: []
+        host_ssh_user:
+          type: string
+          default: ""
+          description: >
+            Instance (host) user for SSH access, either directly (`ssh {run_name}-host`)
+            or for `ProxyJump`ing inside the container. Ignored if `host_ssh_keys` is not set
+          examples:
+            - root
+        host_ssh_keys:
+          type: array
+          items:
+            type: string
+          default: []
+          description: >
+            SSH public keys for access to the instance (host). If set, the keys will be added
+            to the `host_ssh_user`'s `~/.ssh/authorized_keys` when the run starts and removed
+            when the run exits.
+          examples:
+            - "ssh-ed25519 <BASE64> me@laptop"
+        container_ssh_keys:
+          type: array
+          items:
+            type: string
+          default: []
+          description: >
+            SSH public keys for `container_user`. As of 0.18.24, `dstack` submits two keys:
+            project key (generated by the server) and user key (either generated by
+            the CLI client or provided by the user)
+          examples:
+            - ["ssh-rsa <BASE64> project@dstack", "ssh-ed25519 <BASE64> me@laptop"]
+
+    TaskTerminateRequest:
+      title: shim.api.TaskTerminateRequest
+      type: object
+      properties:
+        termination_reason:
+          allOf:
+            - $ref: "#/components/schemas/TerminationReason"
+            - examples:
+              - TERMINATED_BY_USER
+              - TERMINATED_BY_SERVER
+          default: ""
+        termination_message:
+          type: string
+          default: ""
+        timeout:
+          type: boolean
+          default: 0
+          description: >
+            Seconds to wait before killing the container. If zero, kill
+            the container immediately (no graceful shutdown)
+
+    LegacySubmitBody:
+      title: shim.api.LegacySubmitBody
       type: object
       properties:
         username:
@@ -244,8 +626,8 @@ components:
           default: []
           description: (since [0.18.21](https://github.com/dstackai/dstack/releases/tag/0.18.21))
 
-    PullResponse:
-      title: shim.api.PullResponse
+    LegacyPullResponse:
+      title: shim.api.LegacyPullResponse
       type: object
       properties:
         state:
@@ -272,16 +654,16 @@ components:
         - result
       additionalProperties: false
 
-    StopBody:
-      title: shim.api.StopBody
+    LegacyStopBody:
+      title: shim.api.LegacyStopBody
       type: object
       properties:
         force:
           type: boolean
           default: false
 
-    StopResponse:
-      title: shim.api.StopResponse
+    LegacyStopResponse:
+      title: shim.api.LegacyStopResponse
       type: object
       properties:
         state:
@@ -290,17 +672,46 @@ components:
         - state
       additionalProperties: false
 
-    HealthcheckResponse:
-      title: shim.api.HealthcheckResponse
-      type: object
-      properties:
-        service:
-          const: dstack-shim
-        version:
-          type: string
-          examples:
-            - *shim-version
-      required:
-        - service
-        - version
-      additionalProperties: false
+  responses:
+    TaskInfo:
+      description: Task info
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/TaskInfoResponse"
+
+    PlainTextOk:
+      description: ""
+      content:
+        text/plain:
+          schema:
+            type: string
+            examples:
+              - OK
+
+    PlainTextNotFound:
+      description: ""
+      content:
+        text/plain:
+          schema:
+            type: string
+            examples:
+              - not found
+
+    PlainTextConflict:
+      description: ""
+      content:
+        text/plain:
+          schema:
+            type: string
+            examples:
+              - conflict
+
+    PlainTextInternalError:
+      description: ""
+      content:
+        text/plain:
+          schema:
+            type: string
+            examples:
+              - internal error

--- a/runner/docs/shim.openapi.yaml
+++ b/runner/docs/shim.openapi.yaml
@@ -61,7 +61,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/TaskListResponse"
-    put:
+    post:
       tags:
         - *future-api
       summary: Submit and run new task
@@ -93,29 +93,6 @@ paths:
         "200":
           $ref: "#/components/responses/TaskInfo"
 
-    delete:
-      tags:
-        - *future-api
-      summary: Remove task
-      description: >
-        Removes the task from in-memory storage and destroys its associated
-        resources: a container, logs, etc.
-      parameters:
-        - $ref: "#/parameters/taskId"
-      responses:
-        "200":
-          description: Task removed
-          $ref: "#/components/responses/PlainTextOk"
-        "404":
-          description: Task not found
-          $ref: "#/components/responses/PlainTextNotFound"
-        "409":
-          description: Task is not terminated, cannot remove
-          $ref: "#/components/responses/PlainTextConflict"
-        "500":
-          description: Internal error, e.g., failed to remove a container
-          $ref: "#/components/responses/PlainTextInternalError"
-
   /tasks/{id}/terminate:
     post:
       tags:
@@ -141,6 +118,30 @@ paths:
         "200":
           description: Updated task info
           $ref: "#/components/responses/TaskInfo"
+        "404":
+          description: Task not found
+          $ref: "#/components/responses/PlainTextNotFound"
+        "409":
+          description: Task is not terminated, cannot remove
+          $ref: "#/components/responses/PlainTextConflict"
+        "500":
+          description: Internal error, e.g., failed to remove a container
+          $ref: "#/components/responses/PlainTextInternalError"
+
+  /tasks/{id}/remove:
+    post:
+      tags:
+        - *future-api
+      summary: Remove task
+      description: >
+        Removes the task from in-memory storage and destroys its associated
+        resources: a container, logs, etc.
+      parameters:
+        - $ref: "#/parameters/taskId"
+      responses:
+        "200":
+          description: Task removed
+          $ref: "#/components/responses/PlainTextOk"
         "404":
           description: Task not found
           $ref: "#/components/responses/PlainTextNotFound"

--- a/runner/internal/runner/api/http_test.go
+++ b/runner/internal/runner/api/http_test.go
@@ -20,11 +20,29 @@ func (ds DummyRunner) GetState() (shim.RunnerStatus, shim.JobResult) {
 	return ds.State, ds.JobResult
 }
 
-func (ds DummyRunner) Run(context.Context, shim.TaskConfig) error {
+func (ds DummyRunner) Submit(context.Context, shim.TaskConfig) error {
 	return nil
 }
 
-func (ds DummyRunner) Stop(force bool) {}
+func (ds DummyRunner) Run(context.Context, string) error {
+	return nil
+}
+
+func (ds DummyRunner) Terminate(context.Context, string, uint, string, string) error {
+	return nil
+}
+
+func (ds DummyRunner) Remove(context.Context, string) error {
+	return nil
+}
+
+func (ds DummyRunner) TaskIDs() []string {
+	return []string{}
+}
+
+func (ds DummyRunner) TaskInfo(taskID string) shim.TaskInfo {
+	return shim.TaskInfo{}
+}
 
 func (ds DummyRunner) Resources() shim.Resources {
 	return shim.Resources{}
@@ -36,7 +54,7 @@ func TestHealthcheck(t *testing.T) {
 
 	server := api.NewShimServer(":12345", DummyRunner{}, "0.0.1.dev2")
 
-	f := common.JSONResponseHandler("GET", server.HealthcheckGetHandler)
+	f := common.JSONResponseHandler(server.HealthcheckHandler)
 	f(responseRecorder, request)
 
 	if responseRecorder.Code != 200 {

--- a/runner/internal/runner/api/server.go
+++ b/runner/internal/runner/api/server.go
@@ -35,7 +35,7 @@ type Server struct {
 }
 
 func NewServer(tempDir string, homeDir string, workingDir string, address string, version string) (*Server, error) {
-	mux := http.NewServeMux()
+	r := api.NewRouter()
 	ex, err := executor.NewRunExecutor(tempDir, homeDir, workingDir)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func NewServer(tempDir string, homeDir string, workingDir string, address string
 	s := &Server{
 		srv: &http.Server{
 			Addr:    address,
-			Handler: mux,
+			Handler: r,
 		},
 		tempDir:    tempDir,
 		workingDir: workingDir,
@@ -60,14 +60,14 @@ func NewServer(tempDir string, homeDir string, workingDir string, address string
 
 		version: version,
 	}
-	mux.HandleFunc("/api/healthcheck", api.JSONResponseHandler("GET", s.healthcheckGetHandler))
-	mux.HandleFunc("/api/metrics", api.JSONResponseHandler("GET", s.metricsGetHandler))
-	mux.HandleFunc("/api/submit", api.JSONResponseHandler("POST", s.submitPostHandler))
-	mux.HandleFunc("/api/upload_code", api.JSONResponseHandler("POST", s.uploadCodePostHandler))
-	mux.HandleFunc("/api/run", api.JSONResponseHandler("POST", s.runPostHandler))
-	mux.HandleFunc("/api/pull", api.JSONResponseHandler("GET", s.pullGetHandler))
-	mux.HandleFunc("/api/stop", api.JSONResponseHandler("POST", s.stopPostHandler))
-	mux.HandleFunc("/logs_ws", api.JSONResponseHandler("GET", s.logsWsGetHandler))
+	r.AddHandler("GET", "/api/healthcheck", s.healthcheckGetHandler)
+	r.AddHandler("GET", "/api/metrics", s.metricsGetHandler)
+	r.AddHandler("POST", "/api/submit", s.submitPostHandler)
+	r.AddHandler("POST", "/api/upload_code", s.uploadCodePostHandler)
+	r.AddHandler("POST", "/api/run", s.runPostHandler)
+	r.AddHandler("GET", "/api/pull", s.pullGetHandler)
+	r.AddHandler("POST", "/api/stop", s.stopPostHandler)
+	r.AddHandler("GET", "/logs_ws", s.logsWsGetHandler)
 	return s, nil
 }
 

--- a/runner/internal/runner/api/submit_test.go
+++ b/runner/internal/runner/api/submit_test.go
@@ -21,7 +21,7 @@ func TestSubmit(t *testing.T) {
 
 	server := api.NewShimServer(":12340", &dummyRunner, "0.0.1.dev2")
 
-	firstSubmitPost := common.JSONResponseHandler("POST", server.SubmitPostHandler)
+	firstSubmitPost := common.JSONResponseHandler(server.LegacySubmitPostHandler)
 	firstSubmitPost(responseRecorder, request)
 
 	if responseRecorder.Code != 200 {
@@ -35,7 +35,7 @@ func TestSubmit(t *testing.T) {
 	request = httptest.NewRequest("POST", "/api/submit", strings.NewReader("{\"image_name\":\"ubuntu\"}"))
 	responseRecorder = httptest.NewRecorder()
 
-	secondSubmitPost := common.JSONResponseHandler("POST", server.SubmitPostHandler)
+	secondSubmitPost := common.JSONResponseHandler(server.LegacySubmitPostHandler)
 	secondSubmitPost(responseRecorder, request)
 
 	t.Logf("%v", responseRecorder.Result())

--- a/runner/internal/shim/api/http.go
+++ b/runner/internal/shim/api/http.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -10,7 +11,9 @@ import (
 	"github.com/dstackai/dstack/runner/internal/shim"
 )
 
-func (s *ShimServer) HealthcheckGetHandler(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+// Stable API
+
+func (s *ShimServer) HealthcheckHandler(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -20,7 +23,79 @@ func (s *ShimServer) HealthcheckGetHandler(w http.ResponseWriter, r *http.Reques
 	}, nil
 }
 
-func (s *ShimServer) SubmitPostHandler(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+// Future API
+
+func (s *ShimServer) TaskListHandler(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+	return &TaskListResponse{IDs: s.runner.TaskIDs()}, nil
+}
+
+func (s *ShimServer) TaskInfoHandler(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+	taskInfo := s.runner.TaskInfo(r.PathValue("id"))
+	if taskInfo.ID == "" {
+		return nil, &api.Error{Status: http.StatusNotFound}
+	}
+	return TaskInfoResponse(taskInfo), nil
+}
+
+// TaskSubmitHandler submits AND runs a task
+func (s *ShimServer) TaskSubmitHandler(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+	var req TaskSubmitRequest
+	if err := api.DecodeJSONBody(w, r, &req, true); err != nil {
+		return nil, err
+	}
+	taskConfig := shim.TaskConfig(req)
+	if err := s.runner.Submit(r.Context(), taskConfig); err != nil {
+		if errors.Is(err, shim.ErrRequest) {
+			return nil, &api.Error{Status: http.StatusConflict, Err: err}
+		}
+		return nil, &api.Error{Status: http.StatusInternalServerError, Err: err}
+	}
+	go func(taskID string) {
+		if err := s.runner.Run(context.Background(), taskID); err != nil {
+			fmt.Printf("failed task %v", err)
+		}
+	}(taskConfig.ID)
+	return s.runner.TaskInfo(taskConfig.ID), nil
+}
+
+func (s *ShimServer) TaskTerminateHandler(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+	taskID := r.PathValue("id")
+	var req TaskTerminateRequest
+	if err := api.DecodeJSONBody(w, r, &req, true); err != nil {
+		return nil, err
+	}
+	if err := s.runner.Terminate(r.Context(), taskID, req.Timeout, req.TerminationReason, req.TerminationMessage); err != nil {
+		if errors.Is(err, shim.ErrNotFound) {
+			return nil, &api.Error{Status: http.StatusNotFound, Err: err}
+		}
+		if errors.Is(err, shim.ErrRequest) {
+			return nil, &api.Error{Status: http.StatusConflict, Err: err}
+		}
+		return nil, &api.Error{Status: http.StatusInternalServerError, Err: err}
+	}
+	taskInfo := s.runner.TaskInfo(taskID)
+	if taskInfo.ID == "" {
+		return nil, &api.Error{Status: http.StatusNotFound}
+	}
+	return TaskInfoResponse(taskInfo), nil
+}
+
+func (s *ShimServer) TaskRemoveHandler(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+	if err := s.runner.Remove(r.Context(), r.PathValue("id")); err != nil {
+		if errors.Is(err, shim.ErrNotFound) {
+			return nil, &api.Error{Status: http.StatusNotFound, Err: err}
+		}
+		if errors.Is(err, shim.ErrRequest) {
+			return nil, &api.Error{Status: http.StatusConflict, Err: err}
+		}
+		return nil, &api.Error{Status: http.StatusInternalServerError, Err: err}
+	}
+	return nil, nil
+}
+
+// Legacy API
+
+func (s *ShimServer) LegacySubmitPostHandler(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	state, _ := s.runner.GetState()
@@ -28,7 +103,7 @@ func (s *ShimServer) SubmitPostHandler(w http.ResponseWriter, r *http.Request) (
 		return nil, &api.Error{Status: http.StatusConflict}
 	}
 
-	var body SubmitBody
+	var body LegacySubmitBody
 	if err := api.DecodeJSONBody(w, r, &body, true); err != nil {
 		log.Println("Failed to decode submit body", "err", err)
 		return nil, err
@@ -42,57 +117,68 @@ func (s *ShimServer) SubmitPostHandler(w http.ResponseWriter, r *http.Request) (
 		ImageName:        body.ImageName,
 		ContainerUser:    body.ContainerUser,
 		Privileged:       body.Privileged,
-		GpuCount:         -1,
+		GPU:              -1,
 		ShmSize:          body.ShmSize,
-		PublicKeys:       body.PublicKeys,
-		SshUser:          body.SshUser,
-		SshKey:           body.SshKey,
 		Volumes:          body.Volumes,
 		VolumeMounts:     body.VolumeMounts,
 		InstanceMounts:   body.InstanceMounts,
+		HostSshUser:      body.SshUser,
+		HostSshKeys:      []string{body.SshKey},
+		ContainerSshKeys: body.PublicKeys,
 	}
 	go func(taskConfig shim.TaskConfig) {
-		err := s.runner.Run(context.Background(), taskConfig)
-		if err != nil {
-			fmt.Printf("failed Run %v\n", err)
+		if err := s.runner.Submit(context.Background(), taskConfig); err != nil {
+			fmt.Printf("failed Submit %v", err)
+		}
+		if err := s.runner.Run(context.Background(), taskConfig.ID); err != nil {
+			fmt.Printf("failed Run %v", err)
 		}
 	}(taskConfig)
 
 	return nil, nil
 }
 
-func (s *ShimServer) PullGetHandler(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+func (s *ShimServer) LegacyPullGetHandler(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	state, jobResult := s.runner.GetState()
 
-	return &PullResponse{
+	return &LegacyPullResponse{
 		State:  string(state),
 		Result: jobResult,
 	}, nil
 }
 
-func (s *ShimServer) StopPostHandler(w http.ResponseWriter, r *http.Request) (interface{}, error) {
+func (s *ShimServer) LegacyStopPostHandler(w http.ResponseWriter, r *http.Request) (interface{}, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	state, _ := s.runner.GetState()
 	if state == shim.Pending {
-		return &StopResponse{
+		return &LegacyStopResponse{
 			State: string(state),
 		}, nil
 	}
 
-	var body StopBody
+	var body LegacyStopBody
 	if err := api.DecodeJSONBody(w, r, &body, true); err != nil {
 		log.Println("Failed to decode submit stop body", "err", err)
 		return nil, err
 	}
 
-	s.runner.Stop(body.Force)
+	var timeout uint
+	if body.Force {
+		timeout = 0
+	} else {
+		timeout = 10 // Docker default value
+	}
+	if err := s.runner.Terminate(r.Context(), shim.LegacyTaskID, timeout, "", ""); err != nil {
+		log.Println("Failed to terminate", "err", err)
+	}
 
-	return &StopResponse{
+	state, _ = s.runner.GetState()
+	return &LegacyStopResponse{
 		State: string(state),
 	}, nil
 }

--- a/runner/internal/shim/api/schemas.go
+++ b/runner/internal/shim/api/schemas.go
@@ -2,7 +2,41 @@ package api
 
 import "github.com/dstackai/dstack/runner/internal/shim"
 
-type SubmitBody struct {
+// Stable API
+
+type HealthcheckResponse struct {
+	Service string `json:"service"`
+	Version string `json:"version"`
+}
+
+// Future API
+
+type TaskListResponse struct {
+	IDs []string `json:"ids"`
+}
+
+type TaskInfoResponse struct {
+	ID                 string          `json:"id"`
+	Status             shim.TaskStatus `json:"status"`
+	TerminationReason  string          `json:"termination_reason"`
+	TerminationMessage string          `json:"termination_message"`
+	// The following fields are for debugging only, server doesn't need them
+	ContainerName string   `json:"container_name"`
+	ContainerID   string   `json:"container_id"`
+	GpuIDs        []string `json:"gpus_ids"`
+}
+
+type TaskSubmitRequest = shim.TaskConfig
+
+type TaskTerminateRequest struct {
+	TerminationReason  string `json:"termination_reason"`
+	TerminationMessage string `json:"termination_message"`
+	Timeout            uint   `json:"timeout"`
+}
+
+// Legacy API
+
+type LegacySubmitBody struct {
 	Username       string                    `json:"username"`
 	Password       string                    `json:"password"`
 	ImageName      string                    `json:"image_name"`
@@ -18,20 +52,15 @@ type SubmitBody struct {
 	InstanceMounts []shim.InstanceMountPoint `json:"instance_mounts"`
 }
 
-type StopBody struct {
-	Force bool `json:"force"`
-}
-
-type HealthcheckResponse struct {
-	Service string `json:"service"`
-	Version string `json:"version"`
-}
-
-type PullResponse struct {
+type LegacyPullResponse struct {
 	State  string         `json:"state"`
 	Result shim.JobResult `json:"result"`
 }
 
-type StopResponse struct {
+type LegacyStopBody struct {
+	Force bool `json:"force"`
+}
+
+type LegacyStopResponse struct {
 	State string `json:"state"`
 }

--- a/runner/internal/shim/api/server.go
+++ b/runner/internal/shim/api/server.go
@@ -10,11 +10,16 @@ import (
 )
 
 type TaskRunner interface {
-	Run(context.Context, shim.TaskConfig) error
-	GetState() (shim.RunnerStatus, shim.JobResult)
-	Stop(bool)
+	Submit(context.Context, shim.TaskConfig) error
+	Run(ctx context.Context, taskID string) error
+	Terminate(ctx context.Context, taskID string, timeout uint, reason string, message string) error
+	Remove(ctx context.Context, taskID string) error
 
 	Resources() shim.Resources
+	TaskIDs() []string
+	TaskInfo(taskID string) shim.TaskInfo
+
+	GetState() (shim.RunnerStatus, shim.JobResult)
 }
 
 type ShimServer struct {
@@ -27,25 +32,33 @@ type ShimServer struct {
 }
 
 func NewShimServer(address string, runner TaskRunner, version string) *ShimServer {
-	mux := http.NewServeMux()
+	r := api.NewRouter()
 	s := &ShimServer{
 		HttpServer: &http.Server{
 			Addr:    address,
-			Handler: mux,
+			Handler: r,
 		},
 
 		runner: runner,
 
 		version: version,
 	}
+
+	// Stable API
 	// The healthcheck endpoint should stay backward compatible, as it is used for negotiation
-	mux.HandleFunc("/api/healthcheck", api.JSONResponseHandler("GET", s.HealthcheckGetHandler))
-	// The following endpoints constitute a so-called legacy API, where shim has one global state
-	// and is able to process only one task at a time
-	// NOTE: as of 2024-12-10, there is _only_ legacy API, but the "legacy" label is used to
-	// distinguish the "old" API from the upcoming new one
-	mux.HandleFunc("/api/submit", api.JSONResponseHandler("POST", s.SubmitPostHandler))
-	mux.HandleFunc("/api/pull", api.JSONResponseHandler("GET", s.PullGetHandler))
-	mux.HandleFunc("/api/stop", api.JSONResponseHandler("POST", s.StopPostHandler))
+	r.AddHandler("GET", "/api/healthcheck", s.HealthcheckHandler)
+
+	// Future API
+	r.AddHandler("GET", "/api/tasks", s.TaskListHandler)
+	r.AddHandler("GET", "/api/tasks/{id}", s.TaskInfoHandler)
+	r.AddHandler("PUT", "/api/tasks", s.TaskSubmitHandler)
+	r.AddHandler("POST", "/api/tasks/{id}/terminate", s.TaskTerminateHandler)
+	r.AddHandler("DELETE", "/api/tasks/{id}", s.TaskRemoveHandler)
+
+	// Legacy API
+	r.AddHandler("POST", "/api/submit", s.LegacySubmitPostHandler)
+	r.AddHandler("GET", "/api/pull", s.LegacyPullGetHandler)
+	r.AddHandler("POST", "/api/stop", s.LegacyStopPostHandler)
+
 	return s
 }

--- a/runner/internal/shim/api/server.go
+++ b/runner/internal/shim/api/server.go
@@ -51,9 +51,9 @@ func NewShimServer(address string, runner TaskRunner, version string) *ShimServe
 	// Future API
 	r.AddHandler("GET", "/api/tasks", s.TaskListHandler)
 	r.AddHandler("GET", "/api/tasks/{id}", s.TaskInfoHandler)
-	r.AddHandler("PUT", "/api/tasks", s.TaskSubmitHandler)
+	r.AddHandler("POST", "/api/tasks", s.TaskSubmitHandler)
 	r.AddHandler("POST", "/api/tasks/{id}/terminate", s.TaskTerminateHandler)
-	r.AddHandler("DELETE", "/api/tasks/{id}", s.TaskRemoveHandler)
+	r.AddHandler("POST", "/api/tasks/{id}/remove", s.TaskRemoveHandler)
 
 	// Legacy API
 	r.AddHandler("POST", "/api/submit", s.LegacySubmitPostHandler)

--- a/runner/internal/shim/errs.go
+++ b/runner/internal/shim/errs.go
@@ -1,0 +1,35 @@
+package shim
+
+import "errors"
+
+/*
+Definitions of common error types used throughout shim.
+Errors should wrap these errors to simplify error classifications, e.g.:
+
+	func cleanup(containerID string) {
+		...
+		return fmt.Errorf("%w: failed to remove container")
+	}
+
+	if err := cleanup(containerID); errors.Is(err, ErrInternal) {
+		return ErrorResponse {
+			Status: 500,
+			Message: err.Error(),
+		}
+	} else if errors.Is(err, ErrNotFound) {
+		return ErrorResponse {
+			Status: 404,
+			Message: err.Error(),
+		}
+	}
+*/
+var (
+	// shim failed to process request due to internal error
+	ErrInternal = errors.New("internal error")
+	// shim rejected to process request, e.g., bad params, state conflict, etc.
+	ErrRequest = errors.New("request error")
+	// referenced object does not exist
+	ErrNotFound = errors.New("not found")
+	// object already exists (conflict)
+	ErrAlreadyExists = errors.New("already exists")
+)

--- a/runner/internal/shim/host/gpu.go
+++ b/runner/internal/shim/host/gpu.go
@@ -192,3 +192,7 @@ func getAmdRenderNodePath(bdf string) (string, error) {
 	}
 	return path, nil
 }
+
+func IsRenderNodePath(path string) bool {
+	return strings.HasPrefix(path, "/dev/dri/renderD")
+}

--- a/runner/internal/shim/models.go
+++ b/runner/internal/shim/models.go
@@ -9,7 +9,7 @@ type DockerParameters interface {
 	DockerShellCommands([]string) []string
 	DockerMounts(string) ([]mount.Mount, error)
 	DockerPorts() []int
-	MakeRunnerDir() (string, error)
+	MakeRunnerDir(name string) (string, error)
 	DockerPJRTDevice() string
 }
 
@@ -24,7 +24,6 @@ type CLIArgs struct {
 		LogLevel    int
 		DownloadURL string
 		BinaryPath  string
-		TempDir     string
 		HomeDir     string
 		WorkingDir  string
 	}
@@ -63,14 +62,27 @@ type TaskConfig struct {
 	ImageName        string               `json:"image_name"`
 	ContainerUser    string               `json:"container_user"`
 	Privileged       bool                 `json:"privileged"`
-	GpuCount         int                  `json:"gpu_count"`
-	ShmSize          int64                `json:"shm_size"`
-	PublicKeys       []string             `json:"public_keys"`
-	SshUser          string               `json:"ssh_user"`
-	SshKey           string               `json:"ssh_key"`
+	GPU              int                  `json:"gpu"`      // -1 = all available, even if zero; 0 = zero, ...
+	CPU              float64              `json:"cpu"`      // 0.0 = all available; 0.5 = a half of CPU, ...
+	Memory           int64                `json:"memory"`   // bytes; 0 = all avaliable
+	ShmSize          int64                `json:"shm_size"` // bytes; 0 = default (64MiB)
 	Volumes          []VolumeInfo         `json:"volumes"`
 	VolumeMounts     []VolumeMountPoint   `json:"volume_mounts"`
 	InstanceMounts   []InstanceMountPoint `json:"instance_mounts"`
+	HostSshUser      string               `json:"host_ssh_user"`
+	HostSshKeys      []string             `json:"host_ssh_keys"`
+	// TODO: submit keys to runner, not to shim
+	ContainerSshKeys []string `json:"container_ssh_keys"`
+}
+
+type TaskInfo struct {
+	ID                 string
+	Status             TaskStatus
+	TerminationReason  string
+	TerminationMessage string
+	ContainerName      string
+	ContainerID        string
+	GpuIDs             []string
 }
 
 // a surrogate ID used for tasks submitted via legacy API

--- a/runner/internal/shim/runner.go
+++ b/runner/internal/shim/runner.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dstackai/dstack/runner/consts"
 	"github.com/dstackai/dstack/runner/internal/gerrors"
 )
 
@@ -40,7 +41,7 @@ func (c *CLIArgs) getRunnerArgs() []string {
 		"--log-level", strconv.Itoa(c.Runner.LogLevel),
 		"start",
 		"--http-port", strconv.Itoa(c.Runner.HTTPPort),
-		"--temp-dir", c.Runner.TempDir,
+		"--temp-dir", consts.RunnerDir,
 		"--home-dir", c.Runner.HomeDir,
 		"--working-dir", c.Runner.WorkingDir,
 	}

--- a/runner/internal/shim/task.go
+++ b/runner/internal/shim/task.go
@@ -4,17 +4,19 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"log"
 	"sync"
 )
 
 type TaskStatus string
 
 const (
-	// pending -> pulling -> creating -> running -> terminated
-	//    |         |           |
-	//    v         v           v
-	// terminated terminated terminated
+	// pending -> preparing -> pulling -> creating -> running -> terminated
+	//    |         |           |            |
+	//    v         v           v            v
+	// terminated terminated terminated terminated
 	TaskStatusPending    TaskStatus = "pending"
+	TaskStatusPreparing  TaskStatus = "preparing"
 	TaskStatusPulling    TaskStatus = "pulling"
 	TaskStatusCreating   TaskStatus = "creating"
 	TaskStatusRunning    TaskStatus = "running"
@@ -36,6 +38,55 @@ type Task struct {
 	containerID   string
 	cancelPull    context.CancelFunc
 	gpuIDs        []string
+	runnerDir     string // path on host mapped to consts.RunnerDir in container
+
+	mu *sync.Mutex
+}
+
+// Lock is used for exclusive operations, e.g, stopping a container,
+// removing task data, etc.
+func (t *Task) Lock() {
+	if !t.mu.TryLock() {
+		log.Fatalf("task %s already locked!", t.ID)
+	}
+	log.Printf("task %s locked", t.ID)
+}
+
+// Release should be called Unlock, but this name triggers govet copylocks check,
+// since "thanks" to Go implicit interfaces, a struct with Lock/Unlock method pair
+// looks like lock: https://github.com/golang/go/issues/18451
+func (t *Task) Release() {
+	t.mu.Unlock()
+	log.Printf("task %s unlocked", t.ID)
+}
+
+func (t *Task) IsTransitionAllowed(toStatus TaskStatus) bool {
+	if t.Status == TaskStatusTerminated {
+		// terminal status, cannot transition further
+		return false
+	}
+	switch toStatus {
+	case TaskStatusPending:
+		// initial status, task should be Add()ed with it, not Update()d
+		return false
+	case TaskStatusPreparing:
+		return t.Status == TaskStatusPending
+	case TaskStatusPulling:
+		return t.Status == TaskStatusPreparing
+	case TaskStatusCreating:
+		return t.Status == TaskStatusPulling
+	case TaskStatusRunning:
+		return t.Status == TaskStatusCreating
+	case TaskStatusTerminated:
+		// we already checked terminated -> terminated (not allowed),
+		// all other transitions are allowed
+		return true
+	}
+	return false
+}
+
+func (t *Task) SetStatusPreparing() {
+	t.Status = TaskStatusPreparing
 }
 
 func (t *Task) SetStatusPulling(cancelPull context.CancelFunc) {
@@ -60,12 +111,25 @@ func (t *Task) SetStatusTerminated(reason string, message string) {
 	t.cancelPull = nil
 }
 
-func NewTask(cfg TaskConfig) Task {
+func NewTask(id string, status TaskStatus, containerName string, containerID string, gpuIDs []string, runnerDir string) Task {
+	return Task{
+		ID:            id,
+		Status:        status,
+		containerName: containerName,
+		containerID:   containerID,
+		runnerDir:     runnerDir,
+		gpuIDs:        gpuIDs,
+		mu:            &sync.Mutex{},
+	}
+}
+
+func NewTaskFromConfig(cfg TaskConfig) Task {
 	return Task{
 		ID:            cfg.ID,
 		Status:        TaskStatusPending,
 		config:        cfg,
 		containerName: generateUniqueName(cfg.Name, cfg.ID),
+		mu:            &sync.Mutex{},
 	}
 }
 
@@ -73,6 +137,16 @@ type TaskStorage struct {
 	// Task.ID: Task mapping
 	tasks map[string]Task
 	mu    sync.RWMutex
+}
+
+func (ts *TaskStorage) IDs() []string {
+	ts.mu.RLock()
+	defer ts.mu.RUnlock()
+	ids := make([]string, 0, len(ts.tasks))
+	for id := range ts.tasks {
+		ids = append(ids, id)
+	}
+	return ids
 }
 
 // Get a _copy_ of the task. To "commit" changes, use Update()
@@ -95,14 +169,19 @@ func (ts *TaskStorage) Add(task Task) bool {
 }
 
 // Update the _existing_ task. If the task is not in the storage, do nothing and return false
-func (ts *TaskStorage) Update(task Task) bool {
+// If the current status is terminated, do nothing and return false
+func (ts *TaskStorage) Update(task Task) error {
 	ts.mu.Lock()
 	defer ts.mu.Unlock()
-	if _, ok := ts.tasks[task.ID]; !ok {
-		return false
+	currentTask, ok := ts.tasks[task.ID]
+	if !ok {
+		return ErrNotFound
+	}
+	if !currentTask.IsTransitionAllowed(task.Status) {
+		return fmt.Errorf("%w: %s -> %s transition not allowed", ErrRequest, currentTask.Status, task.Status)
 	}
 	ts.tasks[task.ID] = task
-	return true
+	return nil
 }
 
 func (ts *TaskStorage) Delete(id string) {


### PR DESCRIPTION
* Added Future API endpoints `/api/tasks{/...}`
* Added a mechanism to restore shim state on restarts
* Reworked error reporting —  methods now return `error` instead `bool` or (`bool`, `error`) with error category (`ErrNotFound`, `ErrInternal`, etc.) wrapped.
* Simplifed API routing — a new `Router` struct with a simpler interface added
* CPU and memory resource limits added

Part-of: https://github.com/dstackai/dstack/issues/1780