### PR TITLE
Switch AWS gateways from t2.micro to t3.micro

### DIFF
--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -357,7 +357,7 @@ class AWSCompute(
             **aws_resources.create_instances_struct(
                 disk_size=10,
                 image_id=aws_resources.get_gateway_image_id(ec2_client),
-                instance_type="t2.micro",
+                instance_type="t3.micro",
                 iam_instance_profile=None,
                 user_data=get_gateway_user_data(configuration.ssh_key_pub),
                 tags=tags,


### PR DESCRIPTION
Fixes #2409

The PR moves to t3.micro from t2.micro for AWS gateways since t2 is not supported in many regions: https://docs.aws.amazon.com/ec2/latest/instancetypes/ec2-instance-regions.html#instance-types-ca-west-1

