### PR TITLE
Use new JobTerminationReason values

### DIFF
--- a/runner/internal/executor/executor.go
+++ b/runner/internal/executor/executor.go
@@ -169,12 +169,10 @@ func (ex *RunExecutor) Run(ctx context.Context) (err error) {
 		select {
 		case <-timeoutCtx.Done():
 			log.Error(ctx, "Max duration exceeded", "max_duration", ex.jobSpec.MaxDuration)
-			// We do not set "max_duration_exceeded" termination reason yet for backward compatibility
-			// TODO: Set it several releases after 0.18.36
 			ex.SetJobStateWithTerminationReason(
 				ctx,
 				types.JobStateTerminated,
-				types.TerminationReasonContainerExitedWithError,
+				types.TerminationReasonMaxDurationExceeded,
 				"Max duration exceeded",
 			)
 			return gerrors.Wrap(err)

--- a/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
@@ -171,8 +171,7 @@ async def _process_submitted_job(session: AsyncSession, job_model: JobModel):
     except ServerClientError as e:
         logger.warning("%s: failed to prepare run volumes: %s", fmt(job_model), repr(e))
         job_model.status = JobStatus.TERMINATING
-        # TODO: Replace with JobTerminationReason.VOLUME_ERROR in 0.19
-        job_model.termination_reason = JobTerminationReason.TERMINATED_BY_SERVER
+        job_model.termination_reason = JobTerminationReason.VOLUME_ERROR
         job_model.termination_reason_message = e.msg
         job_model.last_processed_at = common_utils.get_current_datetime()
         await session.commit()
@@ -657,8 +656,7 @@ async def _attach_volumes(
             except (ServerClientError, BackendError) as e:
                 logger.warning("%s: failed to attached volume: %s", fmt(job_model), repr(e))
                 job_model.status = JobStatus.TERMINATING
-                # TODO: Replace with JobTerminationReason.VOLUME_ERROR in 0.19
-                job_model.termination_reason = JobTerminationReason.TERMINATED_BY_SERVER
+                job_model.termination_reason = JobTerminationReason.VOLUME_ERROR
                 job_model.termination_reason_message = "Failed to attach volume"
             except Exception:
                 logger.exception(
@@ -666,8 +664,7 @@ async def _attach_volumes(
                     fmt(job_model),
                 )
                 job_model.status = JobStatus.TERMINATING
-                # TODO: Replace with JobTerminationReason.VOLUME_ERROR in 0.19
-                job_model.termination_reason = JobTerminationReason.TERMINATED_BY_SERVER
+                job_model.termination_reason = JobTerminationReason.VOLUME_ERROR
                 job_model.termination_reason_message = "Failed to attach volume"
             finally:
                 job_model.job_runtime_data = job_runtime_data.json()


### PR DESCRIPTION
The PR makes use of JobTerminationReason.VOLUME_ERROR and JobTerminationReason.MAX_DURATION_EXCEEDED that were previously unused due to server backward compatibility with older clients.