### PR TITLE
Support building staging Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,11 +8,15 @@ on:
         description: "Docker image version"
         required: true
       staging:
-        description: "Staging build"
+        description: "Build staging images"
+        type: boolean
+        default: false
+      prepull_staging:
+        description: "Pre-pull staging Docker images"
         type: boolean
         default: false
       build_docker:
-        description: "Build docker images"
+        description: "Build Docker images"
         type: boolean
         default: true
       build_aws:
@@ -34,7 +38,9 @@ on:
 
 env:
   PACKER_VERSION: "1.9.2"
-  BUILD_PREFIX: ${{ inputs.staging && format('stgn-{0}-', github.run_number) || '' }} # staging ? prefix : ''
+  BUILD_DOCKER_REPO: ${{ inputs.staging && 'base-stgn' || 'base' }}
+  PREPULL_DOCKER_REPO: ${{ inputs.prepull_staging && 'base-stgn' || 'base' }}
+  VM_IMAGE_BUILD_PREFIX: ${{ inputs.staging && format('stgn-{0}-', github.run_number) || '' }} # staging ? prefix : ''
 
 jobs:
   build-docker:
@@ -61,7 +67,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Build and upload to DockerHub
         run: |
-          docker buildx build --platform linux/amd64 --build-arg FLAVOR=${{ matrix.flavor }} --build-arg PYTHON=${{ matrix.python }} --push --provenance=false --tag dstackai/base:py${{ matrix.python }}-${{ inputs.image_version }}-cuda-12.1${{ matrix.flavor == 'devel' && '-devel' || '' }} -f base/Dockerfile .
+          docker buildx build --platform linux/amd64 --build-arg FLAVOR=${{ matrix.flavor }} --build-arg PYTHON=${{ matrix.python }} --push --provenance=false --tag dstackai/${{ env.BUILD_DOCKER_REPO }}:py${{ matrix.python }}-${{ inputs.image_version }}-cuda-12.1${{ matrix.flavor == 'devel' && '-devel' || '' }} -f base/Dockerfile .
 
   build-aws-images:
     needs: build-docker
@@ -85,7 +91,7 @@ jobs:
           chmod +x packer
       - name: Run packer
         run: |
-          ./packer build -var-file=versions.json $PROD_VARS -var image_version=${{ inputs.image_version }} -var build_prefix=$BUILD_PREFIX aws-image${{ matrix.variant }}.json
+          ./packer build -var-file=versions.json $PROD_VARS -var image_repo=${{ env.PREPULL_DOCKER_REPO }} -var image_version=${{ inputs.image_version }} -var build_prefix=$VM_IMAGE_BUILD_PREFIX aws-image${{ matrix.variant }}.json
         env:
           PROD_VARS: ${{ !inputs.staging && '-var-file=aws-vars-prod.json' || '' }} # production ? var-file : ''
 
@@ -118,12 +124,12 @@ jobs:
           chmod +x packer
       - name: Run packer
         run: |
-          ./packer build -var-file=versions.json -var image_version=${{ inputs.image_version }} -var build_prefix=$BUILD_PREFIX azure-image${{ matrix.variant }}.json
+          ./packer build -var-file=versions.json -var image_repo=${{ env.PREPULL_DOCKER_REPO }} -var image_version=${{ inputs.image_version }} -var build_prefix=$VM_IMAGE_BUILD_PREFIX azure-image${{ matrix.variant }}.json
       - name: Publish azure image
         if: ${{ !inputs.staging }}
         run: |
-          IMAGE_DEFINITION=${BUILD_PREFIX}dstack${{ matrix.variant }}-${{ inputs.image_version }}
-          IMAGE_NAME=${BUILD_PREFIX}dstack${{ matrix.variant }}-${{ inputs.image_version }}
+          IMAGE_DEFINITION=${VM_IMAGE_BUILD_PREFIX}dstack${{ matrix.variant }}-${{ inputs.image_version }}
+          IMAGE_NAME=${VM_IMAGE_BUILD_PREFIX}dstack${{ matrix.variant }}-${{ inputs.image_version }}
           ../publish_azure_image.sh $IMAGE_DEFINITION $IMAGE_NAME
 
   build-gcp-images:
@@ -156,11 +162,11 @@ jobs:
           chmod +x packer
       - name: Run packer
         run: |
-          ./packer build -var-file=versions.json -var image_version=${{ inputs.image_version }} -var build_prefix=$BUILD_PREFIX gcp-image${{ matrix.variant }}.json
+          ./packer build -var-file=versions.json -var image_repo=${{ env.PREPULL_DOCKER_REPO }} -var image_version=${{ inputs.image_version }} -var build_prefix=$VM_IMAGE_BUILD_PREFIX gcp-image${{ matrix.variant }}.json
       - name: Publish images
         run: |
           IMAGE_VERSION=${IMAGE_VERSION//./-}
-          gcloud compute images add-iam-policy-binding ${BUILD_PREFIX}dstack${{ matrix.variant }}-$IMAGE_VERSION --member='allAuthenticatedUsers' --role='roles/compute.imageUser'
+          gcloud compute images add-iam-policy-binding ${VM_IMAGE_BUILD_PREFIX}dstack${{ matrix.variant }}-$IMAGE_VERSION --member='allAuthenticatedUsers' --role='roles/compute.imageUser'
         env:
           IMAGE_VERSION: ${{ inputs.image_version }}
 
@@ -205,8 +211,9 @@ jobs:
         run: |
           ./packer build \
             -var-file=versions.json \
+            -var image_repo=${{ env.PREPULL_DOCKER_REPO }} \
             -var image_version=${{ inputs.image_version }} \
-            -var build_prefix=$BUILD_PREFIX \
+            -var build_prefix=$VM_IMAGE_BUILD_PREFIX \
             -var oci_compartment_ocid=$OCI_COMPARTMENT \
             -var oci_subnet_ocid=$OCI_SUBNET \
             -var oci_availability_domain=$OCI_AVAILABILITY_DOMAIN \
@@ -221,14 +228,14 @@ jobs:
         if: ${{ !inputs.staging }}
         run: |
           uv run scripts/oci_image_tools.py copy \
-            --image ${BUILD_PREFIX}dstack${{ matrix.variant }}-${{ inputs.image_version }} \
+            --image ${VM_IMAGE_BUILD_PREFIX}dstack${{ matrix.variant }}-${{ inputs.image_version }} \
             --from $OCI_REGION \
             --compartment $OCI_COMPARTMENT
       - name: Publish image in OCI Marketplace
         if: ${{ !inputs.staging }}
         run: |
           uv run scripts/oci_image_tools.py publish \
-            --image ${BUILD_PREFIX}dstack${{ matrix.variant }}-${{ inputs.image_version }} \
+            --image ${VM_IMAGE_BUILD_PREFIX}dstack${{ matrix.variant }}-${{ inputs.image_version }} \
             --compartment $OCI_COMPARTMENT \
             --version ${{ inputs.image_version }} \
             --description "Image for running workloads with dstack - https://dstack.ai/" \

--- a/scripts/packer/aws-image-cuda.json
+++ b/scripts/packer/aws-image-cuda.json
@@ -12,6 +12,7 @@
     "build_prefix": "",
     "ami_regions": "",
     "ami_groups": "",
+    "image_repo": "",
     "image_version": ""
   },
   "builders": [
@@ -83,7 +84,10 @@
     },
     {
       "type": "shell",
-      "environment_vars": ["IMAGE_VERSION={{user `image_version`}}"],
+      "environment_vars": [
+        "IMAGE_REPO={{user `image_repo`}}",
+        "IMAGE_VERSION={{user `image_version`}}"
+      ],
       "script": "provisioners/pull-docker-images.sh"
     }
   ]

--- a/scripts/packer/aws-image.json
+++ b/scripts/packer/aws-image.json
@@ -11,6 +11,7 @@
     "build_prefix": "",
     "ami_regions": "",
     "ami_groups": "",
+    "image_repo": "",
     "image_version": ""
   },
   "builders": [
@@ -73,7 +74,10 @@
     },
     {
       "type": "shell",
-      "environment_vars": ["IMAGE_VERSION={{user `image_version`}}"],
+      "environment_vars": [
+        "IMAGE_REPO={{user `image_repo`}}",
+        "IMAGE_VERSION={{user `image_version`}}"
+      ],
       "script": "provisioners/pull-docker-images.sh"
     }
   ]

--- a/scripts/packer/azure-image-cuda.json
+++ b/scripts/packer/azure-image-cuda.json
@@ -10,6 +10,7 @@
     "build_prefix": "",
     "docker_version": "",
     "cuda_drivers_version": "",
+    "image_repo": "",
     "image_version": ""
   },
   "builders": [{
@@ -74,7 +75,10 @@
     },
     {
       "type": "shell",
-      "environment_vars": ["IMAGE_VERSION={{user `image_version`}}"],
+      "environment_vars": [
+        "IMAGE_REPO={{user `image_repo`}}",
+        "IMAGE_VERSION={{user `image_version`}}"
+      ],
       "script": "provisioners/pull-docker-images.sh"
     },
     {

--- a/scripts/packer/azure-image-grid.json
+++ b/scripts/packer/azure-image-grid.json
@@ -9,6 +9,7 @@
     "azure_vm_size": "Standard_DS1_v2",
     "build_prefix": "",
     "docker_version": "",
+    "image_repo": "",
     "image_version": ""
   },
   "builders": [{
@@ -72,7 +73,10 @@
     },
     {
       "type": "shell",
-      "environment_vars": ["IMAGE_VERSION={{user `image_version`}}"],
+      "environment_vars": [
+        "IMAGE_REPO={{user `image_repo`}}",
+        "IMAGE_VERSION={{user `image_version`}}"
+      ],
       "script": "provisioners/pull-docker-images.sh"
     },
     {

--- a/scripts/packer/azure-image.json
+++ b/scripts/packer/azure-image.json
@@ -9,6 +9,7 @@
     "azure_vm_size": "Standard_DS1_v2",
     "build_prefix": "",
     "docker_version": "",
+    "image_repo": "",
     "image_version": ""
   },
   "builders": [{
@@ -64,7 +65,10 @@
     },
     {
       "type": "shell",
-      "environment_vars": ["IMAGE_VERSION={{user `image_version`}}"],
+      "environment_vars": [
+        "IMAGE_REPO={{user `image_repo`}}",
+        "IMAGE_VERSION={{user `image_version`}}"
+      ],
       "script": "provisioners/pull-docker-images.sh"
     },
     {

--- a/scripts/packer/gcp-image-cuda.json
+++ b/scripts/packer/gcp-image-cuda.json
@@ -3,6 +3,7 @@
     "build_prefix": "",
     "docker_version": "",
     "cuda_drivers_version": "",
+    "image_repo": "",
     "image_version": ""
   },
   "builders": [
@@ -58,7 +59,10 @@
     },
     {
       "type": "shell",
-      "environment_vars": ["IMAGE_VERSION={{user `image_version`}}"],
+      "environment_vars": [
+        "IMAGE_REPO={{user `image_repo`}}",
+        "IMAGE_VERSION={{user `image_version`}}"
+      ],
       "script": "provisioners/pull-docker-images.sh"
     }
   ]

--- a/scripts/packer/gcp-image.json
+++ b/scripts/packer/gcp-image.json
@@ -2,6 +2,7 @@
   "variables": {
     "build_prefix": "",
     "docker_version": "",
+    "image_repo": "",
     "image_version": ""
   },
   "builders": [
@@ -48,7 +49,10 @@
     },
     {
       "type": "shell",
-      "environment_vars": ["IMAGE_VERSION={{user `image_version`}}"],
+      "environment_vars": [
+        "IMAGE_REPO={{user `image_repo`}}",
+        "IMAGE_VERSION={{user `image_version`}}"
+      ],
       "script": "provisioners/pull-docker-images.sh"
     }
   ]

--- a/scripts/packer/oci-image-cuda.json
+++ b/scripts/packer/oci-image-cuda.json
@@ -3,6 +3,7 @@
     "build_prefix": "",
     "docker_version": "",
     "cuda_drivers_version": "",
+    "image_repo": "",
     "image_version": "",
     "oci_availability_domain": "",
     "oci_compartment_ocid": "",
@@ -67,7 +68,10 @@
     },
     {
       "type": "shell",
-      "environment_vars": ["IMAGE_VERSION={{user `image_version`}}"],
+      "environment_vars": [
+        "IMAGE_REPO={{user `image_repo`}}",
+        "IMAGE_VERSION={{user `image_version`}}"
+      ],
       "script": "provisioners/pull-docker-images.sh"
     }
   ]

--- a/scripts/packer/oci-image.json
+++ b/scripts/packer/oci-image.json
@@ -2,6 +2,7 @@
   "variables": {
     "build_prefix": "",
     "docker_version": "",
+    "image_repo": "",
     "image_version": "",
     "oci_availability_domain": "",
     "oci_compartment_ocid": "",
@@ -57,7 +58,10 @@
     },
     {
       "type": "shell",
-      "environment_vars": ["IMAGE_VERSION={{user `image_version`}}"],
+      "environment_vars": [
+        "IMAGE_REPO={{user `image_repo`}}",
+        "IMAGE_VERSION={{user `image_version`}}"
+      ],
       "script": "provisioners/pull-docker-images.sh"
     }
   ]

--- a/scripts/packer/provisioners/pull-docker-images.sh
+++ b/scripts/packer/provisioners/pull-docker-images.sh
@@ -3,11 +3,11 @@
 set -e
 
 IMAGES="
- dstackai/base:py3.13-${IMAGE_VERSION}-cuda-12.1
- dstackai/base:py3.12-${IMAGE_VERSION}-cuda-12.1
- dstackai/base:py3.11-${IMAGE_VERSION}-cuda-12.1
- dstackai/base:py3.10-${IMAGE_VERSION}-cuda-12.1
- dstackai/base:py3.9-${IMAGE_VERSION}-cuda-12.1
+ dstackai/${IMAGE_REPO}:py3.13-${IMAGE_VERSION}-cuda-12.1
+ dstackai/${IMAGE_REPO}:py3.12-${IMAGE_VERSION}-cuda-12.1
+ dstackai/${IMAGE_REPO}:py3.11-${IMAGE_VERSION}-cuda-12.1
+ dstackai/${IMAGE_REPO}:py3.10-${IMAGE_VERSION}-cuda-12.1
+ dstackai/${IMAGE_REPO}:py3.9-${IMAGE_VERSION}-cuda-12.1
 "
 echo "START pull image"
 for img in $IMAGES; do

--- a/src/dstack/_internal/server/services/jobs/configurators/base.py
+++ b/src/dstack/_internal/server/services/jobs/configurators/base.py
@@ -60,7 +60,7 @@ class JobConfigurator(ABC):
     TYPE: RunConfigurationType
 
     _image_config: Optional[ImageConfig] = None
-    # JobSSHKey should be shared for all jobs in a replica for inter-node communitation.
+    # JobSSHKey should be shared for all jobs in a replica for inter-node communication.
     _job_ssh_key: Optional[JobSSHKey] = None
 
     def __init__(self, run_spec: RunSpec):

--- a/src/dstack/_internal/server/services/jobs/configurators/base.py
+++ b/src/dstack/_internal/server/services/jobs/configurators/base.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional, Union
 
 from cachetools import TTLCache, cached
 
-import dstack.version as version
+from dstack._internal import settings
 from dstack._internal.core.errors import DockerRegistryError, ServerClientError
 from dstack._internal.core.models.common import RegistryAuth
 from dstack._internal.core.models.configurations import (
@@ -53,7 +53,7 @@ def get_default_image(python_version: str, nvcc: bool = False) -> str:
     suffix = ""
     if nvcc:
         suffix = "-devel"
-    return f"dstackai/base:py{python_version}-{version.base_image}-cuda-12.1{suffix}"
+    return f"{settings.DSTACK_BASE_IMAGE}:py{python_version}-{settings.DSTACK_BASE_IMAGE_VERSION}-cuda-12.1{suffix}"
 
 
 class JobConfigurator(ABC):

--- a/src/dstack/_internal/settings.py
+++ b/src/dstack/_internal/settings.py
@@ -12,6 +12,10 @@ DSTACK_RELEASE = os.getenv("DSTACK_RELEASE") is not None or version.__is_release
 DSTACK_USE_LATEST_FROM_BRANCH = os.getenv("DSTACK_USE_LATEST_FROM_BRANCH") is not None
 
 
+DSTACK_BASE_IMAGE = os.getenv("DSTACK_BASE_IMAGE", "dstackai/base")
+DSTACK_BASE_IMAGE_VERSION = os.getenv("DSTACK_BASE_IMAGE_VERSION", version.base_image)
+
+
 class FeatureFlags:
     """
     dstack feature flags. Feature flags are temporary and can be used when developing


### PR DESCRIPTION
The PR extends the Build Docker & cloud images workflow to support building staging Docker images and pushing them to dstackai/base-stgn. It also allows choosing between pre-pulling prod or staging Docker images into VM images.