### PR TITLE
Set logsWaitDuration to 5m

### DIFF
--- a/runner/internal/runner/api/server.go
+++ b/runner/internal/runner/api/server.go
@@ -52,7 +52,7 @@ func NewServer(tempDir string, homeDir string, workingDir string, address string
 		wsDoneCh:     make(chan interface{}),
 
 		submitWaitDuration: 5 * time.Minute,
-		logsWaitDuration:   30 * time.Second,
+		logsWaitDuration:   5 * time.Minute,
 
 		executor: ex,
 


### PR DESCRIPTION
Fixes #2790

Tested submitting 100 runs/jobs – no issues.