### PR TITLE
Add health metrics (Part 1)

### DIFF
--- a/docs/docs/guides/metrics.md
+++ b/docs/docs/guides/metrics.md
@@ -176,3 +176,21 @@ telemetry, and more.
     | `dstack_run_type`     | *string*  | Run configuration type | `task`, `dev-environment`              |
     | `dstack_backend`      | *string*  | Backend                | `aws`, `runpod`                        |
     | `dstack_gpu`          | *string?* | GPU name               | `H100`                                 |
+
+### Server health metrics
+
+These are operational metrics to monitor the health of the dstack server. For now, these only include HTTP metrics, but more will be added later.
+
+=== "Metrics"
+    | Name                                     | Type      | Description                       | Examples     |
+    |------------------------------------------|-----------|-----------------------------------|--------------|
+    | `dstack_server_requests_total` | *counter* | Total number of HTTP requests | `100.0` |
+    | `dstack_server_request_duration_seconds` | *histogram*   | HTTP request duration in seconds  | `1.0`|
+
+=== "Labels"
+    | Name                   | Type      | Description   | Examples                               |
+    |------------------------|-----------|:--------------|----------------------------------------|
+    | `method`  | *string*  | HTTP method  | `POST`                                 |
+    | `endpoint`    | *string* | Endpoint path    | `/api/project/main/repos/get`                             |
+    | `http_status`      | *string* | HTTP status code      | `200` |
+    | `project_name` | *string?*  | Project name  | `main`                           |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "gpuhunt==0.1.6",
     "argcomplete>=3.5.0",
     "ignore-python>=0.2.0",
+    "prometheus-fastapi-instrumentator>=7.1.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "gpuhunt==0.1.6",
     "argcomplete>=3.5.0",
     "ignore-python>=0.2.0",
-    "prometheus-fastapi-instrumentator>=7.1.0",
 ]
 
 [project.urls]

--- a/src/dstack/_internal/server/app.py
+++ b/src/dstack/_internal/server/app.py
@@ -11,7 +11,7 @@ from fastapi import FastAPI, Request, Response, status
 from fastapi.datastructures import URL
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
-from prometheus_fastapi_instrumentator import Instrumentator
+from prometheus_client import Counter, Histogram
 
 from dstack._internal.cli.utils.common import console
 from dstack._internal.core.errors import ForbiddenError, ServerClientError
@@ -64,6 +64,18 @@ from dstack._internal.utils.ssh import check_required_ssh_version
 
 logger = get_logger(__name__)
 
+# Server HTTP metrics
+REQUESTS_TOTAL = Counter(
+    "dstack_server_requests_total",
+    "Total number of HTTP requests",
+    ["method", "endpoint", "http_status", "project_name"],
+)
+REQUEST_DURATION = Histogram(
+    "dstack_server_request_duration_seconds",
+    "HTTP request duration in seconds",
+    ["method", "endpoint", "http_status", "project_name"],
+)
+
 
 def create_app() -> FastAPI:
     if settings.SENTRY_DSN is not None:
@@ -78,7 +90,6 @@ def create_app() -> FastAPI:
 
     app = FastAPI(docs_url="/api/docs", lifespan=lifespan)
     app.state.proxy_dependency_injector = ServerProxyDependencyInjector()
-    Instrumentator().instrument(app, metric_namespace="dstack", metric_subsystem="server")
     return app
 
 
@@ -218,6 +229,8 @@ def register_routes(app: FastAPI, ui: bool = True):
         start_time = time.time()
         response: Response = await call_next(request)
         process_time = time.time() - start_time
+        # log process_time to be used in the log_http_metrics middleware
+        request.state.process_time = process_time
         logger.debug(
             "Processed request %s %s in %s. Status: %s",
             request.method,
@@ -225,6 +238,36 @@ def register_routes(app: FastAPI, ui: bool = True):
             f"{process_time:0.6f}s",
             response.status_code,
         )
+        return response
+
+    # this middleware must be defined after the log_request middleware
+    @app.middleware("http")
+    async def log_http_metrics(request: Request, call_next):
+        def _extract_project_name(request: Request):
+            project_name = None
+            prefix = "/api/project/"
+            if request.url.path.startswith(prefix):
+                rest = request.url.path[len(prefix) :]
+                project_name = rest.split("/", 1)[0] if rest else None
+
+            return project_name
+
+        project_name = _extract_project_name(request)
+        response: Response = await call_next(request)
+
+        REQUEST_DURATION.labels(
+            method=request.method,
+            endpoint=request.url.path,
+            http_status=response.status_code,
+            project_name=project_name,
+        ).observe(request.state.process_time)
+
+        REQUESTS_TOTAL.labels(
+            method=request.method,
+            endpoint=request.url.path,
+            http_status=response.status_code,
+            project_name=project_name,
+        ).inc()
         return response
 
     @app.middleware("http")

--- a/src/dstack/_internal/server/app.py
+++ b/src/dstack/_internal/server/app.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI, Request, Response, status
 from fastapi.datastructures import URL
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
+from prometheus_fastapi_instrumentator import Instrumentator
 
 from dstack._internal.cli.utils.common import console
 from dstack._internal.core.errors import ForbiddenError, ServerClientError
@@ -77,6 +78,7 @@ def create_app() -> FastAPI:
 
     app = FastAPI(docs_url="/api/docs", lifespan=lifespan)
     app.state.proxy_dependency_injector = ServerProxyDependencyInjector()
+    Instrumentator().instrument(app, metric_namespace="dstack", metric_subsystem="server")
     return app
 
 

--- a/src/dstack/_internal/server/routers/prometheus.py
+++ b/src/dstack/_internal/server/routers/prometheus.py
@@ -2,8 +2,8 @@ import os
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
-from fastapi.responses import PlainTextResponse, Response
-from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+from fastapi.responses import PlainTextResponse
+from prometheus_client import generate_latest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dstack._internal.server import settings
@@ -24,12 +24,9 @@ router = APIRouter(
 @router.get("/metrics")
 async def get_prometheus_metrics(
     session: Annotated[AsyncSession, Depends(get_session)],
-):
+) -> str:
     if not settings.ENABLE_PROMETHEUS_METRICS:
         raise error_not_found()
     custom_metrics = await prometheus.get_metrics(session=session)
-    instrumentator_metrics = generate_latest().decode()
-    return Response(
-        custom_metrics + instrumentator_metrics,
-        media_type=CONTENT_TYPE_LATEST,
-    )
+    prometheus_metrics = generate_latest()
+    return custom_metrics + prometheus_metrics.decode()

--- a/src/tests/_internal/server/routers/test_prometheus.py
+++ b/src/tests/_internal/server/routers/test_prometheus.py
@@ -39,9 +39,9 @@ from dstack._internal.server.testing.common import (
 BASE_HTTP_METRICS = b"""
 # HELP python_gc_objects_collected_total Objects collected during gc
 # TYPE python_gc_objects_collected_total counter
-python_gc_objects_collected_total{generation="0"} 16262.0
-python_gc_objects_collected_total{generation="1"} 3588.0
-python_gc_objects_collected_total{generation="2"} 325.0
+python_gc_objects_collected_total{generation="0"} 13159.0
+python_gc_objects_collected_total{generation="1"} 1583.0
+python_gc_objects_collected_total{generation="2"} 81.0
 # HELP python_gc_objects_uncollectable_total Uncollectable objects found during GC
 # TYPE python_gc_objects_uncollectable_total counter
 python_gc_objects_uncollectable_total{generation="0"} 0.0
@@ -49,72 +49,40 @@ python_gc_objects_uncollectable_total{generation="1"} 0.0
 python_gc_objects_uncollectable_total{generation="2"} 0.0
 # HELP python_gc_collections_total Number of times this generation was collected
 # TYPE python_gc_collections_total counter
-python_gc_collections_total{generation="0"} 1687.0
-python_gc_collections_total{generation="1"} 153.0
-python_gc_collections_total{generation="2"} 10.0
+python_gc_collections_total{generation="0"} 1609.0
+python_gc_collections_total{generation="1"} 146.0
+python_gc_collections_total{generation="2"} 9.0
 # HELP python_info Python platform information
 # TYPE python_info gauge
 python_info{implementation="CPython",major="3",minor="12",patchlevel="2",version="3.12.2"} 1.0
-# HELP dstack_server_http_requests_total Total number of requests by method, status and handler.
-# TYPE dstack_server_http_requests_total counter
-dstack_server_http_requests_total{handler="/metrics",method="GET",status="2xx"} 1.0
-# HELP dstack_server_http_requests_created Total number of requests by method, status and handler.
-# TYPE dstack_server_http_requests_created gauge
-dstack_server_http_requests_created{handler="/metrics",method="GET",status="2xx"} 1.67262864e+09
-# HELP dstack_server_http_request_size_bytes Content length of incoming requests by handler. Only value of header is respected. Otherwise ignored. No percentile calculated.
-# TYPE dstack_server_http_request_size_bytes summary
-dstack_server_http_request_size_bytes_count{handler="/metrics"} 1.0
-dstack_server_http_request_size_bytes_sum{handler="/metrics"} 0.0
-# HELP dstack_server_http_request_size_bytes_created Content length of incoming requests by handler. Only value of header is respected. Otherwise ignored. No percentile calculated.
-# TYPE dstack_server_http_request_size_bytes_created gauge
-dstack_server_http_request_size_bytes_created{handler="/metrics"} 1.67262864e+09
-# HELP dstack_server_http_response_size_bytes Content length of outgoing responses by handler. Only value of header is respected. Otherwise ignored. No percentile calculated.
-# TYPE dstack_server_http_response_size_bytes summary
-dstack_server_http_response_size_bytes_count{handler="/metrics"} 1.0
-dstack_server_http_response_size_bytes_sum{handler="/metrics"} 17846.0
-# HELP dstack_server_http_response_size_bytes_created Content length of outgoing responses by handler. Only value of header is respected. Otherwise ignored. No percentile calculated.
-# TYPE dstack_server_http_response_size_bytes_created gauge
-dstack_server_http_response_size_bytes_created{handler="/metrics"} 1.67262864e+09
-# HELP dstack_server_http_request_duration_highr_seconds Latency with many buckets but no API specific labels. Made for more accurate percentile calculations.
-# TYPE dstack_server_http_request_duration_highr_seconds histogram
-dstack_server_http_request_duration_highr_seconds_bucket{le="0.01"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="0.025"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="0.05"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="0.075"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="0.1"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="0.25"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="0.5"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="0.75"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="1.0"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="1.5"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="2.0"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="2.5"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="3.0"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="3.5"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="4.0"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="4.5"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="5.0"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="7.5"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="10.0"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="30.0"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="60.0"} 1.0
-dstack_server_http_request_duration_highr_seconds_bucket{le="+Inf"} 1.0
-dstack_server_http_request_duration_highr_seconds_count 1.0
-dstack_server_http_request_duration_highr_seconds_sum 0.0
-# HELP dstack_server_http_request_duration_highr_seconds_created Latency with many buckets but no API specific labels. Made for more accurate percentile calculations.
-# TYPE dstack_server_http_request_duration_highr_seconds_created gauge
-dstack_server_http_request_duration_highr_seconds_created 1.67262864e+09
-# HELP dstack_server_http_request_duration_seconds Latency with only few buckets by handler. Made to be only used if aggregation by handler is important.
-# TYPE dstack_server_http_request_duration_seconds histogram
-dstack_server_http_request_duration_seconds_bucket{handler="/metrics",le="0.1",method="GET"} 1.0
-dstack_server_http_request_duration_seconds_bucket{handler="/metrics",le="0.5",method="GET"} 1.0
-dstack_server_http_request_duration_seconds_bucket{handler="/metrics",le="1.0",method="GET"} 1.0
-dstack_server_http_request_duration_seconds_bucket{handler="/metrics",le="+Inf",method="GET"} 1.0
-dstack_server_http_request_duration_seconds_count{handler="/metrics",method="GET"} 1.0
-dstack_server_http_request_duration_seconds_sum{handler="/metrics",method="GET"} 0.0
-# HELP dstack_server_http_request_duration_seconds_created Latency with only few buckets by handler. Made to be only used if aggregation by handler is important.
-# TYPE dstack_server_http_request_duration_seconds_created gauge
-dstack_server_http_request_duration_seconds_created{handler="/metrics",method="GET"} 1.67262864e+09
+# HELP dstack_server_requests_total Total number of HTTP requests
+# TYPE dstack_server_requests_total counter
+dstack_server_requests_total{endpoint="/metrics",http_status="200",method="GET",project_name="None"} 1.0
+# HELP dstack_server_requests_created Total number of HTTP requests
+# TYPE dstack_server_requests_created gauge
+dstack_server_requests_created{endpoint="/metrics",http_status="200",method="GET",project_name="None"} 1.67262864e+09
+# HELP dstack_server_request_duration_seconds HTTP request duration in seconds
+# TYPE dstack_server_request_duration_seconds histogram
+dstack_server_request_duration_seconds_bucket{endpoint="/metrics",http_status="200",le="0.005",method="GET",project_name="None"} 1.0
+dstack_server_request_duration_seconds_bucket{endpoint="/metrics",http_status="200",le="0.01",method="GET",project_name="None"} 1.0
+dstack_server_request_duration_seconds_bucket{endpoint="/metrics",http_status="200",le="0.025",method="GET",project_name="None"} 1.0
+dstack_server_request_duration_seconds_bucket{endpoint="/metrics",http_status="200",le="0.05",method="GET",project_name="None"} 1.0
+dstack_server_request_duration_seconds_bucket{endpoint="/metrics",http_status="200",le="0.075",method="GET",project_name="None"} 1.0
+dstack_server_request_duration_seconds_bucket{endpoint="/metrics",http_status="200",le="0.1",method="GET",project_name="None"} 1.0
+dstack_server_request_duration_seconds_bucket{endpoint="/metrics",http_status="200",le="0.25",method="GET",project_name="None"} 1.0
+dstack_server_request_duration_seconds_bucket{endpoint="/metrics",http_status="200",le="0.5",method="GET",project_name="None"} 1.0
+dstack_server_request_duration_seconds_bucket{endpoint="/metrics",http_status="200",le="0.75",method="GET",project_name="None"} 1.0
+dstack_server_request_duration_seconds_bucket{endpoint="/metrics",http_status="200",le="1.0",method="GET",project_name="None"} 1.0
+dstack_server_request_duration_seconds_bucket{endpoint="/metrics",http_status="200",le="2.5",method="GET",project_name="None"} 1.0
+dstack_server_request_duration_seconds_bucket{endpoint="/metrics",http_status="200",le="5.0",method="GET",project_name="None"} 1.0
+dstack_server_request_duration_seconds_bucket{endpoint="/metrics",http_status="200",le="7.5",method="GET",project_name="None"} 1.0
+dstack_server_request_duration_seconds_bucket{endpoint="/metrics",http_status="200",le="10.0",method="GET",project_name="None"} 1.0
+dstack_server_request_duration_seconds_bucket{endpoint="/metrics",http_status="200",le="+Inf",method="GET",project_name="None"} 1.0
+dstack_server_request_duration_seconds_count{endpoint="/metrics",http_status="200",method="GET",project_name="None"} 1.0
+dstack_server_request_duration_seconds_sum{endpoint="/metrics",http_status="200",method="GET",project_name="None"} 0.0
+# HELP dstack_server_request_duration_seconds_created HTTP request duration in seconds
+# TYPE dstack_server_request_duration_seconds_created gauge
+dstack_server_request_duration_seconds_created{endpoint="/metrics",http_status="200",method="GET",project_name="None"} 1.67262864e+09
 """
 
 
@@ -283,7 +251,7 @@ class TestGetPrometheusMetrics:
         response = await client.get("/metrics")
 
         assert response.status_code == 200
-        actual = (
+        expected = (
             dedent(f"""\
             # HELP dstack_instance_duration_seconds_total Total seconds the instance is running
             # TYPE dstack_instance_duration_seconds_total counter
@@ -365,7 +333,7 @@ class TestGetPrometheusMetrics:
             + "\n"
             + BASE_HTTP_METRICS.decode().strip()
         )
-        assert response.text.strip() == actual
+        assert response.text.strip() == expected
 
     @patch("dstack._internal.server.routers.prometheus.generate_latest", lambda: BASE_HTTP_METRICS)
     async def test_returns_empty_response_if_no_runs(self, client: AsyncClient):


### PR DESCRIPTION
Part of #2736 -  adding http metrics.

Chose to implement these metrics as custom rather than relying on standard fastapi metrics via instrumentation libraries. Reason being, we need to label `project_name` in order to get metrics at endpoint and project level. Standard libraries like `prometheus-fastapi-instrumentator` and `opentelemetry-instrumentation-fastapi` don't allow adding custom dynamic labels to their default metrics. 

**Note:**

- When adding these metrics, they were overwriting the existing custom metrics since they're both emitted on the same `/metrics` endpoint.
- I had to fetch the http metrics in the `metrics` router endpoint, and combine them with the custom metrics.
- The current approach is emitting the metrics as plain text on the `/metrics` endpoint, however the more standard Prometheus way is to register all the metrics using `prometheus_client` which uses a global registry to collect the metrics from all the app and takes care of emitting them on the `/metrics` endpoint.
- I did this implementation as a quick solution, however I will look into using `prometheus_client` in part 2 of this ticket for the additional custom metrics, if it makes adding new metrics easier, in which case it might require some refactoring of the existing prometheus metrics code.