### PR TITLE
Install DCGM Exporter on dstack-built OS images

### DIFF
--- a/scripts/packer/provisioners/cuda.sh
+++ b/scripts/packer/provisioners/cuda.sh
@@ -17,5 +17,6 @@ rm cuda-keyring_1.0-1_all.deb
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     cuda-drivers-$CUDA_DRIVERS_VERSION \
-    nvidia-fabricmanager-$CUDA_DRIVERS_VERSION
+    nvidia-fabricmanager-$CUDA_DRIVERS_VERSION \
+    datacenter-gpu-manager-4-core datacenter-gpu-manager-exporter
 sudo systemctl enable nvidia-fabricmanager


### PR DESCRIPTION
Part-of: https://github.com/dstackai/dstack/issues/2359