### PR TITLE
Clean up legacy repo fields

### DIFF
--- a/src/dstack/_internal/core/models/repos/base.py
+++ b/src/dstack/_internal/core/models/repos/base.py
@@ -13,11 +13,6 @@ class RepoType(str, Enum):
     VIRTUAL = "virtual"
 
 
-class RepoProtocol(str, Enum):
-    SSH = "ssh"
-    HTTPS = "https"
-
-
 class BaseRepoInfo(CoreModel):
     repo_type: str
 

--- a/src/dstack/_internal/core/models/repos/remote.py
+++ b/src/dstack/_internal/core/models/repos/remote.py
@@ -3,7 +3,7 @@ import re
 import subprocess
 import time
 from dataclasses import dataclass
-from typing import BinaryIO, Callable, Dict, Optional
+from typing import Annotated, Any, BinaryIO, Callable, Dict, Optional
 
 import git
 import pydantic
@@ -12,7 +12,7 @@ from typing_extensions import Literal
 
 from dstack._internal.core.errors import DstackError
 from dstack._internal.core.models.common import CoreModel
-from dstack._internal.core.models.repos.base import BaseRepoInfo, Repo, RepoProtocol
+from dstack._internal.core.models.repos.base import BaseRepoInfo, Repo
 from dstack._internal.utils.hash import get_sha256, slugify
 from dstack._internal.utils.path import PathLike
 from dstack._internal.utils.ssh import get_host_config
@@ -25,20 +25,34 @@ class RepoError(DstackError):
 
 
 class RemoteRepoCreds(CoreModel):
-    protocol: RepoProtocol  # TODO: remove in 0.19
     clone_url: str
     private_key: Optional[str]
     oauth_token: Optional[str]
+
+    # TODO: remove in 0.20. Left for compatibility with CLI <=0.18.44
+    protocol: Annotated[Optional[str], Field(exclude=True)] = None
+
+    class Config:
+        @staticmethod
+        def schema_extra(schema: Dict[str, Any]) -> None:
+            del schema["properties"]["protocol"]
 
 
 class RemoteRepoInfo(BaseRepoInfo):
     repo_type: Literal["remote"] = "remote"
     repo_name: str
 
-    # TODO: remove in 0.19
-    repo_host_name: str = ""
-    repo_port: Optional[int] = None
-    repo_user_name: str = ""
+    # TODO: remove in 0.20. Left for compatibility with CLI <=0.18.44
+    repo_host_name: Annotated[Optional[str], Field(exclude=True)] = None
+    repo_port: Annotated[Optional[int], Field(exclude=True)] = None
+    repo_user_name: Annotated[Optional[str], Field(exclude=True)] = None
+
+    class Config:
+        @staticmethod
+        def schema_extra(schema: Dict[str, Any]) -> None:
+            del schema["properties"]["repo_host_name"]
+            del schema["properties"]["repo_port"]
+            del schema["properties"]["repo_user_name"]
 
 
 class RemoteRunRepoData(RemoteRepoInfo):

--- a/src/dstack/_internal/core/services/repos.py
+++ b/src/dstack/_internal/core/services/repos.py
@@ -10,7 +10,6 @@ from git.exc import GitCommandError
 from dstack._internal.core.errors import DstackError
 from dstack._internal.core.models.config import RepoConfig
 from dstack._internal.core.models.repos import LocalRepo, RemoteRepo, RemoteRepoCreds
-from dstack._internal.core.models.repos.base import RepoProtocol
 from dstack._internal.core.models.repos.remote import GitRepoURL
 from dstack._internal.utils.logging import get_logger
 from dstack._internal.utils.path import PathLike
@@ -41,7 +40,6 @@ def get_local_repo_credentials(
     r = requests.get(f"{url.as_https()}/info/refs?service=git-upload-pack", timeout=10)
     if r.status_code == 200:
         return RemoteRepoCreds(
-            protocol=RepoProtocol.HTTPS,
             clone_url=url.as_https(),
             private_key=None,
             oauth_token=None,
@@ -93,7 +91,6 @@ def check_remote_repo_credentials_https(url: GitRepoURL, oauth_token: str) -> Re
             f"Can't access `{url.as_https()}` using the `{masked}` token"
         )
     return RemoteRepoCreds(
-        protocol=RepoProtocol.HTTPS,
         clone_url=url.as_https(),
         oauth_token=oauth_token,
         private_key=None,
@@ -123,7 +120,6 @@ def check_remote_repo_credentials_ssh(url: GitRepoURL, identity_file: PathLike) 
         )
 
     return RemoteRepoCreds(
-        protocol=RepoProtocol.SSH,
         clone_url=url.as_ssh(),
         private_key=private_key,
         oauth_token=None,

--- a/src/dstack/_internal/server/routers/repos.py
+++ b/src/dstack/_internal/server/routers/repos.py
@@ -66,14 +66,13 @@ async def init_repo(
     You can create `virtual` repos if you don't use git repos.
     """
     user, project = user_project
-    repo_creds = body.repo_creds.to_remote_repo_creds(body.repo_info) if body.repo_creds else None
     await repos.init_repo(
         session=session,
         project=project,
         user=user,
         repo_id=body.repo_id,
         repo_info=body.repo_info,
-        repo_creds=repo_creds,
+        repo_creds=body.repo_creds,
     )
 
 

--- a/src/dstack/_internal/server/schemas/repos.py
+++ b/src/dstack/_internal/server/schemas/repos.py
@@ -4,44 +4,8 @@ from pydantic import Field
 
 from dstack._internal.core.models.common import CoreModel
 from dstack._internal.core.models.repos import AnyRepoInfo
-from dstack._internal.core.models.repos.base import RepoProtocol
-from dstack._internal.core.models.repos.remote import RemoteRepoCreds, RemoteRepoInfo
+from dstack._internal.core.models.repos.remote import RemoteRepoCreds
 from dstack._internal.server.schemas.common import RepoRequest
-
-
-# TODO: in 0.19, either remove this model or make clone_url required
-class RemoteRepoCredsDto(CoreModel):
-    protocol: RepoProtocol
-    clone_url: Optional[str]
-    private_key: Optional[str]
-    oauth_token: Optional[str]
-
-    @staticmethod
-    def from_remote_repo_creds(creds: RemoteRepoCreds) -> "RemoteRepoCredsDto":
-        return RemoteRepoCredsDto(
-            protocol=creds.protocol,
-            clone_url=creds.clone_url,
-            private_key=creds.private_key,
-            oauth_token=creds.oauth_token,
-        )
-
-    def to_remote_repo_creds(self, info: RemoteRepoInfo) -> RemoteRepoCreds:
-        if (clone_url := self.clone_url) is None:
-            netloc = (
-                f"{info.repo_host_name}:{info.repo_port}"
-                if info.repo_port
-                else info.repo_host_name
-            )
-            if self.protocol == RepoProtocol.SSH:
-                clone_url = f"ssh://git@{netloc}/{info.repo_user_name}/{info.repo_name}.git"
-            else:
-                clone_url = f"https://{netloc}/{info.repo_user_name}/{info.repo_name}.git"
-        return RemoteRepoCreds(
-            protocol=self.protocol,
-            clone_url=clone_url,
-            private_key=self.private_key,
-            oauth_token=self.oauth_token,
-        )
 
 
 class GetRepoRequest(RepoRequest):
@@ -51,7 +15,7 @@ class GetRepoRequest(RepoRequest):
 class SaveRepoCredsRequest(RepoRequest):
     repo_info: AnyRepoInfo
     repo_creds: Annotated[
-        Optional[RemoteRepoCredsDto],
+        Optional[RemoteRepoCreds],
         Field(description="The repo creds for accessing private remote repo"),
     ]
 

--- a/src/dstack/_internal/server/testing/common.py
+++ b/src/dstack/_internal/server/testing/common.py
@@ -181,9 +181,6 @@ async def create_repo(
     if info is None:
         info = {
             "repo_type": "remote",
-            "repo_host_name": "",
-            "repo_port": None,
-            "repo_user_name": "",
             "repo_name": "dstack",
         }
     repo = RepoModel(
@@ -206,7 +203,6 @@ async def create_repo_creds(
 ) -> RepoCredsModel:
     if creds is None:
         creds = {
-            "protocol": "https",
             "clone_url": "https://github.com/dstackai/dstack.git",
             "private_key": None,
             "oauth_token": "test_token",

--- a/src/dstack/api/server/_repos.py
+++ b/src/dstack/api/server/_repos.py
@@ -6,7 +6,6 @@ from dstack._internal.core.models.repos import AnyRepoInfo, RemoteRepoCreds, Rep
 from dstack._internal.server.schemas.repos import (
     DeleteReposRequest,
     GetRepoRequest,
-    RemoteRepoCredsDto,
     SaveRepoCredsRequest,
 )
 from dstack.api.server._group import APIClientGroup
@@ -32,9 +31,7 @@ class ReposAPIClient(APIClientGroup):
         body = SaveRepoCredsRequest(
             repo_id=repo_id,
             repo_info=repo_info,
-            repo_creds=RemoteRepoCredsDto.from_remote_repo_creds(repo_creds)
-            if repo_creds
-            else None,
+            repo_creds=repo_creds,
         )
         self._request(f"/api/project/{project_name}/repos/init", body=body.json())
 

--- a/src/tests/_internal/server/routers/test_repos.py
+++ b/src/tests/_internal/server/routers/test_repos.py
@@ -128,7 +128,6 @@ class TestGetRepo:
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         legacy_creds = {
-            "protocol": "https",
             "clone_url": "https://github.com/dstackai/dstack.git",
             "private_key": None,
             "oauth_token": "test_token",
@@ -157,14 +156,12 @@ class TestGetRepo:
         user = await create_user(session=session, global_role=GlobalRole.USER)
         project = await create_project(session=session, owner=user)
         legacy_creds = {
-            "protocol": "https",
             "clone_url": "https://github.com/dstackai/dstack.git",
             "private_key": None,
             "oauth_token": "legacy_creds",
         }
         repo = await create_repo(session=session, project_id=project.id, creds=legacy_creds)
         user_creds = {
-            "protocol": "https",
             "clone_url": "https://github.com/dstackai/dstack.git",
             "private_key": None,
             "oauth_token": "user_creds",
@@ -214,13 +211,9 @@ class TestInitRepo:
             "repo_id": "test_repo",
             "repo_info": {
                 "repo_type": "remote",
-                "repo_host_name": "",
-                "repo_port": None,
-                "repo_user_name": "",
                 "repo_name": "dstack",
             },
             "repo_creds": {
-                "protocol": "https",
                 "clone_url": "https://github.com/dstackai/dstack.git",
                 "private_key": None,
                 "oauth_token": "test_token",
@@ -254,13 +247,9 @@ class TestInitRepo:
             "repo_id": "test_repo",
             "repo_info": {
                 "repo_type": "remote",
-                "repo_host_name": "",
-                "repo_port": None,
-                "repo_user_name": "",
                 "repo_name": "dstack",
             },
             "repo_creds": {
-                "protocol": "https",
                 "clone_url": "https://github.com/dstackai/dstack.git",
                 "private_key": None,
                 "oauth_token": "test_token",
@@ -276,13 +265,9 @@ class TestInitRepo:
             "repo_id": "test_repo",
             "repo_info": {
                 "repo_type": "remote",
-                "repo_host_name": "",
-                "repo_port": None,
-                "repo_user_name": "",
                 "repo_name": "dstack",
             },
             "repo_creds": {
-                "protocol": "https",
                 "clone_url": "https://github.com/dstackai/dstack.git",
                 "private_key": None,
                 "oauth_token": "test_token_updated",

--- a/src/tests/_internal/server/services/test_repos.py
+++ b/src/tests/_internal/server/services/test_repos.py
@@ -7,7 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dstack._internal.core.models.repos import RemoteRepoCreds, RemoteRepoInfo, RepoHeadWithCreds
-from dstack._internal.core.models.repos.base import RepoProtocol, RepoType
+from dstack._internal.core.models.repos.base import RepoType
 from dstack._internal.core.models.users import GlobalRole, ProjectRole
 from dstack._internal.server.models import ProjectModel, RepoCredsModel, UserModel
 from dstack._internal.server.services.projects import add_project_member
@@ -90,7 +90,6 @@ class TestGetRemoteRepo:
     ):
         repo_info = RemoteRepoInfo(repo_type="remote", repo_name="test")
         legacy_repo_creds = RemoteRepoCreds(
-            protocol=RepoProtocol.HTTPS,
             clone_url="https://git.example.com/repo.git",
             private_key=None,
             oauth_token="legacy-oauth-token",
@@ -104,7 +103,6 @@ class TestGetRemoteRepo:
             creds=legacy_repo_creds.dict(),
         )
         user_repo_creds = RemoteRepoCreds(
-            protocol=RepoProtocol.HTTPS,
             clone_url="https://git.example.com/repo.git",
             private_key=None,
             oauth_token="user-oauth-token",
@@ -142,7 +140,6 @@ class TestGetRemoteRepo:
         # another user's creds should be ignored
         another_user = await _create_user(session, project, name="another-user")
         another_user_repo_creds = RemoteRepoCreds(
-            protocol=RepoProtocol.HTTPS,
             clone_url="https://git.example.com/repo.git",
             private_key=None,
             oauth_token="another-oauth-token",
@@ -185,7 +182,6 @@ class TestGetRemoteRepo:
         repo_info = RemoteRepoInfo(repo_type="remote", repo_name="test")
         if with_legacy_creds:
             legacy_repo_creds = RemoteRepoCreds(
-                protocol=RepoProtocol.HTTPS,
                 clone_url="https://git.example.com/repo.git",
                 private_key=None,
                 oauth_token="legacy-oauth-token",
@@ -201,7 +197,6 @@ class TestGetRemoteRepo:
             creds=legacy_repo_creds.dict() if legacy_repo_creds else None,
         )
         user_repo_creds = RemoteRepoCreds(
-            protocol=RepoProtocol.HTTPS,
             clone_url="https://git.example.com/repo.git",
             private_key=None,
             oauth_token="user-oauth-token",
@@ -228,7 +223,6 @@ class TestGetRemoteRepo:
     ):
         repo_info = RemoteRepoInfo(repo_type="remote", repo_name="test")
         legacy_repo_creds = RemoteRepoCreds(
-            protocol=RepoProtocol.HTTPS,
             clone_url="https://git.example.com/repo.git",
             private_key=None,
             oauth_token="legacy-oauth-token",
@@ -259,7 +253,6 @@ class TestInitRemoteRepo:
     ):
         repo_info = RemoteRepoInfo(repo_type="remote", repo_name="test")
         repo_creds = RemoteRepoCreds(
-            protocol=RepoProtocol.HTTPS,
             clone_url="https://git.example.com/repo.git",
             private_key=None,
             oauth_token="oauth-token",
@@ -283,7 +276,6 @@ class TestInitRemoteRepo:
         old_repo_info = RemoteRepoInfo(repo_type="remote", repo_name="old-name")
         new_repo_info = RemoteRepoInfo(repo_type="remote", repo_name="new-name")
         our_repo_creds = RemoteRepoCreds(
-            protocol=RepoProtocol.HTTPS,
             clone_url="https://git.example.com/repo.git",
             private_key=None,
             oauth_token="our-oauth-token",
@@ -323,7 +315,6 @@ class TestInitRemoteRepo:
             creds=None,
         )
         old_repo_creds = RemoteRepoCreds(
-            protocol=RepoProtocol.HTTPS,
             clone_url="https://git.example.com/repo.git",
             private_key=None,
             oauth_token="oauth-token",
@@ -335,7 +326,6 @@ class TestInitRemoteRepo:
             creds=old_repo_creds.dict(),
         )
         new_repo_creds = RemoteRepoCreds(
-            protocol=RepoProtocol.HTTPS,
             clone_url="ssh://git@git.example.com/repo.git",
             private_key="private-key",
             oauth_token=None,
@@ -357,7 +347,6 @@ class TestInitRemoteRepo:
     ):
         repo_info = RemoteRepoInfo(repo_type="remote", repo_name="test")
         legacy_repo_creds = RemoteRepoCreds(
-            protocol=RepoProtocol.HTTPS,
             clone_url="https://git.example.com/repo.git",
             private_key=None,
             oauth_token="legacy-oauth-token",
@@ -371,7 +360,6 @@ class TestInitRemoteRepo:
             creds=legacy_repo_creds.dict(),
         )
         our_repo_creds = RemoteRepoCreds(
-            protocol=RepoProtocol.HTTPS,
             clone_url="https://git.example.com/repo.git",
             private_key=None,
             oauth_token="our-oauth-token",
@@ -384,7 +372,6 @@ class TestInitRemoteRepo:
         )
         another_user = await _create_user(session, project, name="another-user")
         another_user_repo_creds = RemoteRepoCreds(
-            protocol=RepoProtocol.HTTPS,
             clone_url="https://git.example.com/repo.git",
             private_key=None,
             oauth_token="another-oauth-token",


### PR DESCRIPTION
- Drop the logic for building `RemoteRepoCreds.clone_url` on server. Was needed for pre-0.18.6 clients. `RemoteRepoCreds.clone_url` is now required in client requests.
- Drop now-unused repo fields from client requests and API docs. Server will still accept (and ignore) these fields for compatibility with pre-0.19.0 clients that set them to empty values.