### PR TITLE
Support --name for all configurations

### DIFF
--- a/src/dstack/_internal/cli/commands/apply.py
+++ b/src/dstack/_internal/cli/commands/apply.py
@@ -6,12 +6,12 @@ from dstack._internal.cli.services.configurators import (
     get_apply_configurator_class,
     load_apply_configuration,
 )
-from dstack._internal.cli.services.configurators.base import BaseApplyConfigurator
 from dstack._internal.cli.services.repos import (
     init_default_virtual_repo,
     init_repo,
     register_init_repo_args,
 )
+from dstack._internal.cli.utils.common import console
 from dstack._internal.core.errors import CLIError
 from dstack._internal.core.models.configurations import ApplyConfigurationType
 
@@ -92,10 +92,13 @@ class ApplyCommand(APIBaseCommand):
                     configurator_class = get_apply_configurator_class(
                         ApplyConfigurationType(args.help)
                     )
-                else:
-                    configurator_class = BaseApplyConfigurator
-                configurator_class.register_args(self._parser)
+                    configurator_class.register_args(self._parser)
+                    self._parser.print_help()
+                    return
                 self._parser.print_help()
+                console.print(
+                    "\nType `dstack apply -h CONFIGURATION_TYPE` to see configuration-specific options.\n"
+                )
                 return
 
             super()._command(args)
@@ -129,5 +132,5 @@ class ApplyCommand(APIBaseCommand):
                 repo=repo,
             )
         except KeyboardInterrupt:
-            print("\nOperation interrupted by user. Exiting...")
+            console.print("\nOperation interrupted by user. Exiting...")
             exit(0)

--- a/src/dstack/_internal/cli/services/configurators/base.py
+++ b/src/dstack/_internal/cli/services/configurators/base.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 from abc import ABC, abstractmethod
-from typing import List, Optional, cast
+from typing import List, Optional, Union, cast
 
 from dstack._internal.cli.services.args import env_var
 from dstack._internal.core.errors import ConfigurationError
@@ -13,6 +13,8 @@ from dstack._internal.core.models.configurations import (
 from dstack._internal.core.models.envs import Env, EnvSentinel, EnvVarTuple
 from dstack._internal.core.models.repos.base import Repo
 from dstack.api._public import Client
+
+ArgsParser = Union[argparse._ArgumentGroup, argparse.ArgumentParser]
 
 
 class BaseApplyConfigurator(ABC):
@@ -82,7 +84,7 @@ class BaseApplyConfigurator(ABC):
 
 class ApplyEnvVarsConfiguratorMixin:
     @classmethod
-    def register_env_args(cls, parser: argparse.ArgumentParser):
+    def register_env_args(cls, parser: ArgsParser):
         parser.add_argument(
             "-e",
             "--env",

--- a/src/dstack/_internal/cli/services/configurators/fleet.py
+++ b/src/dstack/_internal/cli/services/configurators/fleet.py
@@ -41,10 +41,6 @@ logger = get_logger(__name__)
 class FleetConfigurator(ApplyEnvVarsConfiguratorMixin, BaseApplyConfigurator):
     TYPE: ApplyConfigurationType = ApplyConfigurationType.FLEET
 
-    @classmethod
-    def register_args(cls, parser: argparse.ArgumentParser):
-        cls.register_env_args(parser)
-
     def apply_configuration(
         self,
         conf: FleetConfiguration,
@@ -185,7 +181,20 @@ class FleetConfigurator(ApplyEnvVarsConfiguratorMixin, BaseApplyConfigurator):
 
         console.print(f"Fleet [code]{conf.name}[/] deleted")
 
+    @classmethod
+    def register_args(cls, parser: argparse.ArgumentParser):
+        configuration_group = parser.add_argument_group(f"{cls.TYPE.value} Options")
+        configuration_group.add_argument(
+            "-n",
+            "--name",
+            dest="name",
+            help="The fleet name",
+        )
+        cls.register_env_args(configuration_group)
+
     def apply_args(self, conf: FleetConfiguration, args: argparse.Namespace, unknown: List[str]):
+        if args.name:
+            conf.name = args.name
         self.apply_env_vars(conf.env, args)
         if conf.ssh_config is None and conf.env:
             raise ConfigurationError("`env` is currently supported for SSH fleets only")

--- a/src/dstack/_internal/cli/services/configurators/gateway.py
+++ b/src/dstack/_internal/cli/services/configurators/gateway.py
@@ -39,6 +39,7 @@ class GatewayConfigurator(BaseApplyConfigurator):
         unknown_args: List[str],
         repo: Optional[Repo] = None,
     ):
+        self.apply_args(conf, configurator_args, unknown_args)
         spec = GatewaySpec(
             configuration=conf,
             configuration_path=configuration_path,
@@ -169,6 +170,20 @@ class GatewayConfigurator(BaseApplyConfigurator):
             )
 
         console.print(f"Gateway [code]{conf.name}[/] deleted")
+
+    @classmethod
+    def register_args(cls, parser: argparse.ArgumentParser):
+        configuration_group = parser.add_argument_group(f"{cls.TYPE.value} Options")
+        configuration_group.add_argument(
+            "-n",
+            "--name",
+            dest="name",
+            help="The gateway name",
+        )
+
+    def apply_args(self, conf: GatewayConfiguration, args: argparse.Namespace, unknown: List[str]):
+        if args.name:
+            conf.name = args.name
 
 
 def _get_plan(api: Client, spec: GatewaySpec) -> GatewayPlan:

--- a/src/dstack/_internal/cli/services/configurators/run.py
+++ b/src/dstack/_internal/cli/services/configurators/run.py
@@ -298,20 +298,21 @@ class BaseRunConfigurator(ApplyEnvVarsConfiguratorMixin, BaseApplyConfigurator):
 
     @classmethod
     def register_args(cls, parser: argparse.ArgumentParser):
-        parser.add_argument(
+        configuration_group = parser.add_argument_group(f"{cls.TYPE.value} Options")
+        configuration_group.add_argument(
             "-n",
             "--name",
             dest="run_name",
             help="The name of the run. If not specified, a random name is assigned",
         )
-        parser.add_argument(
+        configuration_group.add_argument(
             "--max-offers",
             help="Number of offers to show in the run plan",
             type=int,
             default=3,
         )
-        cls.register_env_args(parser)
-        parser.add_argument(
+        cls.register_env_args(configuration_group)
+        configuration_group.add_argument(
             "--gpu",
             type=gpu_spec,
             help="Request GPU for the run. "
@@ -319,7 +320,7 @@ class BaseRunConfigurator(ApplyEnvVarsConfiguratorMixin, BaseApplyConfigurator):
             dest="gpu_spec",
             metavar="SPEC",
         )
-        parser.add_argument(
+        configuration_group.add_argument(
             "--disk",
             type=disk_spec,
             help="Request the size range of disk for the run. Example [code]--disk 100GB..[/].",

--- a/src/dstack/_internal/cli/services/configurators/volume.py
+++ b/src/dstack/_internal/cli/services/configurators/volume.py
@@ -38,6 +38,7 @@ class VolumeConfigurator(BaseApplyConfigurator):
         unknown_args: List[str],
         repo: Optional[Repo] = None,
     ):
+        self.apply_args(conf, configurator_args, unknown_args)
         spec = VolumeSpec(
             configuration=conf,
             configuration_path=configuration_path,
@@ -157,6 +158,20 @@ class VolumeConfigurator(BaseApplyConfigurator):
             self.api.client.volumes.delete(project_name=self.api.project, names=[conf.name])
 
         console.print(f"Volume [code]{conf.name}[/] deleted")
+
+    @classmethod
+    def register_args(cls, parser: argparse.ArgumentParser):
+        configuration_group = parser.add_argument_group(f"{cls.TYPE.value} Options")
+        configuration_group.add_argument(
+            "-n",
+            "--name",
+            dest="name",
+            help="The volume name",
+        )
+
+    def apply_args(self, conf: VolumeConfiguration, args: argparse.Namespace, unknown: List[str]):
+        if args.name:
+            conf.name = args.name
 
 
 def _get_plan(api: Client, spec: VolumeSpec) -> VolumePlan:

--- a/src/dstack/_internal/cli/services/repos.py
+++ b/src/dstack/_internal/cli/services/repos.py
@@ -1,7 +1,7 @@
-from argparse import ArgumentParser, _ArgumentGroup
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
+from dstack._internal.cli.services.configurators.base import ArgsParser
 from dstack._internal.core.errors import CLIError
 from dstack._internal.core.models.repos.base import Repo, RepoType
 from dstack._internal.core.models.repos.remote import GitRepoURL, RemoteRepo, RepoError
@@ -12,7 +12,7 @@ from dstack._internal.utils.path import PathLike
 from dstack.api._public import Client
 
 
-def register_init_repo_args(parser: Union[ArgumentParser, _ArgumentGroup]):
+def register_init_repo_args(parser: ArgsParser):
     parser.add_argument(
         "-t",
         "--token",

--- a/src/tests/_internal/cli/services/configurators/test_profile.py
+++ b/src/tests/_internal/cli/services/configurators/test_profile.py
@@ -73,6 +73,6 @@ def apply_args(profile: Profile, args: List[str]) -> Tuple[Profile, argparse.Nam
     parser = argparse.ArgumentParser()
     register_profile_args(parser)
     profile = profile.copy(deep=True)  # to avoid modifying the original profile
-    args = parser.parse_args(args)
-    apply_profile_args(args, profile)
-    return profile, args
+    parsed_args = parser.parse_args(args)
+    apply_profile_args(parsed_args, profile)
+    return profile, parsed_args


### PR DESCRIPTION
The PR:
* Adds `-n`/`--name` to `dstack apply` for all configuration types. This is primarily relevant for #2264 so that it becomes easy to create many volumes using a one liner: `for i in {0..7}; do dstack apply -f .dstack/confs/volume.yaml -n data-volume-$i -y; done`.
* Improves `dstack apply -h` output: a hint to pass configuration type. If a configuration type is specified, prints configuration-specific options in a separate argument group:

```
dstack apply -h
Usage: dstack apply [--project NAME] [-h [TYPE]] [-f FILE] [-y] [--force] [-d]
                    [-P REPO] [--repo-branch REPO_BRANCH] [--repo-hash REPO_HASH]
                    [--no-repo] [-t OAUTH_TOKEN] [--git-identity SSH_PRIVATE_KEY]
                    [--ssh-identity SSH_PRIVATE_KEY] [--local]

Options:
  --project NAME        The name of the project. Defaults to $DSTACK_PROJECT
  -h, --help [TYPE]     Show this help message and exit.
  -f, --file FILE       The path to the configuration file. Defaults to
                        $PWD/.dstack.yml
  -y, --yes             Do not ask for confirmation
  --force               Force apply when no changes detected
  -d, --detach          Exit immediately after sumbitting configuration

Repo Options:
  -P, --repo REPO       The repo to use for the run. Can be a local path or a Git
                        repo URL.
  --repo-branch REPO_BRANCH
                        The repo branch to use for the run
  --repo-hash REPO_HASH
                        The hash of the repo commit to use for the run
  --no-repo             Do not use any repo for the run
  -t, --token OAUTH_TOKEN
                        An authentication token to access a private Git repo
  --git-identity SSH_PRIVATE_KEY
                        The private SSH key path to access a private Git repo
  --ssh-identity SSH_PRIVATE_KEY
                        The private SSH key path for SSH tunneling
  --local               Do not use Git

Type `dstack apply -h CONFIGURATION_TYPE` to see configuration-specific options.
```
```
 dstack apply -h service
Usage: dstack apply [--project NAME] [-h [TYPE]] [-f FILE] [-y] [--force] [-d]
                    [-P REPO] [--repo-branch REPO_BRANCH] [--repo-hash REPO_HASH]
                    [--no-repo] [-t OAUTH_TOKEN] [--git-identity SSH_PRIVATE_KEY]
                    [--ssh-identity SSH_PRIVATE_KEY] [--local] [-n RUN_NAME]
                    [--max-offers MAX_OFFERS] [-e KEY[=VALUE]] [--gpu SPEC]
                    [--disk RANGE] [--profile NAME] [--max-price PRICE]
                    [--max-duration DURATION] [-b NAME] [-r NAME]
                    [--instance-type NAME]
                    [--pool POOL_NAME | -R | --dont-destroy | --idle-duration IDLE_DURATION | --instance NAME]
                    [--spot | --on-demand | --spot-auto | --spot-policy POLICY]
                    [--retry | --no-retry | --retry-duration DURATION]

Options:
  --project NAME        The name of the project. Defaults to $DSTACK_PROJECT
  -h, --help [TYPE]     Show this help message and exit.
  -f, --file FILE       The path to the configuration file. Defaults to
                        $PWD/.dstack.yml
  -y, --yes             Do not ask for confirmation
  --force               Force apply when no changes detected
  -d, --detach          Exit immediately after sumbitting configuration

Repo Options:
  -P, --repo REPO       The repo to use for the run. Can be a local path or a Git
                        repo URL.
  --repo-branch REPO_BRANCH
                        The repo branch to use for the run
  --repo-hash REPO_HASH
                        The hash of the repo commit to use for the run
  --no-repo             Do not use any repo for the run
  -t, --token OAUTH_TOKEN
                        An authentication token to access a private Git repo
  --git-identity SSH_PRIVATE_KEY
                        The private SSH key path to access a private Git repo
  --ssh-identity SSH_PRIVATE_KEY
                        The private SSH key path for SSH tunneling
  --local               Do not use Git

Service Options:
  -n, --name RUN_NAME   The name of the run. If not specified, a random name is
                        assigned
  --max-offers MAX_OFFERS
                        Number of offers to show in the run plan
  -e, --env KEY[=VALUE]
                        Environment variables
  --gpu SPEC            Request GPU for the run. The format is NAME:COUNT:MEMORY
                        (all parts are optional)
  --disk RANGE          Request the size range of disk for the run. Example
                        --disk 100GB...

Profile:
  --profile NAME        The name of the profile. Defaults to $DSTACK_PROFILE
  --max-price PRICE     The maximum price per hour, in dollars
  --max-duration DURATION
                        The maximum duration of the run
  -b, --backend NAME    The backends that will be tried for provisioning
  -r, --region NAME     The regions that will be tried for provisioning
  --instance-type NAME  The cloud-specific instance types that will be tried for
                        provisioning

Pools:
  --pool POOL_NAME      The name of the pool. If not set, the default pool will
                        be used
  -R, --reuse           Reuse instance from pool
  --dont-destroy        Do not destroy instance after the run is finished
  --idle-duration IDLE_DURATION
                        Time to wait before destroying the idle instance
  --instance NAME       Reuse instance from pool with name NAME

Spot Policy:
  --spot                Consider only spot instances
  --on-demand           Consider only on-demand instances
  --spot-auto           Consider both spot and on-demand instances
  --spot-policy POLICY  One of spot, on-demand, auto

Retry Policy:
  --retry
  --no-retry
  --retry-duration DURATION
```
