### PR TITLE
Fix Fabric Manager in AWS/GCP/Azure/OCI OS images

### DIFF
--- a/scripts/packer/provisioners/cuda.sh
+++ b/scripts/packer/provisioners/cuda.sh
@@ -14,9 +14,8 @@ wget https://developer.download.nvidia.com/compute/cuda/repos/$CUDA_DISTRO/$ARCH
 sudo dpkg -i cuda-keyring_1.0-1_all.deb
 rm cuda-keyring_1.0-1_all.deb
 
-CUDA_BRANCH=$(cut -d '.' -f 1 <<< "$CUDA_DRIVERS_VERSION")
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    cuda-drivers-$CUDA_BRANCH=$CUDA_DRIVERS_VERSION \
-    nvidia-fabricmanager-$CUDA_BRANCH=$CUDA_DRIVERS_VERSION
+    cuda-drivers-$CUDA_DRIVERS_VERSION \
+    nvidia-fabricmanager-$CUDA_DRIVERS_VERSION
 sudo systemctl enable nvidia-fabricmanager

--- a/scripts/packer/versions.json
+++ b/scripts/packer/versions.json
@@ -1,4 +1,4 @@
 {
   "docker_version": "27.1.1",
-  "cuda_drivers_version": "535.183.01-1"
+  "cuda_drivers_version": "535"
 }

--- a/src/dstack/version.py
+++ b/src/dstack/version.py
@@ -1,3 +1,3 @@
 __version__ = None
 __is_release__ = False
-base_image = "0.6"
+base_image = "0.7"

--- a/src/dstack/version.py
+++ b/src/dstack/version.py
@@ -1,3 +1,3 @@
 __version__ = None
 __is_release__ = False
-base_image = "0.7"
+base_image = "0.6"


### PR DESCRIPTION
The `cuda-drivers-535` and
`nvidia-fabricmanager-535` packages used to be
pinned to a specific version. However, this didn't
actually pin the driver version, because
`cuda-drivers-535` brings several NVIDIA packages
and allows various versions of them.

```
Package: cuda-drivers-535
Version: 535.183.01-1
...
Depends: libnvidia-common-535 (>= 535.183.01), libnvidia-compute-535 (>= 535.183.01), ..., nvidia-driver-535 (>= 535.183.01), ...
```

This could lead to a version mismatch when a newer
driver version is installed while Fabric Manager
is pinned to an older version.

This commit solves the issue by removing the pin
so that both the driver and the Fabric Manager
have the same latest `535.*` version.

Fixes #2348