### PR TITLE
Use unique names for backend resources

### DIFF
--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -12,7 +12,7 @@ from dstack._internal.core.backends.aws.config import AWSConfig
 from dstack._internal.core.backends.base.compute import (
     Compute,
     get_gateway_user_data,
-    get_instance_name,
+    get_job_instance_name,
     get_user_data,
     merge_tags,
 )
@@ -274,7 +274,7 @@ class AWSCompute(Compute):
         # TODO: run_job is the same for vm-based backends, refactor
         instance_config = InstanceConfiguration(
             project_name=run.project_name,
-            instance_name=get_instance_name(run, job),  # TODO: generate name
+            instance_name=get_job_instance_name(run, job),  # TODO: generate name
             ssh_keys=[
                 SSHKey(public=project_ssh_public_key.strip()),
             ],

--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -11,6 +11,9 @@ from dstack._internal import settings
 from dstack._internal.core.backends.aws.config import AWSConfig
 from dstack._internal.core.backends.base.compute import (
     Compute,
+    generate_unique_gateway_instance_name,
+    generate_unique_instance_name,
+    generate_unique_volume_name,
     get_gateway_user_data,
     get_job_instance_name,
     get_user_data,
@@ -152,10 +155,12 @@ class AWSCompute(Compute):
         if zones is not None and len(zones) == 0:
             raise NoCapacityError("No eligible availability zones")
 
+        instance_name = generate_unique_instance_name(instance_config)
         tags = {
-            "Name": instance_config.instance_name,
+            "Name": instance_name,
             "owner": "dstack",
             "dstack_project": project_name,
+            "dstack_name": instance_config.instance_name,
             "dstack_user": instance_config.user,
         }
         tags = merge_tags(tags=tags, backend_tags=self.config.tags)
@@ -342,10 +347,12 @@ class AWSCompute(Compute):
         ec2_resource = self.session.resource("ec2", region_name=configuration.region)
         ec2_client = self.session.client("ec2", region_name=configuration.region)
 
+        instance_name = generate_unique_gateway_instance_name(configuration)
         tags = {
-            "Name": configuration.instance_name,
+            "Name": instance_name,
             "owner": "dstack",
             "dstack_project": configuration.project_name,
+            "dstack_name": configuration.instance_name,
         }
         if settings.DSTACK_VERSION is not None:
             tags["dstack_version"] = settings.DSTACK_VERSION
@@ -535,11 +542,13 @@ class AWSCompute(Compute):
     def create_volume(self, volume: Volume) -> VolumeProvisioningData:
         ec2_client = self.session.client("ec2", region_name=volume.configuration.region)
 
+        volume_name = generate_unique_volume_name(volume)
         tags = {
-            "Name": volume.configuration.name,
+            "Name": volume_name,
             "owner": "dstack",
-            "dstack_user": volume.user,
             "dstack_project": volume.project_name,
+            "dstack_name": volume.name,
+            "dstack_user": volume.user,
         }
         tags = merge_tags(tags=tags, backend_tags=self.config.tags)
 

--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -410,7 +410,7 @@ class AWSCompute(Compute):
 
         logger.debug("Creating ALB for gateway %s...", configuration.instance_name)
         response = elb_client.create_load_balancer(
-            Name=f"{configuration.instance_name}-lb",
+            Name=f"{instance_name}-lb",
             Subnets=subnets_ids,
             SecurityGroups=[security_group_id],
             Scheme="internet-facing" if configuration.public_ip else "internal",
@@ -425,7 +425,7 @@ class AWSCompute(Compute):
 
         logger.debug("Creating Target Group for gateway %s...", configuration.instance_name)
         response = elb_client.create_target_group(
-            Name=f"{configuration.instance_name}-tg",
+            Name=f"{instance_name}-tg",
             Protocol="HTTP",
             Port=80,
             VpcId=vpc_id,

--- a/src/dstack/_internal/core/backends/azure/compute.py
+++ b/src/dstack/_internal/core/backends/azure/compute.py
@@ -243,7 +243,6 @@ class AzureCompute(Compute):
         )
 
         tags = {
-            "Name": configuration.instance_name,
             "owner": "dstack",
             "dstack_project": configuration.project_name,
             "dstack_name": configuration.instance_name,

--- a/src/dstack/_internal/core/backends/azure/compute.py
+++ b/src/dstack/_internal/core/backends/azure/compute.py
@@ -40,7 +40,7 @@ from dstack._internal.core.backends.azure.config import AzureConfig
 from dstack._internal.core.backends.base.compute import (
     Compute,
     get_gateway_user_data,
-    get_instance_name,
+    get_job_instance_name,
     get_user_data,
     merge_tags,
 )
@@ -197,7 +197,7 @@ class AzureCompute(Compute):
     ) -> JobProvisioningData:
         instance_config = InstanceConfiguration(
             project_name=run.project_name,
-            instance_name=get_instance_name(run, job),  # TODO: generate name
+            instance_name=get_job_instance_name(run, job),  # TODO: generate name
             ssh_keys=[
                 SSHKey(public=project_ssh_public_key.strip()),
             ],

--- a/src/dstack/_internal/core/backends/azure/resources.py
+++ b/src/dstack/_internal/core/backends/azure/resources.py
@@ -6,6 +6,8 @@ from azure.mgmt.network.models import Subnet
 
 from dstack._internal.core.errors import BackendError
 
+MAX_RESOURCE_NAME_LEN = 64
+
 
 def get_network_subnets(
     network_client: network_mgmt.NetworkManagementClient,

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -234,6 +234,21 @@ def generate_unique_instance_name(
     )
 
 
+def generate_unique_instance_name_for_job(
+    run: Run,
+    job: Job,
+    max_length: int = _DEFAULT_MAX_RESOURCE_NAME_LEN,
+) -> str:
+    """
+    Generates a unique instance name for a job valid across all backends.
+    """
+    return generate_unique_backend_name(
+        resource_name=get_job_instance_name(run, job),
+        project_name=run.project_name,
+        max_length=max_length,
+    )
+
+
 def generate_unique_gateway_instance_name(
     gateway_compute_configuration: GatewayComputeConfiguration,
     max_length: int = _DEFAULT_MAX_RESOURCE_NAME_LEN,

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -1,5 +1,7 @@
 import os
+import random
 import re
+import string
 import threading
 from abc import ABC, abstractmethod
 from functools import lru_cache
@@ -31,6 +33,7 @@ from dstack._internal.core.models.volumes import (
     VolumeAttachmentData,
     VolumeProvisioningData,
 )
+from dstack._internal.core.services import is_valid_dstack_resource_name
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -209,8 +212,90 @@ class Compute(ABC):
         return self.get_offers(requirements)
 
 
-def get_instance_name(run: Run, job: Job) -> str:
-    return f"{run.project_name.lower()}-{job.job_spec.job_name}"
+def get_job_instance_name(run: Run, job: Job) -> str:
+    return job.job_spec.job_name
+
+
+_DEFAULT_MAX_RESOURCE_NAME_LEN = 60
+_CLOUD_RESOURCE_SUFFIX_LEN = 8
+
+
+def generate_unique_instance_name(
+    instance_configuration: InstanceConfiguration,
+    max_length: int = _DEFAULT_MAX_RESOURCE_NAME_LEN,
+) -> str:
+    """
+    Generates a unique instance name valid across all backends.
+    """
+    return generate_unique_backend_name(
+        resource_name=instance_configuration.instance_name,
+        project_name=instance_configuration.project_name,
+        max_length=max_length,
+    )
+
+
+def generate_unique_gateway_instance_name(
+    gateway_compute_configuration: GatewayComputeConfiguration,
+    max_length: int = _DEFAULT_MAX_RESOURCE_NAME_LEN,
+) -> str:
+    """
+    Generates a unique gateway instance name valid across all backends.
+    """
+    return generate_unique_backend_name(
+        resource_name=gateway_compute_configuration.instance_name,
+        project_name=gateway_compute_configuration.project_name,
+        max_length=max_length,
+    )
+
+
+def generate_unique_volume_name(
+    volume: Volume,
+    max_length: int = _DEFAULT_MAX_RESOURCE_NAME_LEN,
+) -> str:
+    """
+    Generates a unique volume name valid across all backends.
+    """
+    return generate_unique_backend_name(
+        resource_name=volume.name,
+        project_name=volume.project_name,
+        max_length=max_length,
+    )
+
+
+def generate_unique_backend_name(
+    resource_name: str,
+    project_name: Optional[str],
+    max_length: int,
+) -> str:
+    """
+    Generates a unique resource name valid across all backends.
+    Backend resource names must be unique on every provisioning so that
+    resource re-submission/re-creation doesn't lead to conflicts
+    on backends that require unique names (e.g. Azure, GCP).
+    """
+    # resource_name is guaranteed to be valid in all backends
+    prefix = f"dstack-{resource_name}"
+    if project_name is not None and is_valid_dstack_resource_name(project_name):
+        # project_name is not guaranteed to be valid in all backends,
+        # so we add it only if it passes the validation
+        prefix = f"dstack-{project_name}-{resource_name}"
+    return _generate_unique_backend_name_with_prefix(
+        prefix=prefix,
+        max_length=max_length,
+    )
+
+
+def _generate_unique_backend_name_with_prefix(
+    prefix: str,
+    max_length: int,
+) -> str:
+    prefix_len = max_length - _CLOUD_RESOURCE_SUFFIX_LEN - 1
+    prefix = prefix[:prefix_len]
+    suffix = "".join(
+        random.choice(string.ascii_lowercase + string.digits)
+        for _ in range(_CLOUD_RESOURCE_SUFFIX_LEN)
+    )
+    return f"{prefix}-{suffix}"
 
 
 def get_cloud_config(**config) -> str:

--- a/src/dstack/_internal/core/backends/cudo/compute.py
+++ b/src/dstack/_internal/core/backends/cudo/compute.py
@@ -91,7 +91,7 @@ class CudoCompute(Compute):
                 project_id=self.config.project_id,
                 boot_disk_storage_class="STORAGE_CLASS_NETWORK",
                 boot_disk_size_gib=disk_size,
-                book_disk_id=f"{instance_config.instance_name}_{instance_offer.region}_disk_id",
+                book_disk_id=f"{vm_id}_disk_id",
                 boot_disk_image_id=_get_image_id(gpus_no > 0),
                 data_center_id=instance_offer.region,
                 gpus=gpus_no,

--- a/src/dstack/_internal/core/backends/cudo/compute.py
+++ b/src/dstack/_internal/core/backends/cudo/compute.py
@@ -4,7 +4,7 @@ import requests
 
 from dstack._internal.core.backends.base import Compute
 from dstack._internal.core.backends.base.compute import (
-    get_instance_name,
+    get_job_instance_name,
     get_shim_commands,
 )
 from dstack._internal.core.backends.base.offers import get_catalog_offers
@@ -58,7 +58,7 @@ class CudoCompute(Compute):
     ) -> JobProvisioningData:
         instance_config = InstanceConfiguration(
             project_name=run.project_name,
-            instance_name=get_instance_name(run, job),
+            instance_name=get_job_instance_name(run, job),
             ssh_keys=[
                 SSHKey(public=project_ssh_public_key.strip()),
             ],

--- a/src/dstack/_internal/core/backends/datacrunch/compute.py
+++ b/src/dstack/_internal/core/backends/datacrunch/compute.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Optional
 
 from dstack._internal.core.backends.base import Compute
 from dstack._internal.core.backends.base.compute import (
+    generate_unique_instance_name,
     get_shim_commands,
 )
 from dstack._internal.core.backends.base.offers import get_catalog_offers
@@ -21,6 +22,8 @@ from dstack._internal.core.models.volumes import Volume
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger("datacrunch.compute")
+
+MAX_INSTANCE_NAME_LEN = 60
 
 # Ubuntu 22.04 + CUDA 12.0 + Docker
 # from API https://datacrunch.stoplight.io/docs/datacrunch-public/c46ab45dbc508-get-all-image-types
@@ -78,6 +81,9 @@ class DataCrunchCompute(Compute):
         instance_offer: InstanceOfferWithAvailability,
         instance_config: InstanceConfiguration,
     ) -> JobProvisioningData:
+        instance_name = generate_unique_instance_name(
+            instance_config, max_length=MAX_INSTANCE_NAME_LEN
+        )
         public_keys = instance_config.get_public_keys()
         ssh_ids = []
         for ssh_public_key in public_keys:
@@ -106,8 +112,8 @@ class DataCrunchCompute(Compute):
             instance_type=instance_offer.instance.name,
             ssh_key_ids=ssh_ids,
             startup_script_id=startup_script_ids,
-            hostname=instance_config.instance_name,
-            description=instance_config.instance_name,
+            hostname=instance_name,
+            description=instance_name,
             image=IMAGE_ID,
             disk_size=disk_size,
             location=instance_offer.region,
@@ -119,8 +125,8 @@ class DataCrunchCompute(Compute):
                 "instance_type": instance_offer.instance.name,
                 "ssh_key_ids": ssh_ids,
                 "startup_script_id": startup_script_ids,
-                "hostname": instance_config.instance_name,
-                "description": instance_config.instance_name,
+                "hostname": instance_name,
+                "description": instance_name,
                 "image": IMAGE_ID,
                 "disk_size": disk_size,
                 "location": instance_offer.region,

--- a/src/dstack/_internal/core/backends/gcp/compute.py
+++ b/src/dstack/_internal/core/backends/gcp/compute.py
@@ -12,8 +12,11 @@ import dstack._internal.core.backends.gcp.auth as auth
 import dstack._internal.core.backends.gcp.resources as gcp_resources
 from dstack._internal.core.backends.base.compute import (
     Compute,
+    generate_unique_gateway_instance_name,
+    generate_unique_instance_name,
+    generate_unique_volume_name,
     get_gateway_user_data,
-    get_instance_name,
+    get_job_instance_name,
     get_shim_commands,
     get_user_data,
     merge_tags,
@@ -149,15 +152,9 @@ class GCPCompute(Compute):
     ) -> JobProvisioningData:
         instance_name = instance_config.instance_name
         allocate_public_ip = self.config.allocate_public_ips
-        if not gcp_resources.is_valid_resource_name(instance_name):
-            # In a rare case the instance name is invalid in GCP,
-            # we better use a random instance name than fail provisioning.
-            instance_name = gcp_resources.generate_random_resource_name()
-            logger.warning(
-                "Invalid GCP instance name: %s. A new valid name is generated: %s",
-                instance_config.instance_name,
-                instance_name,
-            )
+        instance_name = generate_unique_instance_name(
+            instance_config, max_length=gcp_resources.MAX_RESOURCE_NAME_LEN
+        )
         authorized_keys = instance_config.get_public_keys()
 
         # get_offers always fills instance_offer.availability_zones
@@ -182,6 +179,7 @@ class GCPCompute(Compute):
         labels = {
             "owner": "dstack",
             "dstack_project": instance_config.project_name.lower(),
+            "dstack_name": instance_config.instance_name,
             "dstack_user": instance_config.user.lower(),
         }
         labels = {k: v for k, v in labels.items() if gcp_resources.is_valid_label_value(v)}
@@ -378,7 +376,7 @@ class GCPCompute(Compute):
         # TODO: run_job is the same for vm-based backends, refactor
         instance_config = InstanceConfiguration(
             project_name=run.project_name,
-            instance_name=get_instance_name(run, job),  # TODO: generate name
+            instance_name=get_job_instance_name(run, job),  # TODO: generate name
             ssh_keys=[
                 SSHKey(public=project_ssh_public_key.strip()),
             ],
@@ -421,6 +419,9 @@ class GCPCompute(Compute):
         else:
             raise ComputeResourceNotFoundError()
 
+        instance_name = generate_unique_gateway_instance_name(
+            configuration, max_length=gcp_resources.MAX_RESOURCE_NAME_LEN
+        )
         # Choose any usable subnet in a VPC.
         # Configuring a specific subnet per region is not supported yet.
         subnetwork = _get_vpc_subnet(
@@ -432,6 +433,7 @@ class GCPCompute(Compute):
         labels = {
             "owner": "dstack",
             "dstack_project": configuration.project_name.lower(),
+            "dstack_name": configuration.instance_name,
         }
         labels = {k: v for k, v in labels.items() if gcp_resources.is_valid_label_value(v)}
         labels = merge_tags(tags=labels, backend_tags=self.config.tags)
@@ -449,7 +451,7 @@ class GCPCompute(Compute):
             authorized_keys=[configuration.ssh_key_pub],
             labels=labels,
             tags=[gcp_resources.DSTACK_GATEWAY_TAG],
-            instance_name=configuration.instance_name,
+            instance_name=instance_name,
             zone=zone,
             service_account=self.config.vm_service_account,
             network=self.config.vpc_resource_name,
@@ -525,16 +527,21 @@ class GCPCompute(Compute):
             )
         zone = zones[0]
 
+        disk_name = generate_unique_volume_name(
+            volume, max_length=gcp_resources.MAX_RESOURCE_NAME_LEN
+        )
+
         labels = {
             "owner": "dstack",
             "dstack_project": volume.project_name.lower(),
+            "dstack_name": volume.name,
             "dstack_user": volume.user,
         }
         labels = {k: v for k, v in labels.items() if gcp_resources.is_valid_label_value(v)}
         labels = merge_tags(tags=labels, backend_tags=self.config.tags)
 
         disk = compute_v1.Disk()
-        disk.name = volume.name
+        disk.name = disk_name
         disk.size_gb = volume.configuration.size_gb
         disk.type_ = f"zones/{zone}/diskTypes/pd-balanced"
         disk.labels = labels
@@ -552,7 +559,7 @@ class GCPCompute(Compute):
         created_disk = self.disk_client.get(
             project=self.config.project_id,
             zone=zone,
-            disk=volume.name,
+            disk=disk_name,
         )
         logger.debug("Created persistent disk for volume %s", volume.name)
         return VolumeProvisioningData(

--- a/src/dstack/_internal/core/backends/gcp/resources.py
+++ b/src/dstack/_internal/core/backends/gcp/resources.py
@@ -1,7 +1,5 @@
 import concurrent.futures
-import random
 import re
-import string
 from typing import Dict, List, Optional
 
 import google.api_core.exceptions
@@ -322,12 +320,13 @@ def _is_valid_label(key: str, value: str) -> bool:
     return is_valid_resource_name(key) and is_valid_label_value(value)
 
 
+MAX_RESOURCE_NAME_LEN = 63
 NAME_PATTERN = re.compile(r"^[a-z][_\-a-z0-9]{0,62}$")
 LABEL_VALUE_PATTERN = re.compile(r"^[_\-a-z0-9]{0,63}$")
 
 
 def is_valid_resource_name(name: str) -> bool:
-    if len(name) < 1 or len(name) > 63:
+    if len(name) < 1 or len(name) > MAX_RESOURCE_NAME_LEN:
         return False
     match = re.match(NAME_PATTERN, name)
     return match is not None
@@ -336,12 +335,6 @@ def is_valid_resource_name(name: str) -> bool:
 def is_valid_label_value(value: str) -> bool:
     match = re.match(LABEL_VALUE_PATTERN, value)
     return match is not None
-
-
-def generate_random_resource_name(length: int = 40) -> str:
-    return random.choice(string.ascii_lowercase) + "".join(
-        random.choice(string.ascii_lowercase + string.digits) for _ in range(length)
-    )
 
 
 def create_tpu_node_struct(

--- a/src/dstack/_internal/core/backends/kubernetes/compute.py
+++ b/src/dstack/_internal/core/backends/kubernetes/compute.py
@@ -9,9 +9,10 @@ from kubernetes import client
 
 from dstack._internal.core.backends.base.compute import (
     Compute,
+    generate_unique_gateway_instance_name,
+    generate_unique_instance_name_for_job,
     get_docker_commands,
     get_dstack_gateway_commands,
-    get_job_instance_name,
 )
 from dstack._internal.core.backends.base.offers import match_requirements
 from dstack._internal.core.backends.kubernetes.config import KubernetesConfig
@@ -99,7 +100,7 @@ class KubernetesCompute(Compute):
         project_ssh_private_key: str,
         volumes: List[Volume],
     ) -> JobProvisioningData:
-        instance_name = get_job_instance_name(run, job)
+        instance_name = generate_unique_instance_name_for_job(run, job)
         commands = get_docker_commands(
             [run.run_spec.ssh_key_pub.strip(), project_ssh_public_key.strip()]
         )
@@ -231,7 +232,7 @@ class KubernetesCompute(Compute):
         # TODO: By default EKS creates a Classic Load Balancer for Load Balancer services.
         # Consider deploying an NLB. It seems it requires some extra configuration on the cluster:
         # https://docs.aws.amazon.com/eks/latest/userguide/network-load-balancing.html
-        instance_name = configuration.instance_name
+        instance_name = generate_unique_gateway_instance_name(configuration)
         commands = _get_gateway_commands(authorized_keys=[configuration.ssh_key_pub])
         self.api.create_namespaced_pod(
             namespace=DEFAULT_NAMESPACE,

--- a/src/dstack/_internal/core/backends/kubernetes/compute.py
+++ b/src/dstack/_internal/core/backends/kubernetes/compute.py
@@ -11,7 +11,7 @@ from dstack._internal.core.backends.base.compute import (
     Compute,
     get_docker_commands,
     get_dstack_gateway_commands,
-    get_instance_name,
+    get_job_instance_name,
 )
 from dstack._internal.core.backends.base.offers import match_requirements
 from dstack._internal.core.backends.kubernetes.config import KubernetesConfig
@@ -99,7 +99,7 @@ class KubernetesCompute(Compute):
         project_ssh_private_key: str,
         volumes: List[Volume],
     ) -> JobProvisioningData:
-        instance_name = get_instance_name(run, job)
+        instance_name = get_job_instance_name(run, job)
         commands = get_docker_commands(
             [run.run_spec.ssh_key_pub.strip(), project_ssh_public_key.strip()]
         )

--- a/src/dstack/_internal/core/backends/lambdalabs/compute.py
+++ b/src/dstack/_internal/core/backends/lambdalabs/compute.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional
 
 from dstack._internal.core.backends.base.compute import (
     Compute,
+    generate_unique_instance_name,
     get_job_instance_name,
     get_shim_commands,
 )
@@ -22,6 +23,8 @@ from dstack._internal.core.models.instances import (
 )
 from dstack._internal.core.models.runs import Job, JobProvisioningData, Requirements, Run
 from dstack._internal.core.models.volumes import Volume
+
+MAX_INSTANCE_NAME_LEN = 60
 
 
 class LambdaCompute(Compute):
@@ -44,6 +47,9 @@ class LambdaCompute(Compute):
     def create_instance(
         self, instance_offer: InstanceOfferWithAvailability, instance_config: InstanceConfiguration
     ) -> JobProvisioningData:
+        instance_name = generate_unique_instance_name(
+            instance_config, max_length=MAX_INSTANCE_NAME_LEN
+        )
         project_ssh_key = instance_config.ssh_keys[0]
         project_key_name = _add_project_ssh_key(
             api_client=self.api_client,
@@ -53,7 +59,7 @@ class LambdaCompute(Compute):
             region_name=instance_offer.region,
             instance_type_name=instance_offer.instance.name,
             ssh_key_names=[project_key_name],
-            name=instance_config.instance_name,
+            name=instance_name,
             quantity=1,
             file_system_names=[],
         )

--- a/src/dstack/_internal/core/backends/lambdalabs/compute.py
+++ b/src/dstack/_internal/core/backends/lambdalabs/compute.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional
 
 from dstack._internal.core.backends.base.compute import (
     Compute,
-    get_instance_name,
+    get_job_instance_name,
     get_shim_commands,
 )
 from dstack._internal.core.backends.base.offers import get_catalog_offers
@@ -107,7 +107,7 @@ class LambdaCompute(Compute):
     ) -> JobProvisioningData:
         instance_config = InstanceConfiguration(
             project_name=run.project_name,
-            instance_name=get_instance_name(run, job),  # TODO: generate name
+            instance_name=get_job_instance_name(run, job),  # TODO: generate name
             ssh_keys=[
                 SSHKey(
                     public=project_ssh_public_key.strip(), private=project_ssh_private_key.strip()

--- a/src/dstack/_internal/core/backends/nebius/compute.py
+++ b/src/dstack/_internal/core/backends/nebius/compute.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 import dstack.version as version
 from dstack._internal import settings
 from dstack._internal.core.backends.base import Compute
-from dstack._internal.core.backends.base.compute import get_instance_name, get_user_data
+from dstack._internal.core.backends.base.compute import get_job_instance_name, get_user_data
 from dstack._internal.core.backends.base.offers import get_catalog_offers
 from dstack._internal.core.backends.nebius.api_client import NebiusAPIClient
 from dstack._internal.core.backends.nebius.config import NebiusConfig
@@ -130,7 +130,7 @@ class NebiusCompute(Compute):
     ) -> JobProvisioningData:
         instance_config = InstanceConfiguration(
             project_name=run.project_name,
-            instance_name=get_instance_name(run, job),  # TODO: generate name
+            instance_name=get_job_instance_name(run, job),  # TODO: generate name
             ssh_keys=[
                 SSHKey(public=project_ssh_public_key.strip()),
             ],

--- a/src/dstack/_internal/core/backends/oci/compute.py
+++ b/src/dstack/_internal/core/backends/oci/compute.py
@@ -6,6 +6,7 @@ import oci
 
 from dstack._internal.core.backends.base.compute import (
     Compute,
+    generate_unique_instance_name,
     get_job_instance_name,
     get_user_data,
 )
@@ -152,6 +153,7 @@ class OCICompute(Compute):
         ]
         cloud_init_user_data = get_user_data(instance_config.get_public_keys(), setup_commands)
 
+        display_name = generate_unique_instance_name(instance_config)
         try:
             instance = resources.launch_instance(
                 region=region,
@@ -159,7 +161,7 @@ class OCICompute(Compute):
                 compartment_id=self.config.compartment_id,
                 subnet_id=subnet.id,
                 security_group_id=security_group.id,
-                display_name=instance_config.instance_name,
+                display_name=display_name,
                 cloud_init_user_data=cloud_init_user_data,
                 shape=instance_offer.instance.name,
                 is_spot=instance_offer.instance.resources.spot,

--- a/src/dstack/_internal/core/backends/oci/compute.py
+++ b/src/dstack/_internal/core/backends/oci/compute.py
@@ -4,7 +4,11 @@ from typing import List, Optional
 
 import oci
 
-from dstack._internal.core.backends.base.compute import Compute, get_instance_name, get_user_data
+from dstack._internal.core.backends.base.compute import (
+    Compute,
+    get_job_instance_name,
+    get_user_data,
+)
 from dstack._internal.core.backends.base.offers import get_catalog_offers
 from dstack._internal.core.backends.oci import resources
 from dstack._internal.core.backends.oci.config import OCIConfig
@@ -98,7 +102,7 @@ class OCICompute(Compute):
     ) -> JobProvisioningData:
         instance_config = InstanceConfiguration(
             project_name=run.project_name,
-            instance_name=get_instance_name(run, job),
+            instance_name=get_job_instance_name(run, job),
             ssh_keys=[SSHKey(public=project_ssh_public_key.strip())],
             user=run.user,
         )

--- a/src/dstack/_internal/core/backends/runpod/compute.py
+++ b/src/dstack/_internal/core/backends/runpod/compute.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 from dstack._internal.core.backends.base import Compute
 from dstack._internal.core.backends.base.compute import (
     generate_unique_instance_name,
+    generate_unique_volume_name,
     get_docker_commands,
     get_job_instance_name,
 )
@@ -33,7 +34,7 @@ from dstack._internal.utils.logging import get_logger
 logger = get_logger(__name__)
 
 # Undocumented but names of len 60 work
-MAX_POD_NAME_LEN = 60
+MAX_RESOURCE_NAME_LEN = 60
 
 CONTAINER_REGISTRY_AUTH_CLEANUP_INTERVAL = 60 * 60 * 24  # 24 hour
 
@@ -81,7 +82,7 @@ class RunpodCompute(Compute):
             user=run.user,
         )
 
-        pod_name = generate_unique_instance_name(instance_config, max_length=MAX_POD_NAME_LEN)
+        pod_name = generate_unique_instance_name(instance_config, max_length=MAX_RESOURCE_NAME_LEN)
         authorized_keys = instance_config.get_public_keys()
         memory_size = round(instance_offer.instance.resources.memory_mib / 1024)
         disk_size = round(instance_offer.instance.resources.disk.size_mib / 1024)
@@ -202,9 +203,10 @@ class RunpodCompute(Compute):
         )
 
     def create_volume(self, volume: Volume) -> VolumeProvisioningData:
+        volume_name = generate_unique_volume_name(volume, max_length=MAX_RESOURCE_NAME_LEN)
         size_gb = volume.configuration.size_gb
         volume_id = self.api_client.create_network_volume(
-            name=volume.name,
+            name=volume_name,
             region=volume.configuration.region,
             size=size_gb,
         )

--- a/src/dstack/_internal/core/backends/runpod/compute.py
+++ b/src/dstack/_internal/core/backends/runpod/compute.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 from dstack._internal.core.backends.base import Compute
 from dstack._internal.core.backends.base.compute import (
+    generate_unique_instance_name,
     get_docker_commands,
     get_job_instance_name,
 )
@@ -30,6 +31,9 @@ from dstack._internal.utils.common import get_current_datetime
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+# Undocumented but names of len 60 work
+MAX_POD_NAME_LEN = 60
 
 CONTAINER_REGISTRY_AUTH_CLEANUP_INTERVAL = 60 * 60 * 24  # 24 hour
 
@@ -77,6 +81,7 @@ class RunpodCompute(Compute):
             user=run.user,
         )
 
+        pod_name = generate_unique_instance_name(instance_config, max_length=MAX_POD_NAME_LEN)
         authorized_keys = instance_config.get_public_keys()
         memory_size = round(instance_offer.instance.resources.memory_mib / 1024)
         disk_size = round(instance_offer.instance.resources.disk.size_mib / 1024)
@@ -98,7 +103,7 @@ class RunpodCompute(Compute):
             bid_per_gpu = instance_offer.price / gpu_count
 
         resp = self.api_client.create_pod(
-            name=instance_config.instance_name,
+            name=pod_name,
             image_name=job.job_spec.image_name,
             gpu_type_id=instance_offer.instance.name,
             cloud_type="SECURE",  # ["ALL", "COMMUNITY", "SECURE"]:

--- a/src/dstack/_internal/core/backends/runpod/compute.py
+++ b/src/dstack/_internal/core/backends/runpod/compute.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 from dstack._internal.core.backends.base import Compute
 from dstack._internal.core.backends.base.compute import (
     get_docker_commands,
-    get_instance_name,
+    get_job_instance_name,
 )
 from dstack._internal.core.backends.base.offers import get_catalog_offers
 from dstack._internal.core.backends.runpod.api_client import RunpodApiClient
@@ -69,7 +69,7 @@ class RunpodCompute(Compute):
     ) -> JobProvisioningData:
         instance_config = InstanceConfiguration(
             project_name=run.project_name,
-            instance_name=get_instance_name(run, job),
+            instance_name=get_job_instance_name(run, job),
             ssh_keys=[
                 SSHKey(public=run.run_spec.ssh_key_pub.strip()),
                 SSHKey(public=project_ssh_public_key.strip()),

--- a/src/dstack/_internal/core/backends/tensordock/compute.py
+++ b/src/dstack/_internal/core/backends/tensordock/compute.py
@@ -4,7 +4,11 @@ from typing import List, Optional
 import requests
 
 from dstack._internal.core.backends.base import Compute
-from dstack._internal.core.backends.base.compute import get_job_instance_name, get_shim_commands
+from dstack._internal.core.backends.base.compute import (
+    generate_unique_instance_name,
+    get_job_instance_name,
+    get_shim_commands,
+)
 from dstack._internal.core.backends.base.offers import get_catalog_offers
 from dstack._internal.core.backends.tensordock.api_client import TensorDockAPIClient
 from dstack._internal.core.backends.tensordock.config import TensorDockConfig
@@ -21,6 +25,10 @@ from dstack._internal.core.models.volumes import Volume
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+
+# Undocumented but names of len 60 work
+MAX_INSTANCE_NAME_LEN = 60
 
 
 class TensorDockCompute(Compute):
@@ -49,10 +57,13 @@ class TensorDockCompute(Compute):
         instance_offer: InstanceOfferWithAvailability,
         instance_config: InstanceConfiguration,
     ) -> JobProvisioningData:
+        instance_name = generate_unique_instance_name(
+            instance_config, max_length=MAX_INSTANCE_NAME_LEN
+        )
         commands = get_shim_commands(authorized_keys=instance_config.get_public_keys())
         try:
             resp = self.api_client.deploy_single(
-                instance_name=instance_config.instance_name,
+                instance_name=instance_name,
                 instance=instance_offer.instance,
                 cloudinit={
                     "ssh_pwauth": False,  # disable password auth

--- a/src/dstack/_internal/core/backends/tensordock/compute.py
+++ b/src/dstack/_internal/core/backends/tensordock/compute.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 import requests
 
 from dstack._internal.core.backends.base import Compute
-from dstack._internal.core.backends.base.compute import get_instance_name, get_shim_commands
+from dstack._internal.core.backends.base.compute import get_job_instance_name, get_shim_commands
 from dstack._internal.core.backends.base.offers import get_catalog_offers
 from dstack._internal.core.backends.tensordock.api_client import TensorDockAPIClient
 from dstack._internal.core.backends.tensordock.config import TensorDockConfig
@@ -113,7 +113,7 @@ class TensorDockCompute(Compute):
     ) -> JobProvisioningData:
         instance_config = InstanceConfiguration(
             project_name=run.project_name,
-            instance_name=get_instance_name(run, job),  # TODO: generate name
+            instance_name=get_job_instance_name(run, job),  # TODO: generate name
             ssh_keys=[
                 SSHKey(public=run.run_spec.ssh_key_pub.strip()),
                 SSHKey(public=project_ssh_public_key.strip()),

--- a/src/dstack/_internal/core/backends/vastai/compute.py
+++ b/src/dstack/_internal/core/backends/vastai/compute.py
@@ -4,7 +4,7 @@ import gpuhunt
 from gpuhunt.providers.vastai import VastAIProvider
 
 from dstack._internal.core.backends.base import Compute
-from dstack._internal.core.backends.base.compute import get_docker_commands, get_instance_name
+from dstack._internal.core.backends.base.compute import get_docker_commands, get_job_instance_name
 from dstack._internal.core.backends.base.offers import get_catalog_offers
 from dstack._internal.core.backends.vastai.api_client import VastAIAPIClient
 from dstack._internal.core.backends.vastai.config import VastAIConfig
@@ -74,7 +74,7 @@ class VastAICompute(Compute):
             [run.run_spec.ssh_key_pub.strip(), project_ssh_public_key.strip()]
         )
         resp = self.api_client.create_instance(
-            instance_name=get_instance_name(run, job),
+            instance_name=get_job_instance_name(run, job),
             bundle_id=instance_offer.instance.name,
             image_name=job.job_spec.image_name,
             onstart=" && ".join(commands),

--- a/src/dstack/_internal/core/backends/vultr/api_client.py
+++ b/src/dstack/_internal/core/backends/vultr/api_client.py
@@ -20,7 +20,7 @@ class VultrApiClient:
             return False
         return True
 
-    def get_instance(self, instance_id: str, plan_type: str):
+    def get_instance(self, instance_id: str, plan_type: str) -> dict:
         if plan_type == "bare-metal":
             response = self._make_request("GET", f"/bare-metals/{instance_id}")
             return response.json()["bare_metal"]
@@ -28,7 +28,7 @@ class VultrApiClient:
             response = self._make_request("GET", f"/instances/{instance_id}")
             return response.json()["instance"]
 
-    def get_vpc_for_region(self, region: str) -> Optional[str]:
+    def get_vpc_for_region(self, region: str) -> Optional[dict]:
         response = self._make_request("GET", "/vpcs?per_page=500")
         vpcs = response.json().get("vpcs", [])
         if vpcs:
@@ -37,7 +37,7 @@ class VultrApiClient:
                     return vpc
         return None
 
-    def create_vpc(self, region: str):
+    def create_vpc(self, region: str) -> dict:
         data = {"region": region, "description": f"dstack-vpc-{region}"}
         response = self._make_request("POST", "/vpcs", data=data)
         return response.json()["vpc"]

--- a/src/dstack/_internal/core/backends/vultr/compute.py
+++ b/src/dstack/_internal/core/backends/vultr/compute.py
@@ -6,6 +6,7 @@ import requests
 
 from dstack._internal.core.backends.base import Compute
 from dstack._internal.core.backends.base.compute import (
+    generate_unique_instance_name,
     get_job_instance_name,
     get_user_data,
 )
@@ -26,6 +27,8 @@ from dstack._internal.core.models.volumes import Volume
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+MAX_INSTANCE_NAME_LEN = 64
 
 
 class VultrCompute(Compute):
@@ -71,6 +74,9 @@ class VultrCompute(Compute):
     def create_instance(
         self, instance_offer: InstanceOfferWithAvailability, instance_config: InstanceConfiguration
     ) -> JobProvisioningData:
+        instance_name = generate_unique_instance_name(
+            instance_config, max_length=MAX_INSTANCE_NAME_LEN
+        )
         # create vpc
         vpc = self.api_client.get_vpc_for_region(instance_offer.region)
         if not vpc:
@@ -85,7 +91,7 @@ class VultrCompute(Compute):
         ]
         instance_id = self.api_client.launch_instance(
             region=instance_offer.region,
-            label=instance_config.instance_name,
+            label=instance_name,
             plan=instance_offer.instance.name,
             user_data=get_user_data(
                 authorized_keys=instance_config.get_public_keys(),

--- a/src/dstack/_internal/core/backends/vultr/compute.py
+++ b/src/dstack/_internal/core/backends/vultr/compute.py
@@ -6,7 +6,7 @@ import requests
 
 from dstack._internal.core.backends.base import Compute
 from dstack._internal.core.backends.base.compute import (
-    get_instance_name,
+    get_job_instance_name,
     get_user_data,
 )
 from dstack._internal.core.backends.base.offers import get_catalog_offers
@@ -62,7 +62,7 @@ class VultrCompute(Compute):
     ) -> JobProvisioningData:
         instance_config = InstanceConfiguration(
             project_name=run.project_name,
-            instance_name=get_instance_name(run, job),
+            instance_name=get_job_instance_name(run, job),
             ssh_keys=[SSHKey(public=project_ssh_public_key.strip())],
             user=run.user,
         )

--- a/src/dstack/_internal/core/models/backends/base.py
+++ b/src/dstack/_internal/core/models/backends/base.py
@@ -15,6 +15,7 @@ class BackendType(str, enum.Enum):
         DATACRUNCH (BackendType): DataCrunch
         KUBERNETES (BackendType): Kubernetes
         LAMBDA (BackendType): Lambda Cloud
+        OCI (BackendType): Oracle Cloud Infrastructure
         RUNPOD (BackendType): Runpod Cloud
         TENSORDOCK (BackendType): TensorDock Marketplace
         VASTAI (BackendType): Vast.ai Marketplace

--- a/src/dstack/_internal/core/services/__init__.py
+++ b/src/dstack/_internal/core/services/__init__.py
@@ -4,5 +4,9 @@ from dstack._internal.core.errors import ServerClientError
 
 
 def validate_dstack_resource_name(resource_name: str):
-    if not re.match("^[a-z][a-z0-9-]{1,40}$", resource_name):
+    if not is_valid_dstack_resource_name(resource_name):
         raise ServerClientError("Resource name should match regex '^[a-z][a-z0-9-]{1,40}$'")
+
+
+def is_valid_dstack_resource_name(resource_name: str) -> bool:
+    return re.match("^[a-z][a-z0-9-]{1,40}$", resource_name) is not None

--- a/src/dstack/_internal/server/testing/common.py
+++ b/src/dstack/_internal/server/testing/common.py
@@ -16,7 +16,7 @@ from dstack._internal.core.models.configurations import (
 )
 from dstack._internal.core.models.envs import Env
 from dstack._internal.core.models.fleets import FleetConfiguration, FleetSpec, FleetStatus
-from dstack._internal.core.models.gateways import GatewayStatus
+from dstack._internal.core.models.gateways import GatewayComputeConfiguration, GatewayStatus
 from dstack._internal.core.models.instances import (
     Disk,
     Gpu,
@@ -420,6 +420,24 @@ async def create_gateway_compute(
     return gateway_compute
 
 
+def get_gateway_compute_configuration(
+    project_name: str = "test-project",
+    instance_name: str = "test-instance",
+    backend: BackendType = BackendType.AWS,
+    region: str = "us",
+    public_ip: bool = True,
+) -> GatewayComputeConfiguration:
+    return GatewayComputeConfiguration(
+        project_name=project_name,
+        instance_name=instance_name,
+        backend=backend,
+        region=region,
+        public_ip=public_ip,
+        ssh_key_pub="",
+        certificate=None,
+    )
+
+
 async def create_pool(
     session: AsyncSession,
     project: ProjectModel,
@@ -533,13 +551,7 @@ async def create_instance(
         requirements = Requirements(resources=ResourcesSpec(cpu=1))
 
     if instance_configuration is None:
-        instance_configuration = InstanceConfiguration(
-            project_name="test_proj",
-            instance_name="test_instance_name",
-            instance_id="test instance id",
-            ssh_keys=[],
-            user="test_user",
-        )
+        instance_configuration = get_instance_configuration()
 
     if volumes is None:
         volumes = []
@@ -579,6 +591,19 @@ async def create_instance(
     session.add(im)
     await session.commit()
     return im
+
+
+def get_instance_configuration(
+    project_name: str = "test-project",
+    instance_name: str = "test-instance",
+    user: str = "dstack-user",
+) -> InstanceConfiguration:
+    return InstanceConfiguration(
+        project_name=project_name,
+        instance_name=instance_name,
+        user=user,
+        ssh_keys=[],
+    )
 
 
 def get_instance_offer_with_availability(

--- a/src/tests/_internal/core/backends/base/test_compute.py
+++ b/src/tests/_internal/core/backends/base/test_compute.py
@@ -1,0 +1,56 @@
+import re
+
+from dstack._internal.core.backends.base.compute import (
+    generate_unique_backend_name,
+    generate_unique_gateway_instance_name,
+    generate_unique_instance_name,
+    generate_unique_volume_name,
+)
+from dstack._internal.server.testing.common import (
+    get_gateway_compute_configuration,
+    get_instance_configuration,
+    get_volume,
+)
+
+
+class TestGenerateUniqueInstanceName:
+    def test_generates_name(self):
+        configuration = get_instance_configuration(
+            project_name="project1", instance_name="my-instance"
+        )
+        name = generate_unique_instance_name(configuration, 60)
+        assert re.match(r"^dstack-project1-my-instance-[a-z0-9]{8}$", name)
+
+
+class TestGenerateUniqueGatewayInstanceName:
+    def test_generates_name(self):
+        configuration = get_gateway_compute_configuration(
+            project_name="project1", instance_name="my-gateway"
+        )
+        name = generate_unique_gateway_instance_name(configuration, 60)
+        assert re.match(r"^dstack-project1-my-gateway-[a-z0-9]{8}$", name)
+
+
+class TestGenerateUniqueVolumeName:
+    def test_generates_name(self):
+        volume = get_volume(project_name="project1", name="my-volume")
+        name = generate_unique_volume_name(volume, 60)
+        assert re.match(r"^dstack-project1-my-volume-[a-z0-9]{8}$", name)
+
+
+class TestGenerateUniqueBackendName:
+    def test_generates_name_with_project(self):
+        name = generate_unique_backend_name("instance", "project", 60)
+        assert re.match(r"^dstack-project-instance-[a-z0-9]{8}$", name)
+
+    def test_generates_name_without_project(self):
+        name = generate_unique_backend_name("instance", None, 60)
+        assert re.match(r"^dstack-instance-[a-z0-9]{8}$", name)
+
+    def test_truncates_long_names(self):
+        name = generate_unique_backend_name("a" * 100, "project", 30)
+        assert re.match(r"^dstack-project-aaaaaa-[a-z0-9]{8}$", name)
+
+    def test_validates_project_name(self):
+        name = generate_unique_backend_name("instance", "invalid_project!@", 60)
+        assert re.match(r"^dstack-instance-[a-z0-9]{8}$", name)


### PR DESCRIPTION
Closes #2341
Fixes #1744

This PR:
* Switches to using the same approach to naming backend resources across all backends. Resources are named `f"{prefix}-{suffix}"` where prefix is `f"dstack-{project}-{resource_name}"[:max_backend_len-9]` and suffix is a randomly generated string of length 8. This approach guarantees that resource names cannot conflict across provisioning attempts (crucial for GCP, Azure), while including the most important info in backend names, thus making it easy to identify the resources.
* Ensures backend resource names are always valid without backend-specific validation. If a part of the name is invalid (e.g. project), it's not included in the name.
* For backends that implement tags, adds `dstack_name` tag that includes full dstack resource name so that the tag can be used for identification if name prefix is truncated.