### PR TITLE
Return repo errors from runner

### DIFF
--- a/runner/internal/executor/executor.go
+++ b/runner/internal/executor/executor.go
@@ -115,7 +115,12 @@ func (ex *RunExecutor) Run(ctx context.Context) (err error) {
 	log.Info(ctx, "Run job", "log_level", log.GetLogger(ctx).Logger.Level.String())
 
 	if err := ex.setupRepo(ctx); err != nil {
-		ex.SetJobState(ctx, types.JobStateFailed)
+		ex.SetJobStateWithTerminationReason(
+			ctx,
+			types.JobStateFailed,
+			types.TerminationReasonContainerExitedWithError,
+			fmt.Sprintf("Failed to set up the repo (%s)", err),
+		)
 		return gerrors.Wrap(err)
 	}
 	cleanupCredentials, err := ex.setupCredentials(ctx)


### PR DESCRIPTION
Closes #2033 

The PR propagates runner repo errors to the server. For example, the CLI now shows the following error if the git credentials expire:

```
...
foolish-kangaroo-1 provisioning completed (running)
Run failed with error code CONTAINER_EXITED_WITH_ERROR.
Error: Failed to set up the repo (  authorization failed)
Check CLI, server, and run logs for more details.
```