### PR TITLE
Allow mounting volumes into /workflow

### DIFF
--- a/docs/docs/concepts/volumes.md
+++ b/docs/docs/concepts/volumes.md
@@ -114,9 +114,6 @@ volumes:
 Once you run this configuration, the contents of the volume will be attached to `/volume_data` inside the dev environment, 
 and its contents will persist across runs.
 
-> Currently, `dstack` does not allow attaching volumes to `/workflow` or any of its subdirectories because this folder is
-> reserved for fetching the repository
-
 ??? info "Multiple regions or backends"
     If you're unsure in advance which region or backend you'd like to use (or which is available),
     you can specify multiple volumes for the same path.

--- a/docs/docs/guides/repos.md
+++ b/docs/docs/guides/repos.md
@@ -81,6 +81,13 @@ $ dstack apply -f .dstack.yml --no-repo
 
 </div>
 
+## Store the repo on a volume
+
+You can use [Volumes](../concepts/volumes.md) to persist repo changes without pushing them to the Git remote.
+Attach a volume to the repo directory (`/workflow`) or any of its subdirectories.
+`dstack` will clone the repo to the volume on the first run.
+On subsequent runs, `dstack` will use the repo contents from the volume instead of cloning the repo.
+
 ## What's next?
 
 1. Read about [dev environments](../concepts/dev-environments.md), [tasks](../concepts/tasks.md), [services](../concepts/services.md)

--- a/src/dstack/_internal/server/services/runs.py
+++ b/src/dstack/_internal/server/services/runs.py
@@ -831,8 +831,6 @@ def _validate_run_spec_and_set_defaults(run_spec: RunSpec):
     for mount_point in run_spec.configuration.volumes:
         if not is_valid_docker_volume_target(mount_point.path):
             raise ServerClientError(f"Invalid volume mount path: {mount_point.path}")
-        if mount_point.path.startswith("/workflow"):
-            raise ServerClientError("Mounting volumes inside /workflow is not supported")
     if run_spec.repo_id is None and run_spec.repo_data is not None:
         raise ServerClientError("repo_data must not be set if repo_id is not set")
     if run_spec.repo_id is not None and run_spec.repo_data is None:


### PR DESCRIPTION
Closes #2464

The PR allows mounting volumes into /workflow and its subdirectories by skipping the repo checkout if the directory is not empty. On the first run, a volume will be populated with the repo files. On subsequent runs, the runner will skip repo checkout and use the files from the volume.

Special case: a new volume can have a `lost+found` dir, which prevents git clone. In that case, the dir is moved from the volume and then restored after cloning.