### PR TITLE
[shim] Revamp logging and CLI

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -25,7 +25,7 @@ Here's the steps to build `dstack-shim` and `dstack-runner` and run `dstack` wit
 3. Start the shim:
 
     ```shell
-    ./shim --home $RUNNER_DIR --runner-binary-path $COMPILED_RUNNER_PATH docker --ssh-key $DSTACK_PUBLIC_KEY
+    ./shim --shim-home $RUNNER_DIR --runner-binary-path $COMPILED_RUNNER_PATH --ssh-key $DSTACK_PUBLIC_KEY
     ```
 
     Notes:

--- a/runner/cmd/shim/main.go
+++ b/runner/cmd/shim/main.go
@@ -4,15 +4,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"time"
 
 	"github.com/dstackai/dstack/runner/consts"
+	"github.com/dstackai/dstack/runner/internal/log"
 	"github.com/dstackai/dstack/runner/internal/shim"
 	"github.com/dstackai/dstack/runner/internal/shim/api"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
 
@@ -24,6 +27,13 @@ func main() {
 	args.Docker.SSHPort = 10022
 	var serviceMode bool
 
+	const defaultLogLevel = int(logrus.InfoLevel)
+
+	ctx := context.Background()
+
+	log.DefaultEntry.Logger.SetLevel(logrus.Level(defaultLogLevel))
+	log.DefaultEntry.Logger.SetOutput(os.Stderr)
+
 	app := &cli.App{
 		Name:    "dstack-shim",
 		Usage:   "Starts dstack-runner or docker container.",
@@ -31,19 +41,40 @@ func main() {
 		Flags: []cli.Flag{
 			/* Shim Parameters */
 			&cli.PathFlag{
-				Name:        "home",
-				Usage:       "Dstack home directory",
+				Name:        "shim-home",
+				Usage:       "Set shim's home directory",
 				Destination: &args.Shim.HomeDir,
-				EnvVars:     []string{"DSTACK_HOME"},
+				DefaultText: path.Join("~", consts.DstackDirPath),
+				EnvVars:     []string{"DSTACK_SHIM_HOME"},
 			},
 			&cli.IntFlag{
 				Name:        "shim-http-port",
-				Usage:       "Set's shim's http port",
+				Usage:       "Set shim's http port",
 				Value:       10998,
 				Destination: &args.Shim.HTTPPort,
 				EnvVars:     []string{"DSTACK_SHIM_HTTP_PORT"},
 			},
+			&cli.IntFlag{
+				Name:        "shim-log-level",
+				Usage:       "Set shim's log level",
+				Value:       defaultLogLevel,
+				Destination: &args.Shim.LogLevel,
+				EnvVars:     []string{"DSTACK_SHIM_LOG_LEVEL"},
+			},
 			/* Runner Parameters */
+			&cli.StringFlag{
+				Name:        "runner-download-url",
+				Usage:       "Set runner's download URL",
+				Destination: &args.Runner.DownloadURL,
+				Required:    true,
+				EnvVars:     []string{"DSTACK_RUNNER_DOWNLOAD_URL"},
+			},
+			&cli.PathFlag{
+				Name:        "runner-binary-path",
+				Usage:       "Path to runner's binary",
+				Destination: &args.Runner.BinaryPath,
+				EnvVars:     []string{"DSTACK_RUNNER_BINARY_PATH"},
+			},
 			&cli.IntFlag{
 				Name:        "runner-http-port",
 				Usage:       "Set runner's http port",
@@ -54,115 +85,118 @@ func main() {
 			&cli.IntFlag{
 				Name:        "runner-log-level",
 				Usage:       "Set runner's log level",
-				Value:       4,
+				Value:       defaultLogLevel,
 				Destination: &args.Runner.LogLevel,
 				EnvVars:     []string{"DSTACK_RUNNER_LOG_LEVEL"},
 			},
-			&cli.StringFlag{
-				Name:        "runner-download-url",
-				Usage:       "Set runner's download URL",
-				Destination: &args.Runner.DownloadURL,
-				EnvVars:     []string{"DSTACK_RUNNER_DOWNLOAD_URL"},
+			/* Docker Parameters */
+			&cli.BoolFlag{
+				Name:        "privileged",
+				Usage:       "Give extended privileges to the container",
+				Destination: &args.Docker.Privileged,
+				EnvVars:     []string{"DSTACK_DOCKER_PRIVILEGED"},
 			},
-			&cli.PathFlag{
-				Name:        "runner-binary-path",
-				Usage:       "Path to runner's binary",
-				Destination: &args.Runner.BinaryPath,
-				EnvVars:     []string{"DSTACK_RUNNER_BINARY_PATH"},
+			&cli.StringFlag{
+				Name:        "ssh-key",
+				Usage:       "Public SSH key",
+				Required:    true,
+				Destination: &args.Docker.ConcatinatedPublicSSHKeys,
+				EnvVars:     []string{"DSTACK_PUBLIC_SSH_KEY"},
+			},
+			&cli.StringFlag{
+				Name:        "pjrt-device",
+				Usage:       "Set the PJRT_DEVICE environment variable (e.g., TPU, GPU)",
+				Destination: &args.Docker.PJRTDevice,
+				EnvVars:     []string{"PJRT_DEVICE"},
+			},
+			/* Misc Parameters */
+			&cli.BoolFlag{
+				Name:        "service",
+				Usage:       "Start as a service",
+				Destination: &serviceMode,
+				EnvVars:     []string{"DSTACK_SERVICE_MODE"},
 			},
 		},
-		Commands: []*cli.Command{
-			{
-				Name:  "docker",
-				Usage: "Starts docker container and modifies entrypoint",
-				Flags: []cli.Flag{
-					/* Docker Parameters */
-					&cli.BoolFlag{
-						Name:        "privileged",
-						Usage:       "Give extended privileges to the container",
-						Destination: &args.Docker.Privileged,
-						EnvVars:     []string{"DSTACK_DOCKER_PRIVILEGED"},
-					},
-					&cli.StringFlag{
-						Name:        "ssh-key",
-						Usage:       "Public SSH key",
-						Required:    true,
-						Destination: &args.Docker.ConcatinatedPublicSSHKeys,
-						EnvVars:     []string{"DSTACK_PUBLIC_SSH_KEY"},
-					},
-					&cli.StringFlag{
-						Name:        "pjrt-device",
-						Usage:       "Set the PJRT_DEVICE environment variable (e.g., TPU, GPU)",
-						Destination: &args.Docker.PJRTDevice,
-						EnvVars:     []string{"PJRT_DEVICE"},
-					},
-					&cli.BoolFlag{
-						Name:        "service",
-						Usage:       "Start as a service",
-						Destination: &serviceMode,
-						EnvVars:     []string{"DSTACK_SERVICE_MODE"},
-					},
-				},
-				Action: func(c *cli.Context) error {
-					if args.Runner.BinaryPath == "" {
-						if err := args.DownloadRunner(); err != nil {
-							return cli.Exit(err, 1)
-						}
-					}
-
-					args.Runner.HomeDir = "/root"
-					args.Runner.WorkingDir = "/workflow"
-
-					var err error
-
-					shimHomeDir := args.Shim.HomeDir
-					if shimHomeDir == "" {
-						home, err := os.UserHomeDir()
-						if err != nil {
-							return cli.Exit(err, 1)
-						}
-						shimHomeDir = filepath.Join(home, consts.DstackDirPath)
-						args.Shim.HomeDir = shimHomeDir
-					}
-					log.Printf("Config Shim: %+v\n", args.Shim)
-					log.Printf("Config Runner: %+v\n", args.Runner)
-					log.Printf("Config Docker: %+v\n", args.Docker)
-
-					dockerRunner, err := shim.NewDockerRunner(&args)
-					if err != nil {
-						return cli.Exit(err, 1)
-					}
-
-					address := fmt.Sprintf(":%d", args.Shim.HTTPPort)
-					shimServer := api.NewShimServer(address, dockerRunner, Version)
-
-					defer func() {
-						shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 5*time.Second)
-						defer cancelShutdown()
-						_ = shimServer.HttpServer.Shutdown(shutdownCtx)
-					}()
-
-					if serviceMode {
-						if err := shim.WriteHostInfo(shimHomeDir, dockerRunner.Resources()); err != nil {
-							if errors.Is(err, os.ErrExist) {
-								log.Println("cannot write host info: file already exists")
-							} else {
-								return cli.Exit(err, 1)
-							}
-						}
-					}
-
-					if err := shimServer.HttpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-						return cli.Exit(err, 1)
-					}
-
-					return nil
-				},
-			},
+		Action: func(c *cli.Context) error {
+			return start(ctx, args, serviceMode)
 		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
-		log.Fatal(err)
+		log.Fatal(ctx, err.Error())
 	}
+}
+
+func start(ctx context.Context, args shim.CLIArgs, serviceMode bool) (err error) {
+	log.DefaultEntry.Logger.SetLevel(logrus.Level(args.Shim.LogLevel))
+
+	shimHomeDir := args.Shim.HomeDir
+	if shimHomeDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return err
+		}
+		shimHomeDir = filepath.Join(home, consts.DstackDirPath)
+		args.Shim.HomeDir = shimHomeDir
+	}
+
+	shimLogFile, err := log.CreateAppendFile(filepath.Join(shimHomeDir, consts.ShimLogFileName))
+	if err != nil {
+		return fmt.Errorf("failed to create shim log file: %w", err)
+	}
+	defer func() {
+		_ = shimLogFile.Close()
+	}()
+
+	originalLogger := log.GetLogger(ctx)
+	loggerOut := io.MultiWriter(originalLogger.Logger.Out, shimLogFile)
+	ctx = log.WithLogger(ctx, log.NewEntry(loggerOut, int(originalLogger.Logger.GetLevel())))
+
+	defer func() {
+		// Should be called _before_ we close shimLogFile
+		// If an error occurs earlier, we still log it to stderr in the main function
+		if err != nil {
+			log.Error(ctx, err.Error())
+		}
+	}()
+
+	if args.Runner.BinaryPath == "" {
+		if err := args.DownloadRunner(ctx); err != nil {
+			return err
+		}
+	}
+
+	log.Debug(ctx, "Shim", "args", args.Shim)
+	log.Debug(ctx, "Runner", "args", args.Runner)
+	log.Debug(ctx, "Docker", "args", args.Docker)
+
+	dockerRunner, err := shim.NewDockerRunner(ctx, &args)
+	if err != nil {
+		return err
+	}
+
+	address := fmt.Sprintf(":%d", args.Shim.HTTPPort)
+	shimServer := api.NewShimServer(ctx, address, dockerRunner, Version)
+
+	defer func() {
+		shutdownCtx, cancelShutdown := context.WithTimeout(ctx, 5*time.Second)
+		defer cancelShutdown()
+		_ = shimServer.HttpServer.Shutdown(shutdownCtx)
+	}()
+
+	if serviceMode {
+		if err := shim.WriteHostInfo(shimHomeDir, dockerRunner.Resources(ctx)); err != nil {
+			if errors.Is(err, os.ErrExist) {
+				log.Error(ctx, "cannot write host info: file already exists")
+			} else {
+				return err
+			}
+		}
+	}
+
+	if err := shimServer.HttpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+
+	return nil
 }

--- a/runner/consts/consts.go
+++ b/runner/consts/consts.go
@@ -12,5 +12,18 @@ const (
 // Error-containing messages will be identified by this signature
 const ExecutorFailedSignature = "Executor failed"
 
-// A directory inside the container where runner stores its files (logs, etc.)
-const RunnerDir = "/tmp/runner"
+// All the following are directories inside the container
+const (
+	// A directory where runner stores its files (logs, etc.)
+	// NOTE: RunnerRuntimeDir would be a more appropriate name, but it's called tempDir
+	// throughout runner's codebase
+	RunnerTempDir = "/tmp/runner"
+	// Currently, it's a directory where autorized_keys, git credentials, etc. are placed
+	// The current user's homedir (as of 2024-12-28, it's always root) should be used
+	// instead of the hardcoded value
+	RunnerHomeDir = "/root"
+	// A repo directory and a default working directory for the job
+	RunnerWorkingDir = "/workflow"
+)
+
+const ShimLogFileName = "shim.log"

--- a/runner/internal/log/log.go
+++ b/runner/internal/log/log.go
@@ -28,6 +28,11 @@ func NewEntry(out io.Writer, level int) *logrus.Entry {
 
 var DefaultEntry = NewEntry(os.Stderr, int(logrus.InfoLevel))
 
+func Fatal(ctx context.Context, msg string, args ...interface{}) {
+	logger := AppendArgs(GetLogger(ctx), args...)
+	logger.Fatal(msg)
+}
+
 func Error(ctx context.Context, msg string, args ...interface{}) {
 	logger := AppendArgs(GetLogger(ctx), args...)
 	logger.Error(msg)

--- a/runner/internal/shim/api/api_test.go
+++ b/runner/internal/shim/api/api_test.go
@@ -42,7 +42,7 @@ func (ds *DummyRunner) TaskInfo(taskID string) shim.TaskInfo {
 	return shim.TaskInfo{}
 }
 
-func (ds *DummyRunner) Resources() shim.Resources {
+func (ds *DummyRunner) Resources(context.Context) shim.Resources {
 	return shim.Resources{}
 }
 

--- a/runner/internal/shim/api/handlers_test.go
+++ b/runner/internal/shim/api/handlers_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -12,7 +13,7 @@ func TestHealthcheck(t *testing.T) {
 	request := httptest.NewRequest("GET", "/api/healthcheck", nil)
 	responseRecorder := httptest.NewRecorder()
 
-	server := NewShimServer(":12345", NewDummyRunner(), "0.0.1.dev2")
+	server := NewShimServer(context.Background(), ":12345", NewDummyRunner(), "0.0.1.dev2")
 
 	f := common.JSONResponseHandler(server.HealthcheckHandler)
 	f(responseRecorder, request)
@@ -29,7 +30,7 @@ func TestHealthcheck(t *testing.T) {
 }
 
 func TestTaskSubmit(t *testing.T) {
-	server := NewShimServer(":12340", NewDummyRunner(), "0.0.1.dev2")
+	server := NewShimServer(context.Background(), ":12340", NewDummyRunner(), "0.0.1.dev2")
 
 	request := httptest.NewRequest("POST", "/api/tasks", strings.NewReader(`{"image_name":"ubuntu"}`))
 	responseRecorder := httptest.NewRecorder()

--- a/runner/internal/shim/docker.go
+++ b/runner/internal/shim/docker.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 	"os/user"
@@ -31,6 +30,7 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/docker/go-units"
 	"github.com/dstackai/dstack/runner/consts"
+	"github.com/dstackai/dstack/runner/internal/log"
 	"github.com/dstackai/dstack/runner/internal/shim/backends"
 	"github.com/dstackai/dstack/runner/internal/shim/host"
 	bytesize "github.com/inhies/go-bytesize"
@@ -58,8 +58,7 @@ type DockerRunner struct {
 	tasks        TaskStorage
 }
 
-func NewDockerRunner(dockerParams DockerParameters) (*DockerRunner, error) {
-	ctx := context.TODO()
+func NewDockerRunner(ctx context.Context, dockerParams DockerParameters) (*DockerRunner, error) {
 	client, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
 	if err != nil {
 		return nil, tracerr.Wrap(err)
@@ -70,7 +69,7 @@ func NewDockerRunner(dockerParams DockerParameters) (*DockerRunner, error) {
 	}
 
 	var gpuVendor host.GpuVendor
-	gpus := host.GetGpuInfo()
+	gpus := host.GetGpuInfo(ctx)
 	if len(gpus) > 0 {
 		gpuVendor = gpus[0].Vendor
 	} else {
@@ -113,7 +112,7 @@ func (d *DockerRunner) restoreStateFromContainers(ctx context.Context) error {
 		containerID := containerShort.ID
 		taskID := containerShort.Labels[LabelKeyTaskID]
 		if taskID == "" {
-			log.Printf("container %s has no %s label", containerID, LabelKeyTaskID)
+			log.Error(ctx, "container has no label", "id", containerID, "label", LabelKeyTaskID)
 			continue
 		}
 		var status TaskStatus
@@ -131,15 +130,16 @@ func (d *DockerRunner) restoreStateFromContainers(ctx context.Context) error {
 		var gpuIDs []string
 		if d.gpuVendor != host.GpuVendorNone {
 			if containerFull, err := d.client.ContainerInspect(ctx, containerID); err != nil {
-				log.Printf("failed to inspect container=%s task=%s", containerID, taskID)
+				log.Error(ctx, "failed to inspect container", "id", containerID, "task", taskID)
 			} else if d.gpuVendor == host.GpuVendorNvidia {
 				deviceRequests := containerFull.HostConfig.Resources.DeviceRequests
 				if len(deviceRequests) == 1 {
 					gpuIDs = deviceRequests[0].DeviceIDs
 				} else if len(deviceRequests) != 0 {
-					log.Printf(
-						"cannot extract GPU IDs container=%s task=%s: more than one DeviceRequest",
-						containerID, taskID,
+					log.Error(
+						ctx,
+						"cannot extract GPU IDs from container: more than one DeviceRequest",
+						"id", containerID, "task", taskID,
 					)
 				}
 			} else {
@@ -152,38 +152,38 @@ func (d *DockerRunner) restoreStateFromContainers(ctx context.Context) error {
 		}
 		var runnerDir string
 		for _, mount := range containerShort.Mounts {
-			if mount.Destination == consts.RunnerDir {
+			if mount.Destination == consts.RunnerTempDir {
 				runnerDir = mount.Source
 				break
 			}
 		}
 		task := NewTask(taskID, status, containerName, containerID, gpuIDs, runnerDir)
 		if !d.tasks.Add(task) {
-			log.Printf("duplicate restored task %s", taskID)
+			log.Error(ctx, "duplicate restored task", "task", taskID)
 		} else {
-			log.Printf("restored task ID=%s, status=%s, gpuIDs=%v", taskID, status, gpuIDs)
+			log.Debug(ctx, "restored task", "task", taskID, "status", status, "gpus", gpuIDs)
 		}
 		if status == TaskStatusRunning && len(gpuIDs) > 0 {
-			lockedGpuIDs := d.gpuLock.Lock(gpuIDs)
-			log.Printf("locked GPU(s) due to running task gpuIDs=%v task=%s", lockedGpuIDs, taskID)
+			lockedGpuIDs := d.gpuLock.Lock(ctx, gpuIDs)
+			log.Debug(ctx, "locked GPU(s) due to running task", "task", taskID, "gpus", lockedGpuIDs)
 		}
 	}
 	return nil
 }
 
-func (d *DockerRunner) Resources() Resources {
-	cpuCount := host.GetCpuCount()
-	totalMemory, err := host.GetTotalMemory()
+func (d *DockerRunner) Resources(ctx context.Context) Resources {
+	cpuCount := host.GetCpuCount(ctx)
+	totalMemory, err := host.GetTotalMemory(ctx)
 	if err != nil {
-		log.Println(err)
+		log.Error(ctx, err.Error())
 	}
-	netAddresses, err := host.GetNetworkAddresses()
+	netAddresses, err := host.GetNetworkAddresses(ctx)
 	if err != nil {
-		log.Println(err)
+		log.Error(ctx, err.Error())
 	}
-	diskSize, err := host.GetDiskSize(d.dockerInfo.DockerRootDir)
+	diskSize, err := host.GetDiskSize(ctx, d.dockerInfo.DockerRootDir)
 	if err != nil {
-		log.Println(err)
+		log.Error(ctx, err.Error())
 	}
 	return Resources{
 		Gpus:         d.gpus,
@@ -229,13 +229,14 @@ func (d *DockerRunner) Submit(ctx context.Context, cfg TaskConfig) error {
 	if ok := d.tasks.Add(task); !ok {
 		return tracerr.Errorf("%w: task %s is already submitted", ErrRequest, task.ID)
 	}
+	log.Debug(ctx, "new task submitted", "task", task.ID)
 	return nil
 }
 
 func (d *DockerRunner) Run(ctx context.Context, taskID string) error {
 	task, ok := d.tasks.Get(taskID)
 	if !ok {
-		log.Printf("cannot run task %s: not found", taskID)
+		log.Error(ctx, "cannot run: not found", "task", taskID)
 		return fmt.Errorf("task %s: %w", taskID, ErrNotFound)
 	}
 
@@ -247,7 +248,7 @@ func (d *DockerRunner) Run(ctx context.Context, taskID string) error {
 		if err := d.tasks.Update(task); err != nil {
 			if currentTask, ok := d.tasks.Get(task.ID); ok && currentTask.Status != task.Status {
 				// ignore error if task is gone or status has not changed, e.g., terminated -> terminated
-				log.Printf("failed to update task %s: %v", task.ID, err)
+				log.Error(ctx, "failed to update", "task", task.ID, "err", err)
 			}
 		}
 	}()
@@ -261,18 +262,18 @@ func (d *DockerRunner) Run(ctx context.Context, taskID string) error {
 	var err error
 
 	if cfg.GPU != 0 {
-		gpuIDs, err := d.gpuLock.Acquire(cfg.GPU)
+		gpuIDs, err := d.gpuLock.Acquire(ctx, cfg.GPU)
 		if err != nil {
-			log.Println(err)
+			log.Error(ctx, err.Error())
 			task.SetStatusTerminated("EXECUTOR_ERROR", err.Error())
 			return tracerr.Wrap(err)
 		}
 		task.gpuIDs = gpuIDs
-		log.Printf("acquired GPU(s) gpuIDs=%v task=%s", gpuIDs, task.ID)
+		log.Debug(ctx, "acquired GPU(s)", "task", task.ID, "gpus", gpuIDs)
 
 		defer func() {
-			releasedGpuIDs := d.gpuLock.Release(task.gpuIDs)
-			log.Printf("released GPU(s) gpuIDs=%v task=%s", releasedGpuIDs, task.ID)
+			releasedGpuIDs := d.gpuLock.Release(ctx, task.gpuIDs)
+			log.Debug(ctx, "released GPU(s)", "task", task.ID, "gpus", releasedGpuIDs)
 		}()
 	}
 
@@ -280,39 +281,39 @@ func (d *DockerRunner) Run(ctx context.Context, taskID string) error {
 		ak := AuthorizedKeys{user: cfg.HostSshUser, lookup: user.Lookup}
 		if err := ak.AppendPublicKeys(cfg.HostSshKeys); err != nil {
 			errMessage := fmt.Sprintf("ak.AppendPublicKeys error: %s", err.Error())
-			log.Println(errMessage)
+			log.Error(ctx, errMessage)
 			task.SetStatusTerminated("EXECUTOR_ERROR", errMessage)
 			return tracerr.Wrap(err)
 		}
 		defer func(cfg TaskConfig) {
 			err := ak.RemovePublicKeys(cfg.HostSshKeys)
 			if err != nil {
-				log.Printf("Error RemovePublicKeys: %s\n", err.Error())
+				log.Error(ctx, "Error RemovePublicKeys", "err", err)
 			}
 		}(cfg)
 	}
 
-	log.Println("Preparing volumes")
+	log.Debug(ctx, "Preparing volumes")
 	// defer unmountVolumes() before calling prepareVolumes(), as the latter
 	// may fail when some volumes are already mounted; if the volume is not mounted,
 	// unmountVolumes() simply skips it
-	defer func() { _ = unmountVolumes(cfg) }()
-	err = prepareVolumes(cfg)
+	defer func() { _ = unmountVolumes(ctx, cfg) }()
+	err = prepareVolumes(ctx, cfg)
 	if err != nil {
 		errMessage := fmt.Sprintf("prepareVolumes error: %s", err.Error())
-		log.Println(errMessage)
+		log.Error(ctx, errMessage)
 		task.SetStatusTerminated("EXECUTOR_ERROR", errMessage)
 		return tracerr.Wrap(err)
 	}
 	err = prepareInstanceMountPoints(cfg)
 	if err != nil {
 		errMessage := fmt.Sprintf("prepareInstanceMountPoints error: %s", err.Error())
-		log.Println(errMessage)
+		log.Error(ctx, errMessage)
 		task.SetStatusTerminated("EXECUTOR_ERROR", errMessage)
 		return tracerr.Wrap(err)
 	}
 
-	log.Println("Pulling image")
+	log.Debug(ctx, "Pulling image")
 	pullCtx, cancelPull := context.WithTimeout(ctx, ImagePullTimeout)
 	defer cancelPull()
 	task.SetStatusPulling(cancelPull)
@@ -321,12 +322,12 @@ func (d *DockerRunner) Run(ctx context.Context, taskID string) error {
 	}
 	if err = pullImage(pullCtx, d.client, cfg); err != nil {
 		errMessage := fmt.Sprintf("pullImage error: %s", err.Error())
-		log.Print(errMessage + "\n")
+		log.Error(ctx, errMessage)
 		task.SetStatusTerminated("CREATING_CONTAINER_ERROR", errMessage)
 		return tracerr.Wrap(err)
 	}
 
-	log.Printf("Creating container name=%s task=%s", task.containerName, task.ID)
+	log.Debug(ctx, "Creating container", "task", task.ID, "name", task.containerName)
 	task.SetStatusCreating()
 	if err := d.tasks.Update(task); err != nil {
 		return tracerr.Errorf("%w: failed to update task %s: %w", ErrInternal, task.ID, err)
@@ -334,30 +335,30 @@ func (d *DockerRunner) Run(ctx context.Context, taskID string) error {
 	containerID, err := d.createContainer(ctx, &task)
 	if err != nil {
 		errMessage := fmt.Sprintf("createContainer error: %s", err.Error())
-		log.Println(errMessage)
+		log.Error(ctx, errMessage)
 		task.SetStatusTerminated("CREATING_CONTAINER_ERROR", errMessage)
 		return tracerr.Wrap(err)
 	}
 
-	log.Printf("Running container name=%s task=%s", task.containerName, task.ID)
+	log.Debug(ctx, "Running container", "task", task.ID, "name", task.containerName)
 	task.SetStatusRunning(containerID)
 	if err := d.tasks.Update(task); err != nil {
 		return tracerr.Errorf("%w: failed to update task %s: %w", ErrInternal, task.ID, err)
 	}
 	if err = d.runContainer(ctx, &task); err != nil {
-		log.Printf("runContainer error: %s\n", err.Error())
+		log.Error(ctx, "runContainer error", "err", err)
 		var errMessage string
-		if lastLogs, err := getContainerLastLogs(d.client, containerID, 5); err == nil {
+		if lastLogs, err := getContainerLastLogs(ctx, d.client, containerID, 5); err == nil {
 			errMessage = strings.Join(lastLogs, "\n")
 		} else {
-			log.Printf("getContainerLastLogs error: %s\n", err.Error())
+			log.Error(ctx, "getContainerLastLogs error", "err", err)
 			errMessage = ""
 		}
 		task.SetStatusTerminated("CONTAINER_EXITED_WITH_ERROR", errMessage)
 		return tracerr.Wrap(err)
 	}
 
-	log.Printf("Container finished successfully, name=%s, id=%s", task.containerName, containerID)
+	log.Debug(ctx, "Container finished successfully", "task", task.ID, "name", task.containerName)
 	task.SetStatusTerminated("DONE_BY_RUNNER", "")
 
 	return nil
@@ -368,24 +369,24 @@ func (d *DockerRunner) Run(ctx context.Context, taskID string) error {
 func (d *DockerRunner) Terminate(ctx context.Context, taskID string, timeout uint, reason string, message string) (err error) {
 	task, ok := d.tasks.Get(taskID)
 	if !ok {
-		log.Printf("cannot terminate task %s: not found", taskID)
+		log.Error(ctx, "cannot terminate task: not found", "task", taskID)
 		return fmt.Errorf("task %s: %w", taskID, ErrNotFound)
 	}
-	task.Lock()
-	defer task.Release()
+	task.Lock(ctx)
+	defer func() { task.Release(ctx) }()
 	defer func() {
 		if err := d.tasks.Update(task); err != nil {
-			log.Printf("failed to update task %s: %v", task.ID, err)
+			log.Error(ctx, "failed to update task", "task", task.ID, "err", err)
 		}
 	}()
 	return d.terminate(ctx, &task, timeout, reason, message)
 }
 
 func (d *DockerRunner) terminate(ctx context.Context, task *Task, timeout uint, reason string, message string) (err error) {
-	log.Printf("terminating task %s", task.ID)
+	log.Debug(ctx, "terminating", "task", task.ID)
 	defer func() {
 		if err != nil {
-			log.Printf("cannot terminate task %s: %v", task.ID, err)
+			log.Error(ctx, "cannot terminate task", "task", task.ID, "err", err)
 		}
 	}()
 	if !task.IsTransitionAllowed(TaskStatusTerminated) {
@@ -407,11 +408,11 @@ func (d *DockerRunner) terminate(ctx context.Context, task *Task, timeout uint, 
 		return fmt.Errorf("%w: should not reach here", ErrInternal)
 	}
 	if len(task.gpuIDs) > 0 {
-		releasedGpuIDs := d.gpuLock.Release(task.gpuIDs)
-		log.Printf("released GPU(s) gpuIDs=%v task=%s", releasedGpuIDs, task.ID)
+		releasedGpuIDs := d.gpuLock.Release(ctx, task.gpuIDs)
+		log.Debug(ctx, "released GPU(s)", "task", task.ID, "gpus", releasedGpuIDs)
 	}
 	task.SetStatusTerminated(reason, message)
-	log.Printf("task %s terminated", task.ID)
+	log.Debug(ctx, "terminated", "task", task.ID)
 	return nil
 }
 
@@ -420,11 +421,11 @@ func (d *DockerRunner) terminate(ctx context.Context, task *Task, timeout uint, 
 func (d *DockerRunner) Remove(ctx context.Context, taskID string) error {
 	task, ok := d.tasks.Get(taskID)
 	if !ok {
-		log.Printf("cannot remove task %s: not found", taskID)
+		log.Error(ctx, "cannot remove: not found", "task", taskID)
 		return fmt.Errorf("task %s: %w", taskID, ErrNotFound)
 	}
-	task.Lock()
-	defer task.Release()
+	task.Lock(ctx)
+	defer func() { task.Release(ctx) }()
 	err := d.remove(ctx, &task)
 	if err == nil {
 		d.tasks.Delete(taskID)
@@ -433,10 +434,10 @@ func (d *DockerRunner) Remove(ctx context.Context, taskID string) error {
 }
 
 func (d *DockerRunner) remove(ctx context.Context, task *Task) (err error) {
-	log.Printf("removing task %s", task.ID)
+	log.Debug(ctx, "removing", "task", task.ID)
 	defer func() {
 		if err != nil {
-			log.Printf("cannot remove task %s: %v", task.ID, err)
+			log.Error(ctx, "cannot remove", "task", task.ID, "err", err)
 		}
 	}()
 	if task.Status != TaskStatusTerminated {
@@ -448,7 +449,7 @@ func (d *DockerRunner) remove(ctx context.Context, task *Task) (err error) {
 		err := d.client.ContainerRemove(ctx, task.containerID, removeOptions)
 		if err != nil {
 			if errdefs.IsNotFound(err) {
-				log.Printf("cannot remove container task=%s: not found", task.ID)
+				log.Error(ctx, "cannot remove container: not found", "task", task.ID)
 			} else {
 				return fmt.Errorf("%w: failed to remove container task=%s: %w", ErrInternal, task.ID, err)
 			}
@@ -458,14 +459,14 @@ func (d *DockerRunner) remove(ctx context.Context, task *Task) (err error) {
 	if task.runnerDir != "" {
 		// Failed attempts to remove or rename runner dir are considered non-fatal
 		if err := os.RemoveAll(task.runnerDir); err != nil {
-			log.Printf("failed to remove runner directory %s: %v", task.runnerDir, err)
+			log.Error(ctx, "failed to remove runner directory", "dir", task.runnerDir, "err", err)
 			trashName := fmt.Sprintf(".trash-%s-%d", task.runnerDir, time.Now().UnixMicro())
 			if err := os.Rename(task.runnerDir, trashName); err != nil {
-				log.Printf("failed to rename runner directory %s: %v", task.runnerDir, err)
+				log.Error(ctx, "failed to rename runner directory", "dir", task.runnerDir, "err", err)
 			}
 		}
 	}
-	log.Printf("task %s removed", task.ID)
+	log.Debug(ctx, "removed", "task", task.ID)
 	return nil
 }
 
@@ -479,9 +480,9 @@ func getBackend(backendType string) (backends.Backend, error) {
 	return nil, fmt.Errorf("unknown backend: %q", backendType)
 }
 
-func prepareVolumes(taskConfig TaskConfig) error {
+func prepareVolumes(ctx context.Context, taskConfig TaskConfig) error {
 	for _, volume := range taskConfig.Volumes {
-		err := formatAndMountVolume(volume)
+		err := formatAndMountVolume(ctx, volume)
 		if err != nil {
 			return tracerr.Wrap(err)
 		}
@@ -489,25 +490,25 @@ func prepareVolumes(taskConfig TaskConfig) error {
 	return nil
 }
 
-func unmountVolumes(taskConfig TaskConfig) error {
+func unmountVolumes(ctx context.Context, taskConfig TaskConfig) error {
 	if len(taskConfig.Volumes) == 0 {
 		return nil
 	}
-	log.Println("Unmounting volumes...")
+	log.Debug(ctx, "Unmounting volumes...")
 	var failed []string
 	for _, volume := range taskConfig.Volumes {
 		mountPoint := getVolumeMountPoint(volume.Name)
 		cmd := exec.Command("mountpoint", mountPoint)
 		if output, err := cmd.CombinedOutput(); err != nil {
-			log.Printf("Skipping %s: %s", mountPoint, output)
+			log.Info(ctx, "skipping", "mountpoint", mountPoint, "output", output)
 			continue
 		}
 		cmd = exec.Command("umount", "-qf", mountPoint)
 		if output, err := cmd.CombinedOutput(); err != nil {
-			log.Printf("Failed to unmount %s: %s", mountPoint, output)
+			log.Error(ctx, "failed to unmount", "mountpoint", mountPoint, "output", output)
 			failed = append(failed, mountPoint)
 		} else {
-			log.Printf("Unmounted: %s\n", mountPoint)
+			log.Debug(ctx, "unmounted", "mountpoint", mountPoint)
 		}
 	}
 	if len(failed) > 0 {
@@ -516,7 +517,7 @@ func unmountVolumes(taskConfig TaskConfig) error {
 	return nil
 }
 
-func formatAndMountVolume(volume VolumeInfo) error {
+func formatAndMountVolume(ctx context.Context, volume VolumeInfo) error {
 	backend, err := getBackend(volume.Backend)
 	if err != nil {
 		return tracerr.Wrap(err)
@@ -525,7 +526,7 @@ func formatAndMountVolume(volume VolumeInfo) error {
 	if err != nil {
 		return tracerr.Wrap(err)
 	}
-	fsCreated, err := initFileSystem(deviceName, !volume.InitFs)
+	fsCreated, err := initFileSystem(ctx, deviceName, !volume.InitFs)
 	if err != nil {
 		return tracerr.Wrap(err)
 	}
@@ -542,7 +543,7 @@ func formatAndMountVolume(volume VolumeInfo) error {
 	if fsCreated {
 		fsRootPerms = 0o777
 	}
-	err = mountDisk(deviceName, getVolumeMountPoint(volume.Name), fsRootPerms)
+	err = mountDisk(ctx, deviceName, getVolumeMountPoint(volume.Name), fsRootPerms)
 	if err != nil {
 		return tracerr.Wrap(err)
 	}
@@ -577,7 +578,7 @@ func prepareInstanceMountPoints(taskConfig TaskConfig) error {
 
 // initFileSystem creates an ext4 file system on a disk only if the disk is not already has a file system.
 // Returns true if the file system is created.
-func initFileSystem(deviceName string, errorIfNotExists bool) (bool, error) {
+func initFileSystem(ctx context.Context, deviceName string, errorIfNotExists bool) (bool, error) {
 	// Run the lsblk command to get filesystem type
 	cmd := exec.Command("lsblk", "-no", "FSTYPE", deviceName)
 	var out bytes.Buffer
@@ -596,26 +597,26 @@ func initFileSystem(deviceName string, errorIfNotExists bool) (bool, error) {
 		return false, fmt.Errorf("disk has no file system")
 	}
 
-	log.Printf("Formatting disk %s with ext4 filesystem...\n", deviceName)
+	log.Debug(ctx, "formatting disk with ext4 filesystem...", "device", deviceName)
 	cmd = exec.Command("mkfs.ext4", "-F", deviceName)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return false, fmt.Errorf("failed to format disk: %w, output: %s", err, string(output))
 	}
-	log.Println("Disk formatted succesfully!")
+	log.Debug(ctx, "disk formatted succesfully!", "device", deviceName)
 	return true, nil
 }
 
-func mountDisk(deviceName, mountPoint string, fsRootPerms os.FileMode) error {
+func mountDisk(ctx context.Context, deviceName, mountPoint string, fsRootPerms os.FileMode) error {
 	// Create the mount point directory if it doesn't exist
 	if _, err := os.Stat(mountPoint); os.IsNotExist(err) {
-		fmt.Printf("Creating mount point %s...\n", mountPoint)
+		log.Debug(ctx, "creating mount point...", "mountpoint", mountPoint)
 		if err := os.MkdirAll(mountPoint, 0o755); err != nil {
 			return fmt.Errorf("failed to create mount point: %w", err)
 		}
 	}
 
 	// Mount the disk to the mount point
-	log.Printf("Mounting disk %s to %s...\n", deviceName, mountPoint)
+	log.Debug(ctx, "mounting disk...", "device", deviceName, "mountpoint", mountPoint)
 	cmd := exec.Command("mount", deviceName, mountPoint)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to mount disk: %w, output: %s", err, string(output))
@@ -627,7 +628,7 @@ func mountDisk(deviceName, mountPoint string, fsRootPerms os.FileMode) error {
 		}
 	}
 
-	log.Println("Disk mounted successfully!")
+	log.Debug(ctx, "disk mounted successfully!")
 	return nil
 }
 
@@ -648,7 +649,10 @@ func pullImage(ctx context.Context, client docker.APIClient, taskConfig TaskConf
 	}
 
 	opts := image.PullOptions{}
-	regAuth, _ := encodeRegistryAuth(taskConfig.RegistryUsername, taskConfig.RegistryPassword)
+	regAuth, err := encodeRegistryAuth(taskConfig.RegistryUsername, taskConfig.RegistryPassword)
+	if err != nil {
+		log.Error(ctx, err.Error())
+	}
 	if regAuth != "" {
 		opts.RegistryAuth = regAuth
 	}
@@ -691,11 +695,11 @@ func pullImage(ctx context.Context, client docker.APIClient, taskConfig TaskConf
 			current[progressRow.Id] = total[progressRow.Id]
 		}
 		if progressRow.Error != "" {
-			log.Printf("Error pulling %s: %s", taskConfig.ImageName, progressRow.Error)
+			log.Error(ctx, "error pulling image", "name", taskConfig.ImageName, "err", progressRow.Error)
 		}
 		if strings.HasPrefix(progressRow.Status, "Status:") {
 			status = true
-			log.Println(progressRow.Status)
+			log.Debug(ctx, progressRow.Status)
 		}
 	}
 
@@ -712,9 +716,9 @@ func pullImage(ctx context.Context, client docker.APIClient, taskConfig TaskConf
 
 	speed := bytesize.New(float64(currentBytes) / duration.Seconds())
 	if status && currentBytes == totalBytes {
-		log.Printf("Image Pull successfully downloaded: %d bytes (%s/s)", currentBytes, speed)
+		log.Debug(ctx, "image successfully pulled", "bytes", currentBytes, "bps", speed)
 	} else {
-		log.Printf("Image Pull interrupted: downloaded %d bytes out of %d (%s/s)", currentBytes, totalBytes, speed)
+		log.Error(ctx, "image pulling interrupted", "bytes", currentBytes, "total", totalBytes, "bps", speed)
 	}
 
 	err = ctx.Err()
@@ -834,8 +838,7 @@ func encodeRegistryAuth(username string, password string) (string, error) {
 
 	encodedConfig, err := json.Marshal(authConfig)
 	if err != nil {
-		log.Println("Failed to encode auth config", "err", err)
-		return "", err
+		return "", fmt.Errorf("failed to encode auth config: %w", err)
 	}
 
 	return base64.URLEncoding.EncodeToString(encodedConfig), nil
@@ -1004,14 +1007,13 @@ func getInstanceMounts(mountPoints []InstanceMountPoint) ([]mount.Mount, error) 
 	return mounts, nil
 }
 
-func getContainerLastLogs(client docker.APIClient, containerID string, n int) ([]string, error) {
+func getContainerLastLogs(ctx context.Context, client docker.APIClient, containerID string, n int) ([]string, error) {
 	options := container.LogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
 		Tail:       fmt.Sprintf("%d", n),
 	}
 
-	ctx := context.Background()
 	muxedReader, err := client.ContainerLogs(ctx, containerID, options)
 	if err != nil {
 		return nil, err
@@ -1061,7 +1063,7 @@ func (c *CLIArgs) DockerMounts(hostRunnerDir string) ([]mount.Mount, error) {
 		{
 			Type:   mount.TypeBind,
 			Source: hostRunnerDir,
-			Target: consts.RunnerDir,
+			Target: consts.RunnerTempDir,
 		},
 		{
 			Type:   mount.TypeBind,

--- a/runner/internal/shim/docker_test.go
+++ b/runner/internal/shim/docker_test.go
@@ -34,7 +34,7 @@ func TestDocker_SSHServer(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 	defer cancel()
 
-	dockerRunner, _ := NewDockerRunner(params)
+	dockerRunner, _ := NewDockerRunner(ctx, params)
 	taskConfig := createTaskConfig(t)
 	defer dockerRunner.Remove(context.Background(), taskConfig.ID)
 
@@ -64,7 +64,7 @@ func TestDocker_SSHServerConnect(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 	defer cancel()
 
-	dockerRunner, _ := NewDockerRunner(params)
+	dockerRunner, _ := NewDockerRunner(ctx, params)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -110,7 +110,7 @@ func TestDocker_ShmNoexecByDefault(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 	defer cancel()
 
-	dockerRunner, _ := NewDockerRunner(params)
+	dockerRunner, _ := NewDockerRunner(ctx, params)
 	taskConfig := createTaskConfig(t)
 	defer dockerRunner.Remove(context.Background(), taskConfig.ID)
 
@@ -132,7 +132,7 @@ func TestDocker_ShmExecIfSizeSpecified(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 	defer cancel()
 
-	dockerRunner, _ := NewDockerRunner(params)
+	dockerRunner, _ := NewDockerRunner(ctx, params)
 	taskConfig := createTaskConfig(t)
 	taskConfig.ShmSize = 1024 * 1024
 	defer dockerRunner.Remove(context.Background(), taskConfig.ID)

--- a/runner/internal/shim/host/host.go
+++ b/runner/internal/shim/host/host.go
@@ -1,21 +1,22 @@
 package host
 
 import (
+	"context"
 	"fmt"
-	"log"
 	"net"
 	"runtime"
 
+	"github.com/dstackai/dstack/runner/internal/log"
 	"github.com/shirou/gopsutil/v4/mem"
 	"golang.org/x/sys/unix"
 )
 
-func GetCpuCount() int {
+func GetCpuCount(ctx context.Context) int {
 	return runtime.NumCPU()
 }
 
 // GetTotalMemory returns total amount of RAM on this system
-func GetTotalMemory() (uint64, error) {
+func GetTotalMemory(ctx context.Context) (uint64, error) {
 	v, err := mem.VirtualMemory()
 	if err != nil {
 		return 0, fmt.Errorf("cannot get total memory: %w", err)
@@ -23,7 +24,7 @@ func GetTotalMemory() (uint64, error) {
 	return v.Total, nil
 }
 
-func GetDiskSize(path string) (uint64, error) {
+func GetDiskSize(ctx context.Context, path string) (uint64, error) {
 	var stat unix.Statfs_t
 	err := unix.Statfs(path, &stat)
 	if err != nil {
@@ -33,7 +34,7 @@ func GetDiskSize(path string) (uint64, error) {
 	return size, nil
 }
 
-func GetNetworkAddresses() ([]string, error) {
+func GetNetworkAddresses(ctx context.Context) ([]string, error) {
 	var addresses []string
 	ifaces, err := net.Interfaces()
 	if err != nil {
@@ -42,7 +43,7 @@ func GetNetworkAddresses() ([]string, error) {
 	for _, iface := range ifaces {
 		addrs, err := iface.Addrs()
 		if err != nil {
-			log.Printf("cannot get addrs for %+v: %v", iface, err)
+			log.Error(ctx, "cannot get addrs", "iface", iface, "err", err)
 			continue
 		}
 		for _, addr := range addrs {

--- a/runner/internal/shim/models.go
+++ b/runner/internal/shim/models.go
@@ -17,15 +17,14 @@ type CLIArgs struct {
 	Shim struct {
 		HTTPPort int
 		HomeDir  string
+		LogLevel int
 	}
 
 	Runner struct {
 		HTTPPort    int
-		LogLevel    int
 		DownloadURL string
 		BinaryPath  string
-		HomeDir     string
-		WorkingDir  string
+		LogLevel    int
 	}
 
 	Docker struct {

--- a/runner/internal/shim/resources.go
+++ b/runner/internal/shim/resources.go
@@ -1,11 +1,12 @@
 package shim
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"log"
 	"sync"
 
+	"github.com/dstackai/dstack/runner/internal/log"
 	"github.com/dstackai/dstack/runner/internal/shim/host"
 )
 
@@ -57,7 +58,7 @@ func NewGpuLock(gpus []host.GpuInfo) (*GpuLock, error) {
 // -1 means "all available GPUs", even if none, that is, Acquire(-1) never fails,
 // even on hosts without GPU
 // To release acquired GPUs, pass the returned resource IDs to Release() method
-func (gl *GpuLock) Acquire(count int) ([]string, error) {
+func (gl *GpuLock) Acquire(ctx context.Context, count int) ([]string, error) {
 	if count == 0 || count < -1 {
 		return nil, fmt.Errorf("count must be either positive or -1, got %d", count)
 	}
@@ -90,15 +91,15 @@ func (gl *GpuLock) Acquire(count int) ([]string, error) {
 // Lock marks passed Resource IDs as locked (busy)
 // This method never fails, it's safe to lock already locked resource or try to lock unknown resource
 // The returned slice contains only actually locked resource IDs
-func (gl *GpuLock) Lock(ids []string) []string {
+func (gl *GpuLock) Lock(ctx context.Context, ids []string) []string {
 	gl.mu.Lock()
 	defer gl.mu.Unlock()
 	lockedIDs := make([]string, 0, len(ids))
 	for _, id := range ids {
 		if locked, ok := gl.lock[id]; !ok {
-			log.Printf("skipping %s: unknown GPU resource", id)
+			log.Warning(ctx, "skip locking: unknown GPU resource", "id", id)
 		} else if locked {
-			log.Printf("skipping %s: already locked", id)
+			log.Info(ctx, "skip locking: GPU already locked", "id", id)
 		} else {
 			gl.lock[id] = true
 			lockedIDs = append(lockedIDs, id)
@@ -110,15 +111,15 @@ func (gl *GpuLock) Lock(ids []string) []string {
 // Release marks passed Resource IDs as idle
 // This method never fails, it's safe to release already idle resource or try to release unknown resource
 // The returned slice contains only actually released resource IDs
-func (gl *GpuLock) Release(ids []string) []string {
+func (gl *GpuLock) Release(ctx context.Context, ids []string) []string {
 	gl.mu.Lock()
 	defer gl.mu.Unlock()
 	releasedIDs := make([]string, 0, len(ids))
 	for _, id := range ids {
 		if locked, ok := gl.lock[id]; !ok {
-			log.Printf("skipping %s: unknown GPU resource", id)
+			log.Warning(ctx, "skip releasing: unknown GPU resource", "id", id)
 		} else if !locked {
-			log.Printf("skipping %s: not locked", id)
+			log.Info(ctx, "skip releasing: GPU not locked", "id", id)
 		} else {
 			gl.lock[id] = false
 			releasedIDs = append(releasedIDs, id)

--- a/runner/internal/shim/task.go
+++ b/runner/internal/shim/task.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"log"
 	"sync"
+
+	"github.com/dstackai/dstack/runner/internal/log"
 )
 
 type TaskStatus string
@@ -45,19 +46,19 @@ type Task struct {
 
 // Lock is used for exclusive operations, e.g, stopping a container,
 // removing task data, etc.
-func (t *Task) Lock() {
+func (t *Task) Lock(ctx context.Context) {
 	if !t.mu.TryLock() {
-		log.Fatalf("task %s already locked!", t.ID)
+		log.Fatal(ctx, "already locked!", "task", t.ID)
 	}
-	log.Printf("task %s locked", t.ID)
+	log.Debug(ctx, "locked", "task", t.ID)
 }
 
 // Release should be called Unlock, but this name triggers govet copylocks check,
 // since "thanks" to Go implicit interfaces, a struct with Lock/Unlock method pair
 // looks like lock: https://github.com/golang/go/issues/18451
-func (t *Task) Release() {
+func (t *Task) Release(ctx context.Context) {
 	t.mu.Unlock()
-	log.Printf("task %s unlocked", t.ID)
+	log.Debug(ctx, "unlocked", "task", t.ID)
 }
 
 func (t *Task) IsTransitionAllowed(toStatus TaskStatus) bool {

--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -263,7 +263,7 @@ class AWSCompute(Compute):
                     price=instance_offer.price,
                     username=username,
                     ssh_port=22,
-                    dockerized=True,  # because `dstack-shim docker` is used
+                    dockerized=True,  # because `dstack-shim` is used
                     ssh_proxy=None,
                     backend_data=None,
                 )

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -190,10 +190,11 @@ def get_user_data(
 
 def get_shim_env(authorized_keys: List[str]) -> Dict[str, str]:
     envs = {
-        "DSTACK_RUNNER_LOG_LEVEL": "6",
+        "DSTACK_SHIM_HOME": DSTACK_WORKING_DIR,
+        "DSTACK_SHIM_LOG_LEVEL": "6",
         "DSTACK_RUNNER_DOWNLOAD_URL": get_dstack_runner_download_url(),
+        "DSTACK_RUNNER_LOG_LEVEL": "6",
         "DSTACK_PUBLIC_SSH_KEY": "\n".join(authorized_keys),
-        "DSTACK_HOME": DSTACK_WORKING_DIR,
     }
     return envs
 
@@ -261,7 +262,7 @@ def get_run_shim_script(is_privileged: bool, pjrt_device: Optional[str]) -> List
     pjrt_device_env = f"--pjrt-device={pjrt_device}" if pjrt_device else ""
 
     return [
-        f"nohup dstack-shim docker {privileged_flag} {pjrt_device_env} >{DSTACK_WORKING_DIR}/shim.log 2>&1 &",
+        f"nohup dstack-shim {privileged_flag} {pjrt_device_env} &",
     ]
 
 

--- a/src/dstack/_internal/core/backends/remote/provisioning.py
+++ b/src/dstack/_internal/core/backends/remote/provisioning.py
@@ -23,7 +23,7 @@ logger = get_logger(__name__)
 
 SSH_CONNECT_TIMEOUT = 10
 
-DSTACK_SHIM_ENV_FILE = "dstack-shim.env"
+DSTACK_SHIM_ENV_FILE = "shim.env"
 
 HOST_INFO_FILE = "host_info.json"
 
@@ -98,11 +98,10 @@ def run_shim_as_systemd_service(client: paramiko.SSHClient, working_dir: str, de
     Type=simple
     User=root
     Restart=always
+    RestartSec=10
     WorkingDirectory={working_dir}
     EnvironmentFile={working_dir}/{DSTACK_SHIM_ENV_FILE}
-    ExecStart=/usr/local/bin/dstack-shim docker
-    StandardOutput=append:/root/.dstack/shim.log
-    StandardError=append:/root/.dstack/shim.log
+    ExecStart=/usr/local/bin/dstack-shim
 
     [Install]
     WantedBy=multi-user.target


### PR DESCRIPTION
* Migrate to context-aware logging facility
* Write to `shim.log` internally (don't rely on systemd/shell std{out,err} redirects, preserves shim logs in journald)
* Add `--shim-log-level`
* Rename `--home` to `--shim-home` for consistency
* Drop `docker` command (it is _the only_ command)