### PR TITLE
Fix Nebius private networks with non-default CIDR

### DIFF
--- a/src/dstack/_internal/core/backends/nebius/compute.py
+++ b/src/dstack/_internal/core/backends/nebius/compute.py
@@ -48,6 +48,8 @@ DOCKER_DAEMON_CONFIG = {
 }
 SETUP_COMMANDS = [
     "ufw allow ssh",
+    "ufw allow from 10.0.0.0/8",
+    "ufw allow from 172.16.0.0/12",
     "ufw allow from 192.168.0.0/16",
     "ufw default deny incoming",
     "ufw default allow outgoing",


### PR DESCRIPTION
Adjust firewall rules to allow traffic from any
private IP ranges. The default IP range is
192.168.0.0/16, but users can configure other
ranges in the console.

#2390