### PR TITLE
Improve GCP creds validation

### DIFF
--- a/src/dstack/_internal/core/backends/gcp/compute.py
+++ b/src/dstack/_internal/core/backends/gcp/compute.py
@@ -70,7 +70,7 @@ class GCPCompute(Compute):
     def __init__(self, config: GCPConfig):
         super().__init__()
         self.config = config
-        self.credentials, self.project_id = auth.authenticate(config.creds)
+        self.credentials, _ = auth.authenticate(config.creds, self.config.project_id)
         self.instances_client = compute_v1.InstancesClient(credentials=self.credentials)
         self.firewalls_client = compute_v1.FirewallsClient(credentials=self.credentials)
         self.regions_client = compute_v1.RegionsClient(credentials=self.credentials)


### PR DESCRIPTION
This PR fixes GCP creds validation not being performed explicitly (`storage_client.list_buckets(max_results=1)` didn't raise for invalid/insufficient creds), which led to misleading error messages in case of invalid creds.