### PR TITLE
Update GRID drivers in Azure VM image

### DIFF
--- a/scripts/packer/provisioners/install-nvidia-grid-driver-for-azure.sh
+++ b/scripts/packer/provisioners/install-nvidia-grid-driver-for-azure.sh
@@ -8,7 +8,7 @@ sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install build-essential linux-azure -y
 
 wget --no-verbose -O NVIDIA-Linux-x86_64-grid.run \
-    https://download.microsoft.com/download/8/d/a/8da4fb8e-3a9b-4e6a-bc9a-72ff64d7a13c/NVIDIA-Linux-x86_64-535.161.08-grid-azure.run
+    https://download.microsoft.com/download/c5319e92-672e-4067-8d85-ab66a7a64db3/NVIDIA-Linux-x86_64-550.144.06-grid-azure.run
 chmod +x NVIDIA-Linux-x86_64-grid.run
 sudo ./NVIDIA-Linux-x86_64-grid.run --silent --disable-nouveau
 rm NVIDIA-Linux-x86_64-grid.run


### PR DESCRIPTION
Update to vGPU 17.x, since vGPU 16.x is expected
to stop working in Azure shortly.

> Update NVIDIA driver on NVads A10_v5 virtual
machines by 31 May 2025

> You're receiving this notification because
you're associated with one or more Azure
subscriptions that use NVads A10 v5 series virtual machines.

> The latest vGPU 18.x driver from NVIDIA is
backward compatible only with vGPU 17.x. Required
action

> To avoid disruptions to your service when we
roll out vGPU 18.x, update the NVIDIA driver in
your NVads A10 v5 virtual machines to vGPU 17.x by 31 May 2025.

Driver download URLs are available at
https://learn.microsoft.com/en-us/azure/virtual-machines/linux/n-series-driver-setup#nvidia-grid-drivers