### PR TITLE
Pin dkms

### DIFF
--- a/scripts/packer/provisioners/cuda.sh
+++ b/scripts/packer/provisioners/cuda.sh
@@ -15,7 +15,9 @@ sudo dpkg -i cuda-keyring_1.0-1_all.deb
 rm cuda-keyring_1.0-1_all.deb
 
 sudo apt-get update
+# Pinned dkms due to https://bugs.launchpad.net/ubuntu/+source/dkms/+bug/2112114
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    dkms=2.8.7-2ubuntu2.2 \
     cuda-drivers-$CUDA_DRIVERS_VERSION \
     nvidia-fabricmanager-$CUDA_DRIVERS_VERSION \
     datacenter-gpu-manager-4-core datacenter-gpu-manager-4-proprietary datacenter-gpu-manager-exporter


### PR DESCRIPTION
VM images failed to build due to a new unstable dkms version: https://github.com/dstackai/dstack/actions/runs/15531994318/job/43722774493

https://bugs.launchpad.net/ubuntu/+source/dkms/+bug/2112114