### PR TITLE
Fix default working dir in containers

### DIFF
--- a/runner/consts/consts.go
+++ b/runner/consts/consts.go
@@ -22,7 +22,7 @@ const (
 	// NOTE: RunnerRuntimeDir would be a more appropriate name, but it's called tempDir
 	// throughout runner's codebase
 	RunnerTempDir = "/tmp/runner"
-	// Currently, it's a directory where autorized_keys, git credentials, etc. are placed
+	// Currently, it's a directory where authorized_keys, git credentials, etc. are placed
 	// The current user's homedir (as of 2024-12-28, it's always root) should be used
 	// instead of the hardcoded value
 	RunnerHomeDir = "/root"

--- a/runner/internal/executor/executor.go
+++ b/runner/internal/executor/executor.go
@@ -261,6 +261,7 @@ func (ex *RunExecutor) execJob(ctx context.Context, jobLogFile io.Writer) error 
 	}
 	cmd.WaitDelay = ex.killDelay // kills the process if it doesn't exit in time
 
+	cmd.Dir = ex.workingDir
 	if ex.jobSpec.WorkingDir != nil {
 		workingDir, err := joinRelPath(ex.workingDir, *ex.jobSpec.WorkingDir)
 		if err != nil {

--- a/runner/internal/executor/executor_test.go
+++ b/runner/internal/executor/executor_test.go
@@ -18,9 +18,22 @@ import (
 
 // todo test get history
 
-func TestExecutor_WorkingDir(t *testing.T) {
+func TestExecutor_WorkingDir_Current(t *testing.T) {
 	var b bytes.Buffer
 	ex := makeTestExecutor(t)
+	workingDir := "."
+	ex.jobSpec.WorkingDir = &workingDir
+	ex.jobSpec.Commands = append(ex.jobSpec.Commands, "pwd")
+
+	err := ex.execJob(context.TODO(), io.Writer(&b))
+	assert.NoError(t, err)
+	assert.Equal(t, ex.workingDir+"\r\n", b.String())
+}
+
+func TestExecutor_WorkingDir_Nil(t *testing.T) {
+	var b bytes.Buffer
+	ex := makeTestExecutor(t)
+	ex.jobSpec.WorkingDir = nil
 	ex.jobSpec.Commands = append(ex.jobSpec.Commands, "pwd")
 
 	err := ex.execJob(context.TODO(), io.Writer(&b))

--- a/runner/internal/runner/api/server.go
+++ b/runner/internal/runner/api/server.go
@@ -16,9 +16,8 @@ import (
 )
 
 type Server struct {
-	srv        *http.Server
-	tempDir    string
-	workingDir string
+	srv     *http.Server
+	tempDir string
 
 	shutdownCh   chan interface{} // server closes this chan on shutdown
 	jobBarrierCh chan interface{} // only server listens on this chan
@@ -45,8 +44,7 @@ func NewServer(tempDir string, homeDir string, workingDir string, address string
 			Addr:    address,
 			Handler: r,
 		},
-		tempDir:    tempDir,
-		workingDir: workingDir,
+		tempDir: tempDir,
 
 		shutdownCh:   make(chan interface{}),
 		jobBarrierCh: make(chan interface{}),


### PR DESCRIPTION
Fixes #2448

The default working dir is supposed to be
`/workflow`. However, `dstack-runner` never
actually defaulted to `/workflow` and didn't set
any working dir if `job_spec.working_dir` is
`null`. This issue only wasn't visible prior to
0.19.0 because older CLI versions used to [rewrite](https://github.com/dstackai/dstack/blob/0f68a19afa2a10075ebb1311b6e5158215db0a62/src/dstack/api/_public/runs.py#L622)
the working dir from `null` to `.` in the
now-deprecated `RunCollection.get_plan` method.