### PR TITLE
Add instance and job cost/usage Prometheus metrics

### DIFF
--- a/contributing/METRICS.md
+++ b/contributing/METRICS.md
@@ -1,0 +1,62 @@
+# Prometheus metrics
+
+If enabled, `dstack` collects and exports the following Prometheus metrics.
+
+> [!NOTE]
+> *string?* denotes optional string.
+
+## Instance metrics
+
+| Metric | Type | Description | Examples |
+|---|---|---|---|
+| `dstack_instance_duration_seconds_total` | *counter* | Total seconds the instance is running | `1123763.22` |
+| `dstack_instance_price_dollars_per_hour` | *gauge* | Instance price, USD/hour | `16.0`|
+| `dstack_instance_gpu_count` | *gauge* | Instance GPU count | `4.0`, `0.0` |
+
+| Label | Type | Examples |
+|---|---|---|
+| `dstack_project_name` | *string* | `main` |
+| `dstack_fleet_name` | *string?* | `my-fleet` |
+| `dstack_fleet_id` | *string?* | `51e837bf-fae9-4a37-ac9c-85c005606c22` |
+| `dstack_instance_name` | *string* | `my-fleet-0` |
+| `dstack_instance_id` | *string* | `8c28c52c-2f94-4a19-8c06-12f1dfee4dd2` |
+| `dstack_instance_type` | *string?* | `g4dn.xlarge` |
+| `dstack_backend` | *string?* | `aws`, `runpod` |
+| `dstack_gpu` | *string?* | `T4` |
+
+## Job metrics
+
+| Metric | Type | Description | Examples |
+|---|---|---|---|
+| `dstack_job_duration_seconds_total` | *counter* | Total seconds the job is running | `520.37` |
+| `dstack_job_price_dollars_per_hour` | *gauge* | Job instance price, USD/hour | `8.0`|
+| `dstack_job_gpu_count` | *gauge* | Job GPU count | `2.0`, `0.0` |
+
+| Label | Type | Examples |
+|---|---|---|
+| `dstack_project_name` | *string* | `main` |
+| `dstack_user_name` | *string* | `alice` |
+| `dstack_run_name` | *string* | `nccl-tests` |
+| `dstack_run_id` | *string* | `51e837bf-fae9-4a37-ac9c-85c005606c22` |
+| `dstack_job_name` | *string* | `nccl-tests-0-0` |
+| `dstack_job_id` | *string* | `8c28c52c-2f94-4a19-8c06-12f1dfee4dd2` |
+| `dstack_job_num` | *integer* | `0` |
+| `dstack_replica_num` | *integer* | `0` |
+| `dstack_run_type` | *string* | `task`, `dev-environment` |
+| `dstack_backend` | *string* | `aws`, `runpod` |
+| `dstack_gpu` | *string?* | `T4` |
+
+## NVIDIA DCGM job metrics
+
+Only on supported backends. Check [`dcgm/exporter.go`](https://github.com/dstackai/dstack/blob/master/runner/internal/shim/dcgm/exporter.go) for the list of metrics.
+
+| Label | Type | Example |
+|---|---|---|
+| `dstack_project_name` | *string* | `main` |
+| `dstack_user_name` | *string* | `alice` |
+| `dstack_run_name` | *string* | `nccl-tests` |
+| `dstack_run_id` | *string* | `51e837bf-fae9-4a37-ac9c-85c005606c22` |
+| `dstack_job_name` | *string* | `nccl-tests-0-0` |
+| `dstack_job_id` | *string* | `8c28c52c-2f94-4a19-8c06-12f1dfee4dd2` |
+| `dstack_job_num` | *integer* | `0` |
+| `dstack_replica_num` | *integer* | `0` |

--- a/docs/docs/guides/metrics.md
+++ b/docs/docs/guides/metrics.md
@@ -1,9 +1,11 @@
 # Prometheus metrics
 
-If enabled, `dstack` collects and exports the following Prometheus metrics.
+If enabled, `dstack` collects and exports Prometheus metrics. Metrics are available at the `/metrics` path.
 
-> [!NOTE]
-> *string?* denotes optional string.
+By default, metrics are disabled. To enable, set the `DSTACK_ENABLE_PROMETHEUS_METRICS` variable.
+
+!!! info "Convention"
+    *type?* denotes an optional type. If a type is optional, an empty string is a valid value.
 
 ## Instance metrics
 
@@ -48,9 +50,18 @@ If enabled, `dstack` collects and exports the following Prometheus metrics.
 
 ## NVIDIA DCGM job metrics
 
-Only on supported backends. Check [`dcgm/exporter.go`](https://github.com/dstackai/dstack/blob/master/runner/internal/shim/dcgm/exporter.go) for the list of metrics.
+A fixed subset of NVIDIA GPU metrics from [DCGM Exporter :material-arrow-top-right-thin:{ .external }](https://docs.nvidia.com/datacenter/dcgm/latest/gpu-telemetry/dcgm-exporter.html){:target="_blank"} on supported cloud backends — AWS, Azure, GCP, OCI — and SSH fleets.
 
-| Label | Type | Example |
+??? info "SSH fleets"
+    In order for DCGM metrics to work, the following packages must be installed on the instances:
+
+    * `datacenter-gpu-manager-4-core`
+    * `datacenter-gpu-manager-4-proprietary`
+    * `datacenter-gpu-manager-exporter`
+
+Check [`dcgm/exporter.go`](https://github.com/dstackai/dstack/blob/master/runner/internal/shim/dcgm/exporter.go) for the list of metrics.
+
+| Label | Type | Examples |
 |---|---|---|
 | `dstack_project_name` | *string* | `main` |
 | `dstack_user_name` | *string* | `alice` |

--- a/docs/docs/guides/server-deployment.md
+++ b/docs/docs/guides/server-deployment.md
@@ -204,18 +204,21 @@ To store logs using GCP Logging, set the `DSTACK_SERVER_GCP_LOGGING_PROJECT` env
 
 ## Metrics
 
-If enabled, `dstack` collects and exports Prometheus metrics from running jobs. Metrics for jobs from all projects are available
-at the `/metrics` path, and metrics for jobs from a specific project are available at the `/metrics/project/<project-name>` path.
+If enabled, `dstack` collects and exports Prometheus metrics. Metrics are available at the `/metrics` path.
 
 By default, metrics are disabled. To enable, set the `DSTACK_ENABLE_PROMETHEUS_METRICS` variable.
 
-Each sample includes a set of `dstack_*` labels, e.g., `dstack_project_name="main"`, `dstack_run_name="vllm-llama32"`.
-
 Currently, `dstack` collects the following metrics:
 
+* Instance metrics: cost, usage
+* Job metrics: cost, usage
 * A fixed subset of NVIDIA GPU metrics from [DCGM Exporter :material-arrow-top-right-thin:{ .external }](https://docs.nvidia.com/datacenter/dcgm/latest/gpu-telemetry/dcgm-exporter.html){:target="_blank"} on supported cloud backends — AWS, Azure, GCP, OCI — and SSH fleets.
 On supported cloud backends the required packages are already installed.
 If you use SSH fleets, install `datacenter-gpu-manager-4-core`, `datacenter-gpu-manager-4-proprietary` and `datacenter-gpu-manager-exporter`.
+
+Each sample includes a set of `dstack_*` labels, e.g., `dstack_project_name="main"`, `dstack_run_name="vllm-llama32"`.
+
+For the detailed list of metrics and labels see the [documentation :material-arrow-top-right-thin:{ .external }](https://github.com/dstackai/dstack/blob/master/contributing/METRICS.md){:target="_blank"}.
 
 ## Encryption
 

--- a/docs/docs/guides/server-deployment.md
+++ b/docs/docs/guides/server-deployment.md
@@ -202,24 +202,6 @@ To store logs using GCP Logging, set the `DSTACK_SERVER_GCP_LOGGING_PROJECT` env
 
     </div>
 
-## Metrics
-
-If enabled, `dstack` collects and exports Prometheus metrics. Metrics are available at the `/metrics` path.
-
-By default, metrics are disabled. To enable, set the `DSTACK_ENABLE_PROMETHEUS_METRICS` variable.
-
-Currently, `dstack` collects the following metrics:
-
-* Instance metrics: cost, usage
-* Job metrics: cost, usage
-* A fixed subset of NVIDIA GPU metrics from [DCGM Exporter :material-arrow-top-right-thin:{ .external }](https://docs.nvidia.com/datacenter/dcgm/latest/gpu-telemetry/dcgm-exporter.html){:target="_blank"} on supported cloud backends — AWS, Azure, GCP, OCI — and SSH fleets.
-On supported cloud backends the required packages are already installed.
-If you use SSH fleets, install `datacenter-gpu-manager-4-core`, `datacenter-gpu-manager-4-proprietary` and `datacenter-gpu-manager-exporter`.
-
-Each sample includes a set of `dstack_*` labels, e.g., `dstack_project_name="main"`, `dstack_run_name="vllm-llama32"`.
-
-For the detailed list of metrics and labels see the [documentation :material-arrow-top-right-thin:{ .external }](https://github.com/dstackai/dstack/blob/master/contributing/METRICS.md){:target="_blank"}.
-
 ## Encryption
 
 By default, `dstack` stores data in plaintext. To enforce encryption, you 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -225,6 +225,7 @@ nav:
       - Guides:
           - Protips: docs/guides/protips.md
           - Server deployment: docs/guides/server-deployment.md
+          - Metrics: docs/guides/metrics.md
           - Troubleshooting: docs/guides/troubleshooting.md
           - Administration: docs/guides/administration.md
       - Reference:

--- a/src/dstack/_internal/server/routers/prometheus.py
+++ b/src/dstack/_internal/server/routers/prometheus.py
@@ -26,7 +26,7 @@ async def get_prometheus_metrics(
     return await prometheus.get_metrics(session=session)
 
 
-@router.get("/metrics/project/{project_name}")
+@router.get("/metrics/project/{project_name}", deprecated=True)
 async def get_project_prometheus_metrics(
     session: Annotated[AsyncSession, Depends(get_session)],
     project: Annotated[ProjectModel, Depends(Project())],

--- a/src/dstack/_internal/server/services/prometheus.py
+++ b/src/dstack/_internal/server/services/prometheus.py
@@ -1,4 +1,6 @@
+import itertools
 from collections.abc import Generator, Iterable
+from datetime import timezone
 
 from prometheus_client import Metric
 from prometheus_client.parser import text_string_to_metric_families
@@ -7,21 +9,172 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
-from dstack._internal.core.models.runs import JobStatus
-from dstack._internal.server.models import JobModel, JobPrometheusMetrics, ProjectModel
+from dstack._internal.core.models.instances import InstanceStatus
+from dstack._internal.core.models.runs import JobStatus, RunSpec
+from dstack._internal.server.models import (
+    InstanceModel,
+    JobModel,
+    JobPrometheusMetrics,
+    ProjectModel,
+    RunModel,
+)
+from dstack._internal.server.services.instances import get_instance_offer
+from dstack._internal.server.services.jobs import get_job_provisioning_data, get_job_runtime_data
+from dstack._internal.utils.common import get_current_datetime
+
+_INSTANCE_DURATION = "dstack_instance_duration_seconds_total"
+_INSTANCE_PRICE = "dstack_instance_price_dollars_per_hour"
+_INSTANCE_GPU_COUNT = "dstack_instance_gpu_count"
+_JOB_DURATION = "dstack_job_duration_seconds_total"
+_JOB_PRICE = "dstack_job_price_dollars_per_hour"
+_JOB_GPU_COUNT = "dstack_job_gpu_count"
 
 
 async def get_metrics(session: AsyncSession) -> str:
+    metrics_iter = itertools.chain(
+        await get_instance_metrics(session),
+        await get_job_metrics(session),
+        await get_job_gpu_metrics(session),
+    )
+    return "\n".join(_render_metrics(metrics_iter)) + "\n"
+
+
+async def get_instance_metrics(session: AsyncSession) -> Iterable[Metric]:
+    res = await session.execute(
+        select(InstanceModel)
+        .join(ProjectModel)
+        .where(
+            InstanceModel.deleted == False,
+            InstanceModel.status.in_(
+                [
+                    InstanceStatus.PROVISIONING,
+                    InstanceStatus.IDLE,
+                    InstanceStatus.BUSY,
+                    InstanceStatus.TERMINATING,
+                ]
+            ),
+        )
+        .order_by(ProjectModel.name, InstanceModel.name)
+        .options(
+            joinedload(InstanceModel.project),
+            joinedload(InstanceModel.fleet),
+        )
+    )
+    instances = res.unique().scalars().all()
+    metrics: dict[str, Metric] = {
+        _INSTANCE_DURATION: Metric(
+            name=_INSTANCE_DURATION,
+            documentation="Total seconds the instance is running",
+            typ="counter",
+        ),
+        _INSTANCE_PRICE: Metric(
+            name=_INSTANCE_PRICE, documentation="Instance price, USD/hour", typ="gauge"
+        ),
+        _INSTANCE_GPU_COUNT: Metric(
+            name=_INSTANCE_GPU_COUNT, documentation="Instance GPU count", typ="gauge"
+        ),
+    }
+    now = get_current_datetime()
+    for instance in instances:
+        fleet = instance.fleet
+        offer = get_instance_offer(instance)
+        gpu = ""
+        gpu_count = 0
+        if offer is not None and len(offer.instance.resources.gpus) > 0:
+            gpu = offer.instance.resources.gpus[0].name
+            gpu_count = len(offer.instance.resources.gpus)
+        labels: dict[str, str] = {
+            "dstack_project_name": instance.project.name,
+            "dstack_fleet_name": fleet.name if fleet is not None else "",
+            "dstack_fleet_id": str(fleet.id) if fleet is not None else "",
+            "dstack_instance_name": str(instance.name),
+            "dstack_instance_id": str(instance.id),
+            "dstack_instance_type": offer.instance.name if offer is not None else "",
+            "dstack_backend": instance.backend.value if instance.backend is not None else "",
+            "dstack_gpu": gpu,
+        }
+        duration = (now - instance.created_at.replace(tzinfo=timezone.utc)).total_seconds()
+        metrics[_INSTANCE_DURATION].add_sample(
+            name=_INSTANCE_DURATION, labels=labels, value=duration
+        )
+        metrics[_INSTANCE_PRICE].add_sample(
+            name=_INSTANCE_PRICE, labels=labels, value=instance.price or 0.0
+        )
+        metrics[_INSTANCE_GPU_COUNT].add_sample(
+            name=_INSTANCE_GPU_COUNT, labels=labels, value=gpu_count
+        )
+    return metrics.values()
+
+
+async def get_job_metrics(session: AsyncSession) -> Iterable[Metric]:
+    res = await session.execute(
+        select(JobModel)
+        .join(ProjectModel)
+        .where(
+            JobModel.status.in_(
+                [
+                    JobStatus.PROVISIONING,
+                    JobStatus.PULLING,
+                    JobStatus.RUNNING,
+                    JobStatus.TERMINATING,
+                ]
+            )
+        )
+        .order_by(ProjectModel.name, JobModel.job_name)
+        .options(
+            joinedload(JobModel.project),
+            joinedload(JobModel.run).joinedload(RunModel.user),
+        )
+    )
+    jobs = res.scalars().all()
+    metrics: dict[str, Metric] = {
+        _JOB_DURATION: Metric(
+            name=_JOB_DURATION, documentation="Total seconds the job is running", typ="counter"
+        ),
+        _JOB_PRICE: Metric(
+            name=_JOB_PRICE, documentation="Job instance price, USD/hour", typ="gauge"
+        ),
+        _JOB_GPU_COUNT: Metric(name=_JOB_GPU_COUNT, documentation="Job GPU count", typ="gauge"),
+    }
+    now = get_current_datetime()
+    for job in jobs:
+        jpd = get_job_provisioning_data(job)
+        if jpd is None:
+            continue
+        jrd = get_job_runtime_data(job)
+        gpus = jpd.instance_type.resources.gpus
+        price = jpd.price
+        if jrd is not None and jrd.offer is not None:
+            gpus = jrd.offer.instance.resources.gpus
+            price = jrd.offer.price
+        run_spec = RunSpec.__response__.parse_raw(job.run.run_spec)
+        labels = _get_job_labels(job)
+        labels["dstack_run_type"] = run_spec.configuration.type
+        labels["dstack_backend"] = jpd.get_base_backend().value
+        labels["dstack_gpu"] = gpus[0].name if gpus else ""
+        duration = (now - job.submitted_at.replace(tzinfo=timezone.utc)).total_seconds()
+        metrics[_JOB_DURATION].add_sample(name=_JOB_DURATION, labels=labels, value=duration)
+        metrics[_JOB_PRICE].add_sample(name=_JOB_PRICE, labels=labels, value=price)
+        metrics[_JOB_GPU_COUNT].add_sample(name=_JOB_GPU_COUNT, labels=labels, value=len(gpus))
+    return metrics.values()
+
+
+async def get_job_gpu_metrics(session: AsyncSession) -> Iterable[Metric]:
     res = await session.execute(
         select(JobPrometheusMetrics)
         .join(JobModel)
         .join(ProjectModel)
         .where(JobModel.status.in_([JobStatus.RUNNING]))
         .order_by(ProjectModel.name, JobModel.job_name)
-        .options(joinedload(JobPrometheusMetrics.job).joinedload(JobModel.project))
+        .options(
+            joinedload(JobPrometheusMetrics.job).joinedload(JobModel.project),
+            joinedload(JobPrometheusMetrics.job)
+            .joinedload(JobModel.run)
+            .joinedload(RunModel.user),
+        )
     )
     metrics_models = res.scalars().all()
-    return _process_metrics(metrics_models)
+    return _parse_and_enrich_job_gpu_metrics(metrics_models)
 
 
 async def get_project_metrics(session: AsyncSession, project: ProjectModel) -> str:
@@ -33,20 +186,20 @@ async def get_project_metrics(session: AsyncSession, project: ProjectModel) -> s
             JobModel.status.in_([JobStatus.RUNNING]),
         )
         .order_by(JobModel.job_name)
-        .options(joinedload(JobPrometheusMetrics.job).joinedload(JobModel.project))
+        .options(
+            joinedload(JobPrometheusMetrics.job).joinedload(JobModel.project),
+            joinedload(JobPrometheusMetrics.job)
+            .joinedload(JobModel.run)
+            .joinedload(RunModel.user),
+        )
     )
     metrics_models = res.scalars().all()
-    return _process_metrics(metrics_models)
+    return "\n".join(_render_metrics(_parse_and_enrich_job_gpu_metrics(metrics_models))) + "\n"
 
 
-def _process_metrics(metrics_models: Iterable[JobPrometheusMetrics]) -> str:
-    metrics = _parse_and_enrich_metrics(metrics_models)
-    if not metrics:
-        return ""
-    return "\n".join(_render_metrics(metrics)) + "\n"
-
-
-def _parse_and_enrich_metrics(metrics_models: Iterable[JobPrometheusMetrics]) -> list[Metric]:
+def _parse_and_enrich_job_gpu_metrics(
+    metrics_models: Iterable[JobPrometheusMetrics],
+) -> Iterable[Metric]:
     metrics: dict[str, Metric] = {}
     for metrics_model in metrics_models:
         for metric in text_string_to_metric_families(metrics_model.text):
@@ -56,18 +209,21 @@ def _parse_and_enrich_metrics(metrics_models: Iterable[JobPrometheusMetrics]) ->
             metric = metrics.setdefault(name, metric)
             for sample in samples:
                 labels = sample.labels
-                labels.update(_get_dstack_labels(metrics_model.job))
+                labels.update(_get_job_labels(metrics_model.job))
                 # text_string_to_metric_families "fixes" counter names appending _total,
                 # we rebuild Sample to revert this
                 metric.samples.append(Sample(name, labels, *sample[2:]))
-    return list(metrics.values())
+    return metrics.values()
 
 
-def _get_dstack_labels(job: JobModel) -> dict[str, str]:
+def _get_job_labels(job: JobModel) -> dict[str, str]:
     return {
         "dstack_project_name": job.project.name,
+        "dstack_user_name": job.run.user.name,
         "dstack_run_name": job.run_name,
+        "dstack_run_id": str(job.run_id),
         "dstack_job_name": job.job_name,
+        "dstack_job_id": str(job.id),
         "dstack_job_num": str(job.job_num),
         "dstack_replica_num": str(job.replica_num),
     }
@@ -75,12 +231,14 @@ def _get_dstack_labels(job: JobModel) -> dict[str, str]:
 
 def _render_metrics(metrics: Iterable[Metric]) -> Generator[str, None, None]:
     for metric in metrics:
+        if not metric.samples:
+            continue
         yield f"# HELP {metric.name} {metric.documentation}"
         yield f"# TYPE {metric.name} {metric.type}"
         for sample in metric.samples:
             parts: list[str] = [f"{sample.name}{{"]
             parts.extend(",".join(f'{name}="{value}"' for name, value in sample.labels.items()))
-            parts.append(f"}} {sample.value}")
+            parts.append(f"}} {float(sample.value)}")
             # text_string_to_metric_families converts milliseconds to float seconds
             if isinstance(sample.timestamp, float):
                 parts.append(f" {int(sample.timestamp * 1000)}")

--- a/src/dstack/_internal/server/testing/common.py
+++ b/src/dstack/_internal/server/testing/common.py
@@ -329,13 +329,17 @@ def get_job_provisioning_data(
     backend: BackendType = BackendType.AWS,
     region: str = "us-east-1",
     gpu_count: int = 0,
+    gpu_name: str = "T4",
     cpu_count: int = 1,
     memory_gib: float = 0.5,
     spot: bool = False,
     hostname: str = "127.0.0.4",
     internal_ip: Optional[str] = "127.0.0.4",
+    price: float = 10.5,
 ) -> JobProvisioningData:
-    gpus = [Gpu(name="T4", memory_mib=16384, vendor=gpuhunt.AcceleratorVendor.NVIDIA)] * gpu_count
+    gpus = [
+        Gpu(name=gpu_name, memory_mib=16384, vendor=gpuhunt.AcceleratorVendor.NVIDIA)
+    ] * gpu_count
     return JobProvisioningData(
         backend=backend,
         instance_type=InstanceType(
@@ -348,7 +352,7 @@ def get_job_provisioning_data(
         hostname=hostname,
         internal_ip=internal_ip,
         region=region,
-        price=10.5,
+        price=price,
         username="ubuntu",
         ssh_port=22,
         dockerized=dockerized,
@@ -451,11 +455,14 @@ async def create_fleet(
     fleet_id: Optional[UUID] = None,
     status: FleetStatus = FleetStatus.ACTIVE,
     deleted: bool = False,
+    name: Optional[str] = None,
 ) -> FleetModel:
     if fleet_id is None:
         fleet_id = uuid.uuid4()
     if spec is None:
         spec = get_fleet_spec()
+    if name is not None:
+        spec.configuration.name = name
     fm = FleetModel(
         id=fleet_id,
         project=project,
@@ -518,6 +525,7 @@ async def create_instance(
     busy_blocks: int = 0,
     name: str = "test_instance",
     volumes: Optional[List[VolumeModel]] = None,
+    price: float = 1.0,
 ) -> InstanceModel:
     if instance_id is None:
         instance_id = uuid.uuid4()
@@ -560,7 +568,7 @@ async def create_instance(
         finished_at=finished_at,
         job_provisioning_data=job_provisioning_data.json(),
         offer=offer.json(),
-        price=1,
+        price=price,
         region=region,
         backend=backend,
         termination_policy=termination_policy,
@@ -597,6 +605,7 @@ def get_instance_offer_with_availability(
     backend: BackendType = BackendType.AWS,
     region: str = "eu-west",
     gpu_count: int = 0,
+    gpu_name: str = "T4",
     cpu_count: int = 2,
     memory_gib: float = 12,
     disk_gib: float = 100.0,
@@ -604,12 +613,16 @@ def get_instance_offer_with_availability(
     blocks: int = 1,
     total_blocks: int = 1,
     availability_zones: Optional[List[str]] = None,
+    price: float = 1.0,
+    instance_type: str = "instance",
 ):
-    gpus = [Gpu(name="T4", memory_mib=16384, vendor=gpuhunt.AcceleratorVendor.NVIDIA)] * gpu_count
+    gpus = [
+        Gpu(name=gpu_name, memory_mib=16384, vendor=gpuhunt.AcceleratorVendor.NVIDIA)
+    ] * gpu_count
     return InstanceOfferWithAvailability(
         backend=backend,
         instance=InstanceType(
-            name="instance",
+            name=instance_type,
             resources=Resources(
                 cpus=cpu_count,
                 memory_mib=int(memory_gib * 1024),
@@ -620,7 +633,7 @@ def get_instance_offer_with_availability(
             ),
         ),
         region=region,
-        price=1,
+        price=price,
         availability=InstanceAvailability.AVAILABLE,
         availability_zones=availability_zones,
         blocks=blocks,

--- a/src/tests/_internal/server/routers/test_prometheus.py
+++ b/src/tests/_internal/server/routers/test_prometheus.py
@@ -1,20 +1,31 @@
+from datetime import datetime, timedelta, timezone
 from textwrap import dedent
+from typing import Optional
 
 import pytest
+from freezegun import freeze_time
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from dstack._internal.core.models.runs import JobStatus
+from dstack._internal.core.models.backends.base import BackendType
+from dstack._internal.core.models.configurations import DevEnvironmentConfiguration
+from dstack._internal.core.models.runs import JobProvisioningData, JobRuntimeData, JobStatus
 from dstack._internal.core.models.users import GlobalRole, ProjectRole
 from dstack._internal.server.models import JobModel, ProjectModel, UserModel
 from dstack._internal.server.services.projects import add_project_member
 from dstack._internal.server.testing.common import (
+    create_fleet,
+    create_instance,
     create_job,
     create_job_prometheus_metrics,
     create_project,
     create_repo,
     create_run,
     create_user,
+    get_instance_offer_with_availability,
+    get_job_provisioning_data,
+    get_job_runtime_data,
+    get_run_spec,
 )
 
 
@@ -23,14 +34,32 @@ def enable_metrics(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("dstack._internal.server.settings.ENABLE_PROMETHEUS_METRICS", True)
 
 
+FAKE_NOW = datetime(2023, 1, 2, 3, 4, tzinfo=timezone.utc)
+
+
+@freeze_time(FAKE_NOW)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
 @pytest.mark.usefixtures("image_config_mock", "test_db", "enable_metrics")
 class TestGetPrometheusMetrics:
     async def test_returns_metrics(self, session: AsyncSession, client: AsyncClient):
-        user = await create_user(session=session, global_role=GlobalRole.USER)
+        user = await create_user(session=session, name="test-user", global_role=GlobalRole.USER)
+        offer = get_instance_offer_with_availability(
+            instance_type="test-type", gpu_count=2, gpu_name="V4", price=12
+        )
         project_2 = await _create_project(session, "project-2", user)
-        job_2_1 = await _create_job(session, "run-1", project_2, user, JobStatus.RUNNING)
+        jpd_2_1 = get_job_provisioning_data(
+            backend=BackendType.AWS, gpu_name="T4", gpu_count=2, price=16
+        )
+        job_2_1 = await _create_job(
+            session=session,
+            run_name="run-1",
+            project=project_2,
+            user=user,
+            status=JobStatus.RUNNING,
+            job_provisioning_data=jpd_2_1,
+            submitted_at=FAKE_NOW - timedelta(seconds=100),
+        )
         await create_job_prometheus_metrics(
             session=session,
             job=job_2_1,
@@ -42,7 +71,18 @@ class TestGetPrometheusMetrics:
             """),
         )
         project_1 = await _create_project(session, "project-1", user)
-        job_1_1 = await _create_job(session, "run-1", project_1, user, JobStatus.RUNNING)
+        jpd_1_1 = get_job_provisioning_data(backend=BackendType.AWS, gpu_count=4, gpu_name="T4")
+        jrd_1_1 = get_job_runtime_data(offer=offer)
+        job_1_1 = await _create_job(
+            session=session,
+            run_name="run-1",
+            project=project_1,
+            user=user,
+            status=JobStatus.RUNNING,
+            job_provisioning_data=jpd_1_1,
+            job_runtime_data=jrd_1_1,
+            submitted_at=FAKE_NOW - timedelta(seconds=120),
+        )
         await create_job_prometheus_metrics(
             session=session,
             job=job_1_1,
@@ -84,30 +124,62 @@ class TestGetPrometheusMetrics:
                 FIELD_1{gpu="1"} 20
             """),
         )
+        fleet = await create_fleet(session=session, project=project_1, name="test-fleet")
+        instance = await create_instance(
+            session=session,
+            project=project_1,
+            fleet=fleet,
+            backend=BackendType.AWS,
+            offer=offer,
+            price=14,
+            created_at=FAKE_NOW - timedelta(hours=1),
+            name="test-instance",
+        )
 
         response = await client.get("/metrics")
 
         assert response.status_code == 200
-        assert response.text == dedent("""\
+        assert response.text == dedent(f"""\
+            # HELP dstack_instance_duration_seconds_total Total seconds the instance is running
+            # TYPE dstack_instance_duration_seconds_total counter
+            dstack_instance_duration_seconds_total{{dstack_project_name="project-1",dstack_fleet_name="test-fleet",dstack_fleet_id="{fleet.id}",dstack_instance_name="test-instance",dstack_instance_id="{instance.id}",dstack_instance_type="test-type",dstack_backend="aws",dstack_gpu="V4"}} 3600.0
+            # HELP dstack_instance_price_dollars_per_hour Instance price, USD/hour
+            # TYPE dstack_instance_price_dollars_per_hour gauge
+            dstack_instance_price_dollars_per_hour{{dstack_project_name="project-1",dstack_fleet_name="test-fleet",dstack_fleet_id="{fleet.id}",dstack_instance_name="test-instance",dstack_instance_id="{instance.id}",dstack_instance_type="test-type",dstack_backend="aws",dstack_gpu="V4"}} 14.0
+            # HELP dstack_instance_gpu_count Instance GPU count
+            # TYPE dstack_instance_gpu_count gauge
+            dstack_instance_gpu_count{{dstack_project_name="project-1",dstack_fleet_name="test-fleet",dstack_fleet_id="{fleet.id}",dstack_instance_name="test-instance",dstack_instance_id="{instance.id}",dstack_instance_type="test-type",dstack_backend="aws",dstack_gpu="V4"}} 2.0
+            # HELP dstack_job_duration_seconds_total Total seconds the job is running
+            # TYPE dstack_job_duration_seconds_total counter
+            dstack_job_duration_seconds_total{{dstack_project_name="project-1",dstack_user_name="test-user",dstack_run_name="run-1",dstack_run_id="{job_1_1.run_id}",dstack_job_name="run-1-0-0",dstack_job_id="{job_1_1.id}",dstack_job_num="0",dstack_replica_num="0",dstack_run_type="dev-environment",dstack_backend="aws",dstack_gpu="V4"}} 120.0
+            dstack_job_duration_seconds_total{{dstack_project_name="project-2",dstack_user_name="test-user",dstack_run_name="run-1",dstack_run_id="{job_2_1.run_id}",dstack_job_name="run-1-0-0",dstack_job_id="{job_2_1.id}",dstack_job_num="0",dstack_replica_num="0",dstack_run_type="dev-environment",dstack_backend="aws",dstack_gpu="T4"}} 100.0
+            # HELP dstack_job_price_dollars_per_hour Job instance price, USD/hour
+            # TYPE dstack_job_price_dollars_per_hour gauge
+            dstack_job_price_dollars_per_hour{{dstack_project_name="project-1",dstack_user_name="test-user",dstack_run_name="run-1",dstack_run_id="{job_1_1.run_id}",dstack_job_name="run-1-0-0",dstack_job_id="{job_1_1.id}",dstack_job_num="0",dstack_replica_num="0",dstack_run_type="dev-environment",dstack_backend="aws",dstack_gpu="V4"}} 12.0
+            dstack_job_price_dollars_per_hour{{dstack_project_name="project-2",dstack_user_name="test-user",dstack_run_name="run-1",dstack_run_id="{job_2_1.run_id}",dstack_job_name="run-1-0-0",dstack_job_id="{job_2_1.id}",dstack_job_num="0",dstack_replica_num="0",dstack_run_type="dev-environment",dstack_backend="aws",dstack_gpu="T4"}} 16.0
+            # HELP dstack_job_gpu_count Job GPU count
+            # TYPE dstack_job_gpu_count gauge
+            dstack_job_gpu_count{{dstack_project_name="project-1",dstack_user_name="test-user",dstack_run_name="run-1",dstack_run_id="{job_1_1.run_id}",dstack_job_name="run-1-0-0",dstack_job_id="{job_1_1.id}",dstack_job_num="0",dstack_replica_num="0",dstack_run_type="dev-environment",dstack_backend="aws",dstack_gpu="V4"}} 2.0
+            dstack_job_gpu_count{{dstack_project_name="project-2",dstack_user_name="test-user",dstack_run_name="run-1",dstack_run_id="{job_2_1.run_id}",dstack_job_name="run-1-0-0",dstack_job_id="{job_2_1.id}",dstack_job_num="0",dstack_replica_num="0",dstack_run_type="dev-environment",dstack_backend="aws",dstack_gpu="T4"}} 2.0
             # HELP FIELD_1 Test field 1
             # TYPE FIELD_1 gauge
-            FIELD_1{gpu="0",dstack_project_name="project-1",dstack_run_name="run-1",dstack_job_name="run-1-0-0",dstack_job_num="0",dstack_replica_num="0"} 350.0
-            FIELD_1{gpu="1",dstack_project_name="project-1",dstack_run_name="run-1",dstack_job_name="run-1-0-0",dstack_job_num="0",dstack_replica_num="0"} 400.0
-            FIELD_1{gpu="0",dstack_project_name="project-1",dstack_run_name="run-2",dstack_job_name="run-2-0-0",dstack_job_num="0",dstack_replica_num="0"} 1200.0
-            FIELD_1{gpu="1",dstack_project_name="project-1",dstack_run_name="run-2",dstack_job_name="run-2-0-0",dstack_job_num="0",dstack_replica_num="0"} 1600.0
-            FIELD_1{gpu="2",dstack_project_name="project-1",dstack_run_name="run-2",dstack_job_name="run-2-0-0",dstack_job_num="0",dstack_replica_num="0"} 2400.0
-            FIELD_1{gpu="0",dstack_project_name="project-2",dstack_run_name="run-1",dstack_job_name="run-1-0-0",dstack_job_num="0",dstack_replica_num="0"} 100.0
-            FIELD_1{gpu="1",dstack_project_name="project-2",dstack_run_name="run-1",dstack_job_name="run-1-0-0",dstack_job_num="0",dstack_replica_num="0"} 200.0
+            FIELD_1{{gpu="0",dstack_project_name="project-1",dstack_user_name="test-user",dstack_run_name="run-1",dstack_run_id="{job_1_1.run_id}",dstack_job_name="run-1-0-0",dstack_job_id="{job_1_1.id}",dstack_job_num="0",dstack_replica_num="0"}} 350.0
+            FIELD_1{{gpu="1",dstack_project_name="project-1",dstack_user_name="test-user",dstack_run_name="run-1",dstack_run_id="{job_1_1.run_id}",dstack_job_name="run-1-0-0",dstack_job_id="{job_1_1.id}",dstack_job_num="0",dstack_replica_num="0"}} 400.0
+            FIELD_1{{gpu="0",dstack_project_name="project-1",dstack_user_name="test-user",dstack_run_name="run-2",dstack_run_id="{job_1_2.run_id}",dstack_job_name="run-2-0-0",dstack_job_id="{job_1_2.id}",dstack_job_num="0",dstack_replica_num="0"}} 1200.0
+            FIELD_1{{gpu="1",dstack_project_name="project-1",dstack_user_name="test-user",dstack_run_name="run-2",dstack_run_id="{job_1_2.run_id}",dstack_job_name="run-2-0-0",dstack_job_id="{job_1_2.id}",dstack_job_num="0",dstack_replica_num="0"}} 1600.0
+            FIELD_1{{gpu="2",dstack_project_name="project-1",dstack_user_name="test-user",dstack_run_name="run-2",dstack_run_id="{job_1_2.run_id}",dstack_job_name="run-2-0-0",dstack_job_id="{job_1_2.id}",dstack_job_num="0",dstack_replica_num="0"}} 2400.0
+            FIELD_1{{gpu="0",dstack_project_name="project-2",dstack_user_name="test-user",dstack_run_name="run-1",dstack_run_id="{job_2_1.run_id}",dstack_job_name="run-1-0-0",dstack_job_id="{job_2_1.id}",dstack_job_num="0",dstack_replica_num="0"}} 100.0
+            FIELD_1{{gpu="1",dstack_project_name="project-2",dstack_user_name="test-user",dstack_run_name="run-1",dstack_run_id="{job_2_1.run_id}",dstack_job_name="run-1-0-0",dstack_job_id="{job_2_1.id}",dstack_job_num="0",dstack_replica_num="0"}} 200.0
             # HELP FIELD_2 Test field 2
             # TYPE FIELD_2 counter
-            FIELD_2{gpu="0",dstack_project_name="project-1",dstack_run_name="run-1",dstack_job_name="run-1-0-0",dstack_job_num="0",dstack_replica_num="0"} 337325.0 1395066363000
-            FIELD_2{gpu="1",dstack_project_name="project-1",dstack_run_name="run-1",dstack_job_name="run-1-0-0",dstack_job_num="0",dstack_replica_num="0"} 987169.0 1395066363010
+            FIELD_2{{gpu="0",dstack_project_name="project-1",dstack_user_name="test-user",dstack_run_name="run-1",dstack_run_id="{job_1_1.run_id}",dstack_job_name="run-1-0-0",dstack_job_id="{job_1_1.id}",dstack_job_num="0",dstack_replica_num="0"}} 337325.0 1395066363000
+            FIELD_2{{gpu="1",dstack_project_name="project-1",dstack_user_name="test-user",dstack_run_name="run-1",dstack_run_id="{job_1_1.run_id}",dstack_job_name="run-1-0-0",dstack_job_id="{job_1_1.id}",dstack_job_num="0",dstack_replica_num="0"}} 987169.0 1395066363010
         """)
 
     async def test_returns_empty_response_if_no_runs(self, client: AsyncClient):
         response = await client.get("/metrics")
         assert response.status_code == 200
-        assert response.text == ""
+        assert response.text == "\n"
 
     async def test_returns_404_if_not_enabled(
         self, monkeypatch: pytest.MonkeyPatch, client: AsyncClient
@@ -122,7 +194,7 @@ class TestGetPrometheusMetrics:
 @pytest.mark.usefixtures("image_config_mock", "test_db", "enable_metrics")
 class TestGetPrometheusProjectMetrics:
     async def test_returns_metrics(self, session: AsyncSession, client: AsyncClient):
-        user = await create_user(session=session, global_role=GlobalRole.USER)
+        user = await create_user(session=session, name="test-user", global_role=GlobalRole.USER)
         project = await _create_project(session, "project-1", user)
         job_1 = await _create_job(session, "run-1", project, user, JobStatus.RUNNING)
         await create_job_prometheus_metrics(
@@ -184,18 +256,18 @@ class TestGetPrometheusProjectMetrics:
         response = await client.get("/metrics/project/project-1")
 
         assert response.status_code == 200
-        assert response.text == dedent("""\
+        assert response.text == dedent(f"""\
             # HELP FIELD_1 Test field 1
             # TYPE FIELD_1 gauge
-            FIELD_1{gpu="0",dstack_project_name="project-1",dstack_run_name="run-1",dstack_job_name="run-1-0-0",dstack_job_num="0",dstack_replica_num="0"} 350.0
-            FIELD_1{gpu="1",dstack_project_name="project-1",dstack_run_name="run-1",dstack_job_name="run-1-0-0",dstack_job_num="0",dstack_replica_num="0"} 400.0
-            FIELD_1{gpu="0",dstack_project_name="project-1",dstack_run_name="run-2",dstack_job_name="run-2-0-0",dstack_job_num="0",dstack_replica_num="0"} 1200.0
-            FIELD_1{gpu="1",dstack_project_name="project-1",dstack_run_name="run-2",dstack_job_name="run-2-0-0",dstack_job_num="0",dstack_replica_num="0"} 1600.0
-            FIELD_1{gpu="2",dstack_project_name="project-1",dstack_run_name="run-2",dstack_job_name="run-2-0-0",dstack_job_num="0",dstack_replica_num="0"} 2400.0
+            FIELD_1{{gpu="0",dstack_project_name="project-1",dstack_user_name="test-user",dstack_run_name="run-1",dstack_run_id="{job_1.run_id}",dstack_job_name="run-1-0-0",dstack_job_id="{job_1.id}",dstack_job_num="0",dstack_replica_num="0"}} 350.0
+            FIELD_1{{gpu="1",dstack_project_name="project-1",dstack_user_name="test-user",dstack_run_name="run-1",dstack_run_id="{job_1.run_id}",dstack_job_name="run-1-0-0",dstack_job_id="{job_1.id}",dstack_job_num="0",dstack_replica_num="0"}} 400.0
+            FIELD_1{{gpu="0",dstack_project_name="project-1",dstack_user_name="test-user",dstack_run_name="run-2",dstack_run_id="{job_2.run_id}",dstack_job_name="run-2-0-0",dstack_job_id="{job_2.id}",dstack_job_num="0",dstack_replica_num="0"}} 1200.0
+            FIELD_1{{gpu="1",dstack_project_name="project-1",dstack_user_name="test-user",dstack_run_name="run-2",dstack_run_id="{job_2.run_id}",dstack_job_name="run-2-0-0",dstack_job_id="{job_2.id}",dstack_job_num="0",dstack_replica_num="0"}} 1600.0
+            FIELD_1{{gpu="2",dstack_project_name="project-1",dstack_user_name="test-user",dstack_run_name="run-2",dstack_run_id="{job_2.run_id}",dstack_job_name="run-2-0-0",dstack_job_id="{job_2.id}",dstack_job_num="0",dstack_replica_num="0"}} 2400.0
             # HELP FIELD_2 Test field 2
             # TYPE FIELD_2 counter
-            FIELD_2{gpu="0",dstack_project_name="project-1",dstack_run_name="run-1",dstack_job_name="run-1-0-0",dstack_job_num="0",dstack_replica_num="0"} 337325.0 1395066363000
-            FIELD_2{gpu="1",dstack_project_name="project-1",dstack_run_name="run-1",dstack_job_name="run-1-0-0",dstack_job_num="0",dstack_replica_num="0"} 987169.0 1395066363010
+            FIELD_2{{gpu="0",dstack_project_name="project-1",dstack_user_name="test-user",dstack_run_name="run-1",dstack_run_id="{job_1.run_id}",dstack_job_name="run-1-0-0",dstack_job_id="{job_1.id}",dstack_job_num="0",dstack_replica_num="0"}} 337325.0 1395066363000
+            FIELD_2{{gpu="1",dstack_project_name="project-1",dstack_user_name="test-user",dstack_run_name="run-1",dstack_run_id="{job_1.run_id}",dstack_job_name="run-1-0-0",dstack_job_id="{job_1.id}",dstack_job_num="0",dstack_replica_num="0"}} 987169.0 1395066363010
         """)
 
     async def test_returns_empty_response_if_no_runs(
@@ -205,7 +277,7 @@ class TestGetPrometheusProjectMetrics:
         await create_project(session=session, owner=user, name="test-project")
         response = await client.get("/metrics/project/test-project")
         assert response.status_code == 200
-        assert response.text == ""
+        assert response.text == "\n"
 
     async def test_returns_404_if_project_doesnt_exist(self, client: AsyncClient):
         response = await client.get("/metrics/project/nonexistent")
@@ -230,15 +302,32 @@ async def _create_project(session: AsyncSession, name: str, user: UserModel) -> 
 
 
 async def _create_job(
-    session: AsyncSession, run_name: str, project: ProjectModel, user: UserModel, status: JobStatus
+    session: AsyncSession,
+    run_name: str,
+    project: ProjectModel,
+    user: UserModel,
+    status: JobStatus,
+    job_provisioning_data: Optional[JobProvisioningData] = None,
+    job_runtime_data: Optional[JobRuntimeData] = None,
+    submitted_at: datetime = FAKE_NOW,
 ) -> JobModel:
     repo = await create_repo(session=session, project_id=project.id, repo_name=f"{run_name}-repo")
+    configuration = DevEnvironmentConfiguration(ide="vscode")
+    run_spec = get_run_spec(run_name=run_name, repo_id=repo.name, configuration=configuration)
     run = await create_run(
         session=session,
         project=project,
         repo=repo,
         user=user,
         run_name=run_name,
+        run_spec=run_spec,
     )
-    job = await create_job(session=session, run=run, status=status)
+    job = await create_job(
+        session=session,
+        run=run,
+        status=status,
+        job_provisioning_data=job_provisioning_data,
+        job_runtime_data=job_runtime_data,
+        submitted_at=submitted_at,
+    )
     return job


### PR DESCRIPTION
* dstack_instance_duration_seconds_total
* dstack_instance_price_dollars_per_hour
* dstack_instance_gpu_count
* dstack_job_duration_seconds_total
* dstack_job_price_dollars_per_hour
* dstack_job_gpu_count

`/metrics/project/<project-name>` is deprecated and does not include new metrics.

Part-of: https://github.com/dstackai/dstack/issues/2431