### PR TITLE
[runner] Rework env variables exporting

### DIFF
--- a/runner/internal/executor/executor_test.go
+++ b/runner/internal/executor/executor_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -206,4 +207,23 @@ func makeCodeTar(t *testing.T, path string) {
 		require.NoError(t, err)
 	}
 	require.NoError(t, tw.Close())
+}
+
+func TestWriteDstackProfile(t *testing.T) {
+	testCases := []string{
+		"",
+		"string 'with 'single' quotes",
+		"multi\nline\tstring",
+	}
+	tmp := t.TempDir()
+	path := tmp + "/dstack_profile"
+	script := fmt.Sprintf(`. '%s'; printf '%%s' "$VAR"`, path)
+	for _, value := range testCases {
+		env := map[string]string{"VAR": value}
+		writeDstackProfile(env, path)
+		cmd := exec.Command("/bin/sh", "-c", script)
+		out, err := cmd.Output()
+		assert.NoError(t, err)
+		assert.Equal(t, value, string(out))
+	}
 }

--- a/runner/internal/shim/docker.go
+++ b/runner/internal/shim/docker.go
@@ -896,7 +896,6 @@ func getSSHShellCommands(openSSHPort int, publicSSHKey string) []string {
 		"chmod 700 ~/.ssh",
 		fmt.Sprintf("echo '%s' > ~/.ssh/authorized_keys", publicSSHKey),
 		"chmod 600 ~/.ssh/authorized_keys",
-		`if [ -f ~/.profile ]; then sed -ie '1s@^@export PATH="'"$PATH"':$PATH"\n\n@' ~/.profile; fi`,
 		// regenerate host keys
 		"rm -rf /etc/ssh/ssh_host_*",
 		"ssh-keygen -A > /dev/null",
@@ -914,7 +913,6 @@ func getSSHShellCommands(openSSHPort int, publicSSHKey string) []string {
 				" -o PidFile=none"+
 				" -o PasswordAuthentication=no"+
 				" -o AllowTcpForwarding=yes"+
-				" -o PermitUserEnvironment=yes"+
 				" -o ClientAliveInterval=30"+
 				" -o ClientAliveCountMax=4",
 			openSSHPort,

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -555,9 +555,7 @@ def get_gateway_user_data(authorized_key: str) -> str:
     )
 
 
-def get_docker_commands(
-    authorized_keys: List[str], fix_path_in_dot_profile: bool = True
-) -> List[str]:
+def get_docker_commands(authorized_keys: list[str]) -> list[str]:
     authorized_keys_content = "\n".join(authorized_keys).strip()
     commands = [
         # save and unset ld.so variables
@@ -581,9 +579,6 @@ def get_docker_commands(
         "chmod 700 ~/.ssh",
         f"echo '{authorized_keys_content}' > ~/.ssh/authorized_keys",
         "chmod 600 ~/.ssh/authorized_keys",
-        r"""if [ -f ~/.profile ]; then sed -ie '1s@^@export PATH="'"$PATH"':$PATH"\n\n@' ~/.profile; fi"""
-        if fix_path_in_dot_profile
-        else ":",
         # regenerate host keys
         "rm -rf /etc/ssh/ssh_host_*",
         "ssh-keygen -A > /dev/null",
@@ -601,7 +596,6 @@ def get_docker_commands(
             " -o PidFile=none"
             " -o PasswordAuthentication=no"
             " -o AllowTcpForwarding=yes"
-            " -o PermitUserEnvironment=yes"
             " -o ClientAliveInterval=30"
             " -o ClientAliveCountMax=4"
         ),

--- a/src/dstack/_internal/core/backends/runpod/compute.py
+++ b/src/dstack/_internal/core/backends/runpod/compute.py
@@ -260,7 +260,7 @@ class RunpodCompute(
 
 
 def _get_docker_args(authorized_keys: List[str]) -> str:
-    commands = get_docker_commands(authorized_keys, False)
+    commands = get_docker_commands(authorized_keys)
     command = " && ".join(commands)
     docker_args = {"cmd": [command], "entrypoint": ["/bin/sh", "-c"]}
     docker_args_escaped = json.dumps(json.dumps(docker_args)).strip('"')


### PR DESCRIPTION
Replace `~/.ssh/environment` (processed by OpenSSH) with a shell script exporting env variables. The shell script is sourced in `/etc/profile`, which is only executed by login shell.

Advantages:

* multi-line variables support (e.g, `DSTACK_NODES_IPS`)
* no hard limit of 1000 variables
* shared by all users
* vars are not redefined by `pam_env` (`/etc/environment`)
* it's unlikely that `/tmp/dstack_profile` and `/etc/profile` are located on a volume, unlike `~/.ssh`; no need for cleanup

Tested supported shells:

* dash (Debian and derivatives, BusyBox distros, e.g., Alpine)
* bash as sh (Fedora and downstream distros)
* bash (almost every distro)

Not supported shells (do not use `/etc/profile`):

* zsh
* fish

Fixes: https://github.com/dstackai/dstack/issues/2371