### PR TITLE
Implement custom per-resource tags

### DIFF
--- a/src/dstack/_internal/core/backends/aws/resources.py
+++ b/src/dstack/_internal/core/backends/aws/resources.py
@@ -448,6 +448,16 @@ def make_tags(tags: Dict[str, str]) -> List[Dict[str, str]]:
     return tags_list
 
 
+def filter_invalid_tags(tags: Dict[str, str]) -> Dict[str, str]:
+    filtered_tags = {}
+    for k, v in tags.items():
+        if not _is_valid_tag(k, v):
+            logger.warning("Skipping invalid tag '%s: %s'", k, v)
+            continue
+        filtered_tags[k] = v
+    return filtered_tags
+
+
 def validate_tags(tags: Dict[str, str]):
     for k, v in tags.items():
         if not _is_valid_tag(k, v):

--- a/src/dstack/_internal/core/backends/azure/compute.py
+++ b/src/dstack/_internal/core/backends/azure/compute.py
@@ -136,13 +136,18 @@ class AzureCompute(
             location=location,
         )
 
-        tags = {
+        base_tags = {
             "owner": "dstack",
             "dstack_project": instance_config.project_name,
             "dstack_name": instance_config.instance_name,
             "dstack_user": instance_config.user,
         }
-        tags = merge_tags(tags=tags, backend_tags=self.config.tags)
+        tags = merge_tags(
+            base_tags=base_tags,
+            backend_tags=self.config.tags,
+            resource_tags=instance_config.tags,
+        )
+        tags = azure_resources.filter_invalid_tags(tags)
 
         # TODO: Support custom availability_zones.
         # Currently, VMs are regional, which means they don't have zone info.
@@ -228,14 +233,19 @@ class AzureCompute(
             location=configuration.region,
         )
 
-        tags = {
+        base_tags = {
             "owner": "dstack",
             "dstack_project": configuration.project_name,
             "dstack_name": configuration.instance_name,
         }
         if settings.DSTACK_VERSION is not None:
-            tags["dstack_version"] = settings.DSTACK_VERSION
-        tags = merge_tags(tags=tags, backend_tags=self.config.tags)
+            base_tags["dstack_version"] = settings.DSTACK_VERSION
+        tags = merge_tags(
+            base_tags=base_tags,
+            backend_tags=self.config.tags,
+            resource_tags=configuration.tags,
+        )
+        tags = azure_resources.filter_invalid_tags(tags)
 
         vm = _launch_instance(
             compute_client=self._compute_client,

--- a/src/dstack/_internal/core/backends/azure/resources.py
+++ b/src/dstack/_internal/core/backends/azure/resources.py
@@ -5,6 +5,10 @@ from azure.mgmt import network as network_mgmt
 from azure.mgmt.network.models import Subnet
 
 from dstack._internal.core.errors import BackendError
+from dstack._internal.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
 
 MAX_RESOURCE_NAME_LEN = 64
 
@@ -75,6 +79,16 @@ def _is_eligible_private_subnet(
         return True
 
     return False
+
+
+def filter_invalid_tags(tags: Dict[str, str]) -> Dict[str, str]:
+    filtered_tags = {}
+    for k, v in tags.items():
+        if not _is_valid_tag(k, v):
+            logger.warning("Skipping invalid tag '%s: %s'", k, v)
+            continue
+        filtered_tags[k] = v
+    return filtered_tags
 
 
 def validate_tags(tags: Dict[str, str]):

--- a/src/dstack/_internal/core/backends/gcp/compute.py
+++ b/src/dstack/_internal/core/backends/gcp/compute.py
@@ -211,8 +211,12 @@ class GCPCompute(
             "dstack_name": instance_config.instance_name,
             "dstack_user": instance_config.user.lower(),
         }
-        labels = {k: v for k, v in labels.items() if gcp_resources.is_valid_label_value(v)}
-        labels = merge_tags(tags=labels, backend_tags=self.config.tags)
+        labels = merge_tags(
+            base_tags=labels,
+            backend_tags=self.config.tags,
+            resource_tags=instance_config.tags,
+        )
+        labels = gcp_resources.filter_invalid_labels(labels)
         is_tpu = (
             _is_tpu(instance_offer.instance.resources.gpus[0].name)
             if instance_offer.instance.resources.gpus
@@ -471,8 +475,12 @@ class GCPCompute(
             "dstack_project": configuration.project_name.lower(),
             "dstack_name": configuration.instance_name,
         }
-        labels = {k: v for k, v in labels.items() if gcp_resources.is_valid_label_value(v)}
-        labels = merge_tags(tags=labels, backend_tags=self.config.tags)
+        labels = merge_tags(
+            base_tags=labels,
+            backend_tags=self.config.tags,
+            resource_tags=configuration.tags,
+        )
+        labels = gcp_resources.filter_invalid_labels(labels)
 
         request = compute_v1.InsertInstanceRequest()
         request.zone = zone
@@ -573,8 +581,12 @@ class GCPCompute(
             "dstack_name": volume.name,
             "dstack_user": volume.user,
         }
-        labels = {k: v for k, v in labels.items() if gcp_resources.is_valid_label_value(v)}
-        labels = merge_tags(tags=labels, backend_tags=self.config.tags)
+        labels = merge_tags(
+            base_tags=labels,
+            backend_tags=self.config.tags,
+            resource_tags=volume.configuration.tags,
+        )
+        labels = gcp_resources.filter_invalid_labels(labels)
 
         disk = compute_v1.Disk()
         disk.name = disk_name

--- a/src/dstack/_internal/core/backends/gcp/resources.py
+++ b/src/dstack/_internal/core/backends/gcp/resources.py
@@ -332,6 +332,16 @@ def get_accelerators(
     return [accelerator_config]
 
 
+def filter_invalid_labels(labels: Dict[str, str]) -> Dict[str, str]:
+    filtered_labels = {}
+    for k, v in labels.items():
+        if not _is_valid_label(k, v):
+            logger.warning("Skipping invalid label '%s: %s'", k, v)
+            continue
+        filtered_labels[k] = v
+    return filtered_labels
+
+
 def validate_labels(labels: Dict[str, str]):
     for k, v in labels.items():
         if not _is_valid_label(k, v):

--- a/src/dstack/_internal/core/models/fleets.py
+++ b/src/dstack/_internal/core/models/fleets.py
@@ -255,7 +255,7 @@ class FleetConfiguration(InstanceGroupParams, FleetProps):
         Field(
             description=(
                 "The custom tags to associate with the resource."
-                " The tags also propagated to the underlying backend resources."
+                " The tags are also propagated to the underlying backend resources."
                 " If there is a conflict with backend-level tags, does not override them"
             )
         ),

--- a/src/dstack/_internal/core/models/fleets.py
+++ b/src/dstack/_internal/core/models/fleets.py
@@ -21,6 +21,7 @@ from dstack._internal.core.models.profiles import (
 )
 from dstack._internal.core.models.resources import Range, ResourcesSpec
 from dstack._internal.utils.json_schema import add_extra_schema_types
+from dstack._internal.utils.tags import tags_validator
 
 
 class FleetStatus(str, Enum):
@@ -249,7 +250,18 @@ class FleetProps(CoreModel):
 
 
 class FleetConfiguration(InstanceGroupParams, FleetProps):
-    pass
+    tags: Annotated[
+        Optional[Dict[str, str]],
+        Field(
+            description=(
+                "The custom tags to associate with the resource."
+                " The tags also propagated to the underlying backend resources."
+                " If there is a conflict with backend-level tags, does not override them"
+            )
+        ),
+    ] = None
+
+    _validate_tags = validator("tags", pre=True, allow_reuse=True)(tags_validator)
 
 
 class FleetSpec(CoreModel):

--- a/src/dstack/_internal/core/models/gateways.py
+++ b/src/dstack/_internal/core/models/gateways.py
@@ -63,7 +63,7 @@ class GatewayConfiguration(CoreModel):
         Field(
             description=(
                 "The custom tags to associate with the gateway."
-                " The tags also propagated to the underlying backend resources."
+                " The tags are also propagated to the underlying backend resources."
                 " If there is a conflict with backend-level tags, does not override them"
             )
         ),

--- a/src/dstack/_internal/core/models/instances.py
+++ b/src/dstack/_internal/core/models/instances.py
@@ -1,6 +1,6 @@
 import datetime
 from enum import Enum
-from typing import List, Optional
+from typing import Dict, List, Optional
 from uuid import UUID
 
 import gpuhunt
@@ -108,6 +108,7 @@ class InstanceConfiguration(CoreModel):
     placement_group_name: Optional[str] = None
     reservation: Optional[str] = None
     volumes: Optional[List[Volume]] = None
+    tags: Optional[Dict[str, str]] = None
 
     def get_public_keys(self) -> List[str]:
         return [ssh_key.public.strip() for ssh_key in self.ssh_keys]

--- a/src/dstack/_internal/core/models/profiles.py
+++ b/src/dstack/_internal/core/models/profiles.py
@@ -6,6 +6,7 @@ from typing_extensions import Annotated, Literal
 
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.common import CoreModel, Duration
+from dstack._internal.utils.tags import tags_validator
 
 DEFAULT_RETRY_DURATION = 3600
 
@@ -243,6 +244,16 @@ class ProfileParams(CoreModel):
     fleets: Annotated[
         Optional[list[str]], Field(description="The fleets considered for reuse")
     ] = None
+    tags: Annotated[
+        Optional[Dict[str, str]],
+        Field(
+            description=(
+                "The custom tags to associate with the resource."
+                " The tags also propagated to the underlying backend resources."
+                " If there is a conflict with backend-level tags, does not override them"
+            )
+        ),
+    ] = None
 
     # Deprecated and unused. Left for compatibility with 0.18 clients.
     pool_name: Annotated[Optional[str], Field(exclude=True)] = None
@@ -269,6 +280,7 @@ class ProfileParams(CoreModel):
     _validate_idle_duration = validator("idle_duration", pre=True, allow_reuse=True)(
         parse_idle_duration
     )
+    _validate_tags = validator("tags", pre=True, allow_reuse=True)(tags_validator)
 
 
 class ProfileProps(CoreModel):

--- a/src/dstack/_internal/core/models/profiles.py
+++ b/src/dstack/_internal/core/models/profiles.py
@@ -249,7 +249,7 @@ class ProfileParams(CoreModel):
         Field(
             description=(
                 "The custom tags to associate with the resource."
-                " The tags also propagated to the underlying backend resources."
+                " The tags are also propagated to the underlying backend resources."
                 " If there is a conflict with backend-level tags, does not override them"
             )
         ),

--- a/src/dstack/_internal/core/models/volumes.py
+++ b/src/dstack/_internal/core/models/volumes.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from enum import Enum
 from pathlib import PurePosixPath
-from typing import List, Literal, Optional, Tuple, Union
+from typing import Dict, List, Literal, Optional, Tuple, Union
 
 from pydantic import Field, validator
 from typing_extensions import Annotated, Self
@@ -11,6 +11,7 @@ from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.common import CoreModel
 from dstack._internal.core.models.resources import Memory
 from dstack._internal.utils.common import get_or_error
+from dstack._internal.utils.tags import tags_validator
 
 
 class VolumeStatus(str, Enum):
@@ -43,6 +44,18 @@ class VolumeConfiguration(CoreModel):
         Optional[str],
         Field(description="The volume ID. Must be specified when registering external volumes"),
     ] = None
+    tags: Annotated[
+        Optional[Dict[str, str]],
+        Field(
+            description=(
+                "The custom tags to associate with the volume."
+                " The tags also propagated to the underlying backend resources."
+                " If there is a conflict with backend-level tags, does not override them"
+            )
+        ),
+    ] = None
+
+    _validate_tags = validator("tags", pre=True, allow_reuse=True)(tags_validator)
 
     @property
     def size_gb(self) -> int:

--- a/src/dstack/_internal/core/models/volumes.py
+++ b/src/dstack/_internal/core/models/volumes.py
@@ -49,7 +49,7 @@ class VolumeConfiguration(CoreModel):
         Field(
             description=(
                 "The custom tags to associate with the volume."
-                " The tags also propagated to the underlying backend resources."
+                " The tags are also propagated to the underlying backend resources."
                 " If there is a conflict with backend-level tags, does not override them"
             )
         ),

--- a/src/dstack/_internal/server/services/fleets.py
+++ b/src/dstack/_internal/server/services/fleets.py
@@ -402,6 +402,7 @@ async def create_fleet_instance_model(
         placement_group_name=placement_group_name,
         reservation=reservation,
         blocks=spec.configuration.blocks,
+        tags=spec.configuration.tags,
     )
     return instance_model
 

--- a/src/dstack/_internal/server/services/gateways/__init__.py
+++ b/src/dstack/_internal/server/services/gateways/__init__.py
@@ -106,6 +106,7 @@ async def create_gateway_compute(
         public_ip=configuration.public_ip,
         ssh_key_pub=gateway_ssh_public_key,
         certificate=configuration.certificate,
+        tags=configuration.tags,
     )
 
     gpd = await run_async(

--- a/src/dstack/_internal/server/services/instances.py
+++ b/src/dstack/_internal/server/services/instances.py
@@ -1,7 +1,7 @@
 import uuid
 from collections.abc import Container, Iterable
 from datetime import datetime, timezone
-from typing import List, Literal, Optional, Union
+from typing import Dict, List, Literal, Optional, Union
 
 import gpuhunt
 from sqlalchemy import and_, or_, select
@@ -411,6 +411,7 @@ async def create_instance_model(
     placement_group_name: Optional[str],
     reservation: Optional[str],
     blocks: Union[Literal["auto"], int],
+    tags: Optional[Dict[str, str]],
 ) -> InstanceModel:
     termination_policy, termination_idle_time = get_termination(
         profile, DEFAULT_FLEET_TERMINATION_IDLE_TIME
@@ -428,6 +429,7 @@ async def create_instance_model(
         instance_id=str(instance_id),
         placement_group_name=placement_group_name,
         reservation=reservation,
+        tags=tags,
     )
     instance = InstanceModel(
         id=instance_id,

--- a/src/dstack/_internal/utils/tags.py
+++ b/src/dstack/_internal/utils/tags.py
@@ -1,0 +1,42 @@
+import re
+from typing import Dict, Optional
+
+# dstack resource tags allow alphanumeric tags with some special symbols in values.
+# Should be valid across most backends (e.g. AWS).
+# Does not guarantee that they are valid across all backends (e.g. GCP).
+# So backends need to filter bad tags out.
+TAG_KEY_PATTERN = re.compile(r"^[_\-a-zA-Z0-9]{1,60}$")
+TAG_VALUE_PATTERN = re.compile(r"^[a-zA-Z0-9 .:/=_\-+@]{0,256}$")
+
+
+def tags_validator(tags: Optional[Dict[str, str]]) -> Optional[Dict[str, str]]:
+    if tags is None:
+        return
+    validate_tags(tags)
+    return tags
+
+
+def validate_tags(tags: Dict[str, str]):
+    for k, v in tags.items():
+        _validate_tag(k, v)
+
+
+def _validate_tag(key: str, value: str):
+    if not is_valid_tag_key(key):
+        raise ValueError(
+            f"Invalid tag key {key}. The key must match regex '{TAG_KEY_PATTERN.pattern}'"
+        )
+    if not is_valid_tag_value(value):
+        raise ValueError(
+            f"Invalid tag value {value}. The value must match regex '{TAG_VALUE_PATTERN.pattern}'"
+        )
+
+
+def is_valid_tag_key(name: str) -> bool:
+    match = re.match(TAG_KEY_PATTERN, name)
+    return match is not None
+
+
+def is_valid_tag_value(value: str) -> bool:
+    match = re.match(TAG_VALUE_PATTERN, value)
+    return match is not None

--- a/src/dstack/api/server/_fleets.py
+++ b/src/dstack/api/server/_fleets.py
@@ -67,6 +67,10 @@ def _get_fleet_spec_excludes(fleet_spec: FleetSpec) -> Optional[Dict]:
     profile = fleet_spec.profile
     if profile.fleets is None:
         profile_excludes.add("fleets")
+    if fleet_spec.configuration.tags is None:
+        configuration_excludes["tags"] = True
+    if profile.tags is None:
+        profile_excludes.add("tags")
     if configuration_excludes:
         spec_excludes["configuration"] = configuration_excludes
     if profile_excludes:

--- a/src/dstack/api/server/_runs.py
+++ b/src/dstack/api/server/_runs.py
@@ -113,6 +113,10 @@ def _get_run_spec_excludes(run_spec: RunSpec) -> Optional[Dict]:
         configuration_excludes["fleets"] = True
     if profile is not None and profile.fleets is None:
         profile_excludes.add("fleets")
+    if configuration.tags is None:
+        configuration_excludes["tags"] = True
+    if profile is not None and profile.tags is None:
+        profile_excludes.add("tags")
     if (
         is_core_model_instance(configuration, ServiceConfiguration)
         and not configuration.rate_limits

--- a/src/dstack/api/server/_volumes.py
+++ b/src/dstack/api/server/_volumes.py
@@ -45,7 +45,6 @@ def _get_volume_configuration_excludes(configuration: VolumeConfiguration) -> Di
     clients backward-compatibility with older servers.
     """
     configuration_excludes = {}
-    # Fields can be excluded like this:
-    # if configuration.availability_zone is None:
-    #     configuration_excludes["availability_zone"] = True
+    if configuration.tags is None:
+        configuration_excludes["tags"] = True
     return {"configuration": configuration_excludes}

--- a/src/tests/_internal/server/routers/test_fleets.py
+++ b/src/tests/_internal/server/routers/test_fleets.py
@@ -349,6 +349,7 @@ class TestCreateFleet:
                     "name": "test-fleet",
                     "reservation": None,
                     "blocks": 1,
+                    "tags": None,
                 },
                 "profile": {
                     "backends": None,
@@ -367,6 +368,7 @@ class TestCreateFleet:
                     "default": False,
                     "reservation": None,
                     "fleets": None,
+                    "tags": None,
                 },
                 "autocreated": False,
             },
@@ -468,6 +470,7 @@ class TestCreateFleet:
                     "name": spec.configuration.name,
                     "reservation": None,
                     "blocks": 1,
+                    "tags": None,
                 },
                 "profile": {
                     "backends": None,
@@ -486,6 +489,7 @@ class TestCreateFleet:
                     "default": False,
                     "reservation": None,
                     "fleets": None,
+                    "tags": None,
                 },
                 "autocreated": False,
             },

--- a/src/tests/_internal/server/routers/test_gateways.py
+++ b/src/tests/_internal/server/routers/test_gateways.py
@@ -78,6 +78,7 @@ class TestListAndGetGateways:
                     "default": False,
                     "public_ip": True,
                     "certificate": {"type": "lets-encrypt"},
+                    "tags": None,
                 },
             }
         ]
@@ -128,6 +129,7 @@ class TestListAndGetGateways:
                 "default": False,
                 "public_ip": True,
                 "certificate": {"type": "lets-encrypt"},
+                "tags": None,
             },
         }
 
@@ -207,6 +209,7 @@ class TestCreateGateway:
                 "default": True,
                 "public_ip": True,
                 "certificate": {"type": "lets-encrypt"},
+                "tags": None,
             },
         }
 
@@ -258,6 +261,7 @@ class TestCreateGateway:
                 "default": True,
                 "public_ip": True,
                 "certificate": {"type": "lets-encrypt"},
+                "tags": None,
             },
         }
 
@@ -385,6 +389,7 @@ class TestDefaultGateway:
                 "default": True,
                 "public_ip": True,
                 "certificate": {"type": "lets-encrypt"},
+                "tags": None,
             },
         }
 
@@ -506,6 +511,7 @@ class TestDeleteGateway:
                     "default": False,
                     "public_ip": True,
                     "certificate": {"type": "lets-encrypt"},
+                    "tags": None,
                 },
             }
         ]
@@ -574,6 +580,7 @@ class TestUpdateGateway:
                 "default": False,
                 "public_ip": True,
                 "certificate": {"type": "lets-encrypt"},
+                "tags": None,
             },
         }
 

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -125,6 +125,7 @@ def get_dev_env_run_plan_dict(
                 "utilization_policy": None,
                 "reservation": None,
                 "fleets": None,
+                "tags": None,
             },
             "configuration_path": "dstack.yaml",
             "profile": {
@@ -144,6 +145,7 @@ def get_dev_env_run_plan_dict(
                 "utilization_policy": None,
                 "reservation": None,
                 "fleets": None,
+                "tags": None,
             },
             "repo_code_hash": None,
             "repo_data": {"repo_dir": "/repo", "repo_type": "local"},
@@ -277,6 +279,7 @@ def get_dev_env_run_dict(
                 "utilization_policy": None,
                 "reservation": None,
                 "fleets": None,
+                "tags": None,
             },
             "configuration_path": "dstack.yaml",
             "profile": {
@@ -296,6 +299,7 @@ def get_dev_env_run_dict(
                 "utilization_policy": None,
                 "reservation": None,
                 "fleets": None,
+                "tags": None,
             },
             "repo_code_hash": None,
             "repo_data": {"repo_dir": "/repo", "repo_type": "local"},

--- a/src/tests/_internal/utils/test_tags.py
+++ b/src/tests/_internal/utils/test_tags.py
@@ -1,0 +1,73 @@
+import pytest
+
+from dstack._internal.utils.tags import is_valid_tag_key, is_valid_tag_value, validate_tags
+
+
+class TestIsValidTagKey:
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "Environment",
+            "Project123",
+            "special-chars_",
+            "a" * 60,
+        ],
+    )
+    def test_valid_tag_key(self, key):
+        assert is_valid_tag_key(key)
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "key\twith\nweird\nspaces",
+            "",
+            "a" * 61,
+            "Invalid#Char",
+        ],
+    )
+    def test_invalid_tag_key(self, key):
+        assert not is_valid_tag_key(key)
+
+
+class TestIsValidTagValue:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "Production",
+            "v1.0",
+            "",
+            "a" * 256,
+        ],
+    )
+    def test_valid_tag_value(self, value):
+        assert is_valid_tag_value(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "a" * 257,
+            "Invalid#Value",
+        ],
+    )
+    def test_invalid_tag_value(self, value):
+        assert is_valid_tag_value(value) is False
+
+
+class TestValidateTags:
+    def test_validate_valid_tags(self):
+        tags = {
+            "Environment": "Production",
+            "project": "Tag_Validator",
+        }
+        assert validate_tags(tags) is None
+
+    @pytest.mark.parametrize(
+        "tags",
+        [
+            {"invalidkey!": "SomeValue"},
+            {"ValidKey": "Invalid#Value"},
+        ],
+    )
+    def test_validate_invalid_tags(self, tags):
+        with pytest.raises(ValueError):
+            validate_tags(tags)


### PR DESCRIPTION
Closes #2518 

The PR adds "tags" property to profiles and run, fleet, volume, and gateway configurations. The tags are propagated to the underlying cloud resources where possible together with backend-level tags.

Example:

```yaml
type: dev-environment
ide: vscode
tags:
  my_custom_tag: some_value
  another_tag: another_value_123
```