### PR TITLE
Fix caching offers with GPU requirements

### DIFF
--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -1,4 +1,3 @@
-import json
 import os
 import re
 import threading
@@ -188,7 +187,7 @@ class Compute(ABC):
         # Requirements is not hashable, so we use a hack to get arguments hash
         if requirements is None:
             return hash(None)
-        return hash(json.dumps(requirements.dict(), sort_keys=True))
+        return hash(requirements.json())
 
     @cachedmethod(
         cache=lambda self: self._offers_cache,


### PR DESCRIPTION
Use `Requirements.json` instead of`Requirements.dict`+`json.dumps`, which fails on enums.

Also remove `sort_keys=True`, which seems to be redundant.

> field order is preserved by .dict() and .json() etc.
https://docs.pydantic.dev/1.10/usage/models/#field-ordering

Fixes #2208