### PR TITLE
Support Nebius tenancies with multiple projects

### DIFF
--- a/docs/docs/concepts/backends.md
+++ b/docs/docs/concepts/backends.md
@@ -647,6 +647,25 @@ projects:
 
     </div>
 
+??? info "Projects"
+    If you have multiple projects per region, specify which ones to use, at most one per region.
+
+    <div editor-title="~/.dstack/server/config.yml">
+
+    ```yaml
+    type: nebius
+    projects:
+    - project-e00jt6t095t1ahrg4re30
+    - project-e01iahuh3cklave4ao1nv
+    creds:
+      type: service_account
+      service_account_id: serviceaccount-e00dhnv9ftgb3cqmej
+      public_key_id: publickey-e00ngaex668htswqy4
+      private_key_file: ~/path/to/key.pem
+    ```
+
+    </div>
+
 !!! info "Python version"
     Nebius is only supported if `dstack server` is running on Python 3.10 or higher.
 

--- a/src/dstack/_internal/core/backends/nebius/compute.py
+++ b/src/dstack/_internal/core/backends/nebius/compute.py
@@ -86,7 +86,11 @@ class NebiusCompute(
 
     @cached_property
     def _region_to_project_id(self) -> dict[str, str]:
-        return resources.get_region_to_project_id_map(self._sdk)
+        return resources.get_region_to_project_id_map(
+            self._sdk,
+            configured_regions=self.config.regions,
+            configured_project_ids=self.config.projects,
+        )
 
     def _get_subnet_id(self, region: str) -> str:
         if region not in self._subnet_id_cache:
@@ -100,7 +104,7 @@ class NebiusCompute(
     ) -> List[InstanceOfferWithAvailability]:
         offers = get_catalog_offers(
             backend=BackendType.NEBIUS,
-            locations=self.config.regions or list(self._region_to_project_id),
+            locations=list(self._region_to_project_id),
             requirements=requirements,
             extra_filter=_supported_instances,
             configurable_disk_size=CONFIGURABLE_DISK_SIZE,

--- a/src/dstack/_internal/core/backends/nebius/configurator.py
+++ b/src/dstack/_internal/core/backends/nebius/configurator.py
@@ -29,20 +29,14 @@ class NebiusConfigurator(Configurator):
         assert isinstance(config.creds, NebiusServiceAccountCreds)
         try:
             sdk = resources.make_sdk(config.creds)
-            available_regions = set(resources.get_region_to_project_id_map(sdk))
+            # check that it's possible to build the projects map with configured settings
+            resources.get_region_to_project_id_map(
+                sdk, configured_regions=config.regions, configured_project_ids=config.projects
+            )
         except (ValueError, RequestError) as e:
             raise_invalid_credentials_error(
                 fields=[["creds"]],
                 details=str(e),
-            )
-        if invalid_regions := set(config.regions or []) - available_regions:
-            raise_invalid_credentials_error(
-                fields=[["regions"]],
-                details=(
-                    f"Configured regions {invalid_regions} do not exist in this Nebius tenancy."
-                    " Omit `regions` to use all regions or select some of the available regions:"
-                    f" {available_regions}"
-                ),
             )
 
     def create_backend(

--- a/src/dstack/_internal/core/backends/nebius/models.py
+++ b/src/dstack/_internal/core/backends/nebius/models.py
@@ -5,6 +5,8 @@ from pydantic import Field, root_validator
 from dstack._internal.core.backends.base.models import fill_data
 from dstack._internal.core.models.common import CoreModel
 
+DEFAULT_PROJECT_NAME_PREFIX = "default-project"
+
 
 class NebiusServiceAccountCreds(CoreModel):
     type: Annotated[Literal["service_account"], Field(description="The type of credentials")] = (
@@ -70,9 +72,20 @@ class NebiusBackendConfig(CoreModel):
         Literal["nebius"],
         Field(description="The type of backend"),
     ] = "nebius"
+    projects: Annotated[
+        Optional[list[str]],
+        Field(
+            description=(
+                "The list of allowed Nebius project IDs."
+                " Omit to use the default project in each region."
+                " The project is considered default if it is the only project in the region"
+                f" or if its name starts with `{DEFAULT_PROJECT_NAME_PREFIX}`"
+            )
+        ),
+    ] = None
     regions: Annotated[
         Optional[list[str]],
-        Field(description="The list of Nebius regions. Omit to use all regions"),
+        Field(description="The list of allowed Nebius regions. Omit to allow all regions"),
     ] = None
 
 

--- a/src/tests/_internal/server/routers/test_backends.py
+++ b/src/tests/_internal/server/routers/test_backends.py
@@ -1,6 +1,8 @@
 import json
 import sys
+from collections.abc import Sequence
 from datetime import datetime, timezone
+from typing import Any, Optional
 from unittest.mock import Mock, patch
 
 import pytest
@@ -195,28 +197,17 @@ class TestCreateBackend:
     @pytest.mark.skipif(sys.version_info < (3, 10), reason="Nebius requires Python 3.10")
     @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     class TestNebius:
-        async def test_creates(self, test_db, session: AsyncSession, client: AsyncClient):
-            user = await create_user(session=session, global_role=GlobalRole.USER)
-            project = await create_project(session=session, owner=user)
-            await add_project_member(
-                session=session, project=project, user=user, project_role=ProjectRole.ADMIN
-            )
-            body = {
-                "type": "nebius",
-                "creds": FAKE_NEBIUS_SERVICE_ACCOUNT_CREDS,
-            }
-            with patch(
-                "dstack._internal.core.backends.nebius.resources.get_region_to_project_id_map"
-            ) as get_region_to_project_id_map:
-                get_region_to_project_id_map.return_value = {"eu-north1": "project-e00test"}
-                response = await client.post(
-                    f"/api/project/{project.name}/backends/create",
-                    headers=get_auth_headers(user.token),
-                    json=body,
-                )
-            assert response.status_code == 200, response.json()
-            res = await session.execute(select(BackendModel))
-            assert len(res.scalars().all()) == 1
+        @staticmethod
+        def project(
+            id: str = "project-e00test",
+            name: str = "default-project-eu-north1",
+            region: str = "eu-north1",
+        ):
+            project = Mock()
+            project.metadata.id = id
+            project.metadata.name = name
+            project.status.region = region
+            return project
 
         async def test_not_creates_with_invalid_creds(
             self, test_db, session: AsyncSession, client: AsyncClient
@@ -231,9 +222,9 @@ class TestCreateBackend:
                 "creds": FAKE_NEBIUS_SERVICE_ACCOUNT_CREDS,
             }
             with patch(
-                "dstack._internal.core.backends.nebius.resources.get_region_to_project_id_map"
-            ) as get_region_to_project_id_map:
-                get_region_to_project_id_map.side_effect = ValueError()
+                "dstack._internal.core.backends.nebius.resources.list_tenant_projects"
+            ) as projects_mock:
+                projects_mock.side_effect = ValueError()
                 response = await client.post(
                     f"/api/project/{project.name}/backends/create",
                     headers=get_auth_headers(user.token),
@@ -243,8 +234,101 @@ class TestCreateBackend:
             res = await session.execute(select(BackendModel))
             assert len(res.scalars().all()) == 0
 
-        async def test_creates_with_regions(
-            self, test_db, session: AsyncSession, client: AsyncClient
+        @pytest.mark.parametrize(
+            ("config_regions", "config_projects", "mocked_projects", "error"),
+            [
+                pytest.param(
+                    None,
+                    None,
+                    [project()],
+                    None,
+                    id="default",
+                ),
+                pytest.param(
+                    ["eu-north1"],
+                    None,
+                    [
+                        project("project-e00test", "default-project-eu-north1", "eu-north1"),
+                        project("project-e01test", "default-project-eu-west1", "eu-west1"),
+                    ],
+                    None,
+                    id="with-regions",
+                ),
+                pytest.param(
+                    ["xx-xxxx1"],
+                    None,
+                    [project()],
+                    "do not exist in this Nebius tenancy",
+                    id="error-invalid-regions",
+                ),
+                pytest.param(
+                    ["eu-north1"],
+                    None,
+                    [
+                        project("project-e00test0", "default-project-eu-north1", "eu-north1"),
+                        project("project-e00test1", "non-default-project", "eu-north1"),
+                    ],
+                    None,
+                    id="finds-default-project-among-many",
+                ),
+                pytest.param(
+                    ["eu-north1"],
+                    None,
+                    [
+                        project("project-e00test0", "non-default-project-0", "eu-north1"),
+                        project("project-e00test1", "non-default-project-1", "eu-north1"),
+                    ],
+                    "Could not find the default project in region eu-north1",
+                    id="error-no-default-project",
+                ),
+                pytest.param(
+                    None,
+                    ["project-e00test0"],
+                    [
+                        project("project-e00test0", "non-default-project-0", "eu-north1"),
+                        project("project-e00test1", "non-default-project-1", "eu-north1"),
+                    ],
+                    None,
+                    id="with-projects",
+                ),
+                pytest.param(
+                    None,
+                    ["project-e00xxxx"],
+                    [project()],
+                    "not found in this Nebius tenancy",
+                    id="error-invalid-projects",
+                ),
+                pytest.param(
+                    None,
+                    ["project-e00test0", "project-e00test1"],
+                    [
+                        project("project-e00test0", "non-default-project-0", "eu-north1"),
+                        project("project-e00test1", "non-default-project-1", "eu-north1"),
+                    ],
+                    "both belong to the same region",
+                    id="error-multiple-projects-in-same-region",
+                ),
+                pytest.param(
+                    ["eu-north1"],
+                    ["project-e00test"],
+                    [
+                        project("project-e00test", "default-project-eu-north1", "eu-north1"),
+                        project("project-e01test", "default-project-eu-west1", "eu-west1"),
+                    ],
+                    None,
+                    id="with-regions-and-projects",
+                ),
+            ],
+        )
+        async def test_create(
+            self,
+            test_db,
+            session: AsyncSession,
+            client: AsyncClient,
+            config_regions: Optional[list[str]],
+            config_projects: Optional[list[str]],
+            mocked_projects: Sequence[Any],
+            error: Optional[str],
         ):
             user = await create_user(session=session, global_role=GlobalRole.USER)
             project = await create_project(session=session, owner=user)
@@ -254,49 +338,27 @@ class TestCreateBackend:
             body = {
                 "type": "nebius",
                 "creds": FAKE_NEBIUS_SERVICE_ACCOUNT_CREDS,
-                "regions": ["eu-north1"],
+                "regions": config_regions,
+                "projects": config_projects,
             }
             with patch(
-                "dstack._internal.core.backends.nebius.resources.get_region_to_project_id_map"
-            ) as get_region_to_project_id_map:
-                get_region_to_project_id_map.return_value = {
-                    "eu-north1": "project-e00test",
-                    "eu-west1": "project-e01test",
-                }
+                "dstack._internal.core.backends.nebius.resources.list_tenant_projects"
+            ) as projects_mock:
+                projects_mock.return_value = mocked_projects
                 response = await client.post(
                     f"/api/project/{project.name}/backends/create",
                     headers=get_auth_headers(user.token),
                     json=body,
                 )
-            assert response.status_code == 200, response.json()
-            res = await session.execute(select(BackendModel))
-            assert len(res.scalars().all()) == 1
-
-        async def test_not_creates_with_invalid_regions(
-            self, test_db, session: AsyncSession, client: AsyncClient
-        ):
-            user = await create_user(session=session, global_role=GlobalRole.USER)
-            project = await create_project(session=session, owner=user)
-            await add_project_member(
-                session=session, project=project, user=user, project_role=ProjectRole.ADMIN
-            )
-            body = {
-                "type": "nebius",
-                "creds": FAKE_NEBIUS_SERVICE_ACCOUNT_CREDS,
-                "regions": ["xx-xxxx1"],
-            }
-            with patch(
-                "dstack._internal.core.backends.nebius.resources.get_region_to_project_id_map"
-            ) as get_region_to_project_id_map:
-                get_region_to_project_id_map.return_value = {"eu-north1": "project-e00test"}
-                response = await client.post(
-                    f"/api/project/{project.name}/backends/create",
-                    headers=get_auth_headers(user.token),
-                    json=body,
-                )
-            assert response.status_code == 400, response.json()
-            res = await session.execute(select(BackendModel))
-            assert len(res.scalars().all()) == 0
+            if not error:
+                assert response.status_code == 200, response.json()
+                res = await session.execute(select(BackendModel))
+                assert len(res.scalars().all()) == 1
+            else:
+                assert response.status_code == 400, response.json()
+                assert error in response.json()["detail"][0]["msg"]
+                res = await session.execute(select(BackendModel))
+                assert len(res.scalars().all()) == 0
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)

--- a/src/tests/_internal/server/routers/test_backends.py
+++ b/src/tests/_internal/server/routers/test_backends.py
@@ -59,6 +59,18 @@ SAMPLE_OCI_SUBNETS = {
 }
 
 
+def _nebius_project(
+    id: str = "project-e00test",
+    name: str = "default-project-eu-north1",
+    region: str = "eu-north1",
+):
+    project = Mock()
+    project.metadata.id = id
+    project.metadata.name = name
+    project.status.region = region
+    return project
+
+
 class TestListBackendTypes:
     @pytest.mark.asyncio
     async def test_returns_backend_types(self, client: AsyncClient):
@@ -197,18 +209,6 @@ class TestCreateBackend:
     @pytest.mark.skipif(sys.version_info < (3, 10), reason="Nebius requires Python 3.10")
     @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     class TestNebius:
-        @staticmethod
-        def project(
-            id: str = "project-e00test",
-            name: str = "default-project-eu-north1",
-            region: str = "eu-north1",
-        ):
-            project = Mock()
-            project.metadata.id = id
-            project.metadata.name = name
-            project.status.region = region
-            return project
-
         async def test_not_creates_with_invalid_creds(
             self, test_db, session: AsyncSession, client: AsyncClient
         ):
@@ -240,7 +240,7 @@ class TestCreateBackend:
                 pytest.param(
                     None,
                     None,
-                    [project()],
+                    [_nebius_project()],
                     None,
                     id="default",
                 ),
@@ -248,8 +248,10 @@ class TestCreateBackend:
                     ["eu-north1"],
                     None,
                     [
-                        project("project-e00test", "default-project-eu-north1", "eu-north1"),
-                        project("project-e01test", "default-project-eu-west1", "eu-west1"),
+                        _nebius_project(
+                            "project-e00test", "default-project-eu-north1", "eu-north1"
+                        ),
+                        _nebius_project("project-e01test", "default-project-eu-west1", "eu-west1"),
                     ],
                     None,
                     id="with-regions",
@@ -257,7 +259,7 @@ class TestCreateBackend:
                 pytest.param(
                     ["xx-xxxx1"],
                     None,
-                    [project()],
+                    [_nebius_project()],
                     "do not exist in this Nebius tenancy",
                     id="error-invalid-regions",
                 ),
@@ -265,8 +267,10 @@ class TestCreateBackend:
                     ["eu-north1"],
                     None,
                     [
-                        project("project-e00test0", "default-project-eu-north1", "eu-north1"),
-                        project("project-e00test1", "non-default-project", "eu-north1"),
+                        _nebius_project(
+                            "project-e00test0", "default-project-eu-north1", "eu-north1"
+                        ),
+                        _nebius_project("project-e00test1", "non-default-project", "eu-north1"),
                     ],
                     None,
                     id="finds-default-project-among-many",
@@ -275,8 +279,8 @@ class TestCreateBackend:
                     ["eu-north1"],
                     None,
                     [
-                        project("project-e00test0", "non-default-project-0", "eu-north1"),
-                        project("project-e00test1", "non-default-project-1", "eu-north1"),
+                        _nebius_project("project-e00test0", "non-default-project-0", "eu-north1"),
+                        _nebius_project("project-e00test1", "non-default-project-1", "eu-north1"),
                     ],
                     "Could not find the default project in region eu-north1",
                     id="error-no-default-project",
@@ -285,8 +289,8 @@ class TestCreateBackend:
                     None,
                     ["project-e00test0"],
                     [
-                        project("project-e00test0", "non-default-project-0", "eu-north1"),
-                        project("project-e00test1", "non-default-project-1", "eu-north1"),
+                        _nebius_project("project-e00test0", "non-default-project-0", "eu-north1"),
+                        _nebius_project("project-e00test1", "non-default-project-1", "eu-north1"),
                     ],
                     None,
                     id="with-projects",
@@ -294,7 +298,7 @@ class TestCreateBackend:
                 pytest.param(
                     None,
                     ["project-e00xxxx"],
-                    [project()],
+                    [_nebius_project()],
                     "not found in this Nebius tenancy",
                     id="error-invalid-projects",
                 ),
@@ -302,8 +306,8 @@ class TestCreateBackend:
                     None,
                     ["project-e00test0", "project-e00test1"],
                     [
-                        project("project-e00test0", "non-default-project-0", "eu-north1"),
-                        project("project-e00test1", "non-default-project-1", "eu-north1"),
+                        _nebius_project("project-e00test0", "non-default-project-0", "eu-north1"),
+                        _nebius_project("project-e00test1", "non-default-project-1", "eu-north1"),
                     ],
                     "both belong to the same region",
                     id="error-multiple-projects-in-same-region",
@@ -312,8 +316,10 @@ class TestCreateBackend:
                     ["eu-north1"],
                     ["project-e00test"],
                     [
-                        project("project-e00test", "default-project-eu-north1", "eu-north1"),
-                        project("project-e01test", "default-project-eu-west1", "eu-west1"),
+                        _nebius_project(
+                            "project-e00test", "default-project-eu-north1", "eu-north1"
+                        ),
+                        _nebius_project("project-e01test", "default-project-eu-west1", "eu-west1"),
                     ],
                     None,
                     id="with-regions-and-projects",


### PR DESCRIPTION
As it turns out, Nebius tenancies can have more than one project per region, this feature is just not public yet.

Address such tenancies in `dstack`:
- Allow configuring projects in the backend config.
- When projects are not configured and `dstack` cannot detect the default project, return a backend configuration error, as this most likely means the backend needs additional configuration.