### PR TITLE
Fix Nginx upstream name conflicts

### DIFF
--- a/src/dstack/_internal/proxy/gateway/resources/nginx/service.jinja2
+++ b/src/dstack/_internal/proxy/gateway/resources/nginx/service.jinja2
@@ -3,7 +3,7 @@ limit_req_zone {{ zone.key }} zone={{ zone.name }}:10m rate={{ zone.rpm }}r/m;
 {% endfor %}
 
 {% if replicas %}
-upstream {{ run_name }} {
+upstream {{ domain }}.upstream {
     {% for replica in replicas %}
     server unix:{{ replica.socket }};  # replica {{ replica.id }}
     {% endfor %}
@@ -37,7 +37,7 @@ server {
 
     {% if replicas %}
     location @websocket {
-        proxy_pass http://{{ run_name }};
+        proxy_pass http://{{ domain }}.upstream;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $host;
         proxy_http_version 1.1;
@@ -46,7 +46,7 @@ server {
         proxy_read_timeout 300s;
     }
     location @ {
-        proxy_pass http://{{ run_name }};
+        proxy_pass http://{{ domain }}.upstream;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $host;
         proxy_read_timeout 300s;

--- a/src/dstack/_internal/proxy/gateway/services/nginx.py
+++ b/src/dstack/_internal/proxy/gateway/services/nginx.py
@@ -58,7 +58,6 @@ class LocationConfig(BaseModel):
 class ServiceConfig(SiteConfig):
     type: Literal["service"] = "service"
     project_name: str
-    run_name: str
     auth: bool
     client_max_body_size: int
     access_log_path: Path

--- a/src/dstack/_internal/proxy/gateway/services/registry.py
+++ b/src/dstack/_internal/proxy/gateway/services/registry.py
@@ -327,7 +327,6 @@ async def get_nginx_service_config(
         domain=service.domain_safe,
         https=service.https_safe,
         project_name=service.project_name,
-        run_name=service.run_name,
         auth=service.auth,
         client_max_body_size=service.client_max_body_size,
         access_log_path=ACCESS_LOG_PATH,

--- a/src/tests/_internal/proxy/gateway/routers/test_registry.py
+++ b/src/tests/_internal/proxy/gateway/routers/test_registry.py
@@ -112,7 +112,7 @@ class TestRegisterService:
         # no auth
         assert "auth_request /_dstack_auth;" not in conf
         # no replicas
-        assert "upstream test-run" not in conf
+        assert "upstream" not in conf
         assert "return 503;" in conf
 
     async def test_register_with_https(self, tmp_path: Path, system_mocks: Mocks) -> None:
@@ -275,7 +275,7 @@ class TestRegisterReplica:
         )
         assert resp.status_code == 200
         conf = (tmp_path / "443-test-run.gtw.test.conf").read_text()
-        assert "upstream test-run" not in conf
+        assert "upstream" not in conf
         # register 2 replicas
         resp = await client.post(
             "/api/registry/test-proj/services/test-run/replicas/register",
@@ -290,7 +290,7 @@ class TestRegisterReplica:
         assert resp.status_code == 200
         assert resp.json() == {"status": "ok"}
         conf = (tmp_path / "443-test-run.gtw.test.conf").read_text()
-        assert "upstream test-run" in conf
+        assert "upstream test-run.gtw.test.upstream" in conf
         assert (m1 := re.search(r"server unix:/(.+)/replica.sock;  # replica xxx-xxx", conf))
         assert (m2 := re.search(r"server unix:/(.+)/replica.sock;  # replica yyy-yyy", conf))
         assert m1.group(1) != m2.group(1)


### PR DESCRIPTION
Fix #2525

Previously, run names were used as upstream names
in Nginx configs. Since run names can be
duplicated in different projects, this could lead
to name conflicts in Nginx configs. This commit
solves the problem by constructing upstream names
based on service domain names, which should be
unique for all services across projects.