### PR TITLE
[chore]: Move connection pool to proxy deps

### DIFF
--- a/src/dstack/_internal/proxy/gateway/deps.py
+++ b/src/dstack/_internal/proxy/gateway/deps.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, AsyncGenerator
 
 from fastapi import Depends, FastAPI, Request
 
@@ -23,9 +23,17 @@ class GatewayDependencyInjector(ProxyDependencyInjector):
         nginx: Nginx,
         stats_collector: StatsCollector,
     ) -> None:
-        super().__init__(repo=repo, auth=auth)
+        super().__init__()
+        self._repo = repo
+        self._auth = auth
         self._nginx = nginx
         self._stats_collector = stats_collector
+
+    async def get_repo(self) -> AsyncGenerator[BaseProxyRepo, None]:
+        yield self._repo
+
+    async def get_auth_provider(self) -> AsyncGenerator[BaseProxyAuthProvider, None]:
+        yield self._auth
 
     def get_nginx(self) -> Nginx:
         return self._nginx

--- a/src/dstack/_internal/proxy/gateway/routers/registry.py
+++ b/src/dstack/_internal/proxy/gateway/routers/registry.py
@@ -11,6 +11,8 @@ from dstack._internal.proxy.gateway.schemas.registry import (
     RegisterServiceRequest,
 )
 from dstack._internal.proxy.gateway.services.nginx import Nginx
+from dstack._internal.proxy.lib.deps import get_service_connection_pool
+from dstack._internal.proxy.lib.services.service_connection import ServiceConnectionPool
 
 router = APIRouter(prefix="/{project_name}")
 
@@ -21,6 +23,7 @@ async def register_service(
     body: RegisterServiceRequest,
     repo: Annotated[GatewayProxyRepo, Depends(get_gateway_proxy_repo)],
     nginx: Annotated[Nginx, Depends(get_nginx)],
+    service_conn_pool: Annotated[ServiceConnectionPool, Depends(get_service_connection_pool)],
 ) -> OkResponse:
     await registry_services.register_service(
         project_name=project_name.lower(),
@@ -33,6 +36,7 @@ async def register_service(
         ssh_private_key=body.ssh_private_key,
         repo=repo,
         nginx=nginx,
+        service_conn_pool=service_conn_pool,
     )
     return OkResponse()
 
@@ -43,12 +47,14 @@ async def unregister_service(
     run_name: str,
     repo: Annotated[GatewayProxyRepo, Depends(get_gateway_proxy_repo)],
     nginx: Annotated[Nginx, Depends(get_nginx)],
+    service_conn_pool: Annotated[ServiceConnectionPool, Depends(get_service_connection_pool)],
 ) -> OkResponse:
     await registry_services.unregister_service(
         project_name=project_name.lower(),
         run_name=run_name.lower(),
         repo=repo,
         nginx=nginx,
+        service_conn_pool=service_conn_pool,
     )
     return OkResponse()
 
@@ -60,6 +66,7 @@ async def register_replica(
     body: RegisterReplicaRequest,
     repo: Annotated[GatewayProxyRepo, Depends(get_gateway_proxy_repo)],
     nginx: Annotated[Nginx, Depends(get_nginx)],
+    service_conn_pool: Annotated[ServiceConnectionPool, Depends(get_service_connection_pool)],
 ) -> OkResponse:
     await registry_services.register_replica(
         project_name=project_name.lower(),
@@ -71,6 +78,7 @@ async def register_replica(
         ssh_proxy=body.ssh_proxy,
         repo=repo,
         nginx=nginx,
+        service_conn_pool=service_conn_pool,
     )
     return OkResponse()
 
@@ -82,6 +90,7 @@ async def unregister_replica(
     job_id: str,
     repo: Annotated[GatewayProxyRepo, Depends(get_gateway_proxy_repo)],
     nginx: Annotated[Nginx, Depends(get_nginx)],
+    service_conn_pool: Annotated[ServiceConnectionPool, Depends(get_service_connection_pool)],
 ) -> OkResponse:
     await registry_services.unregister_replica(
         project_name=project_name.lower(),
@@ -89,6 +98,7 @@ async def unregister_replica(
         replica_id=job_id,
         repo=repo,
         nginx=nginx,
+        service_conn_pool=service_conn_pool,
     )
     return OkResponse()
 

--- a/src/dstack/_internal/proxy/lib/testing/common.py
+++ b/src/dstack/_internal/proxy/lib/testing/common.py
@@ -1,6 +1,22 @@
-from typing import Optional
+from typing import AsyncGenerator, Optional
 
+from dstack._internal.proxy.lib.auth import BaseProxyAuthProvider
+from dstack._internal.proxy.lib.deps import ProxyDependencyInjector
 from dstack._internal.proxy.lib.models import Project, Replica, Service
+from dstack._internal.proxy.lib.repo import BaseProxyRepo
+
+
+class ProxyTestDependencyInjector(ProxyDependencyInjector):
+    def __init__(self, repo: BaseProxyRepo, auth: BaseProxyAuthProvider) -> None:
+        super().__init__()
+        self._repo = repo
+        self._auth = auth
+
+    async def get_repo(self) -> AsyncGenerator[BaseProxyRepo, None]:
+        yield self._repo
+
+    async def get_auth_provider(self) -> AsyncGenerator[BaseProxyAuthProvider, None]:
+        yield self._auth
 
 
 def make_project(name: str) -> Project:

--- a/src/dstack/_internal/server/app.py
+++ b/src/dstack/_internal/server/app.py
@@ -15,8 +15,8 @@ from fastapi.staticfiles import StaticFiles
 from dstack._internal.cli.utils.common import console
 from dstack._internal.core.errors import ForbiddenError, ServerClientError
 from dstack._internal.core.services.configs import update_default_project
+from dstack._internal.proxy.lib.deps import get_injector_from_app
 from dstack._internal.proxy.lib.routers import model_proxy
-from dstack._internal.proxy.lib.services.service_connection import service_replica_connection_pool
 from dstack._internal.server import settings
 from dstack._internal.server.background import start_background_tasks
 from dstack._internal.server.db import get_db, get_session_ctx, migrate
@@ -142,7 +142,8 @@ async def lifespan(app: FastAPI):
     yield
     scheduler.shutdown()
     await gateway_connections_pool.remove_all()
-    await service_replica_connection_pool.remove_all()
+    service_conn_pool = await get_injector_from_app(app).get_service_connection_pool()
+    await service_conn_pool.remove_all()
     await get_db().engine.dispose()
     # Let checked-out DB connections close as dispose() only closes checked-in connections
     await asyncio.sleep(3)

--- a/src/dstack/_internal/server/services/proxy/deps.py
+++ b/src/dstack/_internal/server/services/proxy/deps.py
@@ -9,9 +9,6 @@ from dstack._internal.server.services.proxy.repo import ServerProxyRepo
 
 
 class ServerProxyDependencyInjector(ProxyDependencyInjector):
-    def __init__(self) -> None:
-        pass
-
     async def get_repo(self) -> AsyncGenerator[BaseProxyRepo, None]:
         async with get_session_ctx() as session:
             yield ServerProxyRepo(session)

--- a/src/dstack/_internal/server/services/proxy/routers/service_proxy.py
+++ b/src/dstack/_internal/server/services/proxy/routers/service_proxy.py
@@ -3,8 +3,14 @@ from fastapi.datastructures import URL
 from fastapi.responses import RedirectResponse, Response
 from typing_extensions import Annotated
 
-from dstack._internal.proxy.lib.deps import ProxyAuth, ProxyAuthContext, get_proxy_repo
+from dstack._internal.proxy.lib.deps import (
+    ProxyAuth,
+    ProxyAuthContext,
+    get_proxy_repo,
+    get_service_connection_pool,
+)
 from dstack._internal.proxy.lib.repo import BaseProxyRepo
+from dstack._internal.proxy.lib.services.service_connection import ServiceConnectionPool
 from dstack._internal.server.services.proxy.services import service_proxy
 
 REDIRECTED_HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"]
@@ -29,8 +35,11 @@ async def service_reverse_proxy(
     request: Request,
     auth: Annotated[ProxyAuthContext, Depends(ProxyAuth(auto_enforce=False))],
     repo: Annotated[BaseProxyRepo, Depends(get_proxy_repo)],
+    service_conn_pool: Annotated[ServiceConnectionPool, Depends(get_service_connection_pool)],
 ) -> Response:
-    return await service_proxy.proxy(project_name, run_name, path, request, auth, repo)
+    return await service_proxy.proxy(
+        project_name, run_name, path, request, auth, repo, service_conn_pool
+    )
 
 
 # TODO(#1595): support websockets

--- a/src/dstack/_internal/server/services/proxy/services/service_proxy.py
+++ b/src/dstack/_internal/server/services/proxy/services/service_proxy.py
@@ -8,7 +8,10 @@ from starlette.requests import ClientDisconnect
 from dstack._internal.proxy.lib.deps import ProxyAuthContext
 from dstack._internal.proxy.lib.errors import ProxyError
 from dstack._internal.proxy.lib.repo import BaseProxyRepo
-from dstack._internal.proxy.lib.services.service_connection import get_service_replica_client
+from dstack._internal.proxy.lib.services.service_connection import (
+    ServiceConnectionPool,
+    get_service_replica_client,
+)
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -21,6 +24,7 @@ async def proxy(
     request: fastapi.Request,
     auth: ProxyAuthContext,
     repo: BaseProxyRepo,
+    service_conn_pool: ServiceConnectionPool,
 ) -> fastapi.responses.Response:
     # TODO(#1595): enforce client_max_body_size
 
@@ -33,7 +37,7 @@ async def proxy(
     if service.auth:
         await auth.enforce()
 
-    client = await get_service_replica_client(service, repo)
+    client = await get_service_replica_client(service, repo, service_conn_pool)
 
     try:
         upstream_request = await build_upstream_request(request, path, client)

--- a/src/tests/_internal/proxy/gateway/conftest.py
+++ b/src/tests/_internal/proxy/gateway/conftest.py
@@ -14,8 +14,8 @@ def system_mocks() -> Generator[Mocks, None, None]:
         patch(f"{nginx}.sudo") as sudo,
         patch(f"{nginx}.Nginx.reload") as reload_nginx,
         patch(f"{nginx}.Nginx.run_certbot") as run_certbot,
-        patch(f"{connection}.ServiceReplicaConnection.open") as open_conn,
-        patch(f"{connection}.ServiceReplicaConnection.close") as close_conn,
+        patch(f"{connection}.ServiceConnection.open") as open_conn,
+        patch(f"{connection}.ServiceConnection.close") as close_conn,
     ):
         sudo.return_value = []
         yield Mocks(

--- a/src/tests/_internal/proxy/lib/routers/test_model_proxy.py
+++ b/src/tests/_internal/proxy/lib/routers/test_model_proxy.py
@@ -9,7 +9,6 @@ from fastapi import FastAPI
 
 from dstack._internal.proxy.gateway.repo.repo import GatewayProxyRepo
 from dstack._internal.proxy.lib.auth import BaseProxyAuthProvider
-from dstack._internal.proxy.lib.deps import ProxyDependencyInjector
 from dstack._internal.proxy.lib.models import ChatModel, OpenAIChatModelFormat
 from dstack._internal.proxy.lib.repo import BaseProxyRepo
 from dstack._internal.proxy.lib.routers.model_proxy import router
@@ -24,7 +23,11 @@ from dstack._internal.proxy.lib.schemas.model_proxy import (
 )
 from dstack._internal.proxy.lib.services.model_proxy.clients.base import ChatCompletionsClient
 from dstack._internal.proxy.lib.testing.auth import ProxyTestAuthProvider
-from dstack._internal.proxy.lib.testing.common import make_project, make_service
+from dstack._internal.proxy.lib.testing.common import (
+    ProxyTestDependencyInjector,
+    make_project,
+    make_service,
+)
 
 SAMPLE_RESPONSE = "Hello there, how may I assist you today?"
 
@@ -87,7 +90,7 @@ def make_model(
 
 def make_http_client(repo: BaseProxyRepo, auth: BaseProxyAuthProvider) -> httpx.AsyncClient:
     app = FastAPI()
-    app.state.proxy_dependency_injector = ProxyDependencyInjector(repo=repo, auth=auth)
+    app.state.proxy_dependency_injector = ProxyTestDependencyInjector(repo=repo, auth=auth)
     app.include_router(router, prefix="/proxy/models")
     return httpx.AsyncClient(transport=httpx.ASGITransport(app=app))
 
@@ -110,7 +113,7 @@ def make_openai_client(
 def mock_chat_client() -> Generator[None, None, None]:
     with (
         patch(
-            "dstack._internal.proxy.lib.services.service_connection.ServiceReplicaConnectionPool.get_or_add"
+            "dstack._internal.proxy.lib.services.service_connection.ServiceConnectionPool.get_or_add"
         ),
         patch("dstack._internal.proxy.lib.routers.model_proxy.get_chat_client") as get_client_mock,
     ):


### PR DESCRIPTION
This ensures that the lifetime of the connection
pool is bound to that of the gateway/server app,
and different unit tests don't use the same
connection pool.

Part of #1595