### PR TITLE
Fix request filtering for service stats

### DIFF
--- a/src/dstack/_internal/proxy/gateway/resources/nginx/00-log-format.conf
+++ b/src/dstack/_internal/proxy/gateway/resources/nginx/00-log-format.conf
@@ -1,1 +1,11 @@
-log_format dstack_stat '$time_iso8601 $host $status $request_time';
+log_format dstack_stat '$time_iso8601 $host $status $request_time $dstack_replica_hit';
+
+
+# A hack to avoid this Nginx reload error when no services are registered:
+#     nginx: [emerg] unknown "dstack_replica_hit" variable
+server {
+    listen unix:/tmp/dstack-dummy-nginx.sock;
+    server_name placeholder.local;
+    deny all;
+    set $dstack_replica_hit 0;
+}

--- a/src/dstack/_internal/proxy/gateway/resources/nginx/service.jinja2
+++ b/src/dstack/_internal/proxy/gateway/resources/nginx/service.jinja2
@@ -14,6 +14,7 @@ upstream {{ domain }}.upstream {
 server {
     server_name {{ domain }};
     limit_req_status 429;
+    set $dstack_replica_hit 0;
     access_log {{ access_log_path }} dstack_stat;
     client_max_body_size {{ client_max_body_size }};
 
@@ -23,11 +24,7 @@ server {
         auth_request /_dstack_auth;
         {% endif %}
 
-        {% if replicas %}
         try_files /nonexistent @$http_upgrade;
-        {% else %}
-        return 503;
-        {% endif %}
 
         {% if location.limit_req %}
         limit_req zone={{ location.limit_req.zone }}{% if location.limit_req.burst %} burst={{ location.limit_req.burst }} nodelay{% endif %};
@@ -35,8 +32,9 @@ server {
     }
     {% endfor %}
 
-    {% if replicas %}
     location @websocket {
+        set $dstack_replica_hit 1;
+        {% if replicas %}
         proxy_pass http://{{ domain }}.upstream;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $host;
@@ -44,19 +42,27 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         proxy_read_timeout 300s;
+        {% else %}
+        return 503;
+        {% endif %}
     }
     location @ {
+        set $dstack_replica_hit 1;
+        {% if replicas %}
         proxy_pass http://{{ domain }}.upstream;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $host;
         proxy_read_timeout 300s;
+        {% else %}
+        return 503;
+        {% endif %}
     }
-    {% endif %}
 
     {% if auth %}
     location = /_dstack_auth {
         internal;
         if ($remote_addr = 127.0.0.1) {
+            # for requests from the gateway app, e.g. from the OpenAI-compatible API
             return 200;
         }
         proxy_pass http://localhost:{{ proxy_port }}/api/auth/{{ project_name }};

--- a/src/tests/_internal/proxy/gateway/services/test_stats.py
+++ b/src/tests/_internal/proxy/gateway/services/test_stats.py
@@ -17,11 +17,11 @@ from dstack._internal.proxy.gateway.services.stats import StatsCollector
         pytest.param(
             dedent(
                 """
-                2024-12-06T12:08:00+00:00 srv-0.gtw.test 200 0.100
-                2024-12-06T12:08:00+00:00 srv-1.gtw.test 200 1.100
-                2024-12-06T12:09:15+00:00 srv-0.gtw.test 200 0.200
-                2024-12-06T12:09:15+00:00 srv-1.gtw.test 200 1.200
-                2024-12-06T12:09:45+00:00 srv-0.gtw.test 200 0.300
+                2024-12-06T12:08:00+00:00 srv-0.gtw.test 200 0.100 1
+                2024-12-06T12:08:00+00:00 srv-1.gtw.test 200 1.100 1
+                2024-12-06T12:09:15+00:00 srv-0.gtw.test 200 0.200 1
+                2024-12-06T12:09:15+00:00 srv-1.gtw.test 200 1.200 1
+                2024-12-06T12:09:45+00:00 srv-0.gtw.test 200 0.300 1
                 """
             ),
             {
@@ -41,11 +41,11 @@ from dstack._internal.proxy.gateway.services.stats import StatsCollector
         pytest.param(
             dedent(
                 """
-                2024-12-06T12:08:00+00:00 srv.gtw.test 200 0.100
-                2024-12-06T12:08:00+00:00 srv.gtw.test 200 0.200
-                2024-12-06T12:08:00+00:00 srv.gtw.test 200 0.300
-                2024-12-06T12:08:01+00:00 srv.gtw.test 200 0.400
-                2024-12-06T12:08:01+00:00 srv.gtw.test 200 0.500
+                2024-12-06T12:08:00+00:00 srv.gtw.test 200 0.100 1
+                2024-12-06T12:08:00+00:00 srv.gtw.test 200 0.200 1
+                2024-12-06T12:08:00+00:00 srv.gtw.test 200 0.300 1
+                2024-12-06T12:08:01+00:00 srv.gtw.test 200 0.400 1
+                2024-12-06T12:08:01+00:00 srv.gtw.test 200 0.500 1
                 """
             ),
             {
@@ -60,10 +60,10 @@ from dstack._internal.proxy.gateway.services.stats import StatsCollector
         pytest.param(
             dedent(
                 """
-                2024-12-06T12:04:50+00:00 srv.gtw.test 200 0.400
-                2024-12-06T12:08:00+00:00 srv.gtw.test 200 0.300
-                2024-12-06T12:09:15+00:00 srv.gtw.test 200 0.200
-                2024-12-06T12:09:45+00:00 srv.gtw.test 200 0.100
+                2024-12-06T12:04:50+00:00 srv.gtw.test 200 0.400 1
+                2024-12-06T12:08:00+00:00 srv.gtw.test 200 0.300 1
+                2024-12-06T12:09:15+00:00 srv.gtw.test 200 0.200 1
+                2024-12-06T12:09:45+00:00 srv.gtw.test 200 0.100 1
                 """
             ),
             {
@@ -74,6 +74,23 @@ from dstack._internal.proxy.gateway.services.stats import StatsCollector
                 },
             },
             id="ignores-out-of-window",
+        ),
+        pytest.param(
+            dedent(
+                """
+                2024-12-06T12:08:01+00:00 srv.gtw.test 200 0.100 1
+                2024-12-06T12:08:02+00:00 srv.gtw.test 200 0.200 0
+                2024-12-06T12:08:03+00:00 srv.gtw.test 200 0.300 1
+                """
+            ),
+            {
+                "srv.gtw.test": {
+                    30: Stat(requests=0, request_time=0.0),
+                    60: Stat(requests=0, request_time=0.0),
+                    300: Stat(requests=2, request_time=0.2),
+                },
+            },
+            id="ignores-replica-not-hit",
         ),
         pytest.param(
             dedent(
@@ -93,7 +110,7 @@ from dstack._internal.proxy.gateway.services.stats import StatsCollector
                     300: Stat(requests=4, request_time=0.25),
                 },
             },
-            id="ignores-irrelevant-statuses",
+            id="ignores-irrelevant-statuses-in-legacy-pre-0.19.11-log",
         ),
         pytest.param(
             "",


### PR DESCRIPTION
Instead of relying on status codes or other
heuristics, have Nginx log a flag for each request
forwarded, or intended to be forwarded, to a
service replica. Use these flags to determine
which requests to include in service stats.

This reliably excludes requests that are
terminated by Nginx and hence don't add load to
replicas. These include HTTP to HTTPS redirects,
unauthenticated requests, and requests that
violate rate or body size limits.

Fixes #2662