### PR TITLE
Increase max active resources supported by server

### DIFF
--- a/runner/internal/runner/api/server.go
+++ b/runner/internal/runner/api/server.go
@@ -53,7 +53,7 @@ func NewServer(tempDir string, homeDir string, workingDir string, address string
 		pullDoneCh:   make(chan interface{}),
 		wsDoneCh:     make(chan interface{}),
 
-		submitWaitDuration: 2 * time.Minute,
+		submitWaitDuration: 5 * time.Minute,
 		logsWaitDuration:   30 * time.Second,
 
 		executor: ex,

--- a/src/dstack/_internal/server/app.py
+++ b/src/dstack/_internal/server/app.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib.resources
 import os
 import time
@@ -141,6 +142,9 @@ async def lifespan(app: FastAPI):
     scheduler.shutdown()
     await gateway_connections_pool.remove_all()
     await service_replica_connection_pool.remove_all()
+    await get_db().engine.dispose()
+    # Let checked-out DB connections close as dispose() only closes checked-in connections
+    await asyncio.sleep(3)
 
 
 _ON_STARTUP_HOOKS = []

--- a/src/dstack/_internal/server/background/__init__.py
+++ b/src/dstack/_internal/server/background/__init__.py
@@ -35,17 +35,48 @@ def start_background_tasks() -> AsyncIOScheduler:
     # In-memory locking via locksets does not guarantee
     # that the first waiting for the lock will acquire it.
     # The jitter is needed to give all tasks a chance to acquire locks.
+
+    # The batch_size and interval determine background tasks processing rates.
+    # Currently one server replica can handle:
+    # * 150 active jobs with up to 2 minutes processing latency
+    # * 150 active runs with up to 2 minutes processing latency
+    # * 150 active instances with up to 2 minutes processing latency
     _scheduler.add_job(collect_metrics, IntervalTrigger(seconds=10), max_instances=1)
     _scheduler.add_job(delete_metrics, IntervalTrigger(minutes=5), max_instances=1)
+    # process_submitted_jobs and process_instances processing rate is 75 jobs(instances) per minute.
+    # Currently limited by cloud rate limits such as AWS ListServiceQuotas requests.
+    # TODO: Fix unnecessary requests to clouds and increase this.
     _scheduler.add_job(
-        process_submitted_jobs, IntervalTrigger(seconds=4, jitter=2), max_instances=5
+        process_submitted_jobs,
+        IntervalTrigger(seconds=4, jitter=2),
+        kwargs={"batch_size": 5},
+        max_instances=5,
     )
-    _scheduler.add_job(process_running_jobs, IntervalTrigger(seconds=4, jitter=2), max_instances=5)
     _scheduler.add_job(
-        process_terminating_jobs, IntervalTrigger(seconds=4, jitter=2), max_instances=5
+        process_running_jobs,
+        IntervalTrigger(seconds=4, jitter=2),
+        kwargs={"batch_size": 5},
+        max_instances=5,
     )
-    _scheduler.add_job(process_instances, IntervalTrigger(seconds=4, jitter=2), max_instances=5)
-    _scheduler.add_job(process_runs, IntervalTrigger(seconds=2), max_instances=5)
+    _scheduler.add_job(
+        process_terminating_jobs,
+        IntervalTrigger(seconds=4, jitter=2),
+        kwargs={"batch_size": 5},
+        max_instances=5,
+    )
+    _scheduler.add_job(
+        process_runs,
+        IntervalTrigger(seconds=2, jitter=1),
+        kwargs={"batch_size": 5},
+        max_instances=5,
+    )
+    _scheduler.add_job(
+        process_instances,
+        IntervalTrigger(seconds=4, jitter=2),
+        kwargs={"batch_size": 5},
+        max_instances=5,
+    )
+    _scheduler.add_job(process_fleets, IntervalTrigger(seconds=10, jitter=2))
     _scheduler.add_job(process_gateways_connections, IntervalTrigger(seconds=15))
     _scheduler.add_job(
         process_submitted_gateways, IntervalTrigger(seconds=10, jitter=2), max_instances=5
@@ -53,7 +84,6 @@ def start_background_tasks() -> AsyncIOScheduler:
     _scheduler.add_job(
         process_submitted_volumes, IntervalTrigger(seconds=10, jitter=2), max_instances=5
     )
-    _scheduler.add_job(process_fleets, IntervalTrigger(seconds=15))
-    _scheduler.add_job(process_placement_groups, IntervalTrigger(seconds=30))
+    _scheduler.add_job(process_placement_groups, IntervalTrigger(seconds=30, jitter=5))
     _scheduler.start()
     return _scheduler

--- a/src/dstack/_internal/server/background/tasks/process_instances.py
+++ b/src/dstack/_internal/server/background/tasks/process_instances.py
@@ -106,7 +106,14 @@ PROVISIONING_TIMEOUT_SECONDS = 10 * 60  # 10 minutes in seconds
 logger = get_logger(__name__)
 
 
-async def process_instances() -> None:
+async def process_instances(batch_size: int = 1):
+    tasks = []
+    for _ in range(batch_size):
+        tasks.append(_process_next_instance())
+    await asyncio.gather(*tasks)
+
+
+async def _process_next_instance():
     lock, lockset = get_locker().get_lockset(InstanceModel.__tablename__)
     async with get_session_ctx() as session:
         async with lock:

--- a/src/dstack/_internal/server/background/tasks/process_running_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_running_jobs.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import timedelta
 from typing import Dict, List, Optional
 
@@ -54,7 +55,14 @@ from dstack._internal.utils.logging import get_logger
 logger = get_logger(__name__)
 
 
-async def process_running_jobs():
+async def process_running_jobs(batch_size: int = 1):
+    tasks = []
+    for _ in range(batch_size):
+        tasks.append(_process_next_running_job())
+    await asyncio.gather(*tasks)
+
+
+async def _process_next_running_job():
     lock, lockset = get_locker().get_lockset(JobModel.__tablename__)
     async with get_session_ctx() as session:
         async with lock:

--- a/src/dstack/_internal/server/background/tasks/process_runs.py
+++ b/src/dstack/_internal/server/background/tasks/process_runs.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 import itertools
 from typing import List, Optional, Set, Tuple
@@ -42,7 +43,14 @@ logger = get_logger(__name__)
 RETRY_DELAY = datetime.timedelta(seconds=15)
 
 
-async def process_runs():
+async def process_runs(batch_size: int = 1):
+    tasks = []
+    for _ in range(batch_size):
+        tasks.append(_process_next_run())
+    await asyncio.gather(*tasks)
+
+
+async def _process_next_run():
     run_lock, run_lockset = get_locker().get_lockset(RunModel.__tablename__)
     job_lock, job_lockset = get_locker().get_lockset(JobModel.__tablename__)
     async with get_session_ctx() as session:

--- a/src/dstack/_internal/server/background/tasks/process_runs.py
+++ b/src/dstack/_internal/server/background/tasks/process_runs.py
@@ -322,6 +322,8 @@ async def _process_active_run(session: AsyncSession, run_model: RunModel):
             # use replicas_info from before retrying
             replicas_diff = scaler.scale(replicas_info, stats)
             if replicas_diff != 0:
+                # FIXME: potentially long write transaction
+                # Why do we flush here?
                 await session.flush()
                 await session.refresh(run_model)
                 await scale_run_replicas(session, run_model, replicas_diff)

--- a/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
@@ -289,7 +289,6 @@ async def _process_submitted_job(session: AsyncSession, job_model: JobModel):
         )
         session.add(instance)
         session.add(fleet_model)
-        await session.flush()  # to get im.id
         job_model.used_instance_id = instance.id
 
     volumes_ids = sorted([v.id for vs in volume_models for v in vs])

--- a/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
@@ -204,7 +204,11 @@ async def _process_submitted_job(session: AsyncSession, job_model: JobModel):
         async with get_locker().lock_ctx(InstanceModel.__tablename__, instances_ids):
             # Refetch after lock
             res = await session.execute(
-                select(InstanceModel).where(InstanceModel.id.in_(instances_ids))
+                select(InstanceModel).where(
+                    InstanceModel.id.in_(instances_ids),
+                    InstanceModel.deleted == False,
+                    InstanceModel.job_id.is_(None),
+                )
             )
             pool_instances = list(res.scalars().all())
             instance = await _assign_job_to_pool_instance(

--- a/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
@@ -1,3 +1,4 @@
+import asyncio
 import uuid
 from typing import List, Optional, Tuple
 
@@ -74,7 +75,14 @@ from dstack._internal.utils.logging import get_logger
 logger = get_logger(__name__)
 
 
-async def process_submitted_jobs():
+async def process_submitted_jobs(batch_size: int = 1):
+    tasks = []
+    for _ in range(batch_size):
+        tasks.append(_process_next_submitted_job())
+    await asyncio.gather(*tasks)
+
+
+async def _process_next_submitted_job():
     lock, lockset = get_locker().get_lockset(JobModel.__tablename__)
     async with get_session_ctx() as session:
         async with lock:

--- a/src/dstack/_internal/server/db.py
+++ b/src/dstack/_internal/server/db.py
@@ -2,7 +2,7 @@ from contextlib import asynccontextmanager
 from typing import Optional
 
 from alembic import command, config
-from sqlalchemy import event
+from sqlalchemy import AsyncAdaptedQueuePool, event
 from sqlalchemy.engine.interfaces import DBAPIConnection
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
@@ -19,7 +19,11 @@ class Database:
         if engine is not None:
             self.engine = engine
         else:
-            self.engine = create_async_engine(self.url, echo=settings.SQL_ECHO_ENABLED)
+            self.engine = create_async_engine(
+                self.url,
+                echo=settings.SQL_ECHO_ENABLED,
+                poolclass=AsyncAdaptedQueuePool,
+            )
         self.session_maker = sessionmaker(
             bind=self.engine,
             expire_on_commit=False,
@@ -34,7 +38,7 @@ class Database:
                 cursor.execute("PRAGMA journal_mode=WAL;")
                 cursor.execute("PRAGMA foreign_keys=ON;")
                 cursor.execute("PRAGMA synchronous=NORMAL;")
-                cursor.execute("PRAGMA busy_timeout=10000;")
+                cursor.execute("PRAGMA busy_timeout=30000;")
                 cursor.close()
 
     @property

--- a/src/dstack/_internal/server/db.py
+++ b/src/dstack/_internal/server/db.py
@@ -33,6 +33,7 @@ class Database:
                 cursor = dbapi_connection.cursor()
                 cursor.execute("PRAGMA journal_mode=WAL;")
                 cursor.execute("PRAGMA foreign_keys=ON;")
+                cursor.execute("PRAGMA synchronous=NORMAL;")
                 cursor.execute("PRAGMA busy_timeout=10000;")
                 cursor.close()
 

--- a/src/dstack/_internal/server/services/backends/__init__.py
+++ b/src/dstack/_internal/server/services/backends/__init__.py
@@ -200,6 +200,7 @@ async def update_backend(
         raise ServerClientError("Backend does not exist")
     await run_async(configurator.get_config_values, config)
     backend = await run_async(configurator.create_backend, project=project, config=config)
+    # FIXME: potentially long write transaction
     await session.execute(
         update(BackendModel)
         .where(
@@ -244,6 +245,8 @@ async def delete_backends(
     deleted_backends_types = current_backends_types.intersection(backends_types)
     if len(deleted_backends_types) == 0:
         return
+    # FIXME: potentially long write transaction
+    # Not urgent since backend deletion is a rare operation
     await session.execute(
         delete(BackendModel).where(
             BackendModel.type.in_(deleted_backends_types),

--- a/src/dstack/_internal/server/services/locking.py
+++ b/src/dstack/_internal/server/services/locking.py
@@ -70,8 +70,12 @@ async def _wait_to_lock_many(
     left_to_lock = keys.copy()
     while len(left_to_lock) > 0:
         async with lock:
+            locked_now_num = 0
             for key in left_to_lock:
-                if key not in locked:
-                    locked.add(key)
-                    left_to_lock.remove(key)
+                if key in locked:
+                    # Someone already aquired the lock, wait
+                    break
+                locked.add(key)
+                locked_now_num += 1
+            left_to_lock = left_to_lock[locked_now_num:]
         await asyncio.sleep(delay)

--- a/src/dstack/_internal/server/services/pools.py
+++ b/src/dstack/_internal/server/services/pools.py
@@ -613,8 +613,22 @@ async def create_instance_model(
     termination_policy, termination_idle_time = get_termination(
         profile, DEFAULT_POOL_TERMINATION_IDLE_TIME
     )
+    instance_id = uuid.uuid4()
+    project_ssh_key = SSHKey(
+        public=project.ssh_public_key.strip(),
+        private=project.ssh_private_key.strip(),
+    )
+    instance_config = InstanceConfiguration(
+        project_name=project.name,
+        instance_name=instance_name,
+        user=user.name,
+        instance_id=str(instance_id),
+        ssh_keys=[project_ssh_key],
+        placement_group_name=placement_group_name,
+        reservation=reservation,
+    )
     instance = InstanceModel(
-        id=uuid.uuid4(),
+        id=instance_id,
         name=instance_name,
         instance_num=instance_num,
         project=project,
@@ -624,26 +638,11 @@ async def create_instance_model(
         unreachable=False,
         profile=profile.json(),
         requirements=requirements.json(),
-        instance_configuration=None,
+        instance_configuration=instance_config.json(),
         termination_policy=termination_policy,
         termination_idle_time=termination_idle_time,
     )
     session.add(instance)
-    await session.flush()
-    project_ssh_key = SSHKey(
-        public=project.ssh_public_key.strip(),
-        private=project.ssh_private_key.strip(),
-    )
-    instance_config = InstanceConfiguration(
-        project_name=project.name,
-        instance_name=instance_name,
-        user=user.name,
-        instance_id=str(instance.id),
-        ssh_keys=[project_ssh_key],
-        placement_group_name=placement_group_name,
-        reservation=reservation,
-    )
-    instance.instance_configuration = instance_config.json()
     return instance
 
 

--- a/src/dstack/_internal/server/services/projects.py
+++ b/src/dstack/_internal/server/services/projects.py
@@ -173,6 +173,8 @@ async def set_project_members(
         }
         if new_admins_members != current_admins_members:
             raise ForbiddenError("Access denied: changing project admins")
+    # FIXME: potentially long write transaction
+    # clear_project_members() issues DELETE without commit
     await clear_project_members(session=session, project=project)
     usernames = [m.username for m in members]
     res = await session.execute(select(UserModel).where(UserModel.name.in_(usernames)))

--- a/src/dstack/_internal/server/services/runs.py
+++ b/src/dstack/_internal/server/services/runs.py
@@ -401,6 +401,8 @@ async def apply_plan(
             raise ServerClientError(
                 "Failed to apply plan. Resource has been changed. Try again or use force apply."
             )
+    # FIXME: potentially long write transaction
+    # Avoid getting run_model after update
     await session.execute(
         update(RunModel)
         .where(RunModel.id == current_resource.id)


### PR DESCRIPTION
Closes #2183

This PR improves server performance and documents the new server limits:
* Adds batch processing to background tasks to support more active resources without increased processing latency. 
* Fixes some long write transactions. Some are left with comments since they happen rare and are not critical.
* Fixes a major bug with locking in _wait_to_lock_many().

The new limits is 150 run/jobs/instances. At that load, the server can process resources with <2minutes latency, which is tolerable. Increasing processing rate further leads to cloud rate limit errors (I hit AWS).