### PR TITLE
[Internal] Fix `python-json-logger` deprecation warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ SERVER_DEPS = GATEWAY_AND_SERVER_COMMON_DEPS + [
     "alembic-postgresql-enum",
     "asyncpg",
     "cachetools",
-    "python-json-logger",
+    "python-json-logger>=3.1.0",
     "grpcio>=1.50",  # indirect
 ]
 

--- a/src/dstack/_internal/server/utils/logging.py
+++ b/src/dstack/_internal/server/utils/logging.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import sys
 
-from pythonjsonlogger import jsonlogger
+from pythonjsonlogger.json import JsonFormatter
 
 from dstack._internal.cli.utils.common import console
 from dstack._internal.cli.utils.rich import DstackRichHandler
@@ -25,7 +25,7 @@ def configure_logging():
             fmt="%(levelname)s %(asctime)s.%(msecs)03d %(name)s %(message)s",
             datefmt="%Y-%m-%dT%H:%M:%S",
         ),
-        "json": jsonlogger.JsonFormatter(
+        "json": JsonFormatter(
             "%(asctime)s %(name)s %(levelname)s %(message)s",
             json_ensure_ascii=False,
             rename_fields={"name": "logger", "asctime": "timestamp", "levelname": "level"},


### PR DESCRIPTION
Fixes this warning when running `pytest`:
```
  /opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/site-packages/pythonjsonlogger/jsonlogger.py:11: DeprecationWarning: pythonjsonlogger.jsonlogger has been moved to pythonjsonlogger.json
```