### PR TITLE
Download dstack-runner to well-known location

### DIFF
--- a/runner/cmd/shim/main.go
+++ b/runner/cmd/shim/main.go
@@ -72,6 +72,7 @@ func main() {
 			&cli.PathFlag{
 				Name:        "runner-binary-path",
 				Usage:       "Path to runner's binary",
+				Value:       consts.RunnerBinaryPath,
 				Destination: &args.Runner.BinaryPath,
 				EnvVars:     []string{"DSTACK_RUNNER_BINARY_PATH"},
 			},
@@ -160,10 +161,8 @@ func start(ctx context.Context, args shim.CLIArgs, serviceMode bool) (err error)
 		}
 	}()
 
-	if args.Runner.BinaryPath == "" {
-		if err := args.DownloadRunner(ctx); err != nil {
-			return err
-		}
+	if err := args.DownloadRunner(ctx); err != nil {
+		return err
 	}
 
 	log.Debug(ctx, "Shim", "args", args.Shim)

--- a/runner/consts/consts.go
+++ b/runner/consts/consts.go
@@ -9,6 +9,10 @@ const (
 	RunnerLogFileName        = "runner.log"
 )
 
+// 1. A fixed path inside the container
+// 2. A default path on the host unless overridden via shim CLI
+const RunnerBinaryPath = "/usr/local/bin/dstack-runner"
+
 // Error-containing messages will be identified by this signature
 const ExecutorFailedSignature = "Executor failed"
 

--- a/runner/internal/shim/docker.go
+++ b/runner/internal/shim/docker.go
@@ -1052,7 +1052,7 @@ func (c *CLIArgs) DockerShellCommands(publicKeys []string) []string {
 		concatinatedPublicKeys = strings.Join(publicKeys, "\n")
 	}
 	commands := getSSHShellCommands(c.Docker.SSHPort, concatinatedPublicKeys)
-	commands = append(commands, fmt.Sprintf("%s %s", DstackRunnerBinaryName, strings.Join(c.getRunnerArgs(), " ")))
+	commands = append(commands, fmt.Sprintf("%s %s", consts.RunnerBinaryPath, strings.Join(c.getRunnerArgs(), " ")))
 	return commands
 }
 
@@ -1066,7 +1066,7 @@ func (c *CLIArgs) DockerMounts(hostRunnerDir string) ([]mount.Mount, error) {
 		{
 			Type:   mount.TypeBind,
 			Source: c.Runner.BinaryPath,
-			Target: DstackRunnerBinaryName,
+			Target: consts.RunnerBinaryPath,
 		},
 	}, nil
 }

--- a/src/dstack/_internal/server/background/tasks/process_instances.py
+++ b/src/dstack/_internal/server/background/tasks/process_instances.py
@@ -17,6 +17,8 @@ from dstack._internal.core.backends import (
     BACKENDS_WITH_PLACEMENT_GROUPS_SUPPORT,
 )
 from dstack._internal.core.backends.base.compute import (
+    DSTACK_RUNNER_BINARY_PATH,
+    DSTACK_SHIM_BINARY_PATH,
     DSTACK_WORKING_DIR,
     get_shim_env,
     get_shim_pre_start_commands,
@@ -26,6 +28,7 @@ from dstack._internal.core.backends.remote.provisioning import (
     get_paramiko_connection,
     get_shim_healthcheck,
     host_info_to_instance_type,
+    remove_dstack_runner_if_exists,
     remove_host_info_if_exists,
     run_pre_start_commands,
     run_shim_as_systemd_service,
@@ -388,12 +391,14 @@ def _deploy_instance(
         upload_envs(client, DSTACK_WORKING_DIR, shim_envs)
         logger.debug("The dstack-shim environment variables have been installed")
 
-        # Ensure host info file does not exist
+        # Ensure we have fresh versions of host info.json and dstack-runner
         remove_host_info_if_exists(client, DSTACK_WORKING_DIR)
+        remove_dstack_runner_if_exists(client, DSTACK_RUNNER_BINARY_PATH)
 
         # Run dstack-shim as a systemd service
         run_shim_as_systemd_service(
             client=client,
+            binary_path=DSTACK_SHIM_BINARY_PATH,
             working_dir=DSTACK_WORKING_DIR,
             dev=settings.DSTACK_VERSION is None,
         )


### PR DESCRIPTION
* The default location of runner is /usr/local/bin/dstack-runner now, not a temp directory
* It's possible to override the location with `--runner-binary-path`
* If the runner already exists, shim does not download it again
* When provisioning an instance, server removes runner to ensure we have matching runner version

Fixes: https://github.com/dstackai/dstack/issues/2051