### PR TITLE
Set no-guess-dev for dev package versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ dstack = "dstack._internal.cli.main:main"
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.version.raw-options]
+version_scheme = "no-guess-dev"
+
 [tool.hatch.build.targets.wheel.shared-data]
 "src/dstack/_internal/proxy/gateway/resources" = "dstack/_internal/proxy/gateway/resources"
 "src/dstack/_internal/server/statics" = "dstack/_internal/server/statics"


### PR DESCRIPTION
When building dev dstack package (without release commit), do not increase automatically version from the latest tag (e.g. 0.19.3 => 0.19.4). Add post1 instead.