### PR TITLE
Extend request/response logging

### DIFF
--- a/src/dstack/_internal/server/app.py
+++ b/src/dstack/_internal/server/app.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Awaitable, Callable, List
 
 import sentry_sdk
-from fastapi import FastAPI, Request, status
+from fastapi import FastAPI, Request, Response, status
 from fastapi.datastructures import URL
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
@@ -215,10 +215,14 @@ def register_routes(app: FastAPI, ui: bool = True):
     @app.middleware("http")
     async def log_request(request: Request, call_next):
         start_time = time.time()
-        response = await call_next(request)
+        response: Response = await call_next(request)
         process_time = time.time() - start_time
         logger.debug(
-            "Processed request %s %s in %s", request.method, request.url, f"{process_time:0.6f}s"
+            "Processed request %s %s in %s. Status: %s",
+            request.method,
+            request.url,
+            f"{process_time:0.6f}s",
+            response.status_code,
         )
         return response
 


### PR DESCRIPTION
Server:
- Log response status codes in debug logs.

CLI:
- Log response headers and bodies for any failed requests in debug logs.
- Show more human-readable errors on 403 responses. Such responses are expected after rotating tokens or switching servers.
- Show more detailed errors on unexpected responses.