### PR TITLE
Detect dstack version from file instead of git

### DIFF
--- a/docker/server/stgn/Dockerfile
+++ b/docker/server/stgn/Dockerfile
@@ -22,7 +22,7 @@ ENV PATH="/root/.local/bin/:$PATH"
 
 COPY pyproject.toml uv.lock README.md ./
 COPY src src
-RUN SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv sync --extra all
+RUN uv sync --extra all
 
 COPY docker/server/entrypoint.sh entrypoint.sh
 RUN chmod 777 entrypoint.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,14 +45,14 @@ Changelog = "https://github.com/dstackai/dstack/releases"
 Discord = "https://discord.gg/u8SmfwPpMd"
 
 [build-system]
-requires = ["hatchling", "hatch-vcs", "hatch-fancy-pypi-readme"]
+requires = ["hatchling", "hatch-fancy-pypi-readme"]
 build-backend = "hatchling.build"
 
 [project.scripts]
 dstack = "dstack._internal.cli.main:main"
 
 [tool.hatch.version]
-source = "vcs"
+path = "src/dstack/version.py"
 
 [tool.hatch.version.raw-options]
 version_scheme = "no-guess-dev"

--- a/src/dstack/_internal/cli/commands/server.py
+++ b/src/dstack/_internal/cli/commands/server.py
@@ -1,7 +1,7 @@
 import os
 from argparse import Namespace
 
-from dstack import version
+from dstack._internal import settings
 from dstack._internal.cli.commands import BaseCommand
 from dstack._internal.core.errors import CLIError
 
@@ -78,7 +78,7 @@ class ServerCommand(BaseCommand):
             "dstack._internal.server.main:app",
             host=args.host,
             port=args.port,
-            reload=version.__version__ is None and not reload_disabled,
+            reload=settings.DSTACK_VERSION is None and not reload_disabled,
             log_level=uvicorn_log_level,
             workers=1,
         )

--- a/src/dstack/_internal/cli/utils/updates.py
+++ b/src/dstack/_internal/cli/utils/updates.py
@@ -79,8 +79,7 @@ def _get_last_check_path() -> Path:
 
 
 def check_for_updates():
-    current_version = version.__version__
-    if current_version:
+    if version.__is_release__:
         if _is_last_check_time_outdated():
             logger.debug("Checking for updates...")
             _check_version()

--- a/src/dstack/_internal/settings.py
+++ b/src/dstack/_internal/settings.py
@@ -3,6 +3,11 @@ import os
 from dstack import version
 
 DSTACK_VERSION = os.getenv("DSTACK_VERSION", version.__version__)
+if DSTACK_VERSION == "0.0.0":
+    # The build backend (hatching) requires not None for versions,
+    # but the code currently treats None as dev version.
+    # TODO: update the code to treat 0.0.0 as dev version.
+    DSTACK_VERSION = None
 DSTACK_RELEASE = os.getenv("DSTACK_RELEASE") is not None or version.__is_release__
 DSTACK_USE_LATEST_FROM_BRANCH = os.getenv("DSTACK_USE_LATEST_FROM_BRANCH") is not None
 

--- a/src/dstack/version.py
+++ b/src/dstack/version.py
@@ -1,3 +1,3 @@
-__version__ = None
+__version__ = "0.0.0"
 __is_release__ = False
 base_image = "0.7"


### PR DESCRIPTION
#2455 moved to hatch-vcs to detect dstack version for build from git. This didn't work for github actions out-of-the box due to cloning peculiarities (https://github.com/dstackai/dstack/actions/runs/14490484662/job/40645917910). This PR switches to detecting version from file as before. For this to work with hatch, default dev version is set to "0.0.0" instead of None.