### PR TITLE
Add `datacenter-gpu-manager-4-proprietary` to CUDA images

### DIFF
--- a/docs/docs/guides/server-deployment.md
+++ b/docs/docs/guides/server-deployment.md
@@ -215,7 +215,7 @@ Currently, `dstack` collects the following metrics:
 
 * A fixed subset of NVIDIA GPU metrics from [DCGM Exporter :material-arrow-top-right-thin:{ .external }](https://docs.nvidia.com/datacenter/dcgm/latest/gpu-telemetry/dcgm-exporter.html){:target="_blank"} on supported cloud backends — AWS, Azure, GCP, OCI — and SSH fleets.
 On supported cloud backends the required packages are already installed.
-If you use SSH fleets, install `datacenter-gpu-manager-4-core` and `datacenter-gpu-manager-exporter`.
+If you use SSH fleets, install `datacenter-gpu-manager-4-core`, `datacenter-gpu-manager-4-proprietary` and `datacenter-gpu-manager-exporter`.
 
 ## Encryption
 

--- a/scripts/packer/provisioners/cuda.sh
+++ b/scripts/packer/provisioners/cuda.sh
@@ -18,5 +18,5 @@ sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     cuda-drivers-$CUDA_DRIVERS_VERSION \
     nvidia-fabricmanager-$CUDA_DRIVERS_VERSION \
-    datacenter-gpu-manager-4-core datacenter-gpu-manager-exporter
+    datacenter-gpu-manager-4-core datacenter-gpu-manager-4-proprietary datacenter-gpu-manager-exporter
 sudo systemctl enable nvidia-fabricmanager


### PR DESCRIPTION
This package is an optional dependency for
`datacenter-gpu-manager-4-core` and is not installed automatically as we run `apt` with `--no-install-recommends`.

Required for DCP metrics (`DCGM_FI_PROF_*`).

Fixes: https://github.com/dstackai/dstack/issues/2398