### PR TITLE
Support models with non-standard `finish_reason`

### DIFF
--- a/src/dstack/_internal/proxy/lib/schemas/model_proxy.py
+++ b/src/dstack/_internal/proxy/lib/schemas/model_proxy.py
@@ -2,8 +2,6 @@ from typing import Any, Dict, List, Literal, Optional, Union
 
 from dstack._internal.core.models.common import CoreModel
 
-FinishReason = Literal["stop", "length", "tool_calls", "eos_token"]
-
 
 class ChatMessage(CoreModel):
     role: str  # TODO(egor-s) types
@@ -30,7 +28,7 @@ class ChatCompletionsRequest(CoreModel):
 
 
 class ChatCompletionsChoice(CoreModel):
-    finish_reason: FinishReason
+    finish_reason: str
     index: int
     message: ChatMessage
 
@@ -38,7 +36,7 @@ class ChatCompletionsChoice(CoreModel):
 class ChatCompletionsChunkChoice(CoreModel):
     delta: object
     logprobs: object = {}
-    finish_reason: Optional[FinishReason]
+    finish_reason: Optional[str]
     index: int
 
 

--- a/src/dstack/_internal/proxy/lib/services/model_proxy/clients/tgi.py
+++ b/src/dstack/_internal/proxy/lib/services/model_proxy/clients/tgi.py
@@ -17,7 +17,6 @@ from dstack._internal.proxy.lib.schemas.model_proxy import (
     ChatCompletionsResponse,
     ChatCompletionsUsage,
     ChatMessage,
-    FinishReason,
 )
 from dstack._internal.proxy.lib.services.model_proxy.clients.base import ChatCompletionsClient
 
@@ -180,7 +179,7 @@ class TGIChatCompletions(ChatCompletionsClient):
         }
 
     @staticmethod
-    def finish_reason(reason: str) -> FinishReason:
+    def finish_reason(reason: str) -> str:
         if reason == "stop_sequence" or reason == "eos_token":
             return "stop"
         if reason == "length":


### PR DESCRIPTION
Some model launchers (TGI, sglang) may return
non-standard `finish_reason` values, such as
`"eos_token"` or `""`. This commit removes the
strict parsing of `finish_reason` so that the
OpenAI-compatible endpoint does not fail for these model launchers.

Fixes #2228