### PR TITLE
[Docs] fix YAML indent on trl example

### DIFF
--- a/examples/fine-tuning/trl/README.md
+++ b/examples/fine-tuning/trl/README.md
@@ -67,13 +67,13 @@ commands:
     --hub_model_id peterschmidt85/FineLlama-3.1-8B
 
 resources:
-gpu:
-  # 24GB or more VRAM
-  memory: 24GB..
-  # One or more GPU
-  count: 1..
-# Shared memory (for multi-gpu)
-shm_size: 24GB
+  gpu:
+    # 24GB or more VRAM
+    memory: 24GB..
+    # One or more GPU
+    count: 1..
+  # Shared memory (for multi-gpu)
+  shm_size: 24GB
 ```
 
 </div>


### PR DESCRIPTION
indent `gpu` and `shm_size` under `resources`