### PR TITLE
Fix: handle OSError from os.get_terminal_size() in CLI table rendering for non-TTY environments

### DIFF
--- a/src/dstack/_internal/cli/utils/run.py
+++ b/src/dstack/_internal/cli/utils/run.py
@@ -95,7 +95,11 @@ def print_run_plan(
             props.add_row(th("Inactivity duration"), inactivity_duration)
     props.add_row(th("Reservation"), run_spec.configuration.reservation or "-")
 
-    offers = Table(box=None, expand=os.get_terminal_size()[0] <= 110)
+    try:
+        width = os.get_terminal_size()[0]
+    except OSError:
+        width = 120  # Default width for non-TTY
+    offers = Table(box=None, expand=width <= 110)
     offers.add_column("#")
     offers.add_column("BACKEND", style="grey58", ratio=2)
     offers.add_column("RESOURCES", ratio=4)
@@ -149,7 +153,11 @@ def print_run_plan(
 def get_runs_table(
     runs: List[Run], verbose: bool = False, format_date: DateFormatter = pretty_date
 ) -> Table:
-    table = Table(box=None, expand=os.get_terminal_size()[0] <= 110)
+    try:
+        width = os.get_terminal_size()[0]
+    except OSError:
+        width = 120  # Default width for non-TTY
+    table = Table(box=None, expand=width <= 110)
     table.add_column("NAME", style="bold", no_wrap=True, ratio=2)
     table.add_column("BACKEND", style="grey58", ratio=2)
     table.add_column("RESOURCES", ratio=3 if not verbose else 2)

--- a/src/dstack/_internal/cli/utils/run.py
+++ b/src/dstack/_internal/cli/utils/run.py
@@ -1,4 +1,4 @@
-import os
+import shutil
 from typing import Any, Dict, List, Optional, Union
 
 from rich.markup import escape
@@ -95,11 +95,7 @@ def print_run_plan(
             props.add_row(th("Inactivity duration"), inactivity_duration)
     props.add_row(th("Reservation"), run_spec.configuration.reservation or "-")
 
-    try:
-        width = os.get_terminal_size()[0]
-    except OSError:
-        width = 120  # Default width for non-TTY
-    offers = Table(box=None, expand=width <= 110)
+    offers = Table(box=None, expand=shutil.get_terminal_size(fallback=(120, 40)).columns <= 110)
     offers.add_column("#")
     offers.add_column("BACKEND", style="grey58", ratio=2)
     offers.add_column("RESOURCES", ratio=4)
@@ -153,11 +149,7 @@ def print_run_plan(
 def get_runs_table(
     runs: List[Run], verbose: bool = False, format_date: DateFormatter = pretty_date
 ) -> Table:
-    try:
-        width = os.get_terminal_size()[0]
-    except OSError:
-        width = 120  # Default width for non-TTY
-    table = Table(box=None, expand=width <= 110)
+    table = Table(box=None, expand=shutil.get_terminal_size(fallback=(120, 40)).columns <= 110)
     table.add_column("NAME", style="bold", no_wrap=True, ratio=2)
     table.add_column("BACKEND", style="grey58", ratio=2)
     table.add_column("RESOURCES", ratio=3 if not verbose else 2)


### PR DESCRIPTION
## Summary

This PR fixes a bug in the dstack CLI where running commands like `dstack ps` in a non-interactive environment (subprocess, PTY, or script) would crash with:

Traceback (most recent call last):
  File "/Users/x/.local/bin/dstack", line 10, in <module>
    sys.exit(main())
  File "/Users/x/.local/share/uv/tools/dstack/lib/python3.10/site-packages/dstack/_internal/cli/main.py", line 87, in main
    args.func(args)
  File "/Users/x/.local/share/uv/tools/dstack/lib/python3.10/site-packages/dstack/_internal/cli/commands/ps.py", line 44, in _command
    console.print(run_utils.get_runs_table(runs, verbose=args.verbose))
  File "/Users/x/.local/share/uv/tools/dstack/lib/python3.10/site-packages/dstack/_internal/cli/utils/run.py", line 152, in get_runs_table
    table = Table(box=None, expand=os.get_terminal_size()[0] <= 110)
OSError: [Errno 25] Inappropriate ioctl for device


The error was caused by unguarded calls to `os.get_terminal_size()` in the CLI’s table rendering code. This patch wraps those calls in a try/except block and uses a default width (120) if the call fails, ensuring the CLI works in both TTY and non-TTY environments.

## Details

- All uses of `os.get_terminal_size()` are now wrapped in try/except.
- If an OSError is raised, a default width of 120 is used.
- This prevents crashes when running dstack in automation, CI, or as a subprocess.

## Steps to Reproduce

1. Run `dstack ps` in a Python subprocess or PTY (not a real terminal).
2. Observe the crash with OSError.
3. With this patch, the command works and outputs as expected.

## Why this is needed

- Many users want to automate or monitor dstack runs from scripts or other tools.
- The CLI should not crash in non-interactive environments.

## Related Issue

- https://github.com/dstackai/dstack/issues/2598

---

**Thank you for reviewing!**