### PR TITLE
Pull and store process exit status from jobs

### DIFF
--- a/runner/internal/executor/executor_test.go
+++ b/runner/internal/executor/executor_test.go
@@ -54,10 +54,15 @@ func TestExecutor_HomeDir(t *testing.T) {
 
 func TestExecutor_NonZeroExit(t *testing.T) {
 	ex := makeTestExecutor(t)
-	ex.jobSpec.Commands = append(ex.jobSpec.Commands, "ehco 1") // note: intentional misspelling
+	ex.jobSpec.Commands = append(ex.jobSpec.Commands, "exit 100")
+	makeCodeTar(t, ex.codePath)
 
-	err := ex.execJob(context.TODO(), io.Discard)
+	err := ex.Run(context.TODO())
 	assert.Error(t, err)
+	assert.NotEmpty(t, ex.jobStateHistory)
+	exitStatus := ex.jobStateHistory[len(ex.jobStateHistory)-1].ExitStatus
+	assert.NotNil(t, exitStatus, ex.jobStateHistory)
+	assert.Equal(t, 100, *exitStatus)
 }
 
 func TestExecutor_SSHCredentials(t *testing.T) {

--- a/runner/internal/schemas/schemas.go
+++ b/runner/internal/schemas/schemas.go
@@ -11,6 +11,7 @@ type JobStateEvent struct {
 	Timestamp          int64                   `json:"timestamp"`
 	TerminationReason  types.TerminationReason `json:"termination_reason"`
 	TerminationMessage string                  `json:"termination_message"`
+	ExitStatus         *int                    `json:"exit_status"`
 }
 
 type LogEvent struct {

--- a/src/dstack/_internal/cli/utils/run.py
+++ b/src/dstack/_internal/cli/utils/run.py
@@ -218,6 +218,11 @@ def _get_run_error(run: Run) -> str:
 
 
 def _get_job_error(job: Job) -> str:
-    if job.job_submissions[-1].termination_reason is None:
+    job_submission = job.job_submissions[-1]
+    termination_reason = job_submission.termination_reason
+    exit_status = job_submission.exit_status
+    if termination_reason is None:
         return ""
-    return job.job_submissions[-1].termination_reason.name
+    if exit_status:
+        return f"{termination_reason.name} {exit_status}"
+    return termination_reason.name

--- a/src/dstack/_internal/server/background/tasks/process_running_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_running_jobs.py
@@ -651,6 +651,10 @@ def _process_running(
                 )
             if latest_state_event.termination_message:
                 job_model.termination_reason_message = latest_state_event.termination_message
+        if (exit_status := latest_state_event.exit_status) is not None:
+            job_model.exit_status = exit_status
+            if exit_status != 0:
+                logger.info("%s: non-zero exit status %s", fmt(job_model), exit_status)
     else:
         _terminate_if_inactivity_duration_exceeded(run_model, job_model, resp.no_connections_secs)
     if job_model.status != previous_status:

--- a/src/dstack/_internal/server/migrations/versions/6c1a9d6530ee_add_jobmodel_exit_status.py
+++ b/src/dstack/_internal/server/migrations/versions/6c1a9d6530ee_add_jobmodel_exit_status.py
@@ -1,0 +1,26 @@
+"""Add JobModel.exit_status
+
+Revision ID: 6c1a9d6530ee
+Revises: 7ba3b59d7ca6
+Create Date: 2025-05-09 10:25:19.715852
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "6c1a9d6530ee"
+down_revision = "7ba3b59d7ca6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("jobs", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("exit_status", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("jobs", schema=None) as batch_op:
+        batch_op.drop_column("exit_status")

--- a/src/dstack/_internal/server/models.py
+++ b/src/dstack/_internal/server/models.py
@@ -382,6 +382,7 @@ class JobModel(BaseModel):
         Enum(JobTerminationReason)
     )
     termination_reason_message: Mapped[Optional[str]] = mapped_column(Text)
+    exit_status: Mapped[Optional[int]] = mapped_column(Integer)
     job_spec_data: Mapped[str] = mapped_column(Text)
     job_provisioning_data: Mapped[Optional[str]] = mapped_column(Text)
     runner_timestamp: Mapped[Optional[int]] = mapped_column(BigInteger)

--- a/src/dstack/_internal/server/schemas/runner.py
+++ b/src/dstack/_internal/server/schemas/runner.py
@@ -16,6 +16,7 @@ class JobStateEvent(CoreModel):
     state: JobStatus
     termination_reason: Optional[str] = None
     termination_message: Optional[str] = None
+    exit_status: Optional[int] = None
 
 
 class LogEvent(CoreModel):

--- a/src/dstack/_internal/server/services/jobs/__init__.py
+++ b/src/dstack/_internal/server/services/jobs/__init__.py
@@ -135,6 +135,7 @@ def job_model_to_job_submission(job_model: JobModel) -> JobSubmission:
         status=job_model.status,
         termination_reason=job_model.termination_reason,
         termination_reason_message=job_model.termination_reason_message,
+        exit_status=job_model.exit_status,
         job_provisioning_data=job_provisioning_data,
         job_runtime_data=get_job_runtime_data(job_model),
     )

--- a/src/dstack/api/server/_runs.py
+++ b/src/dstack/api/server/_runs.py
@@ -115,6 +115,8 @@ def _get_apply_plan_excludes(plan: ApplyRunPlanInput) -> Optional[Dict]:
             job_submissions_excludes["job_runtime_data"] = {
                 "offer": {"instance": {"resources": {"cpu_arch"}}}
             }
+        if all(js.exit_status is None for js in job_submissions):
+            job_submissions_excludes["exit_status"] = True
         latest_job_submission = current_resource.latest_job_submission
         if latest_job_submission is not None:
             latest_job_submission_excludes = {}
@@ -127,6 +129,8 @@ def _get_apply_plan_excludes(plan: ApplyRunPlanInput) -> Optional[Dict]:
                 latest_job_submission_excludes["job_runtime_data"] = {
                     "offer": {"instance": {"resources": {"cpu_arch"}}}
                 }
+            if latest_job_submission.exit_status is None:
+                latest_job_submission_excludes["exit_status"] = True
     return {"plan": apply_plan_excludes}
 
 

--- a/src/tests/_internal/server/background/tasks/test_process_running_jobs.py
+++ b/src/tests/_internal/server/background/tasks/test_process_running_jobs.py
@@ -244,7 +244,7 @@ class TestProcessRunningJobs:
         ):
             runner_client_mock = RunnerClientMock.return_value
             runner_client_mock.pull.return_value = PullResponse(
-                job_states=[JobStateEvent(timestamp=1, state=JobStatus.DONE)],
+                job_states=[JobStateEvent(timestamp=1, state=JobStatus.DONE, exit_status=0)],
                 job_logs=[],
                 runner_logs=[],
                 last_updated=2,
@@ -255,6 +255,7 @@ class TestProcessRunningJobs:
         assert job is not None
         assert job.status == JobStatus.TERMINATING
         assert job.termination_reason == JobTerminationReason.DONE_BY_RUNNER
+        assert job.exit_status == 0
         assert job.runner_timestamp == 2
 
     @pytest.mark.asyncio

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -375,6 +375,7 @@ def get_dev_env_run_dict(
                         "status": "submitted",
                         "termination_reason": None,
                         "termination_reason_message": None,
+                        "exit_status": None,
                         "job_provisioning_data": None,
                         "job_runtime_data": None,
                     }
@@ -391,6 +392,7 @@ def get_dev_env_run_dict(
             "status": "submitted",
             "termination_reason": None,
             "termination_reason_message": None,
+            "exit_status": None,
             "job_provisioning_data": None,
             "job_runtime_data": None,
         },
@@ -503,6 +505,7 @@ class TestListRuns:
                                 "status": "submitted",
                                 "termination_reason": None,
                                 "termination_reason_message": None,
+                                "exit_status": None,
                                 "job_provisioning_data": None,
                                 "job_runtime_data": None,
                             }
@@ -519,6 +522,7 @@ class TestListRuns:
                     "status": "submitted",
                     "termination_reason_message": None,
                     "termination_reason": None,
+                    "exit_status": None,
                     "job_provisioning_data": None,
                     "job_runtime_data": None,
                 },


### PR DESCRIPTION
* Pull the exit status from the job, store in JobModel
* Display non-zero statuses in `dstack apply` and `dstack ps -v`

Closes: https://github.com/dstackai/dstack/issues/2570

![Screenshot_2025-05-09_13-50-31](https://github.com/user-attachments/assets/1a87f2b9-5a3e-46f5-9f90-90f8209975ef)

![Screenshot_2025-05-09_14-14-21](https://github.com/user-attachments/assets/e7fa7095-4150-4755-8b4e-d979e0f59377)
