### PR TITLE
Add script to generate boilerplate code for new backend

### DIFF
--- a/scripts/add_backend.py
+++ b/scripts/add_backend.py
@@ -22,10 +22,12 @@ def main():
 
 
 def generate_backend_code(backend_name: str):
+    template_dir_path = Path(__file__).parent.parent.joinpath(
+        "src/dstack/_internal/core/backends/template"
+    )
     env = jinja2.Environment(
-        loader=jinja2.PackageLoader(
-            package_name="dstack",
-            package_path="_internal/core/backends/template",
+        loader=jinja2.FileSystemLoader(
+            searchpath=template_dir_path,
         ),
         keep_trailing_newline=True,
     )

--- a/scripts/add_backend.py
+++ b/scripts/add_backend.py
@@ -1,0 +1,44 @@
+import argparse
+from pathlib import Path
+
+import jinja2
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="This script generates boilerplate code for a new backend"
+    )
+    parser.add_argument(
+        "-n",
+        "--name",
+        help=(
+            "The backend name in CamelCase, e.g. AWS, Runpod, VastAI."
+            " It'll be used for naming backend classes, models, etc."
+        ),
+        required=True,
+    )
+    args = parser.parse_args()
+    generate_backend_code(args.name)
+
+
+def generate_backend_code(backend_name: str):
+    env = jinja2.Environment(
+        loader=jinja2.PackageLoader(
+            package_name="dstack",
+            package_path="_internal/core/backends/template",
+        ),
+        keep_trailing_newline=True,
+    )
+    backend_dir_path = Path(__file__).parent.parent.joinpath(
+        f"src/dstack/_internal/core/backends/{backend_name.lower()}"
+    )
+    backend_dir_path.mkdir(exist_ok=True)
+    for filename in ["backend.py", "compute.py", "configurator.py", "models.py"]:
+        template = env.get_template(f"{filename}.jinja")
+        with open(backend_dir_path.joinpath(filename), "w+") as f:
+            f.write(template.render({"backend_name": backend_name}))
+    backend_dir_path.joinpath("__init__.py").write_text("")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -60,6 +60,11 @@ class Compute(ABC):
     def get_offers(
         self, requirements: Optional[Requirements] = None
     ) -> List[InstanceOfferWithAvailability]:
+        """
+        Returns offers with availability matching `requirements`.
+        If the provider is added to gpuhunt, typically gets offers using `base.offers.get_catalog_offers()`
+        and extends them with availability info.
+        """
         pass
 
     @abstractmethod

--- a/src/dstack/_internal/core/backends/template/backend.py.jinja
+++ b/src/dstack/_internal/core/backends/template/backend.py.jinja
@@ -1,0 +1,16 @@
+from dstack._internal.core.backends.base.backend import Backend
+from dstack._internal.core.backends.{{ backend_name|lower }}.compute import {{ backend_name }}Compute
+from dstack._internal.core.backends.{{ backend_name|lower }}.models import {{ backend_name }}Config
+from dstack._internal.core.models.backends.base import BackendType
+
+
+class {{ backend_name }}Backend(Backend):
+    TYPE = BackendType.{{ backend_name|upper }}
+    COMPUTE_CLASS = {{ backend_name }}Compute
+
+    def __init__(self, config: {{ backend_name }}Config):
+        self.config = config
+        self._compute = {{ backend_name }}Compute(self.config)
+
+    def compute(self) -> {{ backend_name }}Compute:
+        return self._compute

--- a/src/dstack/_internal/core/backends/template/compute.py.jinja
+++ b/src/dstack/_internal/core/backends/template/compute.py.jinja
@@ -1,0 +1,72 @@
+from typing import List, Optional
+
+from dstack._internal.core.backends.base.backend import Compute
+from dstack._internal.core.backends.base.compute import (
+    ComputeWithCreateInstanceSupport,
+    ComputeWithGatewaySupport,
+    ComputeWithMultinodeSupport,
+    ComputeWithPlacementGroupSupport,
+    ComputeWithPrivateGatewaySupport,
+    ComputeWithReservationSupport,
+    ComputeWithVolumeSupport,
+)
+from dstack._internal.core.backends.base.offers import get_catalog_offers
+from dstack._internal.core.backends.{{ backend_name|lower }}.models import {{ backend_name }}Config
+from dstack._internal.core.models.instances import (
+    InstanceConfiguration,
+    InstanceOfferWithAvailability,
+)
+from dstack._internal.core.models.runs import Job, JobProvisioningData, Requirements, Run
+from dstack._internal.core.models.volumes import Volume
+from dstack._internal.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class {{ backend_name }}Compute(
+    # TODO: Choose ComputeWith* classes to extend and implement
+    # ComputeWithCreateInstanceSupport,
+    # ComputeWithMultinodeSupport,
+    # ComputeWithReservationSupport,
+    # ComputeWithPlacementGroupSupport,
+    # ComputeWithGatewaySupport,
+    # ComputeWithPrivateGatewaySupport,
+    # ComputeWithVolumeSupport,
+    Compute,
+):
+    def __init__(self, config: {{ backend_name }}Config):
+        super().__init__()
+        self.config = config
+
+    def get_offers(
+        self, requirements: Optional[Requirements] = None
+    ) -> List[InstanceOfferWithAvailability]:
+        # If the provider is added to gpuhunt, you'd typically get offers
+        # using `get_catalog_offers()` and extend them with availability info.
+        raise NotImplementedError()
+
+    def create_instance(
+        self,
+        instance_offer: InstanceOfferWithAvailability,
+        instance_config: InstanceConfiguration,
+    ) -> JobProvisioningData:
+        # TODO: Implement if backend supports creating instances (VM-based).
+        # Delete if backend can only run jobs (container-based).
+        raise NotImplementedError()
+
+    def run_job(
+        self,
+        run: Run,
+        job: Job,
+        instance_offer: InstanceOfferWithAvailability,
+        project_ssh_public_key: str,
+        project_ssh_private_key: str,
+        volumes: List[Volume],
+    ) -> JobProvisioningData:
+        # TODO: Implement if create_instance() is not implemented. Delete otherwise.
+        raise NotImplementedError()
+
+    def terminate_instance(
+        self, instance_id: str, region: str, backend_data: Optional[str] = None
+    ):
+        raise NotImplementedError()

--- a/src/dstack/_internal/core/backends/template/compute.py.jinja
+++ b/src/dstack/_internal/core/backends/template/compute.py.jinja
@@ -12,7 +12,9 @@ from dstack._internal.core.backends.base.compute import (
 )
 from dstack._internal.core.backends.base.offers import get_catalog_offers
 from dstack._internal.core.backends.{{ backend_name|lower }}.models import {{ backend_name }}Config
+from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.instances import (
+    InstanceAvailability,
     InstanceConfiguration,
     InstanceOfferWithAvailability,
 )
@@ -43,7 +45,20 @@ class {{ backend_name }}Compute(
     ) -> List[InstanceOfferWithAvailability]:
         # If the provider is added to gpuhunt, you'd typically get offers
         # using `get_catalog_offers()` and extend them with availability info.
-        raise NotImplementedError()
+        offers = get_catalog_offers(
+            backend=BackendType.{{ backend_name|upper }},
+            locations=self.config.regions or None,
+            requirements=requirements,
+            # configurable_disk_size=...,  TODO: set in case of boot volume size limits
+        )
+        # TODO: Add availability info to offers
+        return [
+            InstanceOfferWithAvailability(
+                **offer.dict(),
+                availability=InstanceAvailability.UNKNOWN,
+            )
+            for offer in offers
+        ]
 
     def create_instance(
         self,

--- a/src/dstack/_internal/core/backends/template/configurator.py.jinja
+++ b/src/dstack/_internal/core/backends/template/configurator.py.jinja
@@ -1,0 +1,70 @@
+import json
+
+from dstack._internal.core.backends.base.configurator import (
+    BackendRecord,
+    Configurator,
+    raise_invalid_credentials_error,
+)
+from dstack._internal.core.backends.{{ backend_name|lower }}.backend import {{ backend_name }}Backend
+from dstack._internal.core.backends.{{ backend_name|lower }}.models import (
+    Any{{ backend_name }}BackendConfig,
+    Any{{ backend_name }}Creds,
+    {{ backend_name }}BackendConfig,
+    {{ backend_name }}BackendConfigWithCreds,
+    {{ backend_name }}Config,
+    {{ backend_name }}Creds,
+    {{ backend_name }}StoredConfig,
+)
+from dstack._internal.core.models.backends.base import (
+    BackendType,
+)
+
+# TODO: Add all supported regions and default regions
+REGIONS = []
+
+
+class {{ backend_name }}Configurator(Configurator):
+    TYPE = BackendType.{{ backend_name|upper }}
+    BACKEND_CLASS = {{ backend_name }}Backend
+
+    def validate_config(
+        self, config: {{ backend_name }}BackendConfigWithCreds, default_creds_enabled: bool
+    ):
+        self._validate_creds(config.creds)
+        # TODO: Validate additional config parameters if any
+
+    def create_backend(
+        self, project_name: str, config: {{ backend_name }}BackendConfigWithCreds
+    ) -> BackendRecord:
+        if config.regions is None:
+            config.regions = REGIONS
+        return BackendRecord(
+            config={{ backend_name }}StoredConfig(
+                **{{ backend_name }}BackendConfig.__response__.parse_obj(config).dict()
+            ).json(),
+            auth={{ backend_name }}Creds.parse_obj(config.creds).json(),
+        )
+
+    def get_backend_config(
+        self, record: BackendRecord, include_creds: bool
+    ) -> Any{{ backend_name }}BackendConfig:
+        config = self._get_config(record)
+        if include_creds:
+            return {{ backend_name }}BackendConfigWithCreds.__response__.parse_obj(config)
+        return {{ backend_name }}BackendConfig.__response__.parse_obj(config)
+
+    def get_backend(self, record: BackendRecord) -> {{ backend_name }}Backend:
+        config = self._get_config(record)
+        return {{ backend_name }}Backend(config=config)
+
+    def _get_config(self, record: BackendRecord) -> {{ backend_name }}Config:
+        return {{ backend_name }}Config.__response__(
+            **json.loads(record.config),
+            creds={{ backend_name }}Creds.parse_raw(record.auth),
+        )
+
+    def _validate_creds(self, creds: Any{{ backend_name }}Creds):
+        # TODO: Implement API key or other creds validation
+        # if valid:
+        #     return
+        raise_invalid_credentials_error(fields=[["creds", "api_key"]])

--- a/src/dstack/_internal/core/backends/template/models.py.jinja
+++ b/src/dstack/_internal/core/backends/template/models.py.jinja
@@ -1,0 +1,58 @@
+from typing import Annotated, List, Literal, Optional, Union
+
+from pydantic import Field
+
+from dstack._internal.core.models.common import CoreModel
+
+
+# The template uses "api_key" creds as a most popular creds type.
+# TODO: Adjust it or add additional creds models if necessary.
+class {{ backend_name }}APIKeyCreds(CoreModel):
+    type: Annotated[Literal["api_key"], Field(description="The type of credentials")] = "api_key"
+    api_key: Annotated[str, Field(description="The API key")]
+
+
+Any{{ backend_name }}Creds = {{ backend_name }}APIKeyCreds
+{{ backend_name }}Creds = Any{{ backend_name }}Creds
+
+
+class {{ backend_name }}BackendConfig(CoreModel):
+    """
+    The backend config used in the API, server/config.yml, `{{ backend_name }}Configurator`.
+    It also serves as a base class for other backend config models.
+    Should not include creds.
+    """
+    type: Annotated[
+        Literal["{{ backend_name|lower }}"],
+        Field(description="The type of backend"),
+    ] = "{{ backend_name|lower }}"
+    regions: Annotated[
+        Optional[List[str]],
+        Field(description="The list of {{ backend_name }} regions. Omit to use all regions"),
+    ] = None
+    # TODO: Add additional backend parameters if necessary
+
+
+class {{ backend_name }}BackendConfigWithCreds({{ backend_name }}BackendConfig):
+    """
+    Same as `{{ backend_name }}BackendConfig` but also includes creds.
+    """
+    creds: Annotated[Any{{ backend_name }}Creds, Field(description="The credentials")]
+
+
+Any{{ backend_name }}BackendConfig = Union[{{ backend_name }}BackendConfig, {{ backend_name }}BackendConfigWithCreds]
+
+
+class {{ backend_name }}StoredConfig({{ backend_name }}BackendConfig):
+    """
+    The backend config used for config parameters in the DB.
+    Can extend `{{ backend_name }}BackendConfig` with additional parameters.
+    """
+    pass
+
+
+class {{ backend_name }}Config({{ backend_name }}StoredConfig):
+    """
+    The backend config used by `{{ backend_name }}Backend` and `{{ backend_name }}Compute`.
+    """
+    creds: Any{{ backend_name }}Creds

--- a/src/dstack/_internal/core/backends/template/models.py.jinja
+++ b/src/dstack/_internal/core/backends/template/models.py.jinja
@@ -5,7 +5,7 @@ from pydantic import Field
 from dstack._internal.core.models.common import CoreModel
 
 
-# The template uses "api_key" creds as a most popular creds type.
+# The template uses "api_key" creds as the most popular creds type.
 # TODO: Adjust it or add additional creds models if necessary.
 class {{ backend_name }}APIKeyCreds(CoreModel):
     type: Annotated[Literal["api_key"], Field(description="The type of credentials")] = "api_key"


### PR DESCRIPTION
Part of #2372 

The PR adds a `scripts/add_backend.py` script to generate all the necessary files and classes for a new backend and updates the backend guide to use it.