### PR TITLE
Fix OpenAI endpoint on Kubernetes gateways

### DIFF
--- a/src/dstack/_internal/proxy/lib/services/service_connection.py
+++ b/src/dstack/_internal/proxy/lib/services/service_connection.py
@@ -132,7 +132,7 @@ async def get_service_replica_client(service: Service, repo: BaseProxyRepo) -> h
     if service.domain is not None:
         # Forward to Nginx so that requests are visible to StatsCollector in the access log
         return httpx.AsyncClient(
-            base_url="http://localhost",
+            base_url="http://127.0.0.1",
             headers={"Host": service.domain},
             timeout=HTTP_TIMEOUT,
         )


### PR DESCRIPTION
The endpoint didn't work both in the old and the
new gateway implementations. The model proxy
attempted forwarding requests to `localhost` that
resolves to `::1` on Kubernetes gateways, while
Nginx is only listening on `127.0.0.1`.

#1595