### PR TITLE
Fix dstack dependency for gateway

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
           echo "__version__ = \"${{ env.VERSION }}\"" > src/dstack/gateway/version.py
           sed \
             -i.old \
-            "s|@ https://github.com/dstackai/dstack/archive/refs/heads/master.zip|== ${{ env.VERSION }}|" \
+            "s|@ git+https://github.com/dstackai/dstack.git@master|== ${{ env.VERSION }}|" \
             pyproject.toml
           diff pyproject.toml pyproject.toml.old > /dev/null && echo "Could not set version" && exit 1
           uv build

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
     # release builds of dstack-gateway depend on a PyPI version of dstack instead
-    "dstack[gateway] @ https://github.com/dstackai/dstack/archive/refs/heads/master.zip",
+    "dstack[gateway] @ git+https://github.com/dstackai/dstack.git@master",
 ]
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
Specifying "https://github.com/dstackai/dstack/archive/refs/heads/master.zip" does not work with the new hatching setup.