### PR TITLE
Fix terminating TensorDock instances

### DIFF
--- a/src/dstack/_internal/core/backends/tensordock/compute.py
+++ b/src/dstack/_internal/core/backends/tensordock/compute.py
@@ -12,7 +12,7 @@ from dstack._internal.core.backends.base.compute import (
 from dstack._internal.core.backends.base.offers import get_catalog_offers
 from dstack._internal.core.backends.tensordock.api_client import TensorDockAPIClient
 from dstack._internal.core.backends.tensordock.models import TensorDockConfig
-from dstack._internal.core.errors import BackendError, NoCapacityError
+from dstack._internal.core.errors import NoCapacityError
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.instances import (
     InstanceAvailability,
@@ -117,17 +117,4 @@ class TensorDockCompute(
     def terminate_instance(
         self, instance_id: str, region: str, backend_data: Optional[str] = None
     ):
-        try:
-            self.api_client.delete_single(instance_id)
-        except requests.HTTPError as e:
-            logger.error(
-                "An HTTP error occurred when trying to terminate TensorDock instance %s: %s",
-                instance_id,
-                e,
-            )
-        except BackendError as e:
-            logger.error(
-                "TensorDock returned an error when trying to terminate instance %s: %s",
-                instance_id,
-                e,
-            )
+        self.api_client.delete_single_if_exists(instance_id)


### PR DESCRIPTION
Fixes #2479

- Do not handle exceptions in `terminate_instance`, so that they can be detected and termination can be retried
- Ignore termination errors if instance is already terminated
- Increase request timeout, termination and other requests often take more than 12 seconds