### PR TITLE
Drop humanize

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "psutil",
     "gpuhunt==0.1.6",
     "argcomplete>=3.5.0",
-    "humanize>=4.12.3",
 ]
 
 [project.urls]


### PR DESCRIPTION
Follows https://github.com/dstackai/dstack/pull/2691

Dropped humanize dependency in favor of existing function sizeof_fmt.