### PR TITLE
Forbid `python: 3.8` in run configurations

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     steps:
      - name: Checkout repository
        uses: actions/checkout@v4

--- a/src/dstack/_internal/cli/services/configurators/run.py
+++ b/src/dstack/_internal/cli/services/configurators/run.py
@@ -34,7 +34,6 @@ from dstack._internal.core.models.configurations import (
     BaseRunConfigurationWithPorts,
     DevEnvironmentConfiguration,
     PortMapping,
-    PythonVersion,
     RunConfigurationType,
     ServiceConfiguration,
     TaskConfiguration,
@@ -73,12 +72,6 @@ class BaseRunConfigurator(ApplyEnvVarsConfiguratorMixin, BaseApplyConfigurator):
     ):
         self.apply_args(conf, configurator_args, unknown_args)
         self.validate_gpu_vendor_and_image(conf)
-        if conf.python == PythonVersion.PY38:
-            logger.warning(
-                "Specifying [code]python: 3.8[/] in run configurations is deprecated"
-                " and will be forbidden in a future [code]dstack[/] release."
-                " Please upgrade your configuration to a newer Python version."
-            )
         if repo is None:
             repo = self.api.repos.load(Path.cwd())
         config_manager = ConfigManager()

--- a/src/dstack/_internal/core/models/configurations.py
+++ b/src/dstack/_internal/core/models/configurations.py
@@ -31,7 +31,6 @@ class RunConfigurationType(str, Enum):
 
 
 class PythonVersion(str, Enum):
-    PY38 = "3.8"  # TODO(0.19 or earlier): drop 3.8, stop building Docker images with 3.8
     PY39 = "3.9"
     PY310 = "3.10"
     PY311 = "3.11"


### PR DESCRIPTION
Python 3.8 has reached EOL in October 2024 and has been deprecated in run configurations since
`dstack` 0.18.20.

#1833