### PR TITLE
Support A3 Mega GCP clusters with GPUDirect-TCPXO

### DIFF
--- a/.github/workflows/gcp-a3mega-image.yml
+++ b/.github/workflows/gcp-a3mega-image.yml
@@ -2,6 +2,7 @@ name: Build GCP A3 Mega VM image
 
 on:
   - workflow_dispatch
+  - push
 
 env:
   PACKER_VERSION: "1.9.2"

--- a/.github/workflows/gcp-a3mega-image.yml
+++ b/.github/workflows/gcp-a3mega-image.yml
@@ -2,7 +2,6 @@ name: Build GCP A3 Mega VM image
 
 on:
   - workflow_dispatch
-  - push
 
 env:
   PACKER_VERSION: "1.9.2"

--- a/.github/workflows/gcp-a3mega-image.yml
+++ b/.github/workflows/gcp-a3mega-image.yml
@@ -1,0 +1,39 @@
+name: Build GCP A3 Mega VM image
+
+on:
+  - workflow_dispatch
+  - push
+
+env:
+  PACKER_VERSION: "1.9.2"
+  IMAGE_VERSION: ${{ github.run_number }}
+jobs:
+  build-gcp-images:
+    defaults:
+      run:
+        working-directory: scripts/packer
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/531508670106/locations/global/workloadIdentityPools/github-identity-pool/providers/github-id-provider'
+          service_account: 'github-actions@dstack.iam.gserviceaccount.com'
+          create_credentials_file: true
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+      - name: Download packer
+        run: |
+          wget https://releases.hashicorp.com/packer/${{ env.PACKER_VERSION }}/packer_${{ env.PACKER_VERSION }}_linux_amd64.zip
+          unzip packer_${{ env.PACKER_VERSION }}_linux_amd64.zip
+          chmod +x packer
+      - name: Run packer
+        run: |
+          ./packer build -var image_version=${{ env.IMAGE_VERSION }} gcp-a3mega-image.json
+      - name: Publish image
+        run: |
+          gcloud compute images add-iam-policy-binding dstack-a3mega-${{ env.IMAGE_VERSION }} --member='allAuthenticatedUsers' --role='roles/compute.imageUser'

--- a/docs/docs/concepts/backends.md
+++ b/docs/docs/concepts/backends.md
@@ -477,6 +477,8 @@ gcloud projects list --format="json(projectId)"
     compute.networks.updatePolicy
     compute.regions.get
     compute.regions.list
+    compute.resourcePolicies.create
+    compute.resourcePolicies.delete
     compute.routers.list
     compute.subnetworks.list
     compute.subnetworks.use

--- a/examples/misc/a3mega-clusters/README.md
+++ b/examples/misc/a3mega-clusters/README.md
@@ -175,7 +175,7 @@ The networking bandwidth should be close to the maximum bandwidth supported by G
 
 ## Run NCCL workloads with GPUDirect-TCPXO support
 
-To take full advantage of GPUDirect-TCPXO in your workloads, you need properly setup the [NCCL environment variables](https://cloud.google.com/kubernetes-engine/docs/how-to/gpu-bandwidth-gpudirect-tcpx-autopilot#environment-variables-nccl).
+To take full advantage of GPUDirect-TCPXO in your workloads, you need properly set up the [NCCL environment variables](https://cloud.google.com/kubernetes-engine/docs/how-to/gpu-bandwidth-gpudirect-tcpx-autopilot#environment-variables-nccl).
 This can be done with the following commands in your run configuration:
 
 <div editor-title="task.dstack.yml">

--- a/examples/misc/a3mega-clusters/README.md
+++ b/examples/misc/a3mega-clusters/README.md
@@ -136,19 +136,19 @@ nThread 1 nGpus 1 minBytes 8388608 maxBytes 8589934592 step: 2(factor) warmup it
                                                              out-of-place                       in-place          
       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)       
-     8388608        131072     float    none      -1    394.2   21.28   19.95    N/A    392.7   21.36   20.03    N/A
-    16777216        262144     float    none      -1    437.8   38.32   35.92    N/A    434.1   38.65   36.24    N/A
-    33554432        524288     float    none      -1    479.5   69.98   65.61    N/A    479.9   69.92   65.55    N/A
-    67108864       1048576     float    none      -1    755.8   88.79   83.24    N/A    771.9   86.94   81.51    N/A
-   134217728       2097152     float    none      -1   1125.3  119.27  111.81    N/A   1121.8  119.64  112.16    N/A
-   268435456       4194304     float    none      -1   1741.3  154.16  144.53    N/A   1742.2  154.08  144.45    N/A
-   536870912       8388608     float    none      -1   2854.9  188.05  176.30    N/A   2869.8  187.08  175.38    N/A
-  1073741824      16777216     float    none      -1   5536.1  193.95  181.83    N/A   5528.8  194.21  182.07    N/A
-  2147483648      33554432     float    none      -1    10853  197.88  185.51    N/A    10830  198.29  185.90    N/A
-  4294967296      67108864     float    none      -1    21491  199.85  187.36    N/A    21466  200.09  187.58    N/A
-  8589934592     134217728     float    none      -1    42770  200.84  188.29    N/A    42752  200.93  188.37    N/A
+     8388608        131072     float    none      -1    166.6   50.34   47.19    N/A    164.1   51.11   47.92    N/A
+    16777216        262144     float    none      -1    204.6   82.01   76.89    N/A    203.8   82.30   77.16    N/A
+    33554432        524288     float    none      -1    284.0  118.17  110.78    N/A    281.7  119.12  111.67    N/A
+    67108864       1048576     float    none      -1    447.4  150.00  140.62    N/A    443.5  151.31  141.86    N/A
+   134217728       2097152     float    none      -1    808.3  166.05  155.67    N/A    801.9  167.38  156.92    N/A
+   268435456       4194304     float    none      -1   1522.1  176.36  165.34    N/A   1518.7  176.76  165.71    N/A
+   536870912       8388608     float    none      -1   2892.3  185.62  174.02    N/A   2894.4  185.49  173.89    N/A
+  1073741824      16777216     float    none      -1   5532.7  194.07  181.94    N/A   5530.7  194.14  182.01    N/A
+  2147483648      33554432     float    none      -1    10863  197.69  185.34    N/A    10837  198.17  185.78    N/A
+  4294967296      67108864     float    none      -1    21481  199.94  187.45    N/A    21466  200.08  187.58    N/A
+  8589934592     134217728     float    none      -1    42713  201.11  188.54    N/A    42701  201.16  188.59    N/A
 Out of bounds values : 0 OK
-Avg bus bandwidth    : 125.436 
+Avg bus bandwidth    : 146.948 
 
 Done
 ```
@@ -170,7 +170,7 @@ nodes: 2
 commands:
   - |
     NCCL_LIB_DIR="/var/lib/tcpxo/lib64"
-    source ${NCCL_LIB_DIR}/nccl-env-profile.sh
+    source ${NCCL_LIB_DIR}/nccl-env-profile-ll128.sh
     export NCCL_FASTRAK_CTRL_DEV=enp0s12
     export NCCL_FASTRAK_IFNAME=enp6s0,enp7s0,enp13s0,enp14s0,enp134s0,enp135s0,enp141s0,enp142s0
     export NCCL_SOCKET_IFNAME=enp0s12

--- a/examples/misc/a3mega-clusters/README.md
+++ b/examples/misc/a3mega-clusters/README.md
@@ -1,0 +1,206 @@
+# A3 Mega GCP clusters
+
+This example shows how to set up an A3 Mega GCP cluster with [GPUDirect-TCPXO](https://cloud.google.com/kubernetes-engine/docs/how-to/gpu-bandwidth-gpudirect-tcpx-autopilot)
+optimized NCCL communication and run [NCCL Tests](https://github.com/NVIDIA/nccl-tests) on it using `dstack`.
+
+## Overview
+
+GCP's A3 Mega instances are 8xH100 VMs that have 1800Gbps maximum network bandwidth,
+which is the best among H100 GCP instances. To get that network performance, you need
+to set up GPUDirect-TCPXO – the GCP technology for GPU RDMA over TCP. This involves:
+
+* Setting up eight extra data NICs on every node, each NIC in a separate VPC.
+* Building a VM image with the GPUDirect-TCPXO support.
+* Launching an RXDM service container.
+* Installing the GPUDirect-TCPXO NCCL plugin.
+
+`dstack` hides most of the setup complexity and provides optimized A3 Mega GCP clusters out-of-the-box.
+
+## Configure GCP backend
+
+First configure the `gcp` backend for the GPUDirect-TCPXO support.
+You need to specify eight `extra_vpcs` to use for data NICs.
+You also need to specify `vm_service_account` that's authorized to pull GPUDirect-related Docker images:
+
+<div editor-title="~/.dstack/server/config.yml">
+
+```yaml
+projects:
+  - name: main
+    backends:
+    - type: gcp
+      project_id: $MYPROJECT # Replace $MYPROJECT
+      extra_vpcs:
+        - dstack-gpu-data-net-1
+        - dstack-gpu-data-net-2
+        - dstack-gpu-data-net-3
+        - dstack-gpu-data-net-4
+        - dstack-gpu-data-net-5
+        - dstack-gpu-data-net-6
+        - dstack-gpu-data-net-7
+        - dstack-gpu-data-net-8
+      regions: [europe-west4]
+      vm_service_account: a3mega-sa@$MYPROJECT.iam.gserviceaccount.com # Replace $MYPROJECT
+      creds:
+        type: default
+```
+
+</div>
+
+??? info "Create extra VPCs"
+    Create the VPC networks for GPUDirect in your project, each with a subnet and a firewall rule. Choose the GPUDirect-TCPX tab for A3 High machine types, or choose the GPUDirect-TCPXO tab for A3 Mega machine types, then complete the following instructions:
+    
+    ```shell
+    # Specify the region where you intend to deploy the cluster
+    REGION="europe-west4"
+
+    for N in $(seq 1 8); do
+    gcloud compute networks create dstack-gpu-data-net-$N \
+        --subnet-mode=custom \
+        --mtu=8244
+
+    gcloud compute networks subnets create dstack-gpu-data-sub-$N \
+        --network=dstack-gpu-data-net-$N \
+        --region=$REGION \
+        --range=192.168.$N.0/24
+
+    gcloud compute firewall-rules create dstack-gpu-data-internal-$N \
+      --network=dstack-gpu-data-net-$N \
+      --action=ALLOW \
+      --rules=tcp:0-65535,udp:0-65535,icmp \
+      --source-ranges=192.168.0.0/16
+    done
+    ```
+
+??? info "Create Service Account"
+    Create a VM service account that allows VMs to access the `pkg.dev` registry:
+    
+    ```shell
+    PROJECT_ID=$(gcloud config get-value project)
+
+    gcloud iam service-accounts create a3mega-sa \
+        --display-name "Service Account for pulling GCR images"
+
+    gcloud projects add-iam-policy-binding $PROJECT_ID \
+        --member="serviceAccount:a3mega-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
+        --role="roles/artifactregistry.reader"
+    ```
+
+## Create A3 Mega fleet
+
+Once you've configured the `gcp` backend, create the fleet configuration:
+
+<div editor-title="fleet.dstack.yml">
+```yaml
+type: fleet
+name: a3mega-cluster
+nodes: 2
+placement: cluster
+instance_types:
+  - a3-megagpu-8g
+spot_policy: auto
+```
+</div>
+
+and apply the configuration:
+
+<div class="termy">
+
+```shell
+$ dstack apply -f examples/misc/a3mega-clusters/fleet.dstack.yml
+ Project        main                           
+ User           admin                          
+ Configuration  examples/misc/a3mega-clusters/fleet.dstack.yml 
+ Type           fleet                          
+ Fleet type     cloud                          
+ Nodes          2                              
+ Placement      cluster                        
+ Resources      2..xCPU, 8GB.., 100GB.. (disk) 
+ Spot policy    auto                           
+
+ #  BACKEND  REGION        INSTANCE       RESOURCES              SPOT  PRICE      
+ 1  gcp      europe-west4  a3-megagpu-8g  208xCPU, 1872GB,       yes   $22.1525   
+                                          8xH100 (80GB),                          
+                                          100.0GB (disk)                          
+ 2  gcp      europe-west4  a3-megagpu-8g  208xCPU, 1872GB,       no    $64.2718   
+                                          8xH100 (80GB),                          
+                                          100.0GB (disk)                          
+
+Fleet a3mega-cluster does not exist yet.
+Create the fleet? [y/n]: y
+
+Provisioning...
+---> 100%                    
+```
+
+</div>
+
+`dstack` will provision two A3 Mega nodes with GPUDirect-TCPXO configured.
+
+## Run NCCL Tests with GPUDirect-TCPXO support
+
+Once the nodes are provisioned, let's test the network by running NCCL Tests:
+
+<div class="termy">
+
+```shell 
+$ dstack apply -f examples/misc/a3mega-clusters/nccl-tests.dstack.yml 
+
+nccl-tests provisioning completed (running)
+nThread 1 nGpus 1 minBytes 8388608 maxBytes 8589934592 step: 2(factor) warmup iters: 5 iters: 200 agg iters: 1 validation: 0 graph: 0
+
+                                                             out-of-place                       in-place          
+      size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
+       (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)       
+     8388608        131072     float    none      -1    394.2   21.28   19.95    N/A    392.7   21.36   20.03    N/A
+    16777216        262144     float    none      -1    437.8   38.32   35.92    N/A    434.1   38.65   36.24    N/A
+    33554432        524288     float    none      -1    479.5   69.98   65.61    N/A    479.9   69.92   65.55    N/A
+    67108864       1048576     float    none      -1    755.8   88.79   83.24    N/A    771.9   86.94   81.51    N/A
+   134217728       2097152     float    none      -1   1125.3  119.27  111.81    N/A   1121.8  119.64  112.16    N/A
+   268435456       4194304     float    none      -1   1741.3  154.16  144.53    N/A   1742.2  154.08  144.45    N/A
+   536870912       8388608     float    none      -1   2854.9  188.05  176.30    N/A   2869.8  187.08  175.38    N/A
+  1073741824      16777216     float    none      -1   5536.1  193.95  181.83    N/A   5528.8  194.21  182.07    N/A
+  2147483648      33554432     float    none      -1    10853  197.88  185.51    N/A    10830  198.29  185.90    N/A
+  4294967296      67108864     float    none      -1    21491  199.85  187.36    N/A    21466  200.09  187.58    N/A
+  8589934592     134217728     float    none      -1    42770  200.84  188.29    N/A    42752  200.93  188.37    N/A
+Out of bounds values : 0 OK
+Avg bus bandwidth    : 125.436 
+
+Done
+```
+
+The networking bandwidth should be close to the maximum bandwidth supported by GCP.
+
+</div>
+
+## Run NCCL workloads with GPUDirect-TCPXO support
+
+To take full advantage of GPUDirect-TCPXO in your workloads, you need properly setup the [NCCL environment variables](https://cloud.google.com/kubernetes-engine/docs/how-to/gpu-bandwidth-gpudirect-tcpx-autopilot#environment-variables-nccl).
+This can be done with the following commands in your run configuration:
+
+<div editor-title="task.dstack.yml">
+
+```yaml
+type: task
+nodes: 2
+commands:
+  - |
+    NCCL_LIB_DIR="/var/lib/tcpxo/lib64"
+    source ${NCCL_LIB_DIR}/nccl-env-profile.sh
+    export NCCL_FASTRAK_CTRL_DEV=enp0s12
+    export NCCL_FASTRAK_IFNAME=enp6s0,enp7s0,enp13s0,enp14s0,enp134s0,enp135s0,enp141s0,enp142s0
+    export NCCL_SOCKET_IFNAME=enp0s12
+    export NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY="/dev/aperture_devices"
+    export LD_LIBRARY_PATH="${NCCL_LIB_DIR}:${LD_LIBRARY_PATH}"
+    # run NCCL
+resources:
+  # Allocate some shared memory for NCCL
+  shm_size: 16GB
+```
+
+</div>
+
+## Source code
+
+The source code for this example can be found in 
+[`examples/misc/a3mega-clusters` :material-arrow-top-right-thin:{ .external }](https://github.com/dstackai/dstack/blob/master/examples/misc/a3mega-clusters).

--- a/examples/misc/a3mega-clusters/README.md
+++ b/examples/misc/a3mega-clusters/README.md
@@ -1,12 +1,12 @@
-# A3 Mega GCP clusters
+# GCP A3 Mega clusters
 
-This example shows how to set up an A3 Mega GCP cluster with [GPUDirect-TCPXO](https://cloud.google.com/kubernetes-engine/docs/how-to/gpu-bandwidth-gpudirect-tcpx-autopilot)
+This example shows how to set up a GCP A3 Mega cluster with [GPUDirect-TCPXO](https://cloud.google.com/kubernetes-engine/docs/how-to/gpu-bandwidth-gpudirect-tcpx-autopilot)
 optimized NCCL communication and run [NCCL Tests](https://github.com/NVIDIA/nccl-tests) on it using `dstack`.
 
 ## Overview
 
 GCP's A3 Mega instances are 8xH100 VMs that have 1800Gbps maximum network bandwidth,
-which is the best among H100 GCP instances. To get that network performance, you need
+which is the best among GCP H100 instances. To get that network performance, you need
 to set up GPUDirect-TCPXO – the GCP technology for GPU RDMA over TCP. This involves:
 
 * Setting up eight extra data NICs on every node, each NIC in a separate VPC.
@@ -14,13 +14,12 @@ to set up GPUDirect-TCPXO – the GCP technology for GPU RDMA over TCP. This inv
 * Launching an RXDM service container.
 * Installing the GPUDirect-TCPXO NCCL plugin.
 
-`dstack` hides most of the setup complexity and provides optimized A3 Mega GCP clusters out-of-the-box.
+`dstack` hides most of the setup complexity and provides optimized A3 Mega clusters out-of-the-box.
 
 ## Configure GCP backend
 
 First configure the `gcp` backend for the GPUDirect-TCPXO support.
-You need to specify eight `extra_vpcs` to use for data NICs.
-You also need to specify `vm_service_account` that's authorized to pull GPUDirect-related Docker images:
+You need to specify eight `extra_vpcs` to use for data NICs:
 
 <div editor-title="~/.dstack/server/config.yml">
 
@@ -40,7 +39,6 @@ projects:
         - dstack-gpu-data-net-7
         - dstack-gpu-data-net-8
       regions: [europe-west4]
-      vm_service_account: a3mega-sa@$MYPROJECT.iam.gserviceaccount.com # Replace $MYPROJECT
       creds:
         type: default
 ```
@@ -70,20 +68,6 @@ projects:
       --rules=tcp:0-65535,udp:0-65535,icmp \
       --source-ranges=192.168.0.0/16
     done
-    ```
-
-??? info "Create Service Account"
-    Create a VM service account that allows VMs to access the `pkg.dev` registry:
-    
-    ```shell
-    PROJECT_ID=$(gcloud config get-value project)
-
-    gcloud iam service-accounts create a3mega-sa \
-        --display-name "Service Account for pulling GCR images"
-
-    gcloud projects add-iam-policy-binding $PROJECT_ID \
-        --member="serviceAccount:a3mega-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
-        --role="roles/artifactregistry.reader"
     ```
 
 ## Create A3 Mega fleet

--- a/examples/misc/a3mega-clusters/fleet.dstack.yml
+++ b/examples/misc/a3mega-clusters/fleet.dstack.yml
@@ -1,0 +1,7 @@
+type: fleet
+name: a3mega-cluster
+nodes: 2
+placement: cluster
+instance_types:
+  - a3-megagpu-8g
+spot_policy: auto

--- a/examples/misc/a3mega-clusters/nccl-tests.dstack.yml
+++ b/examples/misc/a3mega-clusters/nccl-tests.dstack.yml
@@ -1,0 +1,49 @@
+type: task
+name: nccl-tests
+nodes: 2
+image: nvcr.io/nvidia/pytorch:24.04-py3
+entrypoint: "bash -c" # Need to use bash instead of default dash for nccl-env-profile.sh
+commands:
+  - |
+    # Setup TCPXO NCCL env variables
+    NCCL_LIB_DIR="/var/lib/tcpxo/lib64"
+    source ${NCCL_LIB_DIR}/nccl-env-profile.sh
+    export NCCL_FASTRAK_CTRL_DEV=enp0s12
+    export NCCL_FASTRAK_IFNAME=enp6s0,enp7s0,enp13s0,enp14s0,enp134s0,enp135s0,enp141s0,enp142s0
+    export NCCL_SOCKET_IFNAME=enp0s12
+    export NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY="/dev/aperture_devices"
+    export LD_LIBRARY_PATH="${NCCL_LIB_DIR}:${LD_LIBRARY_PATH}"
+    # Build NCCL Tests
+    git clone https://github.com/NVIDIA/nccl-tests.git
+    cd nccl-tests
+    MPI=1 CC=mpicc CXX=mpicxx make -j
+    cd build
+    # We use FIFO for inter-node communication
+    FIFO=/tmp/dstack_job
+    if [ ${DSTACK_NODE_RANK} -eq 0 ]; then
+      sleep 10
+      echo "${DSTACK_NODES_IPS}" > hostfile
+      MPIRUN='mpirun --allow-run-as-root --hostfile hostfile'
+      # Wait for other nodes
+      while true; do
+        if ${MPIRUN} -n ${DSTACK_NODES_NUM} -N 1 true >/dev/null 2>&1; then
+          break
+        fi
+        echo 'Waiting for nodes...'
+        sleep 5
+      done
+      # Run NCCL Tests
+      ${MPIRUN} \
+        -n ${DSTACK_GPUS_NUM} -N ${DSTACK_GPUS_PER_NODE} \
+        --mca btl tcp,self --mca btl_tcp_if_exclude lo,docker0 \
+        $(env | awk -F= '{print "-x", $1}' | xargs) \
+        ./all_gather_perf -b 8M -e 8G -f 2 -g 1 -w 5 --iters 200 -c 0;
+      # Notify nodes the job is done
+      ${MPIRUN} -n ${DSTACK_NODES_NUM} -N 1 sh -c "echo done > ${FIFO}"
+    else
+      mkfifo ${FIFO}
+      # Wait for a message from the first node
+      cat ${FIFO}
+    fi
+resources:
+  shm_size: 16GB

--- a/examples/misc/a3mega-clusters/nccl-tests.dstack.yml
+++ b/examples/misc/a3mega-clusters/nccl-tests.dstack.yml
@@ -7,7 +7,7 @@ commands:
   - |
     # Setup TCPXO NCCL env variables
     NCCL_LIB_DIR="/var/lib/tcpxo/lib64"
-    source ${NCCL_LIB_DIR}/nccl-env-profile.sh
+    source ${NCCL_LIB_DIR}/nccl-env-profile-ll128.sh
     export NCCL_FASTRAK_CTRL_DEV=enp0s12
     export NCCL_FASTRAK_IFNAME=enp6s0,enp7s0,enp13s0,enp14s0,enp134s0,enp135s0,enp141s0,enp142s0
     export NCCL_SOCKET_IFNAME=enp0s12

--- a/runner/internal/shim/docker.go
+++ b/runner/internal/shim/docker.go
@@ -995,58 +995,19 @@ func configureGpus(config *container.Config, hostConfig *container.HostConfig, v
 	// AMD: ids are DRI render node paths, e.g., /dev/dri/renderD128
 	switch vendor {
 	case host.GpuVendorNvidia:
-		// hostConfig.Resources.DeviceRequests = append(
-		// 	hostConfig.Resources.DeviceRequests,
-		// 	container.DeviceRequest{
-		// 		// Request all capabilities to maximize compatibility with all sorts of GPU workloads.
-		// 		// Default capabilities: utility, compute.
-		// 		// https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/1.16.0/docker-specialized.html
-		// 		Capabilities: [][]string{{"gpu", "utility", "compute", "graphics", "video", "display", "compat32"}},
-		// 		DeviceIDs:    ids,
-		// 	},
-		// )
-		for i := range 8 {
-			devPath := fmt.Sprintf("/dev/nvidia%d", i)
-			hostConfig.Resources.Devices = append(
-				hostConfig.Resources.Devices,
-				container.DeviceMapping{
-					PathOnHost:        devPath,
-					PathInContainer:   devPath,
-					CgroupPermissions: "rwm",
-				},
-			)
-		}
-		hostConfig.Resources.Devices = append(
-			hostConfig.Resources.Devices,
-			container.DeviceMapping{
-				PathOnHost:        "/dev/nvidia-uvm",
-				PathInContainer:   "/dev/nvidia-uvm",
-				CgroupPermissions: "rwm",
-			},
-		)
-		hostConfig.Resources.Devices = append(
-			hostConfig.Resources.Devices,
-			container.DeviceMapping{
-				PathOnHost:        "/dev/nvidiactl",
-				PathInContainer:   "/dev/nvidiactl",
-				CgroupPermissions: "rwm",
+		hostConfig.Resources.DeviceRequests = append(
+			hostConfig.Resources.DeviceRequests,
+			container.DeviceRequest{
+				// Request all capabilities to maximize compatibility with all sorts of GPU workloads.
+				// Default capabilities: utility, compute.
+				// https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/1.16.0/docker-specialized.html
+				Capabilities: [][]string{{"gpu", "utility", "compute", "graphics", "video", "display", "compat32"}},
+				DeviceIDs:    ids,
 			},
 		)
 		hostConfig.Mounts = append(
 			hostConfig.Mounts,
-			mount.Mount{Type: mount.TypeBind, Source: "/var/lib/nvidia/lib64", Target: "/usr/local/nvidia/lib64"},
-		)
-		hostConfig.Mounts = append(
-			hostConfig.Mounts,
-			mount.Mount{Type: mount.TypeBind, Source: "/var/lib/nvidia/bin", Target: "/usr/local/nvidia/bin"},
-		)
-		hostConfig.Mounts = append(
-			hostConfig.Mounts,
-			mount.Mount{Type: mount.TypeBind, Source: "/var/lib/tcpx/lib64", Target: "/usr/local/tcpx/lib64"},
-		)
-		hostConfig.Mounts = append(
-			hostConfig.Mounts,
-			mount.Mount{Type: mount.TypeBind, Source: "/run/tcpx", Target: "/run/tcpx"},
+			mount.Mount{Type: mount.TypeBind, Source: "/dev/aperture_devices", Target: "/dev/aperture_devices"},
 		)
 	case host.GpuVendorAmd:
 		// All options are listed here: https://hub.docker.com/r/rocm/pytorch

--- a/runner/internal/shim/docker.go
+++ b/runner/internal/shim/docker.go
@@ -1034,19 +1034,19 @@ func configureGpus(config *container.Config, hostConfig *container.HostConfig, v
 		)
 		hostConfig.Mounts = append(
 			hostConfig.Mounts,
-			mount.Mount{Type: mount.TypeBind, Source: "/var/lib/nvidia/lib64", Target: "/var/lib/nvidia/lib64"},
+			mount.Mount{Type: mount.TypeBind, Source: "/var/lib/nvidia/lib64", Target: "/usr/local/nvidia/lib64"},
 		)
 		hostConfig.Mounts = append(
 			hostConfig.Mounts,
-			mount.Mount{Type: mount.TypeBind, Source: "/var/lib/nvidia/bin", Target: "/var/lib/nvidia/bin"},
+			mount.Mount{Type: mount.TypeBind, Source: "/var/lib/nvidia/bin", Target: "/usr/local/nvidia/bin"},
+		)
+		hostConfig.Mounts = append(
+			hostConfig.Mounts,
+			mount.Mount{Type: mount.TypeBind, Source: "/var/lib/tcpx/lib64", Target: "/usr/local/tcpx/lib64"},
 		)
 		hostConfig.Mounts = append(
 			hostConfig.Mounts,
 			mount.Mount{Type: mount.TypeBind, Source: "/run/tcpx", Target: "/run/tcpx"},
-		)
-		hostConfig.Mounts = append(
-			hostConfig.Mounts,
-			mount.Mount{Type: mount.TypeBind, Source: "/var/lib/tcpx/lib64", Target: "/var/lib/tcpx/lib64"},
 		)
 	case host.GpuVendorAmd:
 		// All options are listed here: https://hub.docker.com/r/rocm/pytorch

--- a/runner/internal/shim/docker.go
+++ b/runner/internal/shim/docker.go
@@ -1034,11 +1034,15 @@ func configureGpus(config *container.Config, hostConfig *container.HostConfig, v
 		)
 		hostConfig.Mounts = append(
 			hostConfig.Mounts,
-			mount.Mount{Type: mount.TypeBind, Source: "/run/tcpx", Target: "/run/tcpx"},
+			mount.Mount{Type: mount.TypeBind, Source: "/var/lib/nvidia/lib64", Target: "/var/lib/nvidia/lib64"},
 		)
 		hostConfig.Mounts = append(
 			hostConfig.Mounts,
-			mount.Mount{Type: mount.TypeBind, Source: "/var/lib/nvidia/lib64", Target: "/var/lib/nvidia/lib64"},
+			mount.Mount{Type: mount.TypeBind, Source: "/var/lib/nvidia/bin", Target: "/var/lib/nvidia/bin"},
+		)
+		hostConfig.Mounts = append(
+			hostConfig.Mounts,
+			mount.Mount{Type: mount.TypeBind, Source: "/run/tcpx", Target: "/run/tcpx"},
 		)
 		hostConfig.Mounts = append(
 			hostConfig.Mounts,

--- a/runner/internal/shim/docker.go
+++ b/runner/internal/shim/docker.go
@@ -1005,18 +1005,6 @@ func configureGpus(config *container.Config, hostConfig *container.HostConfig, v
 				DeviceIDs:    ids,
 			},
 		)
-		hostConfig.Mounts = append(
-			hostConfig.Mounts,
-			mount.Mount{Type: mount.TypeBind, Source: "/dev/aperture_devices", Target: "/dev/aperture_devices"},
-		)
-		hostConfig.Mounts = append(
-			hostConfig.Mounts,
-			mount.Mount{Type: mount.TypeBind, Source: "/var/lib/tcpxo/lib64", Target: "/var/lib/tcpxo/lib64"},
-		)
-		hostConfig.Mounts = append(
-			hostConfig.Mounts,
-			mount.Mount{Type: mount.TypeBind, Source: "/var/lib/fastrak/lib64", Target: "/var/lib/fastrak/lib64"},
-		)
 	case host.GpuVendorAmd:
 		// All options are listed here: https://hub.docker.com/r/rocm/pytorch
 		// Only --device are mandatory, other seem to be performance-related.

--- a/runner/internal/shim/docker.go
+++ b/runner/internal/shim/docker.go
@@ -1009,6 +1009,14 @@ func configureGpus(config *container.Config, hostConfig *container.HostConfig, v
 			hostConfig.Mounts,
 			mount.Mount{Type: mount.TypeBind, Source: "/dev/aperture_devices", Target: "/dev/aperture_devices"},
 		)
+		hostConfig.Mounts = append(
+			hostConfig.Mounts,
+			mount.Mount{Type: mount.TypeBind, Source: "/var/lib/tcpxo/lib64", Target: "/var/lib/tcpxo/lib64"},
+		)
+		hostConfig.Mounts = append(
+			hostConfig.Mounts,
+			mount.Mount{Type: mount.TypeBind, Source: "/var/lib/fastrak/lib64", Target: "/var/lib/fastrak/lib64"},
+		)
 	case host.GpuVendorAmd:
 		// All options are listed here: https://hub.docker.com/r/rocm/pytorch
 		// Only --device are mandatory, other seem to be performance-related.

--- a/runner/internal/shim/docker.go
+++ b/runner/internal/shim/docker.go
@@ -995,15 +995,54 @@ func configureGpus(config *container.Config, hostConfig *container.HostConfig, v
 	// AMD: ids are DRI render node paths, e.g., /dev/dri/renderD128
 	switch vendor {
 	case host.GpuVendorNvidia:
-		hostConfig.Resources.DeviceRequests = append(
-			hostConfig.Resources.DeviceRequests,
-			container.DeviceRequest{
-				// Request all capabilities to maximize compatibility with all sorts of GPU workloads.
-				// Default capabilities: utility, compute.
-				// https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/1.16.0/docker-specialized.html
-				Capabilities: [][]string{{"gpu", "utility", "compute", "graphics", "video", "display", "compat32"}},
-				DeviceIDs:    ids,
+		// hostConfig.Resources.DeviceRequests = append(
+		// 	hostConfig.Resources.DeviceRequests,
+		// 	container.DeviceRequest{
+		// 		// Request all capabilities to maximize compatibility with all sorts of GPU workloads.
+		// 		// Default capabilities: utility, compute.
+		// 		// https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/1.16.0/docker-specialized.html
+		// 		Capabilities: [][]string{{"gpu", "utility", "compute", "graphics", "video", "display", "compat32"}},
+		// 		DeviceIDs:    ids,
+		// 	},
+		// )
+		for i := range 8 {
+			devPath := fmt.Sprintf("/dev/nvidia%d", i)
+			hostConfig.Resources.Devices = append(
+				hostConfig.Resources.Devices,
+				container.DeviceMapping{
+					PathOnHost:        devPath,
+					PathInContainer:   devPath,
+					CgroupPermissions: "rwm",
+				},
+			)
+		}
+		hostConfig.Resources.Devices = append(
+			hostConfig.Resources.Devices,
+			container.DeviceMapping{
+				PathOnHost:        "/dev/nvidia-uvm",
+				PathInContainer:   "/dev/nvidia-uvm",
+				CgroupPermissions: "rwm",
 			},
+		)
+		hostConfig.Resources.Devices = append(
+			hostConfig.Resources.Devices,
+			container.DeviceMapping{
+				PathOnHost:        "/dev/nvidiactl",
+				PathInContainer:   "/dev/nvidiactl",
+				CgroupPermissions: "rwm",
+			},
+		)
+		hostConfig.Mounts = append(
+			hostConfig.Mounts,
+			mount.Mount{Type: mount.TypeBind, Source: "/run/tcpx", Target: "/run/tcpx"},
+		)
+		hostConfig.Mounts = append(
+			hostConfig.Mounts,
+			mount.Mount{Type: mount.TypeBind, Source: "/var/lib/nvidia/lib64", Target: "/var/lib/nvidia/lib64"},
+		)
+		hostConfig.Mounts = append(
+			hostConfig.Mounts,
+			mount.Mount{Type: mount.TypeBind, Source: "/var/lib/tcpx/lib64", Target: "/var/lib/tcpx/lib64"},
 		)
 	case host.GpuVendorAmd:
 		// All options are listed here: https://hub.docker.com/r/rocm/pytorch

--- a/scripts/packer/gcp-a3mega-image.json
+++ b/scripts/packer/gcp-a3mega-image.json
@@ -19,6 +19,10 @@
     {
       "type": "shell",
       "inline": [
+        "sudo rm /etc/apt/sources.list.d/ar_us_apt_pkg_dev_projects_gce_ai_infra.list",
+        "sudo apt-get update",
+        "sudo apt-get install -y --no-install-recommends datacenter-gpu-manager-4-proprietary datacenter-gpu-manager-exporter",
+        "sudo systemctl disable google-cloud-ops-agent.service",
         "gcloud -q auth configure-docker us-docker.pkg.dev",
         "docker pull us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.14",
         "docker pull us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.8-1"

--- a/scripts/packer/gcp-a3mega-image.json
+++ b/scripts/packer/gcp-a3mega-image.json
@@ -1,0 +1,28 @@
+{
+  "variables": {
+    "image_version": ""
+  },
+  "builders": [
+    {
+      "type": "googlecompute",
+      "project_id": "dstack",
+      "source_image": "dstack-a3mega-20250401t065024z",
+      "image_name": "dstack-a3mega-{{user `image_version`}}",
+      "instance_name": "dstack-a3mega-{{user `image_version`}}",
+      "image_description": "dstack VM image for A3 Mega instances with pre-pulled Docker images. The source image is based on https://cloud.google.com/cluster-toolkit/docs/deploy/deploy-a3-mega-cluster.",
+      "ssh_username": "ubuntu",
+      "zone": "us-central1-a",
+      "disk_size": 100
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "gcloud -q auth configure-docker us-docker.pkg.dev",
+        "docker pull us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.14",
+        "docker pull us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.8-1"
+      ]
+    }
+  ]
+}

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -39,11 +39,11 @@ from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-DSTACK_WORKING_DIR = "/root/.dstack"
+DSTACK_WORKING_DIR = "/etc/.dstack"
 DSTACK_SHIM_BINARY_NAME = "dstack-shim"
-DSTACK_SHIM_BINARY_PATH = f"/usr/local/bin/{DSTACK_SHIM_BINARY_NAME}"
+DSTACK_SHIM_BINARY_PATH = f"/etc/{DSTACK_SHIM_BINARY_NAME}"
 DSTACK_RUNNER_BINARY_NAME = "dstack-runner"
-DSTACK_RUNNER_BINARY_PATH = f"/usr/local/bin/{DSTACK_RUNNER_BINARY_NAME}"
+DSTACK_RUNNER_BINARY_PATH = f"/etc/{DSTACK_RUNNER_BINARY_NAME}"
 
 
 class Compute(ABC):
@@ -525,7 +525,7 @@ def get_run_shim_script(is_privileged: bool, pjrt_device: Optional[str]) -> List
     pjrt_device_env = f"--pjrt-device={pjrt_device}" if pjrt_device else ""
 
     return [
-        f"nohup dstack-shim {privileged_flag} {pjrt_device_env} &",
+        f"nohup {DSTACK_SHIM_BINARY_PATH} {privileged_flag} {pjrt_device_env} &",
     ]
 
 

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -39,11 +39,11 @@ from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-DSTACK_WORKING_DIR = "/etc/.dstack"
+DSTACK_WORKING_DIR = "/root/.dstack"
 DSTACK_SHIM_BINARY_NAME = "dstack-shim"
-DSTACK_SHIM_BINARY_PATH = f"/etc/{DSTACK_SHIM_BINARY_NAME}"
+DSTACK_SHIM_BINARY_PATH = f"/usr/local/bin/{DSTACK_SHIM_BINARY_NAME}"
 DSTACK_RUNNER_BINARY_NAME = "dstack-runner"
-DSTACK_RUNNER_BINARY_PATH = f"/etc/{DSTACK_RUNNER_BINARY_NAME}"
+DSTACK_RUNNER_BINARY_PATH = f"/usr/local/bin/{DSTACK_RUNNER_BINARY_NAME}"
 
 
 class Compute(ABC):

--- a/src/dstack/_internal/core/backends/gcp/compute.py
+++ b/src/dstack/_internal/core/backends/gcp/compute.py
@@ -269,7 +269,10 @@ class GCPCompute(
                     gpus=instance_offer.instance.resources.gpus,
                 ),
                 spot=instance_offer.instance.resources.spot,
-                user_data=get_user_data(authorized_keys),
+                user_data=get_user_data(
+                    authorized_keys,
+                    backend_specific_commands=_get_backend_specific_commands_tcpxo(),
+                ),
                 authorized_keys=authorized_keys,
                 labels=labels,
                 tags=[gcp_resources.DSTACK_INSTANCE_TAG],
@@ -803,6 +806,68 @@ def _is_single_host_tpu(instance_name: str) -> bool:
     else:
         logger.info("Skipping unknown TPU: %s", instance_name)
         return False
+
+
+def _get_backend_specific_commands_tcpx() -> List[str]:
+    return [
+        "cos-extensions install gpu -- --version=latest",
+        "sudo mount --bind /var/lib/nvidia /var/lib/nvidia",
+        "sudo mount -o remount,exec /var/lib/nvidia",
+        (
+            "docker run "
+            "--detach "
+            "--pull=always"
+            "--name receive-datapath-manager "
+            "--privileged "
+            "--cap-add=NET_ADMIN --network=host "
+            "--volume /var/lib/nvidia/lib64:/usr/local/nvidia/lib64 "
+            "--device /dev/nvidia0:/dev/nvidia0 --device /dev/nvidia1:/dev/nvidia1 "
+            "--device /dev/nvidia2:/dev/nvidia2 --device /dev/nvidia3:/dev/nvidia3 "
+            "--device /dev/nvidia4:/dev/nvidia4 --device /dev/nvidia5:/dev/nvidia5 "
+            "--device /dev/nvidia6:/dev/nvidia6 --device /dev/nvidia7:/dev/nvidia7 "
+            "--device /dev/nvidia-uvm:/dev/nvidia-uvm --device /dev/nvidiactl:/dev/nvidiactl "
+            "--env LD_LIBRARY_PATH=/usr/local/nvidia/lib64 "
+            "--volume /run/tcpx:/run/tcpx "
+            "--entrypoint /tcpgpudmarxd/build/app/tcpgpudmarxd "
+            "us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/tcpgpudmarxd "
+            '--gpu_nic_preset a3vm --gpu_shmem_type fd --uds_path "/run/tcpx" --setup_param "--verbose 128 2 0"'
+        ),
+        "sudo iptables -I INPUT -p tcp -m tcp -j ACCEPT",
+        "docker run --rm -v /var/lib:/var/lib us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/nccl-plugin-gpudirecttcpx install --install-nccl",
+        "sudo mount --bind /var/lib/tcpx /var/lib/tcpx",
+        "sudo mount -o remount,exec /var/lib/tcpx",
+    ]
+
+
+def _get_backend_specific_commands_tcpxo() -> List[str]:
+    return [
+        "modprobe import-helper",
+        "gcloud -q auth configure-docker us-docker.pkg.dev",
+        # Install the nccl, nccl-net lib into /var/lib/tcpxo/lib64/.
+        (
+            "docker run --rm --name nccl-installer "
+            "--network=host "
+            "--volume /var/lib:/var/lib "
+            "us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.8-1 "
+            "install --install-nccl"
+        ),
+        # Start FasTrak receive-datapath-manager
+        (
+            "docker run "
+            "--detach "
+            "--pull=always "
+            "--name receive-datapath-manager "
+            "--cap-add=NET_ADMIN "
+            "--network=host "
+            "--privileged "
+            "--gpus all "
+            "--volume /usr/lib32:/usr/local/nvidia/lib64 "
+            "--volume /dev/dmabuf_import_helper:/dev/dmabuf_import_helper "
+            "--env LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu "
+            "us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.14 "
+            "--num_hops=2 --num_nics=8 --uid= --alsologtostderr"
+        ),
+    ]
 
 
 def _get_volume_price(size: int) -> float:

--- a/src/dstack/_internal/core/backends/gcp/compute.py
+++ b/src/dstack/_internal/core/backends/gcp/compute.py
@@ -849,7 +849,7 @@ def _get_extra_subnets(
 
 def _get_image_id(instance_type_name: str, cuda: bool) -> str:
     if instance_type_name == "a3-megagpu-8g":
-        image_name = "dstack-a3mega-2"
+        image_name = "dstack-a3mega-5"
     elif cuda:
         image_name = f"dstack-cuda-{version.base_image}"
     else:

--- a/src/dstack/_internal/core/backends/gcp/configurator.py
+++ b/src/dstack/_internal/core/backends/gcp/configurator.py
@@ -199,3 +199,5 @@ class GCPConfigurator(Configurator):
             )
         except BackendError as e:
             raise ServerClientError(e.args[0])
+        # Not checking config.extra_vpc so that users are not required to configure subnets for all regions
+        # but only for regions they intend to use. Validation will be done on provisioning.

--- a/src/dstack/_internal/core/backends/gcp/features/tcpx.py
+++ b/src/dstack/_internal/core/backends/gcp/features/tcpx.py
@@ -7,7 +7,9 @@ def get_backend_specific_commands_tcpxo() -> List[str]:
         "gcloud -q auth configure-docker us-docker.pkg.dev",
         # Install the nccl, nccl-net lib into /var/lib/tcpxo/lib64/.
         (
-            "docker run --rm --name nccl-installer "
+            "docker run --rm "
+            "--name nccl-installer "
+            "--pull=never "
             "--network=host "
             "--volume /var/lib:/var/lib "
             "us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.8-1 "
@@ -16,9 +18,9 @@ def get_backend_specific_commands_tcpxo() -> List[str]:
         # Start FasTrak receive-datapath-manager
         (
             "docker run "
-            "--detach "
-            "--pull=always "
             "--name receive-datapath-manager "
+            "--detach "
+            "--pull=never "
             "--cap-add=NET_ADMIN "
             "--network=host "
             "--privileged "

--- a/src/dstack/_internal/core/backends/gcp/features/tcpx.py
+++ b/src/dstack/_internal/core/backends/gcp/features/tcpx.py
@@ -1,0 +1,32 @@
+from typing import List
+
+
+def get_backend_specific_commands_tcpxo() -> List[str]:
+    return [
+        "modprobe import-helper",
+        "gcloud -q auth configure-docker us-docker.pkg.dev",
+        # Install the nccl, nccl-net lib into /var/lib/tcpxo/lib64/.
+        (
+            "docker run --rm --name nccl-installer "
+            "--network=host "
+            "--volume /var/lib:/var/lib "
+            "us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.8-1 "
+            "install --install-nccl"
+        ),
+        # Start FasTrak receive-datapath-manager
+        (
+            "docker run "
+            "--detach "
+            "--pull=always "
+            "--name receive-datapath-manager "
+            "--cap-add=NET_ADMIN "
+            "--network=host "
+            "--privileged "
+            "--gpus all "
+            "--volume /usr/lib32:/usr/local/nvidia/lib64 "
+            "--volume /dev/dmabuf_import_helper:/dev/dmabuf_import_helper "
+            "--env LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu "
+            "us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.14 "
+            "--num_hops=2 --num_nics=8 --uid= --alsologtostderr"
+        ),
+    ]

--- a/src/dstack/_internal/core/backends/gcp/models.py
+++ b/src/dstack/_internal/core/backends/gcp/models.py
@@ -33,7 +33,19 @@ class GCPBackendConfig(CoreModel):
     regions: Annotated[
         Optional[List[str]], Field(description="The list of GCP regions. Omit to use all regions")
     ] = None
-    vpc_name: Annotated[Optional[str], Field(description="The name of a custom VPC")] = None
+    vpc_name: Annotated[
+        Optional[str],
+        Field(description="The name of a custom VPC. If not specified, the default VPC is used"),
+    ] = None
+    extra_vpcs: Annotated[
+        Optional[List[str]],
+        Field(
+            description=(
+                "The names of additional VPCs used for GPUDirect. Specify eight VPCs to maximize bandwidth."
+                " Each VPC must have a subnet and a firewall rule allowing internal traffic across all subnets"
+            )
+        ),
+    ] = None
     vpc_project_id: Annotated[
         Optional[str],
         Field(description="The shared VPC hosted project ID. Required for shared VPC only"),

--- a/src/dstack/_internal/core/backends/gcp/resources.py
+++ b/src/dstack/_internal/core/backends/gcp/resources.py
@@ -209,22 +209,6 @@ def _get_network_interfaces(
     return network_interfaces
 
 
-def get_image_id(cuda: bool) -> str:
-    # if not cuda:
-    #     image_name = f"dstack-{version.base_image}"
-    # else:
-    #     image_name = f"dstack-cuda-{version.base_image}"
-    # image_name = image_name.replace(".", "-")
-
-    # return f"projects/dstack/global/images/{image_name}"
-    # return "projects/cos-cloud/global/images/cos-105-17412-535-78" # TCPX
-    return "projects/dstack/global/images/slurm-a3mega-20250327t101736z-cloudinit"  # TCPXO
-
-
-def get_gateway_image_id() -> str:
-    return "projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20230714"
-
-
 def get_vpc_subnet_or_error(
     subnetworks_client: compute_v1.SubnetworksClient,
     vpc_project_id: str,

--- a/src/dstack/_internal/core/backends/gcp/resources.py
+++ b/src/dstack/_internal/core/backends/gcp/resources.py
@@ -434,3 +434,11 @@ def wait_for_operation(operation: Operation, verbose_name: str = "operation", ti
 
 def full_resource_name_to_name(full_resource_name: str) -> str:
     return full_resource_name.split("/")[-1]
+
+
+def get_placement_policy_resource_name(
+    project_id: str,
+    region: str,
+    placement_policy: str,
+) -> str:
+    return f"projects/{project_id}/regions/{region}/resourcePolicies/{placement_policy}"

--- a/src/dstack/_internal/core/backends/gcp/resources.py
+++ b/src/dstack/_internal/core/backends/gcp/resources.py
@@ -117,6 +117,7 @@ def create_instance_struct(
     network: str = "global/networks/default",
     subnetwork: Optional[str] = None,
     allocate_public_ip: bool = True,
+    placement_policy: Optional[str] = None,
 ) -> compute_v1.Instance:
     instance = compute_v1.Instance()
     instance.name = instance_name
@@ -148,6 +149,9 @@ def create_instance_struct(
     ):
         # Attachable GPUs, H100, A100, and L4
         instance.scheduling.on_host_maintenance = "TERMINATE"
+
+    if placement_policy is not None:
+        instance.resource_policies = [placement_policy]
 
     if spot:
         instance.scheduling = compute_v1.Scheduling()

--- a/src/dstack/_internal/server/background/tasks/process_running_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_running_jobs.py
@@ -434,6 +434,10 @@ def _process_provisioning_with_shim(
     for volume, volume_mount in zip(volumes, volume_mounts):
         volume_mount.name = volume.name
 
+    instance_mounts += _get_instance_specific_mounts(
+        job_provisioning_data.backend, job_provisioning_data.instance_type.name
+    )
+
     container_user = "root"
 
     job_runtime_data = get_job_runtime_data(job_model)
@@ -825,3 +829,19 @@ def _submit_job_to_runner(
     # do not log here, because the runner will send a new status
 
     return True
+
+
+def _get_instance_specific_mounts(
+    backend_type: BackendType, instance_type_name: str
+) -> List[InstanceMountPoint]:
+    if backend_type == BackendType.GCP and instance_type_name == "a3-megagpu-8g":
+        return [
+            InstanceMountPoint(
+                instance_path="/dev/aperture_devices", path="/dev/aperture_devices"
+            ),
+            InstanceMountPoint(instance_path="/var/lib/tcpxo/lib64", path="/var/lib/tcpxo/lib64"),
+            InstanceMountPoint(
+                instance_path="/var/lib/fastrak/lib64", path="/var/lib/fastrak/lib64"
+            ),
+        ]
+    return []


### PR DESCRIPTION
Closes #2447 

The PR adds support for GPUDirect-TCPXO on GCP A3 Mega instances:
* Adds `extra_vpcs` parameter to GCP config to configure VPC for GPU NICs.
* Supports placement groups for GCP – fleets with `placement: cluster` now have instances in the same collocated placement.
* Adds a Github Action to build a debian-based VM image with GPUDirect-TCPXO – this is now used for A3 Mega instances.
* Adds A3 Mega specific commands to run on cloud-init that configure GPUDirect-TCPXO.
* Adds an example on how to configure and use GCP A3 Mega with GPUDirect-TCPXO.

TODO:
* Currently to use GPUDirect-TCPXO optimally, certain env variables need to be set up. An example shows how it can be done. The next step may be to configure all the env vars GPUDirect-TCPXO for A3 Mega automatically. Although, it needs to be researched if hardcoding them is a good idea.
* Supporting GPUDirect-TCPX.