### PR TITLE
Change default gpu count to 1..

### DIFF
--- a/src/dstack/_internal/core/models/resources.py
+++ b/src/dstack/_internal/core/models/resources.py
@@ -126,7 +126,7 @@ class ComputeCapability(Tuple[int, int]):
 
 DEFAULT_CPU_COUNT = Range[int](min=2)
 DEFAULT_MEMORY_SIZE = Range[Memory](min=Memory.parse("8GB"))
-DEFAULT_GPU_COUNT = Range[int](min=1, max=1)
+DEFAULT_GPU_COUNT = Range[int](min=1)
 
 
 class CPUSpec(CoreModel):


### PR DESCRIPTION
Closes #2569

The PR changes default GPU count from `1` to `1..`. Thus, if the GPU count is not specified, then `dstack` considers offers with any number of GPUs:

Before

```
✗ dstack apply --gpu H100                
 Resources            cpu=2.. mem=8GB.. disk=100GB.. H100:1
```

After

```
✗ dstack apply --gpu H100                
 Resources            cpu=2.. mem=8GB.. disk=100GB.. H100:1..
```

The resources defaults are set on the CLI side, so the change will take affect after the CLI is updated.