### PR TITLE
Drop dstack logs --attach

### DIFF
--- a/src/dstack/_internal/cli/commands/logs.py
+++ b/src/dstack/_internal/cli/commands/logs.py
@@ -1,6 +1,5 @@
 import argparse
 import sys
-from pathlib import Path
 
 from dstack._internal.cli.commands import APIBaseCommand
 from dstack._internal.cli.services.completion import RunNameCompleter
@@ -18,19 +17,6 @@ class LogsCommand(APIBaseCommand):
         super()._register()
         self._parser.add_argument(
             "-d", "--diagnose", action="store_true", help="Show run diagnostic logs"
-        )
-        self._parser.add_argument(
-            "-a",
-            "--attach",
-            action="store_true",
-            help="Set up an SSH tunnel and print logs as they follow",
-        )
-        self._parser.add_argument(
-            "--ssh-identity",
-            metavar="SSH_PRIVATE_KEY",
-            help="The private SSH key path for SSH tunneling",
-            type=Path,
-            dest="ssh_identity_file",
         )
         self._parser.add_argument(
             "--replica",
@@ -51,14 +37,6 @@ class LogsCommand(APIBaseCommand):
         run = self.api.runs.get(args.run_name)
         if run is None:
             raise CLIError(f"Run {args.run_name} not found")
-        if not args.diagnose and args.attach:
-            if run.status.is_finished():
-                raise CLIError(f"Run {args.run_name} is finished")
-            else:
-                logger.warning(
-                    "`dstack logs --attach` is deprecated in favor of `dstack attach --logs`"
-                )
-                run.attach(args.ssh_identity_file)
         logs = run.logs(
             diagnose=args.diagnose,
             replica_num=args.replica,


### PR DESCRIPTION
The PR drops the `--attach` mode for `dstack logs` command that was earlier deprecated in favor of `dstack attach --logs` (September 2024).