### PR TITLE
Clean up models backward compatibility code

### DIFF
--- a/src/dstack/_internal/cli/utils/gateway.py
+++ b/src/dstack/_internal/cli/utils/gateway.py
@@ -34,7 +34,7 @@ def get_gateways_table(
     for gateway in gateways:
         row = {
             "NAME": gateway.name,
-            "BACKEND": f"{gateway.backend.value} ({gateway.region})",
+            "BACKEND": f"{gateway.configuration.backend.value} ({gateway.configuration.region})",
             "HOSTNAME": gateway.hostname,
             "DOMAIN": gateway.wildcard_domain,
             "DEFAULT": "✓" if gateway.default else "",

--- a/src/dstack/_internal/core/models/fleets.py
+++ b/src/dstack/_internal/core/models/fleets.py
@@ -289,8 +289,7 @@ class FleetSpec(CoreModel):
 
 
 class Fleet(CoreModel):
-    # id is Optional for backward compatibility within 0.18.x
-    id: Optional[uuid.UUID] = None
+    id: uuid.UUID
     name: str
     project_name: str
     spec: FleetSpec

--- a/src/dstack/_internal/core/models/gateways.py
+++ b/src/dstack/_internal/core/models/gateways.py
@@ -76,12 +76,12 @@ class Gateway(CoreModel):
     # The ip address of the gateway instance
     ip_address: Optional[str]
     instance_id: Optional[str]
+    wildcard_domain: Optional[str]
+    default: bool
     # TODO: configuration fields are duplicated on top-level for backward compatibility with 0.18.x
-    # Remove in 0.19
+    # Remove after 0.19
     backend: BackendType
     region: str
-    default: bool
-    wildcard_domain: Optional[str]
 
 
 class GatewayPlan(CoreModel):

--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -457,9 +457,7 @@ class RunPlan(CoreModel):
     run_spec: RunSpec
     job_plans: List[JobPlan]
     current_resource: Optional[Run] = None
-    # Optional for backward-compatibility with 0.18.x servers
-    # TODO: make required in 0.19
-    action: Optional[ApplyAction] = None
+    action: ApplyAction
 
 
 class ApplyRunPlanInput(CoreModel):

--- a/src/dstack/_internal/core/models/volumes.py
+++ b/src/dstack/_internal/core/models/volumes.py
@@ -86,9 +86,7 @@ class VolumeAttachment(CoreModel):
 class Volume(CoreModel):
     id: uuid.UUID
     name: str
-    # Default user to "" for client backward compatibility (old 0.18 servers).
-    # TODO: Remove in 0.19
-    user: str = ""
+    user: str
     project_name: str
     configuration: VolumeConfiguration
     external: bool

--- a/src/dstack/_internal/server/schemas/gateways.py
+++ b/src/dstack/_internal/server/schemas/gateways.py
@@ -1,34 +1,11 @@
-from typing import Dict, List, Optional
+from typing import List
 
-from pydantic import root_validator
-
-from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.common import CoreModel
 from dstack._internal.core.models.gateways import GatewayConfiguration
 
 
 class CreateGatewayRequest(CoreModel):
-    name: Optional[str]
-    backend_type: Optional[BackendType]
-    region: Optional[str]
-    configuration: Optional[GatewayConfiguration]
-
-    @root_validator
-    def fill_configuration(cls, values: Dict) -> Dict:
-        if values.get("configuration", None) is not None:
-            return values
-        backend_type = values.get("backend_type", None)
-        region = values.get("region", None)
-        if backend_type is None:
-            raise ValueError("backend_type must be specified")
-        if region is None:
-            raise ValueError("region must be specified")
-        values["configuration"] = GatewayConfiguration(
-            name=values.get("name", None),
-            backend=backend_type,
-            region=region,
-        )
-        return values
+    configuration: GatewayConfiguration
 
 
 class GetGatewayRequest(CoreModel):

--- a/src/dstack/api/server/_gateways.py
+++ b/src/dstack/api/server/_gateways.py
@@ -1,8 +1,7 @@
-from typing import List, Optional
+from typing import List
 
 from pydantic import parse_obj_as
 
-from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.gateways import Gateway, GatewayConfiguration
 from dstack._internal.server.schemas.gateways import (
     CreateGatewayRequest,
@@ -24,22 +23,12 @@ class GatewaysAPIClient(APIClientGroup):
         resp = self._request(f"/api/project/{project_name}/gateways/get", body=body.json())
         return parse_obj_as(Gateway.__response__, resp.json())
 
-    # gateway_name, backend_type, region are left for backward-compatibility with 0.18.x
-    # TODO: Remove in 0.19
     def create(
         self,
         project_name: str,
-        gateway_name: Optional[str] = None,
-        backend_type: Optional[BackendType] = None,
-        region: Optional[str] = None,
-        configuration: Optional[GatewayConfiguration] = None,
+        configuration: GatewayConfiguration,
     ) -> Gateway:
-        body = CreateGatewayRequest(
-            name=gateway_name,
-            backend_type=backend_type,
-            region=region,
-            configuration=configuration,
-        )
+        body = CreateGatewayRequest(configuration=configuration)
         resp = self._request(f"/api/project/{project_name}/gateways/create", body=body.json())
         return parse_obj_as(Gateway.__response__, resp.json())
 

--- a/src/tests/_internal/server/routers/test_gateways.py
+++ b/src/tests/_internal/server/routers/test_gateways.py
@@ -175,7 +175,14 @@ class TestCreateGateway:
         backend = await create_backend(session, project.id, backend_type=BackendType.AWS)
         response = await client.post(
             f"/api/project/{project.name}/gateways/create",
-            json={"name": "test", "backend_type": "aws", "region": "us"},
+            json={
+                "configuration": {
+                    "type": "gateway",
+                    "name": "test",
+                    "backend": "aws",
+                    "region": "us",
+                },
+            },
             headers=get_auth_headers(user.token),
         )
         assert response.status_code == 200
@@ -218,7 +225,14 @@ class TestCreateGateway:
             g.return_value = "random-name"
             response = await client.post(
                 f"/api/project/{project.name}/gateways/create",
-                json={"name": None, "backend_type": "aws", "region": "us"},
+                json={
+                    "configuration": {
+                        "type": "gateway",
+                        "name": None,
+                        "backend": "aws",
+                        "region": "us",
+                    },
+                },
                 headers=get_auth_headers(user.token),
             )
             g.assert_called_once()
@@ -259,7 +273,14 @@ class TestCreateGateway:
         )
         response = await client.post(
             f"/api/project/{project.name}/gateways/create",
-            json={"name": "test", "backend_type": "aws", "region": "us"},
+            json={
+                "configuration": {
+                    "type": "gateway",
+                    "name": "test",
+                    "backend": "aws",
+                    "region": "us",
+                },
+            },
             headers=get_auth_headers(user.token),
         )
         assert response.status_code == 400


### PR DESCRIPTION
The PR removes models code for handling client backward with older 0.18 servers. Also, marks `dstack gateway create` as deprecated so it can be removed later (it was undocumented anyway).