### PR TITLE
Fix json schema reference and invalid properties errors

### DIFF
--- a/docs/docs/reference/dstack.yml/dev-environment.md
+++ b/docs/docs/reference/dstack.yml/dev-environment.md
@@ -28,7 +28,7 @@ The `dev-environment` configuration type allows running [dev environments](../..
 
 ### `resources`
 
-#SCHEMA# dstack._internal.core.models.resources.ResourcesSpecSchema
+#SCHEMA# dstack._internal.core.models.resources.ResourcesSpec
     overrides:
       show_root_heading: false
       type:
@@ -37,7 +37,7 @@ The `dev-environment` configuration type allows running [dev environments](../..
 
 #### `resources.gpu` { #resources-gpu data-toc-label="gpu" }
 
-#SCHEMA# dstack._internal.core.models.resources.GPUSpecSchema
+#SCHEMA# dstack._internal.core.models.resources.GPUSpec
     overrides:
       show_root_heading: false
       type:
@@ -45,7 +45,7 @@ The `dev-environment` configuration type allows running [dev environments](../..
 
 #### `resources.disk` { #resources-disk data-toc-label="disk" }
 
-#SCHEMA# dstack._internal.core.models.resources.DiskSpecSchema
+#SCHEMA# dstack._internal.core.models.resources.DiskSpec
     overrides:
       show_root_heading: false
       type:

--- a/docs/docs/reference/dstack.yml/fleet.md
+++ b/docs/docs/reference/dstack.yml/fleet.md
@@ -39,7 +39,7 @@ The `fleet` configuration type allows creating and updating fleets.
 
 ### `resources`
 
-#SCHEMA# dstack._internal.core.models.resources.ResourcesSpecSchema
+#SCHEMA# dstack._internal.core.models.resources.ResourcesSpec
     overrides:
       show_root_heading: false
       type:
@@ -48,7 +48,7 @@ The `fleet` configuration type allows creating and updating fleets.
 
 #### `resouces.gpu` { #resources-gpu data-toc-label="gpu" } 
 
-#SCHEMA# dstack._internal.core.models.resources.GPUSpecSchema
+#SCHEMA# dstack._internal.core.models.resources.GPUSpec
     overrides:
       show_root_heading: false
       type:
@@ -56,7 +56,7 @@ The `fleet` configuration type allows creating and updating fleets.
 
 #### `resouces.disk` { #resources-disk data-toc-label="disk" }
 
-#SCHEMA# dstack._internal.core.models.resources.DiskSpecSchema
+#SCHEMA# dstack._internal.core.models.resources.DiskSpec
     overrides:
       show_root_heading: false
       type:

--- a/docs/docs/reference/dstack.yml/service.md
+++ b/docs/docs/reference/dstack.yml/service.md
@@ -90,7 +90,7 @@ The `service` configuration type allows running [services](../../concepts/servic
 
 ### `resources`
 
-#SCHEMA# dstack._internal.core.models.resources.ResourcesSpecSchema
+#SCHEMA# dstack._internal.core.models.resources.ResourcesSpec
     overrides:
       show_root_heading: false
       type:
@@ -99,7 +99,7 @@ The `service` configuration type allows running [services](../../concepts/servic
 
 #### `resouces.gpu` { #resources-gpu data-toc-label="gpu" }
 
-#SCHEMA# dstack._internal.core.models.resources.GPUSpecSchema
+#SCHEMA# dstack._internal.core.models.resources.GPUSpec
     overrides:
       show_root_heading: false
       type:
@@ -107,7 +107,7 @@ The `service` configuration type allows running [services](../../concepts/servic
 
 #### `resouces.disk` { #resources-disk data-toc-label="disk" }
 
-#SCHEMA# dstack._internal.core.models.resources.DiskSpecSchema
+#SCHEMA# dstack._internal.core.models.resources.DiskSpec
     overrides:
       show_root_heading: false
       type:

--- a/docs/docs/reference/dstack.yml/task.md
+++ b/docs/docs/reference/dstack.yml/task.md
@@ -28,7 +28,7 @@ The `task` configuration type allows running [tasks](../../concepts/tasks.md).
 
 ### `resources`
 
-#SCHEMA# dstack._internal.core.models.resources.ResourcesSpecSchema
+#SCHEMA# dstack._internal.core.models.resources.ResourcesSpec
     overrides:
       show_root_heading: false
       type:
@@ -37,7 +37,7 @@ The `task` configuration type allows running [tasks](../../concepts/tasks.md).
 
 #### `resouces.gpu` { #resources-gpu data-toc-label="gpu" }
 
-#SCHEMA# dstack._internal.core.models.resources.GPUSpecSchema
+#SCHEMA# dstack._internal.core.models.resources.GPUSpec
     overrides:
       show_root_heading: false
       type:
@@ -45,7 +45,7 @@ The `task` configuration type allows running [tasks](../../concepts/tasks.md).
 
 #### `resouces.disk` { #resources-disk data-toc-label="disk" }
 
-#SCHEMA# dstack._internal.core.models.resources.DiskSpecSchema
+#SCHEMA# dstack._internal.core.models.resources.DiskSpec
     overrides:
       show_root_heading: false
       type:

--- a/src/dstack/_internal/core/models/configurations.py
+++ b/src/dstack/_internal/core/models/configurations.py
@@ -1,6 +1,6 @@
 import re
 from enum import Enum
-from typing import Any, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import Field, ValidationError, conint, constr, root_validator, validator
 from typing_extensions import Annotated, Literal
@@ -425,4 +425,9 @@ class DstackConfiguration(CoreModel):
     ]
 
     class Config:
-        schema_extra = {"$schema": "http://json-schema.org/draft-07/schema#"}
+        @staticmethod
+        def schema_extra(schema: Dict[str, Any]):
+            schema["$schema"] = "http://json-schema.org/draft-07/schema#"
+            # Allow additionalProperties so that vscode and others not supporting
+            # top-level oneOf do not warn about properties being invalid.
+            schema["additionalProperties"] = True

--- a/src/dstack/_internal/core/models/fleets.py
+++ b/src/dstack/_internal/core/models/fleets.py
@@ -19,6 +19,7 @@ from dstack._internal.core.models.profiles import (
     parse_idle_duration,
 )
 from dstack._internal.core.models.resources import Range, ResourcesSpec
+from dstack._internal.utils.json_schema import add_extra_schema_types
 
 
 class FleetStatus(str, Enum):
@@ -221,6 +222,14 @@ class InstanceGroupParams(CoreModel):
             description="Time to wait before terminating idle instances. Defaults to `5m` for runs and `3d` for fleets. Use `off` for unlimited duration"
         ),
     ] = None
+
+    class Config:
+        @staticmethod
+        def schema_extra(schema: Dict[str, Any], model: Type):
+            add_extra_schema_types(
+                schema["properties"]["nodes"],
+                extra_types=[{"type": "integer"}, {"type": "string"}],
+            )
 
     _validate_idle_duration = validator("idle_duration", pre=True, allow_reuse=True)(
         parse_idle_duration

--- a/src/dstack/_internal/utils/json_schema.py
+++ b/src/dstack/_internal/utils/json_schema.py
@@ -1,0 +1,6 @@
+def add_extra_schema_types(schema_property: dict, extra_types: list[dict]):
+    if "allOf" in schema_property:
+        ref = schema_property.pop("allOf")[0]
+    else:
+        ref = {"type": schema_property.pop("type")}
+    schema_property["anyOf"] = [ref, *extra_types]


### PR DESCRIPTION
Fixes #2430
Fixes #2329 

The PR gets rid of *Schema models that led to ref errors and replaces it with a simple modification of the generated schema. Also, fixes vscode and others complaining about unknown top-level properties.
