### PR TITLE
Support iam_instance_profile for AWS

### DIFF
--- a/docs/docs/concepts/backends.md
+++ b/docs/docs/concepts/backends.md
@@ -122,12 +122,43 @@ There are two ways to configure AWS: using an access key or using the default cr
                     "acm:ListCertificates"
                 ],
                 "Resource": "*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "iam:GetInstanceProfile",
+                    "iam:GetRole",
+                    "iam:PassRole"
+                ],
+                "Resource": "*"
             }
         ]
     }
     ```
 
     The `elasticloadbalancing:*` and `acm:*` permissions are only needed for provisioning gateways with ACM (AWS Certificate Manager) certificates.
+
+    The `iam:*` permissions are only needed if you specify `iam_instance_profile` to assign to EC2 instances.
+
+    You can also limit permissions to specific resources in your account:
+    
+    ```
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            ...
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "iam:GetInstanceProfile",
+                    "iam:GetRole",
+                    "iam:PassRole"
+                ],
+                "Resource": "arn:aws:iam::account-id:role/EC2-roles-for-XYZ-*"
+            }
+        ]
+    }
+    ```
 
 ??? info "VPC"
     By default, `dstack` uses the default VPC. It's possible to customize it:

--- a/src/dstack/_internal/core/backends/aws/resources.py
+++ b/src/dstack/_internal/core/backends/aws/resources.py
@@ -131,7 +131,7 @@ def create_instances_struct(
     disk_size: int,
     image_id: str,
     instance_type: str,
-    iam_instance_profile_arn: Optional[str],
+    iam_instance_profile: Optional[str],
     user_data: str,
     tags: List[Dict[str, str]],
     security_group_id: str,
@@ -166,8 +166,8 @@ def create_instances_struct(
             },
         ],
     )
-    if iam_instance_profile_arn:
-        struct["IamInstanceProfile"] = {"Arn": iam_instance_profile_arn}
+    if iam_instance_profile:
+        struct["IamInstanceProfile"] = {"Name": iam_instance_profile}
     if spot:
         struct["InstanceMarketOptions"] = {
             "MarketType": "spot",

--- a/src/dstack/_internal/core/models/backends/aws.py
+++ b/src/dstack/_internal/core/models/backends/aws.py
@@ -32,6 +32,7 @@ class AWSConfigInfo(CoreModel):
     vpc_ids: Optional[Dict[str, str]] = None
     default_vpcs: Optional[bool] = None
     public_ips: Optional[bool] = None
+    iam_instance_profile: Optional[str] = None
     tags: Optional[Dict[str, str]] = None
     os_images: Optional[AWSOSImageConfig] = None
 
@@ -70,6 +71,7 @@ class AWSConfigInfoWithCredsPartial(CoreModel):
     vpc_ids: Optional[Dict[str, str]]
     default_vpcs: Optional[bool]
     public_ips: Optional[bool]
+    iam_instance_profile: Optional[str]
     tags: Optional[Dict[str, str]]
     os_images: Optional["AWSOSImageConfig"]
 

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -107,6 +107,16 @@ class AWSConfig(CoreModel):
             )
         ),
     ] = None
+    iam_instance_profile: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "The name of the IAM instance profile to associate with EC2 instances."
+                " You can also specify the IAM role name for roles created via the AWS console."
+                " AWS automatically creates an instance profile and gives it the same name as the role"
+            )
+        ),
+    ] = None
     tags: Annotated[
         Optional[Dict[str, str]],
         Field(description="The tags that will be assigned to resources created by `dstack`"),
@@ -251,7 +261,7 @@ class GCPConfig(CoreModel):
         ),
     ] = None
     vm_service_account: Annotated[
-        Optional[str], Field(description="The service account associated with provisioned VMs")
+        Optional[str], Field(description="The service account to associate with provisioned VMs")
     ] = None
     tags: Annotated[
         Optional[Dict[str, str]],

--- a/src/tests/_internal/server/routers/test_backends.py
+++ b/src/tests/_internal/server/routers/test_backends.py
@@ -1335,6 +1335,7 @@ class TestGetConfigInfo:
             "vpc_ids": None,
             "default_vpcs": None,
             "public_ips": None,
+            "iam_instance_profile": None,
             "tags": None,
             "os_images": None,
             "creds": json.loads(backend.auth.plaintext),


### PR DESCRIPTION
Closes #2345

The PR adds `iam_instance_profile` parameter to AWS config that allows specifying IAM instance profile (role) that will be associated with EC2 instances:

```yaml
projects:
- name: main
  backends:
  - type: aws
    iam_instance_profile: dstack-test-role
    creds:
      type: default
```

This can be used to access AWS resources from runs without passing credentials explicitly.