### PR TITLE
Fix ruff version discrepancy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.3  # Should match requirements_dev.txt
+    rev: v0.11.6  # Should match pyproject.toml
     hooks:
       - id: ruff
         name: ruff common

--- a/examples/misc/airflow/dags/dstack_tasks.py
+++ b/examples/misc/airflow/dags/dstack_tasks.py
@@ -38,7 +38,7 @@ def dstack_tasks():
         dstack is installed into the main Airflow environment.
         NOT RECOMMENDED since dstack and Airflow may have conflicting dependencies.
         """
-        return f"cd {DSTACK_REPO_PATH}" " && dstack init" " && dstack apply -y -f task.dstack.yml"
+        return f"cd {DSTACK_REPO_PATH} && dstack init && dstack apply -y -f task.dstack.yml"
 
     @task.bash
     def dstack_cli_apply_venv() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dev = [
     "requests-mock>=1.12.1",
     "openai>=1.68.2",
     "freezegun>=1.5.1",
-    "ruff>=0.11.2",
+    "ruff==0.11.6",  # should match .pre-commit-config.yaml
     "testcontainers>=4.9.2",
     "pytest-xdist>=3.6.1",
 ]

--- a/scripts/oci_image_tools.py
+++ b/scripts/oci_image_tools.py
@@ -420,8 +420,7 @@ def find_image_in_regions(
         )
         if image is None:
             raise ScriptError(
-                f"Image {image_name} does not exist is {region_name}, "
-                f"compartment {compartment_id}"
+                f"Image {image_name} does not exist is {region_name}, compartment {compartment_id}"
             )
         images[region_name] = image
     return images

--- a/src/dstack/_internal/core/models/secrets.py
+++ b/src/dstack/_internal/core/models/secrets.py
@@ -6,4 +6,4 @@ class Secret(CoreModel):
     value: str
 
     def __str__(self) -> str:
-        return f'Secret(name="{self.name}", value={"*"*len(self.value)})'
+        return f'Secret(name="{self.name}", value={"*" * len(self.value)})'

--- a/src/dstack/_internal/server/services/docker.py
+++ b/src/dstack/_internal/server/services/docker.py
@@ -91,8 +91,7 @@ def get_image_config(image_name: str, registry_auth: Optional[RegistryAuth]) -> 
             config_resp = join_byte_stream_checked(config_stream, MAX_CONFIG_OBJECT_SIZE)
             if config_resp is None:
                 raise DockerRegistryError(
-                    "Image config object exceeds the size limit of "
-                    f"{MAX_CONFIG_OBJECT_SIZE} bytes"
+                    f"Image config object exceeds the size limit of {MAX_CONFIG_OBJECT_SIZE} bytes"
                 )
             return ImageConfigObject.__response__.parse_raw(config_resp)
 


### PR DESCRIPTION
Ruff versions in pre commit hooks and in the local environment got out of sync when moving to
pyproject.toml. The versions should be the same so that different ruff versions don't overwrite each
other's changes.