### PR TITLE
Set max_duration to off by default for all run configurations

### DIFF
--- a/src/dstack/_internal/server/services/jobs/configurators/dev.py
+++ b/src/dstack/_internal/server/services/jobs/configurators/dev.py
@@ -6,8 +6,6 @@ from dstack._internal.core.models.runs import RunSpec
 from dstack._internal.server.services.jobs.configurators.base import JobConfigurator
 from dstack._internal.server.services.jobs.configurators.extensions.vscode import VSCodeDesktop
 
-DEFAULT_MAX_DURATION_SECONDS = 6 * 3600
-
 INSTALL_IPYKERNEL = (
     "(echo pip install ipykernel... && pip install -q --no-cache-dir ipykernel 2> /dev/null) || "
     'echo "no pip, ipykernel was not installed"'
@@ -44,7 +42,7 @@ class DevEnvironmentJobConfigurator(JobConfigurator):
         return False
 
     def _default_max_duration(self) -> Optional[int]:
-        return DEFAULT_MAX_DURATION_SECONDS
+        return None
 
     def _spot_policy(self) -> SpotPolicy:
         return self.run_spec.merged_profile.spot_policy or SpotPolicy.ONDEMAND

--- a/src/dstack/_internal/server/services/jobs/configurators/task.py
+++ b/src/dstack/_internal/server/services/jobs/configurators/task.py
@@ -5,8 +5,6 @@ from dstack._internal.core.models.profiles import SpotPolicy
 from dstack._internal.core.models.runs import JobSpec
 from dstack._internal.server.services.jobs.configurators.base import JobConfigurator
 
-DEFAULT_MAX_DURATION_SECONDS = 72 * 3600
-
 
 class TaskJobConfigurator(JobConfigurator):
     TYPE: RunConfigurationType = RunConfigurationType.TASK
@@ -29,7 +27,7 @@ class TaskJobConfigurator(JobConfigurator):
         return True
 
     def _default_max_duration(self) -> Optional[int]:
-        return DEFAULT_MAX_DURATION_SECONDS
+        return None
 
     def _spot_policy(self) -> SpotPolicy:
         return self.run_spec.merged_profile.spot_policy or SpotPolicy.ONDEMAND


### PR DESCRIPTION
Closes #2349 
Addresses #2344

The PR sets `max_duration` to `off` by default for all run configurations. Previously, the default was 72h for tasks, 6h for dev environments, and off for services.