### PR TITLE
Introduce ComputeWith classes to detect compute features

### DIFF
--- a/contributing/BACKENDS.md
+++ b/contributing/BACKENDS.md
@@ -117,13 +117,8 @@ Refer to examples:
 ##### 2.4.4. Create the backend compute class
 
 Under the backend directory you've created, create the `compute.py` file and define the
-backend compute class there (should extend `dstack._internal.core.backends.base.compute.Compute`).
-
-You'll have to implement `get_offers`, `run_job` and `terminate_instance`.
-You may need to implement `update_provisioning_data`, see its docstring for details.
-
-For VM-based backends, also implement the `create_instance` method and add the backend name to
-[`BACKENDS_WITH_CREATE_INSTANCE_SUPPORT`](`https://github.com/dstackai/dstack/blob/master/src/dstack/_internal/core/backends/__init__.py`).
+backend compute class that extends the `dstack._internal.core.backends.base.compute.Compute` class.
+It can also extend and implement `ComputeWith*` classes to support additional features such as fleets, volumes, gateways, placement groups, etc.
 
 Refer to examples:
 [datacrunch](https://github.com/dstackai/dstack/blob/master/src/dstack/_internal/core/backends/datacrunch/compute.py),

--- a/contributing/BACKENDS.md
+++ b/contributing/BACKENDS.md
@@ -118,7 +118,7 @@ Refer to examples:
 
 Under the backend directory you've created, create the `compute.py` file and define the
 backend compute class that extends the `dstack._internal.core.backends.base.compute.Compute` class.
-It can also extend and implement `ComputeWith*` classes to support additional features such as fleets, volumes, gateways, placement groups, etc.
+It can also extend and implement `ComputeWith*` classes to support additional features such as fleets, volumes, gateways, placement groups, etc. For example, it should extend `ComputeWithCreateInstanceSupport` to support fleets.
 
 Refer to examples:
 [datacrunch](https://github.com/dstackai/dstack/blob/master/src/dstack/_internal/core/backends/datacrunch/compute.py),

--- a/src/dstack/_internal/core/backends/__init__.py
+++ b/src/dstack/_internal/core/backends/__init__.py
@@ -1,42 +1,58 @@
+from dstack._internal.core.backends.base.compute import (
+    ComputeWithCreateInstanceSupport,
+    ComputeWithGatewaySupport,
+    ComputeWithMultinodeSupport,
+    ComputeWithPlacementGroupSupport,
+    ComputeWithPrivateGatewaySupport,
+    ComputeWithReservationSupport,
+    ComputeWithVolumeSupport,
+)
+from dstack._internal.core.backends.base.configurator import Configurator
+from dstack._internal.core.backends.configurators import list_available_configurator_classes
 from dstack._internal.core.models.backends.base import BackendType
 
-BACKENDS_WITH_MULTINODE_SUPPORT = [
-    BackendType.AWS,
-    BackendType.AZURE,
-    BackendType.GCP,
-    BackendType.REMOTE,
-    BackendType.OCI,
-    BackendType.VULTR,
-]
-BACKENDS_WITH_CREATE_INSTANCE_SUPPORT = [
-    BackendType.AWS,
-    BackendType.DSTACK,
-    BackendType.AZURE,
-    BackendType.CUDO,
-    BackendType.DATACRUNCH,
-    BackendType.GCP,
-    BackendType.LAMBDA,
-    BackendType.OCI,
-    BackendType.TENSORDOCK,
-    BackendType.VULTR,
-]
-BACKENDS_WITH_PLACEMENT_GROUPS_SUPPORT = [
-    BackendType.AWS,
-]
-BACKENDS_WITH_RESERVATION_SUPPORT = [
-    BackendType.AWS,
-]
 
-BACKENDS_WITH_GATEWAY_SUPPORT = [
-    BackendType.AWS,
-    BackendType.AZURE,
-    BackendType.GCP,
-    BackendType.KUBERNETES,
-]
-BACKENDS_WITH_PRIVATE_GATEWAY_SUPPORT = [BackendType.AWS]
-BACKENDS_WITH_VOLUMES_SUPPORT = [
-    BackendType.AWS,
-    BackendType.GCP,
-    BackendType.LOCAL,
-    BackendType.RUNPOD,
-]
+def _get_backends_with_compute_feature(
+    configurator_classes: list[type[Configurator]],
+    compute_feature_class: type,
+) -> list[BackendType]:
+    backend_types = []
+    for configurator_class in configurator_classes:
+        compute_class = configurator_class.BACKEND_CLASS.COMPUTE_CLASS
+        if issubclass(compute_class, compute_feature_class):
+            backend_types.append(configurator_class.TYPE)
+    return backend_types
+
+
+_configurator_classes = list_available_configurator_classes()
+
+
+# TODO: Add LocalBackend to lists if it's enabled
+BACKENDS_WITH_CREATE_INSTANCE_SUPPORT = _get_backends_with_compute_feature(
+    configurator_classes=_configurator_classes,
+    compute_feature_class=ComputeWithCreateInstanceSupport,
+)
+BACKENDS_WITH_MULTINODE_SUPPORT = [BackendType.REMOTE] + _get_backends_with_compute_feature(
+    configurator_classes=_configurator_classes,
+    compute_feature_class=ComputeWithMultinodeSupport,
+)
+BACKENDS_WITH_PLACEMENT_GROUPS_SUPPORT = _get_backends_with_compute_feature(
+    configurator_classes=_configurator_classes,
+    compute_feature_class=ComputeWithPlacementGroupSupport,
+)
+BACKENDS_WITH_RESERVATION_SUPPORT = _get_backends_with_compute_feature(
+    configurator_classes=_configurator_classes,
+    compute_feature_class=ComputeWithReservationSupport,
+)
+BACKENDS_WITH_GATEWAY_SUPPORT = _get_backends_with_compute_feature(
+    configurator_classes=_configurator_classes,
+    compute_feature_class=ComputeWithGatewaySupport,
+)
+BACKENDS_WITH_PRIVATE_GATEWAY_SUPPORT = _get_backends_with_compute_feature(
+    configurator_classes=_configurator_classes,
+    compute_feature_class=ComputeWithPrivateGatewaySupport,
+)
+BACKENDS_WITH_VOLUMES_SUPPORT = _get_backends_with_compute_feature(
+    configurator_classes=_configurator_classes,
+    compute_feature_class=ComputeWithVolumeSupport,
+)

--- a/src/dstack/_internal/core/backends/__init__.py
+++ b/src/dstack/_internal/core/backends/__init__.py
@@ -27,6 +27,7 @@ def _get_backends_with_compute_feature(
 _configurator_classes = list_available_configurator_classes()
 
 
+# The following backend lists do not include unavailable backends (i.e. backends missing deps).
 # TODO: Add LocalBackend to lists if it's enabled
 BACKENDS_WITH_CREATE_INSTANCE_SUPPORT = _get_backends_with_compute_feature(
     configurator_classes=_configurator_classes,

--- a/src/dstack/_internal/core/backends/aws/backend.py
+++ b/src/dstack/_internal/core/backends/aws/backend.py
@@ -8,7 +8,8 @@ from dstack._internal.core.models.backends.base import BackendType
 
 
 class AWSBackend(Backend):
-    TYPE: BackendType = BackendType.AWS
+    TYPE = BackendType.AWS
+    COMPUTE_CLASS = AWSCompute
 
     def __init__(self, config: AWSConfig):
         self.config = config

--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -12,6 +12,13 @@ from dstack._internal.core.backends.aws.config import AWSConfig
 from dstack._internal.core.backends.aws.models import AWSAccessKeyCreds
 from dstack._internal.core.backends.base.compute import (
     Compute,
+    ComputeWithCreateInstanceSupport,
+    ComputeWithGatewaySupport,
+    ComputeWithMultinodeSupport,
+    ComputeWithPlacementGroupSupport,
+    ComputeWithPrivateGatewaySupport,
+    ComputeWithReservationSupport,
+    ComputeWithVolumeSupport,
     generate_unique_gateway_instance_name,
     generate_unique_instance_name,
     generate_unique_volume_name,
@@ -62,7 +69,16 @@ class AWSVolumeBackendData(CoreModel):
     iops: int
 
 
-class AWSCompute(Compute):
+class AWSCompute(
+    Compute,
+    ComputeWithCreateInstanceSupport,
+    ComputeWithMultinodeSupport,
+    ComputeWithReservationSupport,
+    ComputeWithPlacementGroupSupport,
+    ComputeWithGatewaySupport,
+    ComputeWithPrivateGatewaySupport,
+    ComputeWithVolumeSupport,
+):
     def __init__(self, config: AWSConfig):
         super().__init__()
         self.config = config

--- a/src/dstack/_internal/core/backends/aws/configurator.py
+++ b/src/dstack/_internal/core/backends/aws/configurator.py
@@ -53,7 +53,8 @@ MAIN_REGION = "us-east-1"
 
 
 class AWSConfigurator(Configurator):
-    TYPE: BackendType = BackendType.AWS
+    TYPE = BackendType.AWS
+    BACKEND_CLASS = AWSBackend
 
     def validate_config(self, config: AWSBackendConfigWithCreds, default_creds_enabled: bool):
         if is_core_model_instance(config.creds, AWSDefaultCreds) and not default_creds_enabled:

--- a/src/dstack/_internal/core/backends/azure/backend.py
+++ b/src/dstack/_internal/core/backends/azure/backend.py
@@ -6,7 +6,8 @@ from dstack._internal.core.models.backends.base import BackendType
 
 
 class AzureBackend(Backend):
-    TYPE: BackendType = BackendType.AZURE
+    TYPE = BackendType.AZURE
+    COMPUTE_CLASS = AzureCompute
 
     def __init__(self, config: AzureConfig):
         self.config = config

--- a/src/dstack/_internal/core/backends/azure/compute.py
+++ b/src/dstack/_internal/core/backends/azure/compute.py
@@ -39,6 +39,9 @@ from dstack._internal.core.backends.azure import utils as azure_utils
 from dstack._internal.core.backends.azure.config import AzureConfig
 from dstack._internal.core.backends.base.compute import (
     Compute,
+    ComputeWithCreateInstanceSupport,
+    ComputeWithGatewaySupport,
+    ComputeWithMultinodeSupport,
     generate_unique_gateway_instance_name,
     generate_unique_instance_name,
     get_gateway_user_data,
@@ -71,7 +74,12 @@ logger = get_logger(__name__)
 CONFIGURABLE_DISK_SIZE = Range[Memory](min=Memory.parse("30GB"), max=Memory.parse("4095GB"))
 
 
-class AzureCompute(Compute):
+class AzureCompute(
+    Compute,
+    ComputeWithCreateInstanceSupport,
+    ComputeWithMultinodeSupport,
+    ComputeWithGatewaySupport,
+):
     def __init__(self, config: AzureConfig, credential: TokenCredential):
         super().__init__()
         self.config = config

--- a/src/dstack/_internal/core/backends/azure/configurator.py
+++ b/src/dstack/_internal/core/backends/azure/configurator.py
@@ -72,7 +72,8 @@ MAIN_LOCATION = "eastus"
 
 
 class AzureConfigurator(Configurator):
-    TYPE: BackendType = BackendType.AZURE
+    TYPE = BackendType.AZURE
+    BACKEND_CLASS = AzureBackend
 
     def validate_config(self, config: AzureBackendConfigWithCreds, default_creds_enabled: bool):
         if is_core_model_instance(config.creds, AzureDefaultCreds) and not default_creds_enabled:

--- a/src/dstack/_internal/core/backends/base/backend.py
+++ b/src/dstack/_internal/core/backends/base/backend.py
@@ -1,12 +1,18 @@
 from abc import ABC, abstractmethod
+from typing import ClassVar
 
 from dstack._internal.core.backends.base.compute import Compute
 from dstack._internal.core.models.backends.base import BackendType
 
 
 class Backend(ABC):
-    TYPE: BackendType
+    TYPE: ClassVar[BackendType]
+    # `COMPUTE_CLASS` is used to introspect compute features without initializing it.
+    COMPUTE_CLASS: ClassVar[type[Compute]]
 
     @abstractmethod
     def compute(self) -> Compute:
+        """
+        Returns Compute instance.
+        """
         pass

--- a/src/dstack/_internal/core/backends/base/configurator.py
+++ b/src/dstack/_internal/core/backends/base/configurator.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, List, Optional
+from typing import Any, ClassVar, List, Optional
 from uuid import UUID
 
 from dstack._internal.core.backends.base.backend import Backend
@@ -47,7 +47,9 @@ class Configurator(ABC):
     in `dstack._internal.core.backends.configurators`.
     """
 
-    TYPE: BackendType
+    TYPE: ClassVar[BackendType]
+    # `BACKEND_CLASS` is used to introspect backend features without initializing it.
+    BACKEND_CLASS: ClassVar[type[Backend]]
 
     @abstractmethod
     def validate_config(self, config: AnyBackendConfigWithCreds, default_creds_enabled: bool):

--- a/src/dstack/_internal/core/backends/configurators.py
+++ b/src/dstack/_internal/core/backends/configurators.py
@@ -132,6 +132,10 @@ def list_available_backend_types() -> List[BackendType]:
     return available_backend_types
 
 
+def list_available_configurator_classes() -> List[type[Configurator]]:
+    return _CONFIGURATOR_CLASSES
+
+
 def register_configurator(configurator: Type[Configurator]):
     """
     A hook to for registering new configurators without importing them.

--- a/src/dstack/_internal/core/backends/configurators.py
+++ b/src/dstack/_internal/core/backends/configurators.py
@@ -109,6 +109,7 @@ except ImportError:
 
 
 _BACKEND_TYPE_TO_CONFIGURATOR_CLASS_MAP = {c.TYPE: c for c in _CONFIGURATOR_CLASSES}
+_BACKEND_TYPES = [c.TYPE for c in _CONFIGURATOR_CLASSES]
 
 
 def get_configurator(backend_type: Union[BackendType, str]) -> Optional[Configurator]:
@@ -126,13 +127,13 @@ def list_available_backend_types() -> List[BackendType]:
     """
     Lists all backend types available on the server.
     """
-    available_backend_types = []
-    for configurator_class in _BACKEND_TYPE_TO_CONFIGURATOR_CLASS_MAP.values():
-        available_backend_types.append(configurator_class.TYPE)
-    return available_backend_types
+    return _BACKEND_TYPES
 
 
 def list_available_configurator_classes() -> List[type[Configurator]]:
+    """
+    Lists all backend configurator classes available on the server.
+    """
     return _CONFIGURATOR_CLASSES
 
 

--- a/src/dstack/_internal/core/backends/cudo/backend.py
+++ b/src/dstack/_internal/core/backends/cudo/backend.py
@@ -5,7 +5,8 @@ from dstack._internal.core.models.backends.base import BackendType
 
 
 class CudoBackend(Backend):
-    TYPE: BackendType = BackendType.CUDO
+    TYPE = BackendType.CUDO
+    COMPUTE_CLASS = CudoCompute
 
     def __init__(self, config: CudoConfig):
         self.config = config

--- a/src/dstack/_internal/core/backends/cudo/compute.py
+++ b/src/dstack/_internal/core/backends/cudo/compute.py
@@ -4,6 +4,7 @@ import requests
 
 from dstack._internal.core.backends.base.backend import Compute
 from dstack._internal.core.backends.base.compute import (
+    ComputeWithCreateInstanceSupport,
     generate_unique_instance_name,
     get_job_instance_name,
     get_shim_commands,
@@ -29,7 +30,10 @@ logger = get_logger(__name__)
 MAX_RESOURCE_NAME_LEN = 30
 
 
-class CudoCompute(Compute):
+class CudoCompute(
+    Compute,
+    ComputeWithCreateInstanceSupport,
+):
     def __init__(self, config: CudoConfig):
         super().__init__()
         self.config = config

--- a/src/dstack/_internal/core/backends/cudo/configurator.py
+++ b/src/dstack/_internal/core/backends/cudo/configurator.py
@@ -29,7 +29,8 @@ DEFAULT_REGION = "no-luster-1"
 
 
 class CudoConfigurator(Configurator):
-    TYPE: BackendType = BackendType.CUDO
+    TYPE = BackendType.CUDO
+    BACKEND_CLASS = CudoBackend
 
     def validate_config(self, config: CudoBackendConfigWithCreds, default_creds_enabled: bool):
         self._validate_cudo_api_key(config.creds.api_key)

--- a/src/dstack/_internal/core/backends/datacrunch/backend.py
+++ b/src/dstack/_internal/core/backends/datacrunch/backend.py
@@ -5,7 +5,8 @@ from dstack._internal.core.models.backends.base import BackendType
 
 
 class DataCrunchBackend(Backend):
-    TYPE: BackendType = BackendType.DATACRUNCH
+    TYPE = BackendType.DATACRUNCH
+    COMPUTE_CLASS = DataCrunchCompute
 
     def __init__(self, config: DataCrunchConfig):
         self.config = config

--- a/src/dstack/_internal/core/backends/datacrunch/compute.py
+++ b/src/dstack/_internal/core/backends/datacrunch/compute.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Optional
 
 from dstack._internal.core.backends.base.backend import Compute
 from dstack._internal.core.backends.base.compute import (
+    ComputeWithCreateInstanceSupport,
     generate_unique_instance_name,
     get_shim_commands,
 )
@@ -33,7 +34,10 @@ IMAGE_SIZE = Memory.parse("50GB")
 CONFIGURABLE_DISK_SIZE = Range[Memory](min=IMAGE_SIZE, max=None)
 
 
-class DataCrunchCompute(Compute):
+class DataCrunchCompute(
+    Compute,
+    ComputeWithCreateInstanceSupport,
+):
     def __init__(self, config: DataCrunchConfig):
         super().__init__()
         self.config = config

--- a/src/dstack/_internal/core/backends/datacrunch/configurator.py
+++ b/src/dstack/_internal/core/backends/datacrunch/configurator.py
@@ -26,7 +26,8 @@ DEFAULT_REGION = "FIN-01"
 
 
 class DataCrunchConfigurator(Configurator):
-    TYPE: BackendType = BackendType.DATACRUNCH
+    TYPE = BackendType.DATACRUNCH
+    BACKEND_CLASS = DataCrunchBackend
 
     def validate_config(
         self, config: DataCrunchBackendConfigWithCreds, default_creds_enabled: bool

--- a/src/dstack/_internal/core/backends/gcp/backend.py
+++ b/src/dstack/_internal/core/backends/gcp/backend.py
@@ -5,7 +5,8 @@ from dstack._internal.core.models.backends.base import BackendType
 
 
 class GCPBackend(Backend):
-    TYPE: BackendType = BackendType.GCP
+    TYPE = BackendType.GCP
+    COMPUTE_CLASS = GCPCompute
 
     def __init__(self, config: GCPConfig):
         self.config = config

--- a/src/dstack/_internal/core/backends/gcp/compute.py
+++ b/src/dstack/_internal/core/backends/gcp/compute.py
@@ -12,6 +12,10 @@ import dstack._internal.core.backends.gcp.auth as auth
 import dstack._internal.core.backends.gcp.resources as gcp_resources
 from dstack._internal.core.backends.base.compute import (
     Compute,
+    ComputeWithCreateInstanceSupport,
+    ComputeWithGatewaySupport,
+    ComputeWithMultinodeSupport,
+    ComputeWithVolumeSupport,
     generate_unique_gateway_instance_name,
     generate_unique_instance_name,
     generate_unique_volume_name,
@@ -69,7 +73,13 @@ class GCPVolumeDiskBackendData(CoreModel):
     disk_type: str
 
 
-class GCPCompute(Compute):
+class GCPCompute(
+    Compute,
+    ComputeWithCreateInstanceSupport,
+    ComputeWithMultinodeSupport,
+    ComputeWithGatewaySupport,
+    ComputeWithVolumeSupport,
+):
     def __init__(self, config: GCPConfig):
         super().__init__()
         self.config = config

--- a/src/dstack/_internal/core/backends/gcp/configurator.py
+++ b/src/dstack/_internal/core/backends/gcp/configurator.py
@@ -111,7 +111,8 @@ MAIN_REGION = "us-east1"
 
 
 class GCPConfigurator(Configurator):
-    TYPE: BackendType = BackendType.GCP
+    TYPE = BackendType.GCP
+    BACKEND_CLASS = GCPBackend
 
     def validate_config(self, config: GCPBackendConfigWithCreds, default_creds_enabled: bool):
         if is_core_model_instance(config.creds, GCPDefaultCreds) and not default_creds_enabled:

--- a/src/dstack/_internal/core/backends/kubernetes/backend.py
+++ b/src/dstack/_internal/core/backends/kubernetes/backend.py
@@ -5,7 +5,8 @@ from dstack._internal.core.models.backends.base import BackendType
 
 
 class KubernetesBackend(Backend):
-    TYPE: BackendType = BackendType.KUBERNETES
+    TYPE = BackendType.KUBERNETES
+    COMPUTE_CLASS = KubernetesCompute
 
     def __init__(self, config: KubernetesConfig):
         self.config = config

--- a/src/dstack/_internal/core/backends/kubernetes/compute.py
+++ b/src/dstack/_internal/core/backends/kubernetes/compute.py
@@ -9,6 +9,7 @@ from kubernetes import client
 
 from dstack._internal.core.backends.base.compute import (
     Compute,
+    ComputeWithGatewaySupport,
     generate_unique_gateway_instance_name,
     generate_unique_instance_name_for_job,
     get_docker_commands,
@@ -54,7 +55,10 @@ NVIDIA_GPU_NAME_TO_GPU_INFO = {gpu.name: gpu for gpu in KNOWN_NVIDIA_GPUS}
 NVIDIA_GPU_NAMES = NVIDIA_GPU_NAME_TO_GPU_INFO.keys()
 
 
-class KubernetesCompute(Compute):
+class KubernetesCompute(
+    Compute,
+    ComputeWithGatewaySupport,
+):
     def __init__(self, config: KubernetesConfig):
         super().__init__()
         self.config = config.copy()

--- a/src/dstack/_internal/core/backends/kubernetes/configurator.py
+++ b/src/dstack/_internal/core/backends/kubernetes/configurator.py
@@ -19,7 +19,8 @@ logger = get_logger(__name__)
 
 
 class KubernetesConfigurator(Configurator):
-    TYPE: BackendType = BackendType.KUBERNETES
+    TYPE = BackendType.KUBERNETES
+    BACKEND_CLASS = KubernetesBackend
 
     def validate_config(
         self, config: KubernetesBackendConfigWithCreds, default_creds_enabled: bool

--- a/src/dstack/_internal/core/backends/lambdalabs/backend.py
+++ b/src/dstack/_internal/core/backends/lambdalabs/backend.py
@@ -5,7 +5,8 @@ from dstack._internal.core.models.backends.base import BackendType
 
 
 class LambdaBackend(Backend):
-    TYPE: BackendType = BackendType.LAMBDA
+    TYPE = BackendType.LAMBDA
+    COMPUTE_CLASS = LambdaCompute
 
     def __init__(self, config: LambdaConfig):
         self.config = config

--- a/src/dstack/_internal/core/backends/lambdalabs/compute.py
+++ b/src/dstack/_internal/core/backends/lambdalabs/compute.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional
 
 from dstack._internal.core.backends.base.compute import (
     Compute,
+    ComputeWithCreateInstanceSupport,
     generate_unique_instance_name,
     get_job_instance_name,
     get_shim_commands,
@@ -27,7 +28,10 @@ from dstack._internal.core.models.volumes import Volume
 MAX_INSTANCE_NAME_LEN = 60
 
 
-class LambdaCompute(Compute):
+class LambdaCompute(
+    Compute,
+    ComputeWithCreateInstanceSupport,
+):
     def __init__(self, config: LambdaConfig):
         super().__init__()
         self.config = config

--- a/src/dstack/_internal/core/backends/lambdalabs/configurator.py
+++ b/src/dstack/_internal/core/backends/lambdalabs/configurator.py
@@ -40,7 +40,8 @@ DEFAULT_REGION = "us-east-1"
 
 
 class LambdaConfigurator(Configurator):
-    TYPE: BackendType = BackendType.LAMBDA
+    TYPE = BackendType.LAMBDA
+    BACKEND_CLASS = LambdaBackend
 
     def validate_config(self, config: LambdaBackendConfigWithCreds, default_creds_enabled: bool):
         self._validate_lambda_api_key(config.creds.api_key)

--- a/src/dstack/_internal/core/backends/local/backend.py
+++ b/src/dstack/_internal/core/backends/local/backend.py
@@ -4,7 +4,8 @@ from dstack._internal.core.models.backends.base import BackendType
 
 
 class LocalBackend(Backend):
-    TYPE: BackendType = BackendType.LOCAL
+    TYPE = BackendType.LOCAL
+    COMPUTE_CLASS = LocalCompute
 
     def __init__(self):
         self._compute = LocalCompute()

--- a/src/dstack/_internal/core/backends/local/compute.py
+++ b/src/dstack/_internal/core/backends/local/compute.py
@@ -1,6 +1,10 @@
 from typing import List, Optional
 
-from dstack._internal.core.backends.base.compute import Compute
+from dstack._internal.core.backends.base.compute import (
+    Compute,
+    ComputeWithCreateInstanceSupport,
+    ComputeWithVolumeSupport,
+)
 from dstack._internal.core.consts import DSTACK_RUNNER_SSH_PORT
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.instances import (
@@ -18,7 +22,11 @@ from dstack._internal.utils.logging import get_logger
 logger = get_logger(__name__)
 
 
-class LocalCompute(Compute):
+class LocalCompute(
+    Compute,
+    ComputeWithCreateInstanceSupport,
+    ComputeWithVolumeSupport,
+):
     def get_offers(
         self, requirements: Optional[Requirements] = None
     ) -> List[InstanceOfferWithAvailability]:
@@ -83,6 +91,12 @@ class LocalCompute(Compute):
             ssh_proxy=None,
             dockerized=True,
             backend_data=None,
+        )
+
+    def register_volume(self, volume: Volume) -> VolumeProvisioningData:
+        return VolumeProvisioningData(
+            volume_id=volume.volume_id,
+            size_gb=volume.configuration.size_gb,
         )
 
     def create_volume(self, volume: Volume) -> VolumeProvisioningData:

--- a/src/dstack/_internal/core/backends/nebius/backend.py
+++ b/src/dstack/_internal/core/backends/nebius/backend.py
@@ -5,7 +5,8 @@ from dstack._internal.core.models.backends.base import BackendType
 
 
 class NebiusBackend(Backend):
-    TYPE: BackendType = BackendType.NEBIUS
+    TYPE = BackendType.NEBIUS
+    COMPUTE_CLASS = NebiusCompute
 
     def __init__(self, config: NebiusConfig):
         self.config = config

--- a/src/dstack/_internal/core/backends/nebius/configurator.py
+++ b/src/dstack/_internal/core/backends/nebius/configurator.py
@@ -24,7 +24,8 @@ REGIONS = ["eu-north1-c"]
 
 
 class NebiusConfigurator(Configurator):
-    TYPE: BackendType = BackendType.NEBIUS
+    TYPE = BackendType.NEBIUS
+    BACKEND_CLASS = NebiusBackend
 
     def validate_config(self, config: NebiusBackendConfigWithCreds, default_creds_enabled: bool):
         self._validate_nebius_creds(config.creds)

--- a/src/dstack/_internal/core/backends/oci/backend.py
+++ b/src/dstack/_internal/core/backends/oci/backend.py
@@ -5,7 +5,8 @@ from dstack._internal.core.models.backends.base import BackendType
 
 
 class OCIBackend(Backend):
-    TYPE: BackendType = BackendType.OCI
+    TYPE = BackendType.OCI
+    COMPUTE_CLASS = OCICompute
 
     def __init__(self, config: OCIConfig):
         self.config = config

--- a/src/dstack/_internal/core/backends/oci/compute.py
+++ b/src/dstack/_internal/core/backends/oci/compute.py
@@ -6,6 +6,8 @@ import oci
 
 from dstack._internal.core.backends.base.compute import (
     Compute,
+    ComputeWithCreateInstanceSupport,
+    ComputeWithMultinodeSupport,
     generate_unique_instance_name,
     get_job_instance_name,
     get_user_data,
@@ -46,7 +48,11 @@ SUPPORTED_SHAPE_FAMILIES = [
 CONFIGURABLE_DISK_SIZE = Range[Memory](min=Memory.parse("50GB"), max=Memory.parse("32TB"))
 
 
-class OCICompute(Compute):
+class OCICompute(
+    Compute,
+    ComputeWithCreateInstanceSupport,
+    ComputeWithMultinodeSupport,
+):
     def __init__(self, config: OCIConfig):
         super().__init__()
         self.config = config

--- a/src/dstack/_internal/core/backends/oci/configurator.py
+++ b/src/dstack/_internal/core/backends/oci/configurator.py
@@ -44,7 +44,8 @@ SUPPORTED_REGIONS = frozenset(
 
 
 class OCIConfigurator(Configurator):
-    TYPE: BackendType = BackendType.OCI
+    TYPE = BackendType.OCI
+    BACKEND_CLASS = OCIBackend
 
     def validate_config(self, config: OCIBackendConfigWithCreds, default_creds_enabled: bool):
         if is_core_model_instance(config.creds, OCIDefaultCreds) and not default_creds_enabled:

--- a/src/dstack/_internal/core/backends/runpod/backend.py
+++ b/src/dstack/_internal/core/backends/runpod/backend.py
@@ -5,7 +5,8 @@ from dstack._internal.core.models.backends.base import BackendType
 
 
 class RunpodBackend(Backend):
-    TYPE: BackendType = BackendType.RUNPOD
+    TYPE = BackendType.RUNPOD
+    COMPUTE_CLASS = RunpodCompute
 
     def __init__(self, config: RunpodConfig):
         self.config = config

--- a/src/dstack/_internal/core/backends/runpod/compute.py
+++ b/src/dstack/_internal/core/backends/runpod/compute.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 from dstack._internal.core.backends.base.backend import Compute
 from dstack._internal.core.backends.base.compute import (
+    ComputeWithVolumeSupport,
     generate_unique_instance_name,
     generate_unique_volume_name,
     get_docker_commands,
@@ -39,7 +40,10 @@ MAX_RESOURCE_NAME_LEN = 60
 CONTAINER_REGISTRY_AUTH_CLEANUP_INTERVAL = 60 * 60 * 24  # 24 hour
 
 
-class RunpodCompute(Compute):
+class RunpodCompute(
+    Compute,
+    ComputeWithVolumeSupport,
+):
     _last_cleanup_time = None
 
     def __init__(self, config: RunpodConfig):

--- a/src/dstack/_internal/core/backends/runpod/configurator.py
+++ b/src/dstack/_internal/core/backends/runpod/configurator.py
@@ -18,7 +18,8 @@ from dstack._internal.core.models.backends.base import BackendType
 
 
 class RunpodConfigurator(Configurator):
-    TYPE: BackendType = BackendType.RUNPOD
+    TYPE = BackendType.RUNPOD
+    BACKEND_CLASS = RunpodBackend
 
     def validate_config(self, config: RunpodBackendConfigWithCreds, default_creds_enabled: bool):
         self._validate_runpod_api_key(config.creds.api_key)

--- a/src/dstack/_internal/core/backends/tensordock/backend.py
+++ b/src/dstack/_internal/core/backends/tensordock/backend.py
@@ -5,7 +5,8 @@ from dstack._internal.core.models.backends.base import BackendType
 
 
 class TensorDockBackend(Backend):
-    TYPE: BackendType = BackendType.TENSORDOCK
+    TYPE = BackendType.TENSORDOCK
+    COMPUTE_CLASS = TensorDockCompute
 
     def __init__(self, config: TensorDockConfig):
         self.config = config

--- a/src/dstack/_internal/core/backends/tensordock/compute.py
+++ b/src/dstack/_internal/core/backends/tensordock/compute.py
@@ -5,6 +5,7 @@ import requests
 
 from dstack._internal.core.backends.base.backend import Compute
 from dstack._internal.core.backends.base.compute import (
+    ComputeWithCreateInstanceSupport,
     generate_unique_instance_name,
     get_job_instance_name,
     get_shim_commands,
@@ -31,7 +32,10 @@ logger = get_logger(__name__)
 MAX_INSTANCE_NAME_LEN = 60
 
 
-class TensorDockCompute(Compute):
+class TensorDockCompute(
+    Compute,
+    ComputeWithCreateInstanceSupport,
+):
     def __init__(self, config: TensorDockConfig):
         super().__init__()
         self.config = config

--- a/src/dstack/_internal/core/backends/tensordock/configurator.py
+++ b/src/dstack/_internal/core/backends/tensordock/configurator.py
@@ -24,7 +24,8 @@ REGIONS = []
 
 
 class TensorDockConfigurator(Configurator):
-    TYPE: BackendType = BackendType.TENSORDOCK
+    TYPE = BackendType.TENSORDOCK
+    BACKEND_CLASS = TensorDockBackend
 
     def validate_config(
         self, config: TensorDockBackendConfigWithCreds, default_creds_enabled: bool

--- a/src/dstack/_internal/core/backends/vastai/backend.py
+++ b/src/dstack/_internal/core/backends/vastai/backend.py
@@ -5,7 +5,8 @@ from dstack._internal.core.models.backends.base import BackendType
 
 
 class VastAIBackend(Backend):
-    TYPE: BackendType = BackendType.VASTAI
+    TYPE = BackendType.VASTAI
+    COMPUTE_CLASS = VastAICompute
 
     def __init__(self, config: VastAIConfig):
         self.config = config

--- a/src/dstack/_internal/core/backends/vastai/configurator.py
+++ b/src/dstack/_internal/core/backends/vastai/configurator.py
@@ -24,7 +24,8 @@ REGIONS = []
 
 
 class VastAIConfigurator(Configurator):
-    TYPE: BackendType = BackendType.VASTAI
+    TYPE = BackendType.VASTAI
+    BACKEND_CLASS = VastAIBackend
 
     def validate_config(self, config: VastAIBackendConfigWithCreds, default_creds_enabled: bool):
         self._validate_vastai_creds(config.creds.api_key)

--- a/src/dstack/_internal/core/backends/vultr/backend.py
+++ b/src/dstack/_internal/core/backends/vultr/backend.py
@@ -5,7 +5,8 @@ from dstack._internal.core.models.backends.base import BackendType
 
 
 class VultrBackend(Backend):
-    TYPE: BackendType = BackendType.VULTR
+    TYPE = BackendType.VULTR
+    COMPUTE_CLASS = VultrCompute
 
     def __init__(self, config: VultrConfig):
         self.config = config

--- a/src/dstack/_internal/core/backends/vultr/compute.py
+++ b/src/dstack/_internal/core/backends/vultr/compute.py
@@ -6,6 +6,8 @@ import requests
 
 from dstack._internal.core.backends.base.backend import Compute
 from dstack._internal.core.backends.base.compute import (
+    ComputeWithCreateInstanceSupport,
+    ComputeWithMultinodeSupport,
     generate_unique_instance_name,
     get_job_instance_name,
     get_user_data,
@@ -31,7 +33,11 @@ logger = get_logger(__name__)
 MAX_INSTANCE_NAME_LEN = 64
 
 
-class VultrCompute(Compute):
+class VultrCompute(
+    Compute,
+    ComputeWithCreateInstanceSupport,
+    ComputeWithMultinodeSupport,
+):
     def __init__(self, config: VultrConfig):
         super().__init__()
         self.config = config

--- a/src/dstack/_internal/core/backends/vultr/configurator.py
+++ b/src/dstack/_internal/core/backends/vultr/configurator.py
@@ -23,7 +23,8 @@ REGIONS = []
 
 
 class VultrConfigurator(Configurator):
-    TYPE: BackendType = BackendType.VULTR
+    TYPE = BackendType.VULTR
+    BACKEND_CLASS = VultrBackend
 
     def validate_config(self, config: VultrBackendConfigWithCreds, default_creds_enabled: bool):
         self._validate_vultr_api_key(config.creds.api_key)

--- a/src/dstack/_internal/server/services/backends/__init__.py
+++ b/src/dstack/_internal/server/services/backends/__init__.py
@@ -11,7 +11,10 @@ from dstack._internal.core.backends.base.configurator import (
     Configurator,
     StoredBackendRecord,
 )
-from dstack._internal.core.backends.configurators import get_configurator
+from dstack._internal.core.backends.configurators import (
+    get_configurator,
+    list_available_backend_types,
+)
 from dstack._internal.core.backends.local.backend import LocalBackend
 from dstack._internal.core.backends.models import (
     AnyBackendConfig,
@@ -364,3 +367,12 @@ async def get_instance_offers(
     offers = heapq.merge(*offers_by_backend, key=lambda i: i[1].price)
     # Put NOT_AVAILABLE, NO_QUOTA, and BUSY instances at the end, do not sort by price
     return sorted(offers, key=lambda i: not i[1].availability.is_available())
+
+
+def check_backed_type_available(backend_type: BackendType):
+    if backend_type not in list_available_backend_types():
+        raise BackendNotAvailable(
+            f"Backend {backend_type.value} not available."
+            " Ensure that backend dependencies are installed."
+            f" Available backends: {[b.value for b in list_available_backend_types()]}."
+        )

--- a/src/dstack/_internal/server/services/backends/__init__.py
+++ b/src/dstack/_internal/server/services/backends/__init__.py
@@ -369,7 +369,7 @@ async def get_instance_offers(
     return sorted(offers, key=lambda i: not i[1].availability.is_available())
 
 
-def check_backed_type_available(backend_type: BackendType):
+def check_backend_type_available(backend_type: BackendType):
     if backend_type not in list_available_backend_types():
         raise BackendNotAvailable(
             f"Backend {backend_type.value} not available."

--- a/src/dstack/_internal/server/services/fleets.py
+++ b/src/dstack/_internal/server/services/fleets.py
@@ -308,7 +308,7 @@ async def get_create_instance_offers(
     offers = [
         (backend, offer)
         for backend, offer in offers
-        if backend.TYPE in BACKENDS_WITH_CREATE_INSTANCE_SUPPORT
+        if offer.backend in BACKENDS_WITH_CREATE_INSTANCE_SUPPORT
     ]
     return offers
 
@@ -600,7 +600,7 @@ async def create_instance(
     )
 
     # Raise error if no backends suppport create_instance
-    backend_types = set((backend.TYPE for backend, _ in offers))
+    backend_types = set(offer.backend for _, offer in offers)
     if all(
         (backend_type not in BACKENDS_WITH_CREATE_INSTANCE_SUPPORT)
         for backend_type in backend_types

--- a/src/dstack/_internal/server/services/gateways/__init__.py
+++ b/src/dstack/_internal/server/services/gateways/__init__.py
@@ -39,6 +39,7 @@ from dstack._internal.server import settings
 from dstack._internal.server.db import get_db
 from dstack._internal.server.models import GatewayComputeModel, GatewayModel, ProjectModel
 from dstack._internal.server.services.backends import (
+    check_backed_type_available,
     get_project_backend_by_type_or_error,
     get_project_backend_with_model_by_type_or_error,
 )
@@ -537,10 +538,12 @@ def gateway_model_to_gateway(gateway_model: GatewayModel) -> Gateway:
 
 
 def _validate_gateway_configuration(configuration: GatewayConfiguration):
+    check_backed_type_available(configuration.backend)
     if configuration.backend not in BACKENDS_WITH_GATEWAY_SUPPORT:
         raise ServerClientError(
-            f"Gateways are not supported for {configuration.backend.value} backend. "
-            f"Supported backends: {[b.value for b in BACKENDS_WITH_GATEWAY_SUPPORT]}."
+            f"Gateways are not supported for {configuration.backend.value} backend."
+            " Available backends with gateway support:"
+            f" {[b.value for b in BACKENDS_WITH_GATEWAY_SUPPORT]}."
         )
 
     if configuration.name is not None:
@@ -552,7 +555,8 @@ def _validate_gateway_configuration(configuration: GatewayConfiguration):
     ):
         raise ServerClientError(
             f"Private gateways are not supported for {configuration.backend.value} backend. "
-            f"Supported backends: {[b.value for b in BACKENDS_WITH_PRIVATE_GATEWAY_SUPPORT]}."
+            " Available backends with private gateway support:"
+            f" {[b.value for b in BACKENDS_WITH_PRIVATE_GATEWAY_SUPPORT]}."
         )
 
     if configuration.certificate is not None:

--- a/src/dstack/_internal/server/services/gateways/__init__.py
+++ b/src/dstack/_internal/server/services/gateways/__init__.py
@@ -39,7 +39,7 @@ from dstack._internal.server import settings
 from dstack._internal.server.db import get_db
 from dstack._internal.server.models import GatewayComputeModel, GatewayModel, ProjectModel
 from dstack._internal.server.services.backends import (
-    check_backed_type_available,
+    check_backend_type_available,
     get_project_backend_by_type_or_error,
     get_project_backend_with_model_by_type_or_error,
 )
@@ -538,7 +538,7 @@ def gateway_model_to_gateway(gateway_model: GatewayModel) -> Gateway:
 
 
 def _validate_gateway_configuration(configuration: GatewayConfiguration):
-    check_backed_type_available(configuration.backend)
+    check_backend_type_available(configuration.backend)
     if configuration.backend not in BACKENDS_WITH_GATEWAY_SUPPORT:
         raise ServerClientError(
             f"Gateways are not supported for {configuration.backend.value} backend."

--- a/src/dstack/_internal/server/services/volumes.py
+++ b/src/dstack/_internal/server/services/volumes.py
@@ -376,7 +376,7 @@ async def generate_volume_name(session: AsyncSession, project: ProjectModel) -> 
 def _validate_volume_configuration(configuration: VolumeConfiguration):
     if configuration.volume_id is None and configuration.size is None:
         raise ServerClientError("Volume must specify either volume_id or size")
-    backends_services.check_backed_type_available(configuration.backend)
+    backends_services.check_backend_type_available(configuration.backend)
     if configuration.backend not in BACKENDS_WITH_VOLUMES_SUPPORT:
         raise ServerClientError(
             f"Volumes are not supported for {configuration.backend.value} backend."

--- a/src/dstack/_internal/server/services/volumes.py
+++ b/src/dstack/_internal/server/services/volumes.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 
 from dstack._internal.core.backends import BACKENDS_WITH_VOLUMES_SUPPORT
+from dstack._internal.core.backends.base.compute import ComputeWithVolumeSupport
 from dstack._internal.core.errors import (
     BackendNotAvailable,
     ResourceExistsError,
@@ -409,7 +410,9 @@ async def _delete_volume(session: AsyncSession, project: ProjectModel, volume_mo
         )
         return
 
+    compute = backend.compute()
+    assert isinstance(compute, ComputeWithVolumeSupport)
     await common.run_async(
-        backend.compute().delete_volume,
+        compute.delete_volume,
         volume=volume,
     )

--- a/src/dstack/_internal/server/services/volumes.py
+++ b/src/dstack/_internal/server/services/volumes.py
@@ -376,10 +376,11 @@ async def generate_volume_name(session: AsyncSession, project: ProjectModel) -> 
 def _validate_volume_configuration(configuration: VolumeConfiguration):
     if configuration.volume_id is None and configuration.size is None:
         raise ServerClientError("Volume must specify either volume_id or size")
+    backends_services.check_backed_type_available(configuration.backend)
     if configuration.backend not in BACKENDS_WITH_VOLUMES_SUPPORT:
         raise ServerClientError(
-            f"Volumes are not supported for {configuration.backend.value} backend. "
-            f"Supported backends: {[b.value for b in BACKENDS_WITH_VOLUMES_SUPPORT]}."
+            f"Volumes are not supported for {configuration.backend.value} backend."
+            f" Available backends with volumes support: {[b.value for b in BACKENDS_WITH_VOLUMES_SUPPORT]}."
         )
     if configuration.name is not None:
         validate_dstack_resource_name(configuration.name)

--- a/src/dstack/_internal/server/testing/common.py
+++ b/src/dstack/_internal/server/testing/common.py
@@ -8,6 +8,16 @@ from uuid import UUID
 import gpuhunt
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from dstack._internal.core.backends.base.compute import (
+    Compute,
+    ComputeWithCreateInstanceSupport,
+    ComputeWithGatewaySupport,
+    ComputeWithMultinodeSupport,
+    ComputeWithPlacementGroupSupport,
+    ComputeWithPrivateGatewaySupport,
+    ComputeWithReservationSupport,
+    ComputeWithVolumeSupport,
+)
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.common import NetworkMode
 from dstack._internal.core.models.configurations import (
@@ -947,3 +957,20 @@ class AsyncContextManager:
 
     async def __aexit__(self, exc_type, exc, traceback):
         pass
+
+
+class ComputeMockSpec(
+    Compute,
+    ComputeWithCreateInstanceSupport,
+    ComputeWithMultinodeSupport,
+    ComputeWithReservationSupport,
+    ComputeWithPlacementGroupSupport,
+    ComputeWithGatewaySupport,
+    ComputeWithPrivateGatewaySupport,
+    ComputeWithVolumeSupport,
+):
+    """
+    Can be used to create Compute mocks that pass all isinstance asserts.
+    """
+
+    pass

--- a/src/tests/_internal/server/background/tasks/test_process_gateways.py
+++ b/src/tests/_internal/server/background/tasks/test_process_gateways.py
@@ -8,6 +8,7 @@ from dstack._internal.core.models.gateways import GatewayProvisioningData, Gatew
 from dstack._internal.server.background.tasks.process_gateways import process_submitted_gateways
 from dstack._internal.server.testing.common import (
     AsyncContextManager,
+    ComputeMockSpec,
     create_backend,
     create_gateway,
     create_project,
@@ -37,6 +38,7 @@ class TestProcessSubmittedGateways:
             m.return_value = (backend, aws)
             pool_add.return_value = MagicMock()
             pool_add.return_value.client.return_value = MagicMock(AsyncContextManager())
+            aws.compute.return_value = Mock(spec=ComputeMockSpec)
             aws.compute.return_value.create_gateway.return_value = GatewayProvisioningData(
                 instance_id="i-1234567890",
                 ip_address="2.2.2.2",
@@ -68,6 +70,7 @@ class TestProcessSubmittedGateways:
         ) as m:
             aws = Mock()
             m.return_value = (backend, aws)
+            aws.compute.return_value = Mock(spec=ComputeMockSpec)
             aws.compute.return_value.create_gateway.side_effect = BackendError("Some error")
             await process_submitted_gateways()
             m.assert_called_once()
@@ -99,6 +102,7 @@ class TestProcessSubmittedGateways:
             aws = Mock()
             m.return_value = (backend, aws)
             connect_to_gateway_with_retry_mock.return_value = None
+            aws.compute.return_value = Mock(spec=ComputeMockSpec)
             aws.compute.return_value.create_gateway.return_value = GatewayProvisioningData(
                 instance_id="i-1234567890",
                 ip_address="2.2.2.2",

--- a/src/tests/_internal/server/background/tasks/test_process_instances.py
+++ b/src/tests/_internal/server/background/tasks/test_process_instances.py
@@ -28,6 +28,7 @@ from dstack._internal.server.background.tasks.process_instances import (
     process_instances,
 )
 from dstack._internal.server.testing.common import (
+    ComputeMockSpec,
     create_instance,
     create_job,
     create_pool,
@@ -531,6 +532,7 @@ class TestCreateInstance:
                 price=1.0,
                 availability=InstanceAvailability.AVAILABLE,
             )
+            backend_mock.compute.return_value = Mock(spec=ComputeMockSpec)
             backend_mock.compute.return_value.get_offers_cached.return_value = [offer]
             backend_mock.compute.return_value.create_instance.return_value = JobProvisioningData(
                 backend=offer.backend,

--- a/src/tests/_internal/server/background/tasks/test_process_placement_groups.py
+++ b/src/tests/_internal/server/background/tasks/test_process_placement_groups.py
@@ -7,6 +7,7 @@ from dstack._internal.server.background.tasks.process_placement_groups import (
     process_placement_groups,
 )
 from dstack._internal.server.testing.common import (
+    ComputeMockSpec,
     create_fleet,
     create_placement_group,
     create_project,
@@ -34,6 +35,7 @@ class TestProcessPlacementGroups:
         with patch("dstack._internal.server.services.backends.get_project_backend_by_type") as m:
             aws_mock = Mock()
             m.return_value = aws_mock
+            aws_mock.compute.return_value = Mock(spec=ComputeMockSpec)
             await process_placement_groups()
             aws_mock.compute.return_value.delete_placement_group.assert_called_once()
         await session.refresh(placement_group1)

--- a/src/tests/_internal/server/background/tasks/test_process_submitted_jobs.py
+++ b/src/tests/_internal/server/background/tasks/test_process_submitted_jobs.py
@@ -29,6 +29,7 @@ from dstack._internal.core.models.volumes import (
 from dstack._internal.server.background.tasks.process_submitted_jobs import process_submitted_jobs
 from dstack._internal.server.models import InstanceModel, JobModel, VolumeAttachmentModel
 from dstack._internal.server.testing.common import (
+    ComputeMockSpec,
     create_fleet,
     create_instance,
     create_job,
@@ -506,6 +507,7 @@ class TestProcessSubmittedJobs:
             backend_mock = Mock()
             m.return_value = backend_mock
             backend_mock.TYPE = BackendType.AWS
+            backend_mock.compute.return_value = Mock(spec=ComputeMockSpec)
             backend_mock.compute.return_value.attach_volume.return_value = VolumeAttachmentData()
             # Submitted jobs processing happens in two steps
             await process_submitted_jobs()

--- a/src/tests/_internal/server/background/tasks/test_process_submitted_volumes.py
+++ b/src/tests/_internal/server/background/tasks/test_process_submitted_volumes.py
@@ -7,6 +7,7 @@ from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.volumes import VolumeProvisioningData, VolumeStatus
 from dstack._internal.server.background.tasks.process_volumes import process_submitted_volumes
 from dstack._internal.server.testing.common import (
+    ComputeMockSpec,
     create_project,
     create_user,
     create_volume,
@@ -40,6 +41,7 @@ class TestProcessSubmittedVolumes:
         ) as m:
             aws_mock = Mock()
             m.return_value = aws_mock
+            aws_mock.compute.return_value = Mock(spec=ComputeMockSpec)
             aws_mock.compute.return_value.create_volume.return_value = VolumeProvisioningData(
                 backend=BackendType.AWS,
                 volume_id="1234",

--- a/src/tests/_internal/server/background/tasks/test_process_terminating_jobs.py
+++ b/src/tests/_internal/server/background/tasks/test_process_terminating_jobs.py
@@ -16,6 +16,7 @@ from dstack._internal.server.background.tasks.process_terminating_jobs import (
 from dstack._internal.server.models import InstanceModel, JobModel, VolumeAttachmentModel
 from dstack._internal.server.services.volumes import volume_model_to_volume
 from dstack._internal.server.testing.common import (
+    ComputeMockSpec,
     create_instance,
     create_job,
     create_pool,
@@ -114,6 +115,7 @@ class TestProcessTerminatingJobs:
         with patch("dstack._internal.server.services.backends.get_project_backend_by_type") as m:
             backend_mock = Mock()
             m.return_value = backend_mock
+            backend_mock.compute.return_value = Mock(spec=ComputeMockSpec)
             backend_mock.compute.return_value.is_volume_detached.return_value = True
             await process_terminating_jobs()
             m.assert_awaited_once()
@@ -163,6 +165,7 @@ class TestProcessTerminatingJobs:
         with patch("dstack._internal.server.services.backends.get_project_backend_by_type") as m:
             backend_mock = Mock()
             m.return_value = backend_mock
+            backend_mock.compute.return_value = Mock(spec=ComputeMockSpec)
             backend_mock.compute.return_value.is_volume_detached.return_value = False
             await process_terminating_jobs()
             m.assert_awaited_once()
@@ -188,6 +191,7 @@ class TestProcessTerminatingJobs:
             ) + timedelta(minutes=30)
             backend_mock = Mock()
             m.return_value = backend_mock
+            backend_mock.compute.return_value = Mock(spec=ComputeMockSpec)
             backend_mock.compute.return_value.is_volume_detached.return_value = False
             await process_terminating_jobs()
             m.assert_awaited_once()
@@ -205,6 +209,7 @@ class TestProcessTerminatingJobs:
         with patch("dstack._internal.server.services.backends.get_project_backend_by_type") as m:
             backend_mock = Mock()
             m.return_value = backend_mock
+            backend_mock.compute.return_value = Mock(spec=ComputeMockSpec)
             backend_mock.compute.return_value.is_volume_detached.return_value = True
             await process_terminating_jobs()
             m.assert_awaited_once()
@@ -319,13 +324,15 @@ class TestProcessTerminatingJobs:
         with patch("dstack._internal.server.services.backends.get_project_backend_by_type") as m:
             backend_mock = Mock()
             m.return_value = backend_mock
+            backend_mock.compute.return_value = Mock(spec=ComputeMockSpec)
             backend_mock.compute.return_value.is_volume_detached.return_value = True
 
             await process_terminating_jobs()
 
-        m.assert_awaited_once()
-        backend_mock.compute.return_value.detach_volume.assert_called_once()
-        backend_mock.compute.return_value.is_volume_detached.assert_called_once()
+            m.assert_awaited_once()
+            backend_mock.compute.return_value.detach_volume.assert_called_once()
+            backend_mock.compute.return_value.is_volume_detached.assert_called_once()
+
         await session.refresh(job)
         await session.refresh(instance)
         assert job.status == JobStatus.TERMINATED

--- a/src/tests/_internal/server/routers/test_gateways.py
+++ b/src/tests/_internal/server/routers/test_gateways.py
@@ -13,6 +13,7 @@ from dstack._internal.server.services.gateways import (
 )
 from dstack._internal.server.services.projects import add_project_member
 from dstack._internal.server.testing.common import (
+    ComputeMockSpec,
     create_backend,
     create_gateway,
     create_gateway_compute,
@@ -437,8 +438,10 @@ class TestDeleteGateway:
             "dstack._internal.server.services.gateways.get_project_backend_by_type_or_error"
         ) as m:
             aws = Mock()
+            aws.compute.return_value = Mock(spec=ComputeMockSpec)
             aws.compute.return_value.terminate_gateway.return_value = None  # success
             gcp = Mock()
+            gcp.compute.return_value = Mock(spec=ComputeMockSpec)
             gcp.compute.return_value.terminate_gateway.side_effect = DstackError()  # fail
 
             def get_backend(project, backend_type):

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -51,6 +51,7 @@ from dstack._internal.server.schemas.runs import ApplyRunPlanRequest, CreateInst
 from dstack._internal.server.services.projects import add_project_member
 from dstack._internal.server.services.runs import run_model_to_run
 from dstack._internal.server.testing.common import (
+    ComputeMockSpec,
     create_backend,
     create_gateway,
     create_gateway_compute,
@@ -1616,6 +1617,7 @@ class TestCreateInstance:
             )
             backend = Mock()
             backend.TYPE = BackendType.AZURE
+            backend.compute.return_value = Mock(spec=ComputeMockSpec)
             backend.compute.return_value.get_offers_cached.return_value = [offer]
             backend.compute.return_value.create_instance.side_effect = NotImplementedError()
             run_plan_by_req.return_value = [(backend, offer)]
@@ -1658,6 +1660,7 @@ class TestCreateInstance:
 
             backend = Mock()
             backend.TYPE = BackendType.VASTAI
+            backend.compute.return_value = Mock(spec=ComputeMockSpec)
             backend.compute.return_value.get_offers_cached.return_value = [offers]
             backend.compute.return_value.create_instance.side_effect = NotImplementedError()
             run_plan_by_req.return_value = [(backend, offers)]

--- a/src/tests/_internal/server/routers/test_volumes.py
+++ b/src/tests/_internal/server/routers/test_volumes.py
@@ -14,6 +14,7 @@ from dstack._internal.core.models.users import GlobalRole, ProjectRole
 from dstack._internal.server.models import VolumeAttachmentModel, VolumeModel
 from dstack._internal.server.services.projects import add_project_member
 from dstack._internal.server.testing.common import (
+    ComputeMockSpec,
     create_instance,
     create_pool,
     create_project,
@@ -366,6 +367,7 @@ class TestDeleteVolumes:
         ) as m:
             aws_mock = Mock()
             m.return_value = aws_mock
+            aws_mock.compute.return_value = Mock(spec=ComputeMockSpec)
             response = await client.post(
                 f"/api/project/{project.name}/volumes/delete",
                 headers=get_auth_headers(user.token),


### PR DESCRIPTION
Part of #2372

This PR moves optional `Compute` methods to `ComputeWith*` feature classes. This makes it explicit which methods are required for different features and also allows building `BACKENDS_WITH_*` lists dynamically instead of hardcoding them.

Notes:
* Compute instances now need to be type-narrowed like `assert isinstance(compute, ComputeWithPlacementGroupSupport)`. This is still better than previous implicit assumption about method being implemented.
* `BACKENDS_WITH_*` lists now contain only available backend types. This does not affect any behavior except for error messages that return supported backend types. Errors are clarified to return _available_ backend types.