### PR TITLE
Support new AWS CPU series

### DIFF
--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -826,18 +826,23 @@ def _get_regions_to_zones(session: boto3.Session, regions: List[str]) -> Dict[st
 
 def _supported_instances(offer: InstanceOffer) -> bool:
     for family in [
+        "m7i.",
+        "c7i.",
+        "r7i.",
+        "t3.",
         "t2.small",
         "c5.",
         "m5.",
-        "g4dn.",
-        "g5.",
+        "p5.",
+        "p5e.",
+        "p4d.",
+        "p4de.",
+        "p3.",
         "g6.",
         "g6e.",
         "gr6.",
-        "p3.",
-        "p4d.",
-        "p4de.",
-        "p5.",
+        "g5.",
+        "g4dn.",
     ]:
         if offer.instance.name.startswith(family):
             return True


### PR DESCRIPTION
The PR adds support for new AWS CPU series based on Intel Xeon Sapphire Rapids: M7i, C7i, and R7i. It also adds support for the T3 family, which is the next generation burstable general-purpose instance type. Previously, only M5, C5 and t2.small CPU instances were supported.

New instances work out-of-the-box and do not require additional changes to dstack.