### PR TITLE
Support Nebius InfiniBand clusters

### DIFF
--- a/src/dstack/_internal/core/backends/azure/compute.py
+++ b/src/dstack/_internal/core/backends/azure/compute.py
@@ -62,6 +62,7 @@ from dstack._internal.core.models.instances import (
     InstanceOfferWithAvailability,
     InstanceType,
 )
+from dstack._internal.core.models.placement import PlacementGroup
 from dstack._internal.core.models.resources import Memory, Range
 from dstack._internal.core.models.runs import JobProvisioningData, Requirements
 from dstack._internal.utils.logging import get_logger
@@ -109,6 +110,7 @@ class AzureCompute(
         self,
         instance_offer: InstanceOfferWithAvailability,
         instance_config: InstanceConfiguration,
+        placement_group: Optional[PlacementGroup],
     ) -> JobProvisioningData:
         instance_name = generate_unique_instance_name(
             instance_config, max_length=azure_resources.MAX_RESOURCE_NAME_LEN

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -178,7 +178,7 @@ class ComputeWithCreateInstanceSupport(ABC):
         )
         instance_offer = instance_offer.copy()
         self._restrict_instance_offer_az_to_volumes_az(instance_offer, volumes)
-        return self.create_instance(instance_offer, instance_config)
+        return self.create_instance(instance_offer, instance_config, placement_group=None)
 
     def _restrict_instance_offer_az_to_volumes_az(
         self,

--- a/src/dstack/_internal/core/backends/cudo/compute.py
+++ b/src/dstack/_internal/core/backends/cudo/compute.py
@@ -18,6 +18,7 @@ from dstack._internal.core.models.instances import (
     InstanceConfiguration,
     InstanceOfferWithAvailability,
 )
+from dstack._internal.core.models.placement import PlacementGroup
 from dstack._internal.core.models.runs import JobProvisioningData, Requirements
 from dstack._internal.utils.logging import get_logger
 
@@ -58,6 +59,7 @@ class CudoCompute(
         self,
         instance_offer: InstanceOfferWithAvailability,
         instance_config: InstanceConfiguration,
+        placement_group: Optional[PlacementGroup],
     ) -> JobProvisioningData:
         vm_id = generate_unique_instance_name(instance_config, max_length=MAX_RESOURCE_NAME_LEN)
         public_keys = instance_config.get_public_keys()

--- a/src/dstack/_internal/core/backends/datacrunch/compute.py
+++ b/src/dstack/_internal/core/backends/datacrunch/compute.py
@@ -20,6 +20,7 @@ from dstack._internal.core.models.instances import (
     InstanceOffer,
     InstanceOfferWithAvailability,
 )
+from dstack._internal.core.models.placement import PlacementGroup
 from dstack._internal.core.models.resources import Memory, Range
 from dstack._internal.core.models.runs import JobProvisioningData, Requirements
 from dstack._internal.utils.logging import get_logger
@@ -85,6 +86,7 @@ class DataCrunchCompute(
         self,
         instance_offer: InstanceOfferWithAvailability,
         instance_config: InstanceConfiguration,
+        placement_group: Optional[PlacementGroup],
     ) -> JobProvisioningData:
         instance_name = generate_unique_instance_name(
             instance_config, max_length=MAX_INSTANCE_NAME_LEN

--- a/src/dstack/_internal/core/backends/gcp/auth.py
+++ b/src/dstack/_internal/core/backends/gcp/auth.py
@@ -19,7 +19,7 @@ def authenticate(creds: AnyGCPCreds, project_id: Optional[str] = None) -> Tuple[
     credentials, credentials_project_id = get_credentials(creds)
     if project_id is None:
         # If project_id is not specified explicitly, try using credentials' project_id.
-        # Explicit project_id takes precedence bacause credentials' project_id may be irrelevant.
+        # Explicit project_id takes precedence because credentials' project_id may be irrelevant.
         # For example, with Workload Identity Federation for GKE, it's cluster project_id.
         project_id = credentials_project_id
     if project_id is None:

--- a/src/dstack/_internal/core/backends/lambdalabs/compute.py
+++ b/src/dstack/_internal/core/backends/lambdalabs/compute.py
@@ -20,6 +20,7 @@ from dstack._internal.core.models.instances import (
     InstanceOffer,
     InstanceOfferWithAvailability,
 )
+from dstack._internal.core.models.placement import PlacementGroup
 from dstack._internal.core.models.runs import JobProvisioningData, Requirements
 
 MAX_INSTANCE_NAME_LEN = 60
@@ -46,7 +47,10 @@ class LambdaCompute(
         return offers_with_availability
 
     def create_instance(
-        self, instance_offer: InstanceOfferWithAvailability, instance_config: InstanceConfiguration
+        self,
+        instance_offer: InstanceOfferWithAvailability,
+        instance_config: InstanceConfiguration,
+        placement_group: Optional[PlacementGroup],
     ) -> JobProvisioningData:
         instance_name = generate_unique_instance_name(
             instance_config, max_length=MAX_INSTANCE_NAME_LEN

--- a/src/dstack/_internal/core/backends/local/compute.py
+++ b/src/dstack/_internal/core/backends/local/compute.py
@@ -15,6 +15,7 @@ from dstack._internal.core.models.instances import (
     InstanceType,
     Resources,
 )
+from dstack._internal.core.models.placement import PlacementGroup
 from dstack._internal.core.models.runs import Job, JobProvisioningData, Requirements, Run
 from dstack._internal.core.models.volumes import Volume, VolumeProvisioningData
 from dstack._internal.utils.logging import get_logger
@@ -53,6 +54,7 @@ class LocalCompute(
         self,
         instance_offer: InstanceOfferWithAvailability,
         instance_config: InstanceConfiguration,
+        placement_group: Optional[PlacementGroup],
     ) -> JobProvisioningData:
         return JobProvisioningData(
             backend=instance_offer.backend,

--- a/src/dstack/_internal/core/backends/nebius/compute.py
+++ b/src/dstack/_internal/core/backends/nebius/compute.py
@@ -317,7 +317,10 @@ class NebiusCompute(
         backend_data = NebiusPlacementGroupBackendData.load(
             placement_group.provisioning_data.backend_data
         )
-        return backend_data.cluster.fabric in _get_suitable_infiniband_fabrics(instance_offer)
+        return (
+            backend_data.cluster is None
+            or backend_data.cluster.fabric in _get_suitable_infiniband_fabrics(instance_offer)
+        )
 
 
 class NebiusInstanceBackendData(CoreModel):

--- a/src/dstack/_internal/core/backends/nebius/compute.py
+++ b/src/dstack/_internal/core/backends/nebius/compute.py
@@ -1,6 +1,8 @@
 import json
+import random
 import shlex
 import time
+from dataclasses import dataclass
 from functools import cached_property
 from typing import List, Optional
 
@@ -13,13 +15,18 @@ from dstack._internal.core.backends.base.backend import Compute
 from dstack._internal.core.backends.base.compute import (
     ComputeWithCreateInstanceSupport,
     ComputeWithMultinodeSupport,
+    ComputeWithPlacementGroupSupport,
     generate_unique_instance_name,
     get_user_data,
 )
 from dstack._internal.core.backends.base.offers import get_catalog_offers
 from dstack._internal.core.backends.nebius import resources
 from dstack._internal.core.backends.nebius.models import NebiusConfig, NebiusServiceAccountCreds
-from dstack._internal.core.errors import BackendError, NotYetTerminated, ProvisioningError
+from dstack._internal.core.errors import (
+    BackendError,
+    NotYetTerminated,
+    ProvisioningError,
+)
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.common import CoreModel
 from dstack._internal.core.models.instances import (
@@ -27,6 +34,11 @@ from dstack._internal.core.models.instances import (
     InstanceConfiguration,
     InstanceOffer,
     InstanceOfferWithAvailability,
+)
+from dstack._internal.core.models.placement import (
+    PlacementGroup,
+    PlacementGroupProvisioningData,
+    PlacementStrategy,
 )
 from dstack._internal.core.models.resources import Memory, Range
 from dstack._internal.core.models.runs import JobProvisioningData, Requirements
@@ -69,9 +81,28 @@ SUPPORTED_PLATFORMS = [
 ]
 
 
+@dataclass(frozen=True)
+class InfinibandFabric:
+    name: str
+    platform: str
+    region: str
+
+
+# https://docs.nebius.com/compute/clusters/gpu#fabrics
+INFINIBAND_FABRICS = [
+    InfinibandFabric("fabric-2", "gpu-h100-sxm", "eu-north1"),
+    InfinibandFabric("fabric-3", "gpu-h100-sxm", "eu-north1"),
+    InfinibandFabric("fabric-4", "gpu-h100-sxm", "eu-north1"),
+    InfinibandFabric("fabric-5", "gpu-h200-sxm", "eu-west1"),
+    InfinibandFabric("fabric-6", "gpu-h100-sxm", "eu-north1"),
+    InfinibandFabric("fabric-7", "gpu-h200-sxm", "eu-north1"),
+]
+
+
 class NebiusCompute(
     ComputeWithCreateInstanceSupport,
     ComputeWithMultinodeSupport,
+    ComputeWithPlacementGroupSupport,
     Compute,
 ):
     def __init__(self, config: NebiusConfig):
@@ -121,6 +152,7 @@ class NebiusCompute(
         self,
         instance_offer: InstanceOfferWithAvailability,
         instance_config: InstanceConfiguration,
+        placement_group: Optional[PlacementGroup],
     ) -> JobProvisioningData:
         # NOTE: This method can block for a long time as it waits for the boot disk to be created
         # and the instance to enter the STARTING state. This has to be done in create_instance so
@@ -128,6 +160,14 @@ class NebiusCompute(
         # instance.
         instance_name = generate_unique_instance_name(instance_config)
         platform, preset = instance_offer.instance.name.split()
+        cluster_id = None
+        if placement_group:
+            assert placement_group.provisioning_data is not None
+            backend_data = NebiusPlacementGroupBackendData.load(
+                placement_group.provisioning_data.backend_data
+            )
+            if backend_data.cluster is not None:
+                cluster_id = backend_data.cluster.id
         create_disk_op = resources.create_disk(
             sdk=self._sdk,
             name=instance_name,
@@ -155,6 +195,7 @@ class NebiusCompute(
                 ),
                 platform=platform,
                 preset=preset,
+                cluster_id=cluster_id,
                 disk_id=create_disk_op.resource_id,
                 subnet_id=self._get_subnet_id(instance_offer.region),
             )
@@ -230,12 +271,74 @@ class NebiusCompute(
         with resources.ignore_errors([StatusCode.NOT_FOUND]):
             resources.delete_disk(self._sdk, backend_data_parsed.boot_disk_id)
 
+    def create_placement_group(
+        self,
+        placement_group: PlacementGroup,
+        master_instance_offer: InstanceOffer,
+    ) -> PlacementGroupProvisioningData:
+        assert placement_group.configuration.placement_strategy == PlacementStrategy.CLUSTER
+        backend_data = NebiusPlacementGroupBackendData(cluster=None)
+        # Only create a Nebius cluster if the instance supports it.
+        # For other instances, return dummy PlacementGroupProvisioningData.
+        if fabrics := _get_suitable_infiniband_fabrics(master_instance_offer):
+            fabric = random.choice(fabrics)
+            op = resources.create_cluster(
+                self._sdk,
+                name=placement_group.name,
+                project_id=self._region_to_project_id[placement_group.configuration.region],
+                fabric=fabric,
+            )
+            backend_data.cluster = NebiusClusterBackendData(id=op.resource_id, fabric=fabric)
+        return PlacementGroupProvisioningData(
+            backend=BackendType.NEBIUS,
+            backend_data=backend_data.json(),
+        )
+
+    def delete_placement_group(self, placement_group: PlacementGroup) -> None:
+        assert placement_group.provisioning_data is not None
+        backend_data = NebiusPlacementGroupBackendData.load(
+            placement_group.provisioning_data.backend_data
+        )
+        if backend_data.cluster is not None:
+            with resources.ignore_errors([StatusCode.NOT_FOUND]):
+                resources.delete_cluster(self._sdk, backend_data.cluster.id)
+
+    def is_suitable_placement_group(
+        self,
+        placement_group: PlacementGroup,
+        instance_offer: InstanceOffer,
+    ) -> bool:
+        if not (
+            placement_group.configuration.backend == BackendType.NEBIUS
+            and placement_group.configuration.region == instance_offer.region
+        ):
+            return False
+        assert placement_group.provisioning_data is not None
+        backend_data = NebiusPlacementGroupBackendData.load(
+            placement_group.provisioning_data.backend_data
+        )
+        return backend_data.cluster.fabric in _get_suitable_infiniband_fabrics(instance_offer)
+
 
 class NebiusInstanceBackendData(CoreModel):
     boot_disk_id: str
 
     @classmethod
     def load(cls, raw: Optional[str]) -> "NebiusInstanceBackendData":
+        assert raw is not None
+        return cls.__response__.parse_raw(raw)
+
+
+class NebiusClusterBackendData(CoreModel):
+    id: str
+    fabric: str
+
+
+class NebiusPlacementGroupBackendData(CoreModel):
+    cluster: Optional[NebiusClusterBackendData]
+
+    @classmethod
+    def load(cls, raw: Optional[str]) -> "NebiusPlacementGroupBackendData":
         assert raw is not None
         return cls.__response__.parse_raw(raw)
 
@@ -274,3 +377,15 @@ def _wait_for_instance(sdk: SDK, op: SDKOperation[Operation]) -> None:
 def _supported_instances(offer: InstanceOffer) -> bool:
     platform, _ = offer.instance.name.split()
     return platform in SUPPORTED_PLATFORMS and not offer.instance.resources.spot
+
+
+def _get_suitable_infiniband_fabrics(offer: InstanceOffer) -> list[str]:
+    if len(offer.instance.resources.gpus) < 8:
+        # From the create VM page in the Nebius Console:
+        # > Only virtual machines with at least 8 NVIDIA® Hopper® H100 or H200 GPUs
+        # > can be added to the cluster
+        return []
+    platform, _ = offer.instance.name.split()
+    return [
+        f.name for f in INFINIBAND_FABRICS if f.platform == platform and f.region == offer.region
+    ]

--- a/src/dstack/_internal/core/backends/oci/compute.py
+++ b/src/dstack/_internal/core/backends/oci/compute.py
@@ -23,6 +23,7 @@ from dstack._internal.core.models.instances import (
     InstanceOffer,
     InstanceOfferWithAvailability,
 )
+from dstack._internal.core.models.placement import PlacementGroup
 from dstack._internal.core.models.resources import Memory, Range
 from dstack._internal.core.models.runs import JobProvisioningData, Requirements
 
@@ -105,6 +106,7 @@ class OCICompute(
         self,
         instance_offer: InstanceOfferWithAvailability,
         instance_config: InstanceConfiguration,
+        placement_group: Optional[PlacementGroup],
     ) -> JobProvisioningData:
         region = self.regions[instance_offer.region]
 

--- a/src/dstack/_internal/core/backends/template/compute.py.jinja
+++ b/src/dstack/_internal/core/backends/template/compute.py.jinja
@@ -18,6 +18,7 @@ from dstack._internal.core.models.instances import (
     InstanceConfiguration,
     InstanceOfferWithAvailability,
 )
+from dstack._internal.core.models.placement import PlacementGroup
 from dstack._internal.core.models.runs import Job, JobProvisioningData, Requirements, Run
 from dstack._internal.core.models.volumes import Volume
 from dstack._internal.utils.logging import get_logger
@@ -64,6 +65,7 @@ class {{ backend_name }}Compute(
         self,
         instance_offer: InstanceOfferWithAvailability,
         instance_config: InstanceConfiguration,
+        placement_group: Optional[PlacementGroup],
     ) -> JobProvisioningData:
         # TODO: Implement if backend supports creating instances (VM-based).
         # Delete if backend can only run jobs (container-based).

--- a/src/dstack/_internal/core/backends/tensordock/compute.py
+++ b/src/dstack/_internal/core/backends/tensordock/compute.py
@@ -19,6 +19,7 @@ from dstack._internal.core.models.instances import (
     InstanceConfiguration,
     InstanceOfferWithAvailability,
 )
+from dstack._internal.core.models.placement import PlacementGroup
 from dstack._internal.core.models.runs import JobProvisioningData, Requirements
 from dstack._internal.utils.logging import get_logger
 
@@ -57,6 +58,7 @@ class TensorDockCompute(
         self,
         instance_offer: InstanceOfferWithAvailability,
         instance_config: InstanceConfiguration,
+        placement_group: Optional[PlacementGroup],
     ) -> JobProvisioningData:
         instance_name = generate_unique_instance_name(
             instance_config, max_length=MAX_INSTANCE_NAME_LEN

--- a/src/dstack/_internal/core/backends/vultr/compute.py
+++ b/src/dstack/_internal/core/backends/vultr/compute.py
@@ -22,6 +22,7 @@ from dstack._internal.core.models.instances import (
     InstanceOffer,
     InstanceOfferWithAvailability,
 )
+from dstack._internal.core.models.placement import PlacementGroup
 from dstack._internal.core.models.runs import JobProvisioningData, Requirements
 from dstack._internal.utils.logging import get_logger
 
@@ -58,7 +59,10 @@ class VultrCompute(
         return offers
 
     def create_instance(
-        self, instance_offer: InstanceOfferWithAvailability, instance_config: InstanceConfiguration
+        self,
+        instance_offer: InstanceOfferWithAvailability,
+        instance_config: InstanceConfiguration,
+        placement_group: Optional[PlacementGroup],
     ) -> JobProvisioningData:
         instance_name = generate_unique_instance_name(
             instance_config, max_length=MAX_INSTANCE_NAME_LEN

--- a/src/dstack/_internal/core/models/instances.py
+++ b/src/dstack/_internal/core/models/instances.py
@@ -105,7 +105,6 @@ class InstanceConfiguration(CoreModel):
     user: str  # dstack user name
     ssh_keys: List[SSHKey]
     instance_id: Optional[str] = None
-    placement_group_name: Optional[str] = None
     reservation: Optional[str] = None
     volumes: Optional[List[Volume]] = None
     tags: Optional[Dict[str, str]] = None

--- a/src/dstack/_internal/core/models/volumes.py
+++ b/src/dstack/_internal/core/models/volumes.py
@@ -159,7 +159,7 @@ class VolumeMountPoint(CoreModel):
             description=(
                 "The network volume name or the list of network volume names to mount."
                 " If a list is specified, one of the volumes in the list will be mounted."
-                " Specify volumes from different backends/regions to increase availability."
+                " Specify volumes from different backends/regions to increase availability"
             )
         ),
     ]

--- a/src/dstack/_internal/server/background/tasks/process_fleets.py
+++ b/src/dstack/_internal/server/background/tasks/process_fleets.py
@@ -1,15 +1,16 @@
-from sqlalchemy import select, update
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from dstack._internal.core.models.fleets import FleetStatus
 from dstack._internal.server.db import get_session_ctx
-from dstack._internal.server.models import FleetModel, PlacementGroupModel
+from dstack._internal.server.models import FleetModel
 from dstack._internal.server.services.fleets import (
     is_fleet_empty,
     is_fleet_in_use,
 )
 from dstack._internal.server.services.locking import get_locker
+from dstack._internal.server.services.placement import schedule_fleet_placement_groups_deletion
 from dstack._internal.utils.common import get_current_datetime
 from dstack._internal.utils.logging import get_logger
 
@@ -68,16 +69,6 @@ async def _autodelete_fleet(session: AsyncSession, fleet_model: FleetModel):
     fleet_model.status = FleetStatus.TERMINATED
     fleet_model.deleted = True
     fleet_model.last_processed_at = get_current_datetime()
-    await _mark_placement_groups_as_ready_for_deletion(session=session, fleet_model=fleet_model)
+    await schedule_fleet_placement_groups_deletion(session=session, fleet_id=fleet_model.id)
     await session.commit()
     logger.info("Fleet %s deleted", fleet_model.name)
-
-
-async def _mark_placement_groups_as_ready_for_deletion(
-    session: AsyncSession, fleet_model: FleetModel
-):
-    await session.execute(
-        update(PlacementGroupModel)
-        .where(PlacementGroupModel.fleet_id == fleet_model.id)
-        .values(fleet_deleted=True)
-    )

--- a/src/dstack/_internal/server/background/tasks/process_placement_groups.py
+++ b/src/dstack/_internal/server/background/tasks/process_placement_groups.py
@@ -66,7 +66,7 @@ async def _delete_placement_groups(
 
 
 async def _delete_placement_group(placement_group_model: PlacementGroupModel):
-    logger.info("Deleting placement group %s", placement_group_model.name)
+    logger.debug("Deleting placement group %s", placement_group_model.name)
     placement_group = placement_group_model_to_placement_group(placement_group_model)
     if placement_group.provisioning_data is None:
         logger.error(

--- a/src/dstack/_internal/server/models.py
+++ b/src/dstack/_internal/server/models.py
@@ -659,7 +659,8 @@ class PlacementGroupModel(BaseModel):
 
     fleet_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("fleets.id"))
     fleet: Mapped["FleetModel"] = relationship(foreign_keys=[fleet_id])
-    fleet_deleted: Mapped[bool] = mapped_column(Boolean, default=False)  # TODO: rename
+    # TODO: rename `fleet_deleted` -> `to_be_deleted`
+    fleet_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
 
     created_at: Mapped[datetime] = mapped_column(NaiveDateTime, default=get_current_datetime)
     last_processed_at: Mapped[datetime] = mapped_column(

--- a/src/dstack/_internal/server/models.py
+++ b/src/dstack/_internal/server/models.py
@@ -659,7 +659,7 @@ class PlacementGroupModel(BaseModel):
 
     fleet_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("fleets.id"))
     fleet: Mapped["FleetModel"] = relationship(foreign_keys=[fleet_id])
-    fleet_deleted: Mapped[bool] = mapped_column(Boolean, default=False)
+    fleet_deleted: Mapped[bool] = mapped_column(Boolean, default=False)  # TODO: rename
 
     created_at: Mapped[datetime] = mapped_column(NaiveDateTime, default=get_current_datetime)
     last_processed_at: Mapped[datetime] = mapped_column(

--- a/src/dstack/_internal/server/services/instances.py
+++ b/src/dstack/_internal/server/services/instances.py
@@ -408,7 +408,6 @@ async def create_instance_model(
     requirements: Requirements,
     instance_name: str,
     instance_num: int,
-    placement_group_name: Optional[str],
     reservation: Optional[str],
     blocks: Union[Literal["auto"], int],
     tags: Optional[Dict[str, str]],
@@ -427,7 +426,6 @@ async def create_instance_model(
         user=user.name,
         ssh_keys=[project_ssh_key],
         instance_id=str(instance_id),
-        placement_group_name=placement_group_name,
         reservation=reservation,
         tags=tags,
     )

--- a/src/dstack/_internal/server/services/offers.py
+++ b/src/dstack/_internal/server/services/offers.py
@@ -8,12 +8,14 @@ from dstack._internal.core.backends import (
     BACKENDS_WITH_RESERVATION_SUPPORT,
 )
 from dstack._internal.core.backends.base.backend import Backend
+from dstack._internal.core.backends.base.compute import ComputeWithPlacementGroupSupport
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.instances import (
     InstanceOfferWithAvailability,
     InstanceType,
     Resources,
 )
+from dstack._internal.core.models.placement import PlacementGroup
 from dstack._internal.core.models.profiles import Profile
 from dstack._internal.core.models.runs import JobProvisioningData, Requirements
 from dstack._internal.core.models.volumes import Volume
@@ -31,6 +33,7 @@ async def get_offers_by_requirements(
     volumes: Optional[List[List[Volume]]] = None,
     privileged: bool = False,
     instance_mounts: bool = False,
+    placement_group: Optional[PlacementGroup] = None,
     blocks: Union[int, Literal["auto"]] = 1,
 ) -> List[Tuple[Backend, InstanceOfferWithAvailability]]:
     backends: List[Backend] = await backends_services.get_project_backends(project=project)
@@ -114,6 +117,18 @@ async def get_offers_by_requirements(
                 ]
                 if new_offer.availability_zones:
                     new_offers.append((b, new_offer))
+        offers = new_offers
+
+    if placement_group is not None:
+        new_offers = []
+        for b, o in offers:
+            for backend in backends:
+                compute = backend.compute()
+                if isinstance(
+                    compute, ComputeWithPlacementGroupSupport
+                ) and compute.is_suitable_placement_group(placement_group, o):
+                    new_offers.append((b, o))
+                    break
         offers = new_offers
 
     if profile.instance_types is not None:

--- a/src/dstack/_internal/server/services/placement.py
+++ b/src/dstack/_internal/server/services/placement.py
@@ -41,7 +41,7 @@ async def schedule_fleet_placement_groups_deletion(
                 PlacementGroupModel.id.not_in(except_placement_group_ids),
             )
         )
-        .values(fleet_deleted=True)  # TODO: rename `fleet_deleted`
+        .values(fleet_deleted=True)  # TODO: rename `fleet_deleted` -> `to_be_deleted`
     )
 
 

--- a/src/dstack/_internal/server/services/placement.py
+++ b/src/dstack/_internal/server/services/placement.py
@@ -1,8 +1,9 @@
+from collections.abc import Iterable
 from typing import Optional
 from uuid import UUID
 
 from git import List
-from sqlalchemy import select
+from sqlalchemy import and_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dstack._internal.core.models.placement import (
@@ -13,15 +14,35 @@ from dstack._internal.core.models.placement import (
 from dstack._internal.server.models import PlacementGroupModel
 
 
-async def get_fleet_placement_groups(
+async def get_fleet_placement_group_models(
     session: AsyncSession,
     fleet_id: UUID,
-) -> List[PlacementGroup]:
+) -> List[PlacementGroupModel]:
     res = await session.execute(
-        select(PlacementGroupModel).where(PlacementGroupModel.fleet_id == fleet_id)
+        select(PlacementGroupModel).where(
+            and_(
+                PlacementGroupModel.fleet_id == fleet_id,
+                PlacementGroupModel.deleted == False,
+                PlacementGroupModel.fleet_deleted == False,
+            )
+        )
     )
-    placement_groups = res.scalars().all()
-    return [placement_group_model_to_placement_group(pg) for pg in placement_groups]
+    return list(res.scalars().all())
+
+
+async def schedule_fleet_placement_groups_deletion(
+    session: AsyncSession, fleet_id: UUID, except_placement_group_ids: Iterable[UUID] = ()
+) -> None:
+    await session.execute(
+        update(PlacementGroupModel)
+        .where(
+            and_(
+                PlacementGroupModel.fleet_id == fleet_id,
+                PlacementGroupModel.id.not_in(except_placement_group_ids),
+            )
+        )
+        .values(fleet_deleted=True)  # TODO: rename `fleet_deleted`
+    )
 
 
 def placement_group_model_to_placement_group(


### PR DESCRIPTION
An InfiniBand cluster is now created automatically when provisioning 8xH100 or 8xH200 instances using a fleet configuration with `placement: cluster`.

Nebius clusters were supported using `dstack`
placement groups. Several changes were made to the placement group management logic:
- The offer for the master instance of the fleet is passed to `Compute.create_placement_group`, which allows to set different placement group settings based on the offer. Nebius requires different settings for H100 and H200 clusters.
- `Compute.is_suitable_placement_group` is introduced to allow choosing an appropriate placement group when creating the master instance and filtering offers for non-master instances based on backend-specific placement group properties. Nebius currently only provides homogeneous clusters, so offers need to be filtered based on the placement group.
- The placement group object is passed to `Compute.create_instance` to allow adding the instance to the placement group using its backend-specific properties, such as cluster ID on Nebius.
- The placement group name is generated at master instance provisioning time, not at fleet creation time. This allows to have different placement group names for the same fleet and avoid name conflicts, since multiple placement groups can be created while `dstack` is trying different offers for the master instance.
- Placement groups that were created during master instance provisioning but didn't end up being used are now cleaned up. Nebius quotas limit the number of clusters, so unused clusters need to be cleaned up quickly, without waiting for fleet deletion.
- If all offers failed for the master instance, `dstack` will no longer attempt to provision other fleet instances to avoid them being provisioned without a placement group or without connectivity at all.
- Placement group creation errors are now handled gracefully, so that `dstack` can move on to other master instance offers, which may lead to creating different placement groups. For example, if `dstack` cannot create a cluster in one Nebius region because of a missing quota, it may attempt to create a cluster in another region.

#2590