### PR TITLE
Fix GitIgnore

### DIFF
--- a/src/dstack/_internal/utils/ignore.py
+++ b/src/dstack/_internal/utils/ignore.py
@@ -20,6 +20,8 @@ class GitIgnore:
         self.load_recursive()
 
     def load_ignore_file(self, path: str, ignore_file: Path):
+        if path != "." and not path.startswith("./"):
+            path = "./" + path
         if path not in self.ignore_globs:
             self.ignore_globs[path] = []
         with ignore_file.open("r") as f:


### PR DESCRIPTION
`ignore()` builds paths with leading `./`, e.g., `./path/to` while `load_recursive()` builds relative paths using `Path.relative_to()`, which produces paths without `./`, e.g., `path/to`.

Fixes: https://github.com/dstackai/dstack/issues/2485