### PR TITLE
Fix is_public allowing null

### DIFF
--- a/src/dstack/_internal/server/schemas/projects.py
+++ b/src/dstack/_internal/server/schemas/projects.py
@@ -1,4 +1,4 @@
-from typing import Annotated, List, Optional
+from typing import Annotated, List
 
 from pydantic import Field
 
@@ -8,7 +8,7 @@ from dstack._internal.core.models.users import ProjectRole
 
 class CreateProjectRequest(CoreModel):
     project_name: str
-    is_public: Optional[bool] = False
+    is_public: bool = False
 
 
 class DeleteProjectsRequest(CoreModel):

--- a/src/dstack/api/server/_projects.py
+++ b/src/dstack/api/server/_projects.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List
 
 from pydantic import parse_obj_as
 
@@ -17,7 +17,7 @@ class ProjectsAPIClient(APIClientGroup):
         resp = self._request("/api/projects/list")
         return parse_obj_as(List[Project.__response__], resp.json())
 
-    def create(self, project_name: str, is_public: Optional[bool] = False) -> Project:
+    def create(self, project_name: str, is_public: bool = False) -> Project:
         body = CreateProjectRequest(project_name=project_name, is_public=is_public)
         resp = self._request("/api/projects/create", body=body.json())
         return parse_obj_as(Project.__response__, resp.json())


### PR DESCRIPTION
Follows #2759 

It was possible to pass `"is_public": null` when creating projects, which is not necessary and leads to wrong type annotations. Having a default value is sufficient for backward compatibility.