### PR TITLE
Support vm_managed_identity for Azure

### DIFF
--- a/docs/docs/concepts/backends.md
+++ b/docs/docs/concepts/backends.md
@@ -338,6 +338,8 @@ There are two ways to configure Azure: using a client secret or using the defaul
                     "Microsoft.Compute/disks/write",
                     "Microsoft.Compute/disks/read",
                     "Microsoft.Compute/disks/delete",
+                    "Microsoft.ManagedIdentity/userAssignedIdentities/assign/action",
+                    "Microsoft.ManagedIdentity/userAssignedIdentities/read",
                     "Microsoft.Network/networkSecurityGroups/*",
                     "Microsoft.Network/locations/*",
                     "Microsoft.Network/virtualNetworks/*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ azure = [
     "azure-mgmt-network>=23.0.0,<28.0.0",
     "azure-mgmt-resource>=22.0.0",
     "azure-mgmt-authorization>=3.0.0",
+    "azure-mgmt-msi>=7.0.0",
     "dstack[server]",
 ]
 gcp = [

--- a/src/dstack/_internal/core/backends/azure/compute.py
+++ b/src/dstack/_internal/core/backends/azure/compute.py
@@ -136,6 +136,10 @@ class AzureCompute(
             location=location,
         )
 
+        managed_identity_resource_group, managed_identity_name = parse_vm_managed_identity(
+            self.config.vm_managed_identity
+        )
+
         base_tags = {
             "owner": "dstack",
             "dstack_project": instance_config.project_name,
@@ -159,7 +163,8 @@ class AzureCompute(
             network_security_group=network_security_group,
             network=network,
             subnet=subnet,
-            managed_identity=None,
+            managed_identity_name=managed_identity_name,
+            managed_identity_resource_group=managed_identity_resource_group,
             image_reference=_get_image_ref(
                 compute_client=self._compute_client,
                 location=location,
@@ -255,7 +260,8 @@ class AzureCompute(
             network_security_group=network_security_group,
             network=network,
             subnet=subnet,
-            managed_identity=None,
+            managed_identity_name=None,
+            managed_identity_resource_group=None,
             image_reference=_get_gateway_image_ref(),
             vm_size="Standard_B1ms",
             instance_name=instance_name,
@@ -336,6 +342,21 @@ def get_resource_group_network_subnet_or_error(
 
     subnet_name = subnets[0]
     return resource_group, network_name, subnet_name
+
+
+def parse_vm_managed_identity(
+    vm_managed_identity: Optional[str],
+) -> Tuple[Optional[str], Optional[str]]:
+    if vm_managed_identity is None:
+        return None, None
+    try:
+        resource_group, managed_identity = vm_managed_identity.split("/")
+        return resource_group, managed_identity
+    except Exception:
+        raise ComputeError(
+            "`vm_managed_identity` specified in incorrect format."
+            " Supported format: 'managedIdentityResourceGroup/managedIdentityName'"
+        )
 
 
 def _parse_config_vpc_id(vpc_id: str) -> Tuple[str, str]:
@@ -466,7 +487,8 @@ def _launch_instance(
     network_security_group: str,
     network: str,
     subnet: str,
-    managed_identity: Optional[str],
+    managed_identity_name: Optional[str],
+    managed_identity_resource_group: Optional[str],
     image_reference: ImageReference,
     vm_size: str,
     instance_name: str,
@@ -487,6 +509,20 @@ def _launch_instance(
     if allocate_public_ip:
         public_ip_address_configuration = VirtualMachinePublicIPAddressConfiguration(
             name="public_ip_config",
+        )
+    managed_identity = None
+    if managed_identity_name is not None:
+        if managed_identity_resource_group is None:
+            managed_identity_resource_group = resource_group
+        managed_identity = VirtualMachineIdentity(
+            type=ResourceIdentityType.USER_ASSIGNED,
+            user_assigned_identities={
+                azure_utils.get_managed_identity_id(
+                    subscription_id,
+                    managed_identity_resource_group,
+                    managed_identity_name,
+                ): UserAssignedIdentitiesValue(),
+            },
         )
     try:
         poller = compute_client.virtual_machines.begin_create_or_update(
@@ -552,16 +588,7 @@ def _launch_instance(
                 ),
                 priority="Spot" if spot else "Regular",
                 eviction_policy="Delete" if spot else None,
-                identity=None
-                if managed_identity is None
-                else VirtualMachineIdentity(
-                    type=ResourceIdentityType.USER_ASSIGNED,
-                    user_assigned_identities={
-                        azure_utils.get_managed_identity_id(
-                            subscription_id, resource_group, managed_identity
-                        ): UserAssignedIdentitiesValue()
-                    },
-                ),
+                identity=managed_identity,
                 user_data=base64.b64encode(user_data.encode()).decode(),
                 tags=tags,
             ),

--- a/src/dstack/_internal/core/backends/azure/models.py
+++ b/src/dstack/_internal/core/backends/azure/models.py
@@ -62,6 +62,15 @@ class AzureBackendConfig(CoreModel):
             )
         ),
     ] = None
+    vm_managed_identity: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "The managed identity to associate with provisioned VMs."
+                " Must have a format `managedIdentityResourceGroup/managedIdentityName`"
+            )
+        ),
+    ] = None
     tags: Annotated[
         Optional[Dict[str, str]],
         Field(description="The tags that will be assigned to resources created by `dstack`"),


### PR DESCRIPTION
Closes #2606 

This PR adds a new `vm_managed_identity` property to the Azure backend config:

```yaml
- type: azure
  ...
  vm_managed_identity: dstack-rg/my-managed-identity
```


The specified managed identity is assigned to provisioned VMs, which can be used to access Azure resources from runs without passing credentials explicitly.

**New permissions**

The changes require new Azure permissions for the Azure backend credentials:
```
"Microsoft.ManagedIdentity/userAssignedIdentities/assign/action"
"Microsoft.ManagedIdentity/userAssignedIdentities/read"
```