### PR TITLE
Revert "Use AS_COMPACT collocation for gcp placement groups (#2587)"

### DIFF
--- a/src/dstack/_internal/core/backends/gcp/compute.py
+++ b/src/dstack/_internal/core/backends/gcp/compute.py
@@ -411,10 +411,8 @@ class GCPCompute(
             name=placement_group.name,
             region=placement_group.configuration.region,
             group_placement_policy=compute_v1.ResourcePolicyGroupPlacementPolicy(
-                # GCP documents only collocation="COLLOCATED"
-                # but collocation="AS_COMPACT" actually places VMs on the same host
-                # and improves networking performance. Discovered with Gemini.
-                collocation="AS_COMPACT",
+                availability_domain_count=1,
+                collocation="COLLOCATED",
             ),
         )
         self.resource_policies_client.insert(


### PR DESCRIPTION
This reverts commit fd0c144259c51ef7e841215d96a0c961ea1e816d.

Fixes: https://github.com/dstackai/dstack/issues/2591