### PR TITLE
Move cachetools to base deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ BASE_DEPS = [
     "cryptography",
     "packaging",
     "python-dateutil",
+    "cachetools",
     "gitpython",
     "jsonschema",
     "paramiko>=3.2.0",
@@ -74,7 +75,6 @@ SERVER_DEPS = GATEWAY_AND_SERVER_COMMON_DEPS + [
     "sentry-sdk[fastapi]",
     "alembic-postgresql-enum",
     "asyncpg",
-    "cachetools",
     "python-json-logger>=3.1.0",
     "prometheus-client",
     "grpcio>=1.50",  # indirect


### PR DESCRIPTION
The PR fixes cachetools being listed as server dependencies, although it's a part of a base installation too. `pip install dstack` (without extras) was broken starting from 0.19.0.

```
✗ uvx dstack
Traceback (most recent call last):
  File "/Users/r4victor/.local/share/uv/tools/dstack/bin/dstack", line 4, in <module>
    from dstack._internal.cli.main import main
  File "/Users/r4victor/.local/share/uv/tools/dstack/lib/python3.11/site-packages/dstack/_internal/cli/main.py", line 7, in <module>
    from dstack._internal.cli.commands.apply import ApplyCommand
  File "/Users/r4victor/.local/share/uv/tools/dstack/lib/python3.11/site-packages/dstack/_internal/cli/commands/__init__.py", line 8, in <module>
    from dstack._internal.cli.services.completion import ProjectNameCompleter
  File "/Users/r4victor/.local/share/uv/tools/dstack/lib/python3.11/site-packages/dstack/_internal/cli/services/completion.py", line 11, in <module>
    from dstack.api import Client
  File "/Users/r4victor/.local/share/uv/tools/dstack/lib/python3.11/site-packages/dstack/api/__init__.py", line 22, in <module>
    from dstack.api._public import BackendCollection, Client, RepoCollection, RunCollection
  File "/Users/r4victor/.local/share/uv/tools/dstack/lib/python3.11/site-packages/dstack/api/_public/__init__.py", line 3, in <module>
    import dstack._internal.core.services.api_client as api_client_service
  File "/Users/r4victor/.local/share/uv/tools/dstack/lib/python3.11/site-packages/dstack/_internal/core/services/api_client.py", line 5, in <module>
    from dstack.api.server import APIClient
  File "/Users/r4victor/.local/share/uv/tools/dstack/lib/python3.11/site-packages/dstack/api/server/__init__.py", line 11, in <module>
    from dstack.api.server._backends import BackendsAPIClient
  File "/Users/r4victor/.local/share/uv/tools/dstack/lib/python3.11/site-packages/dstack/api/server/_backends.py", line 5, in <module>
    from dstack._internal.core.backends.models import (
  File "/Users/r4victor/.local/share/uv/tools/dstack/lib/python3.11/site-packages/dstack/_internal/core/backends/__init__.py", line 1, in <module>
    from dstack._internal.core.backends.base.compute import (
  File "/Users/r4victor/.local/share/uv/tools/dstack/lib/python3.11/site-packages/dstack/_internal/core/backends/base/compute.py", line 13, in <module>
    from cachetools import TTLCache, cachedmethod
ModuleNotFoundError: No module named 'cachetools'
```