### PR TITLE
Add head node support for SSH fleets

### DIFF
--- a/docs/docs/concepts/fleets.md
+++ b/docs/docs/concepts/fleets.md
@@ -300,6 +300,47 @@ ssh_config:
     - 3.255.177.52
 ```
 
+#### Head node
+
+If fleet nodes are behind a head node, configure [`proxy_jump`](../reference/dstack.yml/fleet.md#proxy_jump):
+
+<div editor-title="examples/misc/fleets/.dstack.yml">
+
+    ```yaml
+    type: fleet
+    name: my-fleet
+
+    ssh_config:
+      user: ubuntu
+      identity_file: ~/.ssh/worker_node_key
+      hosts:
+        - 3.255.177.51
+        - 3.255.177.52
+      proxy_jump:
+        hostname: 3.255.177.50
+        user: ubuntu
+        identity_file: ~/.ssh/head_node_key
+    ```
+
+</div>
+
+To be able to attach to runs, both explicitly with `dstack attach` and implicitly with `dstack apply`, you must either
+add a front node key (`~/.ssh/head_node_key`) to an SSH agent or configure a key path in `~/.ssh/config`:
+
+<div editor-title="~/.ssh/config">
+
+    ```
+    Host 3.255.177.50
+        IdentityFile ~/.ssh/head_node_key
+    ```
+
+</div>
+
+where `Host` must match `ssh_config.proxy_jump.hostname` or `ssh_config.hosts[n].proxy_jump.hostname` if you configure head nodes
+on a per-worker basis.
+
+> Currently, [services](services.md) do not work on instances with a head node setup.
+
 !!! info "Reference"
     For all SSH fleet configuration options, refer to the [reference](../reference/dstack.yml/fleet.md).
 

--- a/docs/docs/reference/dstack.yml/fleet.md
+++ b/docs/docs/reference/dstack.yml/fleet.md
@@ -17,11 +17,25 @@ The `fleet` configuration type allows creating and updating fleets.
       show_root_heading: false
       item_id_prefix: ssh_config-
 
+#### `ssh_config.proxy_jump` { #ssh_config-proxy_jump data-toc-label="proxy_jump" }
+
+#SCHEMA# dstack._internal.core.models.fleets.SSHProxyParams
+    overrides:
+      show_root_heading: false
+      item_id_prefix: proxy_jump-
+
 #### `ssh_config.hosts[n]` { #ssh_config-hosts data-toc-label="hosts" }
 
 #SCHEMA# dstack._internal.core.models.fleets.SSHHostParams
     overrides:
       show_root_heading: false
+
+##### `ssh_config.hosts[n].proxy_jump` { #proxy_jump data-toc-label="hosts[n].proxy_jump" }
+
+#SCHEMA# dstack._internal.core.models.fleets.SSHProxyParams
+    overrides:
+      show_root_heading: false
+      item_id_prefix: hosts-proxy_jump-
 
 ### `resources`
 

--- a/src/dstack/_internal/cli/services/configurators/fleet.py
+++ b/src/dstack/_internal/cli/services/configurators/fleet.py
@@ -201,13 +201,16 @@ class FleetConfigurator(ApplyEnvVarsConfiguratorMixin, BaseApplyConfigurator):
 
 
 def _preprocess_spec(spec: FleetSpec):
-    if spec.configuration.ssh_config is not None:
-        spec.configuration.ssh_config.ssh_key = _resolve_ssh_key(
-            spec.configuration.ssh_config.identity_file
-        )
-        for host in spec.configuration.ssh_config.hosts:
+    ssh_config = spec.configuration.ssh_config
+    if ssh_config is not None:
+        ssh_config.ssh_key = _resolve_ssh_key(ssh_config.identity_file)
+        if ssh_config.proxy_jump is not None:
+            ssh_config.proxy_jump.ssh_key = _resolve_ssh_key(ssh_config.proxy_jump.identity_file)
+        for host in ssh_config.hosts:
             if not isinstance(host, str):
                 host.ssh_key = _resolve_ssh_key(host.identity_file)
+                if host.proxy_jump is not None:
+                    host.proxy_jump.ssh_key = _resolve_ssh_key(host.proxy_jump.identity_file)
 
 
 def _resolve_ssh_key(ssh_key_path: Optional[str]) -> Optional[SSHKey]:

--- a/src/dstack/_internal/core/models/fleets.py
+++ b/src/dstack/_internal/core/models/fleets.py
@@ -39,6 +39,14 @@ class InstanceGroupPlacement(str, Enum):
     CLUSTER = "cluster"
 
 
+class SSHProxyParams(CoreModel):
+    hostname: Annotated[str, Field(description="The IP address or domain of proxy host")]
+    port: Annotated[Optional[int], Field(description="The SSH port of proxy host")] = None
+    user: Annotated[str, Field(description="The user to log in with for proxy host")]
+    identity_file: Annotated[str, Field(description="The private key to use for proxy host")]
+    ssh_key: Optional[SSHKey] = None
+
+
 class SSHHostParams(CoreModel):
     hostname: Annotated[str, Field(description="The IP address or domain to connect to")]
     port: Annotated[
@@ -49,6 +57,9 @@ class SSHHostParams(CoreModel):
     )
     identity_file: Annotated[
         Optional[str], Field(description="The private key to use for this host")
+    ] = None
+    proxy_jump: Annotated[
+        Optional[SSHProxyParams], Field(description="The SSH proxy configuration for this host")
     ] = None
     internal_ip: Annotated[
         Optional[str],
@@ -96,6 +107,9 @@ class SSHParams(CoreModel):
         Optional[str], Field(description="The private key to use for all hosts")
     ] = None
     ssh_key: Optional[SSHKey] = None
+    proxy_jump: Annotated[
+        Optional[SSHProxyParams], Field(description="The SSH proxy configuration for all hosts")
+    ] = None
     hosts: Annotated[
         List[Union[SSHHostParams, str]],
         Field(

--- a/src/dstack/_internal/core/models/instances.py
+++ b/src/dstack/_internal/core/models/instances.py
@@ -92,6 +92,8 @@ class RemoteConnectionInfo(CoreModel):
     port: int
     ssh_user: str
     ssh_keys: List[SSHKey]
+    ssh_proxy: Optional[SSHConnectionParams] = None
+    ssh_proxy_keys: Optional[list[SSHKey]] = None
     env: Env = Env()
 
 

--- a/src/dstack/_internal/core/services/ssh/attach.py
+++ b/src/dstack/_internal/core/services/ssh/attach.py
@@ -108,7 +108,7 @@ class SSHAttach:
             if ssh_proxy is not None:
                 # SSH instance with jump host
                 # dstack has no IdentityFile for jump host, it must be either preconfigured
-                # in the ~/.ssh/config of loaded into ssh-agent
+                # in the ~/.ssh/config or loaded into ssh-agent
                 hosts[f"{run_name}-jump-host"] = {
                     "HostName": ssh_proxy.hostname,
                     "Port": ssh_proxy.port,

--- a/src/dstack/_internal/server/services/jobs/__init__.py
+++ b/src/dstack/_internal/server/services/jobs/__init__.py
@@ -7,6 +7,7 @@ from uuid import UUID
 import requests
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
 
 import dstack._internal.server.services.backends as backends_services
 from dstack._internal.core.backends.base import Backend
@@ -20,7 +21,7 @@ from dstack._internal.core.errors import (
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.common import is_core_model_instance
 from dstack._internal.core.models.configurations import RunConfigurationType
-from dstack._internal.core.models.instances import InstanceStatus, RemoteConnectionInfo
+from dstack._internal.core.models.instances import InstanceStatus
 from dstack._internal.core.models.runs import (
     Job,
     JobProvisioningData,
@@ -49,6 +50,7 @@ from dstack._internal.server.services.jobs.configurators.dev import DevEnvironme
 from dstack._internal.server.services.jobs.configurators.service import ServiceJobConfigurator
 from dstack._internal.server.services.jobs.configurators.task import TaskJobConfigurator
 from dstack._internal.server.services.logging import fmt
+from dstack._internal.server.services.pools import get_instance_ssh_private_keys
 from dstack._internal.server.services.runner import client
 from dstack._internal.server.services.runner.ssh import runner_ssh_tunnel
 from dstack._internal.server.services.volumes import (
@@ -170,29 +172,22 @@ _configuration_type_to_configurator_class_map = {c.TYPE: c for c in _job_configu
 
 
 async def stop_runner(session: AsyncSession, job_model: JobModel):
-    project = await session.get(ProjectModel, job_model.project_id)
-    ssh_private_key = project.ssh_private_key
-
     res = await session.execute(
-        select(InstanceModel).where(
+        select(InstanceModel)
+        .where(
             InstanceModel.project_id == job_model.project_id,
             InstanceModel.id == job_model.instance_id,
         )
+        .options(joinedload(InstanceModel.project))
     )
     instance: Optional[InstanceModel] = res.scalar()
 
-    # TODO: Drop this logic and always use project key once it's safe to assume that most on-prem
-    # fleets are (re)created after this change: https://github.com/dstackai/dstack/pull/1716
-    if instance and instance.remote_connection_info is not None:
-        remote_conn_info: RemoteConnectionInfo = RemoteConnectionInfo.__response__.parse_raw(
-            instance.remote_connection_info
-        )
-        ssh_private_key = remote_conn_info.ssh_keys[0].private
+    ssh_private_keys = get_instance_ssh_private_keys(common.get_or_error(instance))
     try:
         jpd = get_job_provisioning_data(job_model)
         if jpd is not None:
             jrd = get_job_runtime_data(job_model)
-            await run_async(_stop_runner, ssh_private_key, jpd, jrd, job_model)
+            await run_async(_stop_runner, ssh_private_keys, jpd, jrd, job_model)
     except SSHError:
         logger.debug("%s: failed to stop runner", fmt(job_model))
 
@@ -239,16 +234,8 @@ async def process_terminating_job(
     jpd = get_job_provisioning_data(job_model)
     if jpd is not None:
         logger.debug("%s: stopping container", fmt(job_model))
-        ssh_private_key = instance_model.project.ssh_private_key
-        # TODO: Drop this logic and always use project key once it's safe to assume that
-        # most on-prem fleets are (re)created after this change:
-        # https://github.com/dstackai/dstack/pull/1716
-        if instance_model and instance_model.remote_connection_info is not None:
-            remote_conn_info: RemoteConnectionInfo = RemoteConnectionInfo.__response__.parse_raw(
-                instance_model.remote_connection_info
-            )
-            ssh_private_key = remote_conn_info.ssh_keys[0].private
-        await stop_container(job_model, jpd, ssh_private_key)
+        ssh_private_keys = get_instance_ssh_private_keys(instance_model)
+        await stop_container(job_model, jpd, ssh_private_keys)
         volume_models: list[VolumeModel]
         if jrd is not None and jrd.volume_names is not None:
             volume_models = await list_project_volume_models(
@@ -351,14 +338,16 @@ def _set_job_termination_status(job_model: JobModel):
 
 
 async def stop_container(
-    job_model: JobModel, job_provisioning_data: JobProvisioningData, ssh_private_key: str
+    job_model: JobModel,
+    job_provisioning_data: JobProvisioningData,
+    ssh_private_keys: tuple[str, Optional[str]],
 ):
     if job_provisioning_data.dockerized:
         # send a request to the shim to terminate the docker container
         # SSHError and RequestException are caught in the `runner_ssh_tunner` decorator
         await run_async(
             _shim_submit_stop,
-            ssh_private_key,
+            ssh_private_keys,
             job_provisioning_data,
             None,
             job_model,

--- a/src/dstack/_internal/server/services/pools.py
+++ b/src/dstack/_internal/server/services/pools.py
@@ -760,7 +760,7 @@ async def create_ssh_instance_model(
     ssh_user: str,
     ssh_keys: List[SSHKey],
     ssh_proxy: Optional[SSHConnectionParams],
-    ssh_proxy_keys: list[SSHKey],
+    ssh_proxy_keys: Optional[list[SSHKey]],
     env: Env,
     blocks: Union[Literal["auto"], int],
 ) -> InstanceModel:

--- a/src/dstack/_internal/server/services/pools.py
+++ b/src/dstack/_internal/server/services/pools.py
@@ -30,6 +30,7 @@ from dstack._internal.core.models.instances import (
     InstanceType,
     RemoteConnectionInfo,
     Resources,
+    SSHConnectionParams,
     SSHKey,
 )
 from dstack._internal.core.models.pools import Instance, Pool, PoolInstances
@@ -291,6 +292,27 @@ def get_instance_profile(instance_model: InstanceModel) -> Profile:
 
 def get_instance_requirements(instance_model: InstanceModel) -> Requirements:
     return Requirements.__response__.parse_raw(instance_model.requirements)
+
+
+def get_instance_ssh_private_keys(instance_model: InstanceModel) -> tuple[str, Optional[str]]:
+    """
+    Returns a pair of SSH private keys: host key and optional proxy jump key.
+    """
+    host_private_key = instance_model.project.ssh_private_key
+    if instance_model.remote_connection_info is None:
+        # Cloud instance
+        return host_private_key, None
+    # SSH instance
+    rci = RemoteConnectionInfo.__response__.parse_raw(instance_model.remote_connection_info)
+    if rci.ssh_proxy is None:
+        return host_private_key, None
+    if rci.ssh_proxy_keys is None:
+        # Inconsistent RemoteConnectionInfo structure - proxy without keys
+        raise ValueError("Missing instance SSH proxy private keys")
+    proxy_private_keys = [key.private for key in rci.ssh_proxy_keys if key.private is not None]
+    if not proxy_private_keys:
+        raise ValueError("No instance SSH proxy private key found")
+    return host_private_key, proxy_private_keys[0]
 
 
 async def generate_instance_name(
@@ -737,6 +759,8 @@ async def create_ssh_instance_model(
     port: int,
     ssh_user: str,
     ssh_keys: List[SSHKey],
+    ssh_proxy: Optional[SSHConnectionParams],
+    ssh_proxy_keys: list[SSHKey],
     env: Env,
     blocks: Union[Literal["auto"], int],
 ) -> InstanceModel:
@@ -773,6 +797,8 @@ async def create_ssh_instance_model(
         port=port,
         ssh_user=ssh_user,
         ssh_keys=ssh_keys,
+        ssh_proxy=ssh_proxy,
+        ssh_proxy_keys=ssh_proxy_keys,
         env=env,
     )
     im = InstanceModel(

--- a/src/dstack/_internal/utils/ssh.py
+++ b/src/dstack/_internal/utils/ssh.py
@@ -159,7 +159,7 @@ def get_ssh_config(path: PathLike, host: str) -> Optional[Dict[str, str]]:
         return None
 
 
-def update_ssh_config(path: PathLike, host: str, options: Dict[str, Union[str, FilePath]]):
+def update_ssh_config(path: PathLike, host: str, options: Dict[str, Union[str, int, FilePath]]):
     Path(path).parent.mkdir(parents=True, exist_ok=True)
     with FileLock(str(path) + ".lock"):
         copy_mode = True

--- a/src/tests/_internal/server/background/tasks/test_process_running_jobs.py
+++ b/src/tests/_internal/server/background/tasks/test_process_running_jobs.py
@@ -103,6 +103,13 @@ class TestProcessRunningJobs:
             repo=repo,
             user=user,
         )
+        pool = await create_pool(session=session, project=project)
+        instance = await create_instance(
+            session=session,
+            project=project,
+            pool=pool,
+            status=InstanceStatus.BUSY,
+        )
         job_provisioning_data = get_job_provisioning_data(dockerized=False)
         job = await create_job(
             session=session,
@@ -110,6 +117,8 @@ class TestProcessRunningJobs:
             status=JobStatus.PROVISIONING,
             submitted_at=datetime(2023, 1, 2, 5, 12, 30, 5, tzinfo=timezone.utc),
             job_provisioning_data=job_provisioning_data,
+            instance=instance,
+            instance_assigned=True,
         )
         with (
             patch("dstack._internal.server.services.runner.ssh.SSHTunnel") as SSHTunnelMock,
@@ -144,12 +153,21 @@ class TestProcessRunningJobs:
             repo=repo,
             user=user,
         )
+        pool = await create_pool(session=session, project=project)
+        instance = await create_instance(
+            session=session,
+            project=project,
+            pool=pool,
+            status=InstanceStatus.BUSY,
+        )
         job_provisioning_data = get_job_provisioning_data(dockerized=False)
         job = await create_job(
             session=session,
             run=run,
             status=JobStatus.PROVISIONING,
             job_provisioning_data=job_provisioning_data,
+            instance=instance,
+            instance_assigned=True,
         )
         with (
             patch("dstack._internal.server.services.runner.ssh.SSHTunnel") as SSHTunnelMock,
@@ -186,12 +204,21 @@ class TestProcessRunningJobs:
             repo=repo,
             user=user,
         )
+        pool = await create_pool(session=session, project=project)
+        instance = await create_instance(
+            session=session,
+            project=project,
+            pool=pool,
+            status=InstanceStatus.BUSY,
+        )
         job_provisioning_data = get_job_provisioning_data(dockerized=False)
         job = await create_job(
             session=session,
             run=run,
             status=JobStatus.RUNNING,
             job_provisioning_data=job_provisioning_data,
+            instance=instance,
+            instance_assigned=True,
         )
         with (
             patch("dstack._internal.server.services.runner.ssh.SSHTunnel") as SSHTunnelMock,
@@ -277,6 +304,13 @@ class TestProcessRunningJobs:
             run_name="test-run",
             run_spec=run_spec,
         )
+        pool = await create_pool(session=session, project=project)
+        instance = await create_instance(
+            session=session,
+            project=project,
+            pool=pool,
+            status=InstanceStatus.BUSY,
+        )
         job_provisioning_data = get_job_provisioning_data(dockerized=True)
 
         with patch(
@@ -288,6 +322,8 @@ class TestProcessRunningJobs:
                 run=run,
                 status=JobStatus.PROVISIONING,
                 job_provisioning_data=job_provisioning_data,
+                instance=instance,
+                instance_assigned=True,
             )
 
         await process_running_jobs()
@@ -337,12 +373,21 @@ class TestProcessRunningJobs:
             repo=repo,
             user=user,
         )
+        pool = await create_pool(session=session, project=project)
+        instance = await create_instance(
+            session=session,
+            project=project,
+            pool=pool,
+            status=InstanceStatus.BUSY,
+        )
         job = await create_job(
             session=session,
             run=run,
             status=JobStatus.PULLING,
             job_provisioning_data=get_job_provisioning_data(dockerized=True),
             job_runtime_data=get_job_runtime_data(network_mode="bridge", ports=None),
+            instance=instance,
+            instance_assigned=True,
         )
         shim_client_mock.get_task.return_value.status = TaskStatus.RUNNING
         shim_client_mock.get_task.return_value.ports = [
@@ -385,6 +430,13 @@ class TestProcessRunningJobs:
             repo=repo,
             user=user,
         )
+        pool = await create_pool(session=session, project=project)
+        instance = await create_instance(
+            session=session,
+            project=project,
+            pool=pool,
+            status=InstanceStatus.BUSY,
+        )
         job_provisioning_data = get_job_provisioning_data(dockerized=True)
         job = await create_job(
             session=session,
@@ -392,6 +444,8 @@ class TestProcessRunningJobs:
             status=JobStatus.PULLING,
             job_provisioning_data=job_provisioning_data,
             job_runtime_data=get_job_runtime_data(network_mode="bridge", ports=None),
+            instance=instance,
+            instance_assigned=True,
         )
         shim_client_mock.get_task.return_value.status = TaskStatus.RUNNING
         shim_client_mock.get_task.return_value.ports = None
@@ -470,12 +524,21 @@ class TestProcessRunningJobs:
             run_name="test-run",
             run_spec=run_spec,
         )
+        pool = await create_pool(session=session, project=project)
+        instance = await create_instance(
+            session=session,
+            project=project,
+            pool=pool,
+            status=InstanceStatus.BUSY,
+        )
         job = await create_job(
             session=session,
             run=run,
             status=JobStatus.PROVISIONING,
             job_provisioning_data=get_job_provisioning_data(dockerized=True),
             submitted_at=get_current_datetime(),
+            instance=instance,
+            instance_assigned=True,
         )
         monkeypatch.setattr(
             "dstack._internal.server.services.runner.ssh.SSHTunnel", Mock(return_value=MagicMock())
@@ -588,11 +651,20 @@ class TestProcessRunningJobs:
                 ),
             ),
         )
+        pool = await create_pool(session=session, project=project)
+        instance = await create_instance(
+            session=session,
+            project=project,
+            pool=pool,
+            status=InstanceStatus.BUSY,
+        )
         job = await create_job(
             session=session,
             run=run,
             status=JobStatus.RUNNING,
             job_provisioning_data=get_job_provisioning_data(),
+            instance=instance,
+            instance_assigned=True,
         )
         with (
             patch("dstack._internal.server.services.runner.ssh.SSHTunnel") as SSHTunnelMock,

--- a/src/tests/_internal/server/routers/test_fleets.py
+++ b/src/tests/_internal/server/routers/test_fleets.py
@@ -450,6 +450,7 @@ class TestCreateFleet:
                         "port": None,
                         "identity_file": None,
                         "ssh_key": None,  # should not return ssh_key
+                        "proxy_jump": None,
                         "hosts": ["1.1.1.1"],
                         "network": None,
                     },

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -18,6 +18,7 @@ from dstack._internal.core.models.gateways import GatewayStatus
 from dstack._internal.core.models.instances import (
     InstanceAvailability,
     InstanceOfferWithAvailability,
+    InstanceStatus,
     InstanceType,
     Resources,
 )
@@ -47,7 +48,9 @@ from dstack._internal.server.testing.common import (
     create_backend,
     create_gateway,
     create_gateway_compute,
+    create_instance,
     create_job,
+    create_pool,
     create_project,
     create_repo,
     create_run,
@@ -1315,11 +1318,20 @@ class TestStopRuns:
             user=user,
             status=RunStatus.RUNNING,
         )
+        pool = await create_pool(session=session, project=project)
+        instance = await create_instance(
+            session=session,
+            project=project,
+            pool=pool,
+            status=InstanceStatus.BUSY,
+        )
         job = await create_job(
             session=session,
             run=run,
             job_provisioning_data=get_job_provisioning_data(),
             status=JobStatus.RUNNING,
+            instance=instance,
+            instance_assigned=True,
         )
         with patch("dstack._internal.server.services.jobs._stop_runner") as stop_runner:
             response = await client.post(


### PR DESCRIPTION
* Add `proxy_jump` property
* Store configuration as part of `RemoteConnectionInfo`
* Always use a project key to connect to SSH instances, drop backward compatibility code (previously, the user-provided key was used, as the project key was not added to the SSH instance, this was fixed in https://github.com/dstackai/dstack/pull/1716)

NOTE: services are not currently supported, proxy support will be added in a separate PR.

Part-of: https://github.com/dstackai/dstack/issues/2010