### PR TITLE
Support non-root Docker images in Vast.ai

### DIFF
--- a/examples/deployment/nim/README.md
+++ b/examples/deployment/nim/README.md
@@ -114,7 +114,7 @@ The source-code of this example can be found in
 [`examples/deployment/nim` :material-arrow-top-right-thin:{ .external }](https://github.com/dstackai/dstack/blob/master/examples/deployment/nim){:target="_blank"}.
 
 ??? warning "Limitations"
-    NIM isn't working yet with `runpod` and `vastai` backends. 
+    NIM doesn't work yet with the `runpod` backend. 
     Track the [issue :material-arrow-top-right-thin:{ .external }](https://github.com/dstackai/dstack/issues/1535){:target="_blank"} for progress.
 
 ## What's next?

--- a/src/dstack/_internal/core/backends/vastai/api_client.py
+++ b/src/dstack/_internal/core/backends/vastai/api_client.py
@@ -67,6 +67,7 @@ class VastAIAPIClient:
             "env": {
                 "-p 10022:10022": "1",
             },
+            "user": "root",
             "onstart": "/bin/sh",
             "args": ["-c", onstart],
             "runtype": "args",


### PR DESCRIPTION
Vast.ai recently added an option to override the
container user. This allows us to run
dstack-runner as root regardless of the Docker
image, thus supporting Docker images with a
non-root default user, such as NVIDIA NIM.

Related to #1535