### PR TITLE
Remove excessive project_id check for GCP

### DIFF
--- a/src/dstack/_internal/core/backends/gcp/resources.py
+++ b/src/dstack/_internal/core/backends/gcp/resources.py
@@ -64,7 +64,7 @@ def check_vpc(
                 region=region,
             )
     except google.api_core.exceptions.NotFound:
-        raise ComputeError(f"Failed to find Shared VPC project {vpc_project_id}")
+        raise ComputeError(f"Failed to find VPC project {vpc_project_id}")
 
     if allocate_public_ip:
         return


### PR DESCRIPTION
Removes a check that config.project_id == credentials.project_id since it's not the case sometimes (e.g. Workload Identity Federation for GKE). `config.project_id` is still validated indirectly when checking VPC.