### PR TITLE
Include statics as artifacts in both wheel and sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,15 @@ dstack = "dstack._internal.cli.main:main"
 [tool.hatch.version]
 path = "src/dstack/version.py"
 
-[tool.hatch.build.targets.wheel.shared-data]
-"src/dstack/_internal/proxy/gateway/resources" = "dstack/_internal/proxy/gateway/resources"
-"src/dstack/_internal/server/statics" = "dstack/_internal/server/statics"
+[tool.hatch.build.targets.sdist]
+artifacts = [
+    "src/dstack/_internal/server/statics/**",
+]
+
+[tool.hatch.build.targets.wheel]
+artifacts = [
+    "src/dstack/_internal/server/statics/**",
+]
 
 [tool.hatch.metadata.hooks.fancy-pypi-readme]
 content-type = "text/markdown"


### PR DESCRIPTION
Fixes #2543 

Release 0.19.4 did not include UI due to migration to hatching (#2455). By default, hatching does not include files listed in .gitignore even if there are specified in tool.hatch.build.targets.wheel.shared-data.

The correct approach seems to be to specify [artifacts](https://hatch.pypa.io/1.13/config/build/#artifacts):

> If you want to include files that are [ignored by your VCS](https://hatch.pypa.io/1.13/config/build/#vcs), such as those that might be created by [build hooks](https://hatch.pypa.io/1.13/config/build/#build-hooks), you can use the artifacts option. This option is semantically equivalent to include.

Note that unlike `artifacts`, `include` does not work with files in .gitignore.

Also, included files has to be specified for different build targets separately: wheel and sdist.

