### PR TITLE
Support RunPod Community Cloud

### DIFF
--- a/docs/docs/concepts/backends.md
+++ b/docs/docs/concepts/backends.md
@@ -617,6 +617,43 @@ projects:
 
 </div>
 
+??? info "Community Cloud"
+    By default, `dstack` considers instance offers from both the Secure Cloud and the
+    [Community Cloud :material-arrow-top-right-thin:{ .external }](https://docs.runpod.io/references/faq/#secure-cloud-vs-community-cloud).
+
+    You can tell them apart by their regions.
+    Secure Cloud regions contain datacenter IDs such as `CA-MTL-3`.
+    Community Cloud regions contain country codes such as `CA`.
+
+    <div class="termy">
+
+    ```shell
+    $ dstack apply -f .dstack.yml -b runpod
+
+     #  BACKEND  REGION    INSTANCE               SPOT  PRICE
+     1  runpod   CA        NVIDIA A100 80GB PCIe  yes   $0.6
+     2  runpod   CA-MTL-3  NVIDIA A100 80GB PCIe  yes   $0.82
+    ```
+
+    </div>
+
+    If you don't want to use the Community Cloud, set `community_cloud: false` in the backend settings.
+
+    <div editor-title="~/.dstack/server/config.yml">
+
+    ```yaml
+    projects:
+      - name: main
+        backends:
+          - type: runpod
+            creds:
+              type: api_key
+              api_key: US9XTPDIV8AR42MMINY8TCKRB8S4E7LNRQ6CAUQ9
+            community_cloud: false
+    ```
+
+    </div>
+
 ### Vultr
 
 Log into your [Vultr :material-arrow-top-right-thin:{ .external }](https://www.vultr.com/) account, click `Account` in the sidebar, select `API`, find the `Personal Access Token` panel and click the `Enable API` button. In the `Access Control` panel, allow API requests from all addresses or from the subnet where your `dstack` server is deployed.

--- a/docs/docs/reference/server/config.yml.md
+++ b/docs/docs/reference/server/config.yml.md
@@ -143,7 +143,7 @@ to configure [backends](../../concepts/backends.md) and other [sever-level setti
         type:
             required: true
 
-###### `projects[n].backends[type=runpod]` { #runpod data-toc-label="runpod" }
+##### `projects[n].backends[type=runpod]` { #runpod data-toc-label="runpod" }
 
 #SCHEMA# dstack._internal.server.services.config.RunpodConfig
     overrides:
@@ -160,7 +160,7 @@ to configure [backends](../../concepts/backends.md) and other [sever-level setti
         type:
             required: true
 
-###### `projects[n].backends[type=vastai]` { #vastai data-toc-label="vastai" }
+##### `projects[n].backends[type=vastai]` { #vastai data-toc-label="vastai" }
 
 #SCHEMA# dstack._internal.server.services.config.VastAIConfig
     overrides:

--- a/src/dstack/_internal/core/backends/runpod/config.py
+++ b/src/dstack/_internal/core/backends/runpod/config.py
@@ -4,6 +4,14 @@ from dstack._internal.core.models.backends.runpod import (
     RunpodStoredConfig,
 )
 
+RUNPOD_COMMUNITY_CLOUD_DEFAULT = True
+
 
 class RunpodConfig(RunpodStoredConfig, BackendConfig):
     creds: AnyRunpodCreds
+
+    @property
+    def allow_community_cloud(self) -> bool:
+        if self.community_cloud is not None:
+            return self.community_cloud
+        return RUNPOD_COMMUNITY_CLOUD_DEFAULT

--- a/src/dstack/_internal/core/models/backends/runpod.py
+++ b/src/dstack/_internal/core/models/backends/runpod.py
@@ -10,6 +10,7 @@ from dstack._internal.core.models.common import CoreModel
 class RunpodConfigInfo(CoreModel):
     type: Literal["runpod"] = "runpod"
     regions: Optional[List[str]] = None
+    community_cloud: Optional[bool] = None
 
 
 class RunpodStoredConfig(RunpodConfigInfo):
@@ -33,6 +34,7 @@ class RunpodConfigInfoWithCredsPartial(CoreModel):
     type: Literal["runpod"] = "runpod"
     creds: Optional[AnyRunpodCreds]
     regions: Optional[List[str]]
+    community_cloud: Optional[bool]
 
 
 class RunpodConfigValues(CoreModel):

--- a/src/dstack/_internal/server/services/backends/configurators/runpod.py
+++ b/src/dstack/_internal/server/services/backends/configurators/runpod.py
@@ -3,11 +3,7 @@ from typing import List
 
 from dstack._internal.core.backends.base import Backend
 from dstack._internal.core.backends.runpod import RunpodBackend, RunpodConfig, api_client
-from dstack._internal.core.models.backends.base import (
-    BackendType,
-    ConfigElementValue,
-    ConfigMultiElement,
-)
+from dstack._internal.core.models.backends.base import BackendType, ConfigMultiElement
 from dstack._internal.core.models.backends.runpod import (
     RunpodConfigInfo,
     RunpodConfigInfoWithCreds,
@@ -22,25 +18,6 @@ from dstack._internal.server.services.backends.configurators.base import (
     raise_invalid_credentials_error,
 )
 
-REGIONS = [
-    "CA-MTL-1",
-    "CA-MTL-2",
-    "CA-MTL-3",
-    "EU-NL-1",
-    "EU-RO-1",
-    "EU-SE-1",
-    "EUR-IS-1",
-    "EUR-IS-2",
-    "US-CA-1",
-    "US-GA-1",
-    "US-GA-2",
-    "US-KS-2",
-    "US-OR-1",
-    "US-TX-3",
-]
-
-DEFAULT_REGION = "CA-MTL-1"
-
 
 class RunpodConfigurator(Configurator):
     TYPE: BackendType = BackendType.RUNPOD
@@ -50,16 +27,12 @@ class RunpodConfigurator(Configurator):
         if config.creds is None:
             return config_values
         self._validate_runpod_api_key(config.creds.api_key)
-        config_values.regions = self._get_regions_element(
-            selected=config.regions or [DEFAULT_REGION]
-        )
+        config_values.regions = self._get_regions_element(selected=config.regions or [])
         return config_values
 
     def create_backend(
         self, project: ProjectModel, config: RunpodConfigInfoWithCreds
     ) -> BackendModel:
-        if config.regions is None:
-            config.regions = REGIONS
         return BackendModel(
             project_id=project.id,
             type=self.TYPE.value,
@@ -80,10 +53,7 @@ class RunpodConfigurator(Configurator):
         return RunpodBackend(config=config)
 
     def _get_regions_element(self, selected: List[str]) -> ConfigMultiElement:
-        element = ConfigMultiElement(selected=selected)
-        for r in REGIONS:
-            element.values.append(ConfigElementValue(value=r, label=r))
-        return element
+        return ConfigMultiElement(selected=selected)
 
     def _get_backend_config(self, model: BackendModel) -> RunpodConfig:
         return RunpodConfig(

--- a/src/dstack/_internal/server/services/config.py
+++ b/src/dstack/_internal/server/services/config.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field, ValidationError, root_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
 
+from dstack._internal.core.backends.runpod.config import RUNPOD_COMMUNITY_CLOUD_DEFAULT
 from dstack._internal.core.errors import (
     BackendNotAvailable,
     ResourceNotExistsError,
@@ -427,6 +428,15 @@ class RunpodConfig(CoreModel):
     regions: Annotated[
         Optional[List[str]],
         Field(description="The list of RunPod regions. Omit to use all regions"),
+    ] = None
+    community_cloud: Annotated[
+        Optional[bool],
+        Field(
+            description=(
+                "Whether Community Cloud offers can be suggested in addition to Secure Cloud."
+                f" Defaults to `{str(RUNPOD_COMMUNITY_CLOUD_DEFAULT).lower()}`"
+            )
+        ),
     ] = None
     creds: Annotated[AnyRunpodCreds, Field(description="The credentials")]
 


### PR DESCRIPTION
- Deploy offers in the designated cloud based on their region.
- Drop the hardcoded list of regions and use all regions by default (_actually_ solves #1573).
- Fix the `server/config.yml` reference to include RunPod and Vast.ai in the ToC.

https://github.com/dstackai/dstack/issues/1892