### PR TITLE
Allow to configure Nebius InfiniBand fabrics

### DIFF
--- a/src/dstack/_internal/core/backends/nebius/configurator.py
+++ b/src/dstack/_internal/core/backends/nebius/configurator.py
@@ -9,6 +9,7 @@ from dstack._internal.core.backends.base.configurator import (
 )
 from dstack._internal.core.backends.nebius import resources
 from dstack._internal.core.backends.nebius.backend import NebiusBackend
+from dstack._internal.core.backends.nebius.fabrics import get_all_infiniband_fabrics
 from dstack._internal.core.backends.nebius.models import (
     AnyNebiusBackendConfig,
     NebiusBackendConfig,
@@ -37,6 +38,16 @@ class NebiusConfigurator(Configurator):
             raise_invalid_credentials_error(
                 fields=[["creds"]],
                 details=str(e),
+            )
+        valid_fabrics = get_all_infiniband_fabrics()
+        if invalid_fabrics := set(config.fabrics or []) - valid_fabrics:
+            raise_invalid_credentials_error(
+                fields=[["fabrics"]],
+                details=(
+                    "These InfiniBand fabrics do not exist or are not known to dstack:"
+                    f" {sorted(invalid_fabrics)}. Omit `fabrics` to allow all fabrics or select"
+                    f" some of the valid options: {sorted(valid_fabrics)}"
+                ),
             )
 
     def create_backend(

--- a/src/dstack/_internal/core/backends/nebius/fabrics.py
+++ b/src/dstack/_internal/core/backends/nebius/fabrics.py
@@ -1,0 +1,47 @@
+from collections.abc import Container
+from dataclasses import dataclass
+from typing import Optional
+
+from dstack._internal.core.models.instances import InstanceOffer
+
+
+@dataclass(frozen=True)
+class InfinibandFabric:
+    name: str
+    platform: str
+    region: str
+
+
+# https://docs.nebius.com/compute/clusters/gpu#fabrics
+INFINIBAND_FABRICS = [
+    InfinibandFabric("fabric-2", "gpu-h100-sxm", "eu-north1"),
+    InfinibandFabric("fabric-3", "gpu-h100-sxm", "eu-north1"),
+    InfinibandFabric("fabric-4", "gpu-h100-sxm", "eu-north1"),
+    InfinibandFabric("fabric-5", "gpu-h200-sxm", "eu-west1"),
+    InfinibandFabric("fabric-6", "gpu-h100-sxm", "eu-north1"),
+    InfinibandFabric("fabric-7", "gpu-h200-sxm", "eu-north1"),
+]
+
+
+def get_suitable_infiniband_fabrics(
+    offer: InstanceOffer, allowed_fabrics: Optional[Container[str]]
+) -> list[str]:
+    if len(offer.instance.resources.gpus) < 8:
+        # From the create VM page in the Nebius Console:
+        # > Only virtual machines with at least 8 NVIDIA® Hopper® H100 or H200 GPUs
+        # > can be added to the cluster
+        return []
+    platform, _ = offer.instance.name.split()
+    return [
+        f.name
+        for f in INFINIBAND_FABRICS
+        if (
+            f.platform == platform
+            and f.region == offer.region
+            and (allowed_fabrics is None or f.name in allowed_fabrics)
+        )
+    ]
+
+
+def get_all_infiniband_fabrics() -> set[str]:
+    return {f.name for f in INFINIBAND_FABRICS}

--- a/src/dstack/_internal/core/backends/nebius/models.py
+++ b/src/dstack/_internal/core/backends/nebius/models.py
@@ -87,6 +87,14 @@ class NebiusBackendConfig(CoreModel):
         Optional[list[str]],
         Field(description="The list of allowed Nebius regions. Omit to allow all regions"),
     ] = None
+    fabrics: Annotated[
+        Optional[list[str]],
+        Field(
+            description=(
+                "The list of allowed fabrics for InfiniBand clusters. Omit to allow all fabrics"
+            )
+        ),
+    ] = None
 
 
 class NebiusBackendConfigWithCreds(NebiusBackendConfig):


### PR DESCRIPTION
Add an option in Nebius backend settings to limit
the list of allowed fabrics for InfiniBand
clusters. This can be useful for larger customers
that have capacity reservations tied to a specific fabric.

#2590