### PR TITLE
Implement offers cache

### DIFF
--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -60,6 +60,7 @@ class AWSVolumeBackendData(CoreModel):
 
 class AWSCompute(Compute):
     def __init__(self, config: AWSConfig):
+        super().__init__()
         self.config = config
         if is_core_model_instance(config.creds, AWSAccessKeyCreds):
             self.session = boto3.Session(

--- a/src/dstack/_internal/core/backends/cudo/compute.py
+++ b/src/dstack/_internal/core/backends/cudo/compute.py
@@ -27,6 +27,7 @@ logger = get_logger(__name__)
 
 class CudoCompute(Compute):
     def __init__(self, config: CudoConfig):
+        super().__init__()
         self.config = config
         self.api_client = CudoApiClient(config.creds.api_key)
 

--- a/src/dstack/_internal/core/backends/datacrunch/compute.py
+++ b/src/dstack/_internal/core/backends/datacrunch/compute.py
@@ -32,6 +32,7 @@ CONFIGURABLE_DISK_SIZE = Range[Memory](min=IMAGE_SIZE, max=None)
 
 class DataCrunchCompute(Compute):
     def __init__(self, config: DataCrunchConfig):
+        super().__init__()
         self.config = config
         self.api_client = DataCrunchAPIClient(config.creds.client_id, config.creds.client_secret)
 

--- a/src/dstack/_internal/core/backends/gcp/compute.py
+++ b/src/dstack/_internal/core/backends/gcp/compute.py
@@ -68,6 +68,7 @@ class GCPVolumeDiskBackendData(CoreModel):
 
 class GCPCompute(Compute):
     def __init__(self, config: GCPConfig):
+        super().__init__()
         self.config = config
         self.credentials, self.project_id = auth.authenticate(config.creds)
         self.instances_client = compute_v1.InstancesClient(credentials=self.credentials)

--- a/src/dstack/_internal/core/backends/kubernetes/compute.py
+++ b/src/dstack/_internal/core/backends/kubernetes/compute.py
@@ -54,6 +54,7 @@ NVIDIA_GPU_NAMES = NVIDIA_GPU_NAME_TO_GPU_INFO.keys()
 
 class KubernetesCompute(Compute):
     def __init__(self, config: KubernetesConfig):
+        super().__init__()
         self.config = config
         self.api = get_api_from_config_data(config.kubeconfig.data)
 

--- a/src/dstack/_internal/core/backends/lambdalabs/compute.py
+++ b/src/dstack/_internal/core/backends/lambdalabs/compute.py
@@ -26,6 +26,7 @@ from dstack._internal.core.models.volumes import Volume
 
 class LambdaCompute(Compute):
     def __init__(self, config: LambdaConfig):
+        super().__init__()
         self.config = config
         self.api_client = LambdaAPIClient(config.creds.api_key)
 

--- a/src/dstack/_internal/core/backends/nebius/compute.py
+++ b/src/dstack/_internal/core/backends/nebius/compute.py
@@ -35,6 +35,7 @@ CONFIGURABLE_DISK_SIZE = Range[Memory](min=Memory.parse("50GB"), max=Memory.pars
 
 class NebiusCompute(Compute):
     def __init__(self, config: NebiusConfig):
+        super().__init__()
         self.config = config
         self.api_client = NebiusAPIClient(json.loads(self.config.creds.data))
 

--- a/src/dstack/_internal/core/backends/oci/compute.py
+++ b/src/dstack/_internal/core/backends/oci/compute.py
@@ -43,6 +43,7 @@ CONFIGURABLE_DISK_SIZE = Range[Memory](min=Memory.parse("50GB"), max=Memory.pars
 
 class OCICompute(Compute):
     def __init__(self, config: OCIConfig):
+        super().__init__()
         self.config = config
         self.regions = make_region_clients_map(config.regions or [], config.creds)
 

--- a/src/dstack/_internal/core/backends/runpod/compute.py
+++ b/src/dstack/_internal/core/backends/runpod/compute.py
@@ -38,6 +38,7 @@ class RunpodCompute(Compute):
     _last_cleanup_time = None
 
     def __init__(self, config: RunpodConfig):
+        super().__init__()
         self.config = config
         self.api_client = RunpodApiClient(config.creds.api_key)
 

--- a/src/dstack/_internal/core/backends/tensordock/compute.py
+++ b/src/dstack/_internal/core/backends/tensordock/compute.py
@@ -25,6 +25,7 @@ logger = get_logger(__name__)
 
 class TensorDockCompute(Compute):
     def __init__(self, config: TensorDockConfig):
+        super().__init__()
         self.config = config
         self.api_client = TensorDockAPIClient(config.creds.api_key, config.creds.api_token)
 

--- a/src/dstack/_internal/core/backends/vastai/compute.py
+++ b/src/dstack/_internal/core/backends/vastai/compute.py
@@ -25,6 +25,7 @@ logger = get_logger(__name__)
 
 class VastAICompute(Compute):
     def __init__(self, config: VastAIConfig):
+        super().__init__()
         self.config = config
         self.api_client = VastAIAPIClient(config.creds.api_key)
         self.catalog = gpuhunt.Catalog(balance_resources=False, auto_reload=False)

--- a/src/dstack/_internal/core/backends/vultr/compute.py
+++ b/src/dstack/_internal/core/backends/vultr/compute.py
@@ -30,6 +30,7 @@ logger = get_logger(__name__)
 
 class VultrCompute(Compute):
     def __init__(self, config: VultrConfig):
+        super().__init__()
         self.config = config
         self.api_client = VultrApiClient(config.creds.api_key)
 

--- a/src/dstack/_internal/server/background/__init__.py
+++ b/src/dstack/_internal/server/background/__init__.py
@@ -43,38 +43,36 @@ def start_background_tasks() -> AsyncIOScheduler:
     # * 150 active instances with up to 2 minutes processing latency
     _scheduler.add_job(collect_metrics, IntervalTrigger(seconds=10), max_instances=1)
     _scheduler.add_job(delete_metrics, IntervalTrigger(minutes=5), max_instances=1)
-    # process_submitted_jobs and process_instances processing rate is 75 jobs(instances) per minute.
-    # Currently limited by cloud rate limits such as AWS ListServiceQuotas requests.
-    # TODO: Fix unnecessary requests to clouds and increase this.
+    # process_submitted_jobs and process_instances max processing rate is 75 jobs(instances) per minute.
     _scheduler.add_job(
         process_submitted_jobs,
         IntervalTrigger(seconds=4, jitter=2),
         kwargs={"batch_size": 5},
-        max_instances=5,
+        max_instances=2,
     )
     _scheduler.add_job(
         process_running_jobs,
         IntervalTrigger(seconds=4, jitter=2),
         kwargs={"batch_size": 5},
-        max_instances=5,
+        max_instances=2,
     )
     _scheduler.add_job(
         process_terminating_jobs,
         IntervalTrigger(seconds=4, jitter=2),
         kwargs={"batch_size": 5},
-        max_instances=5,
+        max_instances=2,
     )
     _scheduler.add_job(
         process_runs,
         IntervalTrigger(seconds=2, jitter=1),
         kwargs={"batch_size": 5},
-        max_instances=5,
+        max_instances=2,
     )
     _scheduler.add_job(
         process_instances,
         IntervalTrigger(seconds=4, jitter=2),
         kwargs={"batch_size": 5},
-        max_instances=5,
+        max_instances=2,
     )
     _scheduler.add_job(process_fleets, IntervalTrigger(seconds=10, jitter=2))
     _scheduler.add_job(process_gateways_connections, IntervalTrigger(seconds=15))

--- a/src/dstack/_internal/server/db.py
+++ b/src/dstack/_internal/server/db.py
@@ -23,6 +23,8 @@ class Database:
                 self.url,
                 echo=settings.SQL_ECHO_ENABLED,
                 poolclass=AsyncAdaptedQueuePool,
+                pool_size=settings.DB_POOL_SIZE,
+                max_overflow=settings.DB_MAX_OVERFLOW,
             )
         self.session_maker = sessionmaker(
             bind=self.engine,

--- a/src/dstack/_internal/server/services/backends/__init__.py
+++ b/src/dstack/_internal/server/services/backends/__init__.py
@@ -421,7 +421,7 @@ async def get_instance_offers(
     Returns list of instances satisfying minimal resource requirements sorted by price
     """
     logger.info("Requesting instance offers from backends: %s", [b.TYPE.value for b in backends])
-    tasks = [run_async(backend.compute().get_offers, requirements) for backend in backends]
+    tasks = [run_async(backend.compute().get_offers_cached, requirements) for backend in backends]
     offers_by_backend = []
     for backend, result in zip(backends, await asyncio.gather(*tasks, return_exceptions=True)):
         if isinstance(result, BackendError):

--- a/src/dstack/_internal/server/settings.py
+++ b/src/dstack/_internal/server/settings.py
@@ -26,6 +26,10 @@ LOG_FORMAT = os.getenv("DSTACK_SERVER_LOG_FORMAT", "rich").lower()
 ALEMBIC_MIGRATIONS_LOCATION = os.getenv(
     "DSTACK_ALEMBIC_MIGRATIONS_LOCATION", "dstack._internal.server:migrations"
 )
+# Users may want to increase pool size to support more concurrent resources
+# if their db supports many connections
+DB_POOL_SIZE = int(os.getenv("DSTACK_DB_POOL_SIZE", 10))
+DB_MAX_OVERFLOW = int(os.getenv("DSTACK_DB_MAX_OVERFLOW", 10))
 
 SERVER_CONFIG_DISABLED = os.getenv("DSTACK_SERVER_CONFIG_DISABLED") is not None
 SERVER_CONFIG_ENABLED = not SERVER_CONFIG_DISABLED

--- a/src/tests/_internal/server/background/tasks/test_process_instances.py
+++ b/src/tests/_internal/server/background/tasks/test_process_instances.py
@@ -492,7 +492,7 @@ class TestCreateInstance:
 
             backend_mock = Mock()
             backend_mock.TYPE = BackendType.AWS
-            backend_mock.compute.return_value.get_offers.return_value = [offer]
+            backend_mock.compute.return_value.get_offers_cached.return_value = [offer]
             backend_mock.compute.return_value.create_instance.return_value = JobProvisioningData(
                 backend=offer.backend,
                 instance_type=offer.instance,

--- a/src/tests/_internal/server/background/tasks/test_process_submitted_jobs.py
+++ b/src/tests/_internal/server/background/tasks/test_process_submitted_jobs.py
@@ -126,7 +126,7 @@ class TestProcessSubmittedJobs:
             backend_mock = Mock()
             m.return_value = [backend_mock]
             backend_mock.TYPE = backend
-            backend_mock.compute.return_value.get_offers.return_value = [offer]
+            backend_mock.compute.return_value.get_offers_cached.return_value = [offer]
             backend_mock.compute.return_value.run_job.return_value = JobProvisioningData(
                 backend=offer.backend,
                 instance_type=offer.instance,
@@ -143,7 +143,7 @@ class TestProcessSubmittedJobs:
             )
             await process_submitted_jobs()
             m.assert_called_once()
-            backend_mock.compute.return_value.get_offers.assert_called_once()
+            backend_mock.compute.return_value.get_offers_cached.assert_called_once()
             backend_mock.compute.return_value.run_job.assert_called_once()
 
         await session.refresh(job)
@@ -199,7 +199,7 @@ class TestProcessSubmittedJobs:
             backend_mock = Mock()
             m.return_value = [backend_mock]
             backend_mock.TYPE = BackendType.RUNPOD
-            backend_mock.compute.return_value.get_offers.return_value = [offer]
+            backend_mock.compute.return_value.get_offers_cached.return_value = [offer]
             backend_mock.compute.return_value.run_job.return_value = JobProvisioningData(
                 backend=offer.backend,
                 instance_type=offer.instance,
@@ -218,7 +218,7 @@ class TestProcessSubmittedJobs:
                 datetime_mock.return_value = datetime(2023, 1, 2, 3, 30, 0, tzinfo=timezone.utc)
                 await process_submitted_jobs()
             m.assert_called_once()
-            backend_mock.compute.return_value.get_offers.assert_not_called()
+            backend_mock.compute.return_value.get_offers_cached.assert_not_called()
             backend_mock.compute.return_value.run_job.assert_not_called()
 
         await session.refresh(job)
@@ -272,7 +272,7 @@ class TestProcessSubmittedJobs:
             backend_mock = Mock()
             m.return_value = [backend_mock]
             backend_mock.TYPE = BackendType.RUNPOD
-            backend_mock.compute.return_value.get_offers.return_value = [offer]
+            backend_mock.compute.return_value.get_offers_cached.return_value = [offer]
             backend_mock.compute.return_value.run_job.return_value = JobProvisioningData(
                 backend=offer.backend,
                 instance_type=offer.instance,
@@ -291,7 +291,7 @@ class TestProcessSubmittedJobs:
                 datetime_mock.return_value = datetime(2023, 1, 2, 3, 30, 0, tzinfo=timezone.utc)
                 await process_submitted_jobs()
             m.assert_called_once()
-            backend_mock.compute.return_value.get_offers.assert_not_called()
+            backend_mock.compute.return_value.get_offers_cached.assert_not_called()
             backend_mock.compute.return_value.run_job.assert_not_called()
 
         await session.refresh(job)
@@ -494,7 +494,7 @@ class TestProcessSubmittedJobs:
             backend_mock = Mock()
             m.return_value = [backend_mock]
             backend_mock.TYPE = BackendType.AWS
-            backend_mock.compute.return_value.get_offers.return_value = [offer]
+            backend_mock.compute.return_value.get_offers_cached.return_value = [offer]
             backend_mock.compute.return_value.run_job.return_value = JobProvisioningData(
                 backend=offer.backend,
                 instance_type=offer.instance,
@@ -511,7 +511,7 @@ class TestProcessSubmittedJobs:
             )
             await process_submitted_jobs()
             m.assert_called_once()
-            backend_mock.compute.return_value.get_offers.assert_called_once()
+            backend_mock.compute.return_value.get_offers_cached.assert_called_once()
             backend_mock.compute.return_value.run_job.assert_called_once()
 
         await session.refresh(job)

--- a/src/tests/_internal/server/routers/test_fleets.py
+++ b/src/tests/_internal/server/routers/test_fleets.py
@@ -773,13 +773,13 @@ class TestGetPlan:
             backend_mock = Mock()
             m.return_value = [backend_mock]
             backend_mock.TYPE = BackendType.AWS
-            backend_mock.compute.return_value.get_offers.return_value = offers
+            backend_mock.compute.return_value.get_offers_cached.return_value = offers
             response = await client.post(
                 f"/api/project/{project.name}/fleets/get_plan",
                 headers=get_auth_headers(user.token),
                 json={"spec": spec.dict()},
             )
-            backend_mock.compute.return_value.get_offers.assert_called_once()
+            backend_mock.compute.return_value.get_offers_cached.assert_called_once()
 
         assert response.status_code == 200
         assert response.json() == {

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -725,10 +725,12 @@ class TestGetRunPlan:
         with patch("dstack._internal.server.services.backends.get_project_backends") as m:
             backend_mock_aws = Mock()
             backend_mock_aws.TYPE = BackendType.AWS
-            backend_mock_aws.compute.return_value.get_offers.return_value = [offer_aws]
+            backend_mock_aws.compute.return_value.get_offers_cached.return_value = [offer_aws]
             backend_mock_runpod = Mock()
             backend_mock_runpod.TYPE = BackendType.RUNPOD
-            backend_mock_runpod.compute.return_value.get_offers.return_value = [offer_runpod]
+            backend_mock_runpod.compute.return_value.get_offers_cached.return_value = [
+                offer_runpod
+            ]
             m.return_value = [backend_mock_aws, backend_mock_runpod]
             response = await client.post(
                 f"/api/project/{project.name}/runs/get_plan",
@@ -785,10 +787,12 @@ class TestGetRunPlan:
         with patch("dstack._internal.server.services.backends.get_project_backends") as m:
             backend_mock_aws = Mock()
             backend_mock_aws.TYPE = BackendType.AWS
-            backend_mock_aws.compute.return_value.get_offers.return_value = [offer_aws]
+            backend_mock_aws.compute.return_value.get_offers_cached.return_value = [offer_aws]
             backend_mock_runpod = Mock()
             backend_mock_runpod.TYPE = BackendType.RUNPOD
-            backend_mock_runpod.compute.return_value.get_offers.return_value = [offer_runpod]
+            backend_mock_runpod.compute.return_value.get_offers_cached.return_value = [
+                offer_runpod
+            ]
             m.return_value = [backend_mock_aws, backend_mock_runpod]
             response = await client.post(
                 f"/api/project/{project.name}/runs/get_plan",
@@ -845,10 +849,12 @@ class TestGetRunPlan:
         with patch("dstack._internal.server.services.backends.get_project_backends") as m:
             backend_mock_aws = Mock()
             backend_mock_aws.TYPE = BackendType.AWS
-            backend_mock_aws.compute.return_value.get_offers.return_value = [offer_aws]
+            backend_mock_aws.compute.return_value.get_offers_cached.return_value = [offer_aws]
             backend_mock_runpod = Mock()
             backend_mock_runpod.TYPE = BackendType.RUNPOD
-            backend_mock_runpod.compute.return_value.get_offers.return_value = [offer_runpod]
+            backend_mock_runpod.compute.return_value.get_offers_cached.return_value = [
+                offer_runpod
+            ]
             m.return_value = [backend_mock_aws, backend_mock_runpod]
             response = await client.post(
                 f"/api/project/{project.name}/runs/get_plan",
@@ -1476,7 +1482,7 @@ class TestCreateInstance:
                 availability=InstanceAvailability.AVAILABLE,
             )
             backend = Mock()
-            backend.compute.return_value.get_offers.return_value = [offer]
+            backend.compute.return_value.get_offers_cached.return_value = [offer]
             backend.compute.return_value.create_instance.return_value = JobProvisioningData(
                 backend=offer.backend,
                 instance_type=offer.instance,
@@ -1548,7 +1554,7 @@ class TestCreateInstance:
             )
             backend = Mock()
             backend.TYPE = BackendType.AZURE
-            backend.compute.return_value.get_offers.return_value = [offer]
+            backend.compute.return_value.get_offers_cached.return_value = [offer]
             backend.compute.return_value.create_instance.side_effect = NotImplementedError()
             run_plan_by_req.return_value = [(backend, offer)]
             response = await client.post(
@@ -1590,7 +1596,7 @@ class TestCreateInstance:
 
             backend = Mock()
             backend.TYPE = BackendType.VASTAI
-            backend.compute.return_value.get_offers.return_value = [offers]
+            backend.compute.return_value.get_offers_cached.return_value = [offers]
             backend.compute.return_value.create_instance.side_effect = NotImplementedError()
             run_plan_by_req.return_value = [(backend, offers)]
 


### PR DESCRIPTION
Closes #2195 

The PR implements a simple TTL 30s cache for Compute.get_offers().

Some other improvements:
* AzureCompute.get_offers() is optimized to get quotas for different regions in parallel – reduced get_offers time for all regions/offers from ~30s to ~8s.
* SQLalchemy pool_size and max_overflow are made configurable with bigger default (10 vs 5). max_instances for background tasks is reduced to 2. This is all to prevent a possible SQLalchemy's queue limit overflow – I got it when provisioning > 30 instances at once – process_instances tasks held all the db connections for too long since it's slow when provisioning.