### PR TITLE
Update Nebius default project detection

### DIFF
--- a/src/dstack/_internal/core/backends/nebius/models.py
+++ b/src/dstack/_internal/core/backends/nebius/models.py
@@ -5,7 +5,7 @@ from pydantic import Field, root_validator
 from dstack._internal.core.backends.base.models import fill_data
 from dstack._internal.core.models.common import CoreModel
 
-DEFAULT_PROJECT_NAME_PREFIX = "default-project"
+DEFAULT_PROJECT_NAME_PREFIX = "default"
 
 
 class NebiusServiceAccountCreds(CoreModel):


### PR DESCRIPTION
It seems that Nebius has changed the default
project naming scheme. The project that was
automatically created for us in the newly
introduced `us-central1` region is called
`default-us-central1`.