### PR TITLE
Retry on `VOLUME_ERROR` and `INSTANCE_UNREACHABLE`

### DIFF
--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -148,6 +148,19 @@ class JobTerminationReason(str, Enum):
         }
         return mapping[self]
 
+    def to_retry_event(self) -> Optional[RetryEvent]:
+        """
+        Returns:
+            the retry event this termination reason triggers
+            or None if this termination reason should not be retried
+        """
+        mapping = {
+            self.FAILED_TO_START_DUE_TO_NO_CAPACITY: RetryEvent.NO_CAPACITY,
+            self.INTERRUPTED_BY_NO_CAPACITY: RetryEvent.INTERRUPTION,
+        }
+        default = RetryEvent.ERROR if self.to_status() == JobStatus.FAILED else None
+        return mapping.get(self, default)
+
 
 class Requirements(CoreModel):
     # TODO: Make requirements' fields required

--- a/src/tests/_internal/core/models/test_runs.py
+++ b/src/tests/_internal/core/models/test_runs.py
@@ -1,3 +1,4 @@
+from dstack._internal.core.models.profiles import RetryEvent
 from dstack._internal.core.models.runs import (
     JobStatus,
     JobSubmission,
@@ -20,10 +21,16 @@ def test_run_termination_reason_to_status_works_with_all_enum_variants():
         assert isinstance(run_status, RunStatus)
 
 
-def test_job_termination_reason_to_status_works_with_all_enum_varians():
+def test_job_termination_reason_to_status_works_with_all_enum_variants():
     for job_termination_reason in JobTerminationReason:
         job_status = job_termination_reason.to_status()
         assert isinstance(job_status, JobStatus)
+
+
+def test_job_termination_reason_to_retry_event_works_with_all_enum_variants():
+    for job_termination_reason in JobTerminationReason:
+        retry_event = job_termination_reason.to_retry_event()
+        assert retry_event is None or isinstance(retry_event, RetryEvent)
 
 
 # Will fail if JobTerminationReason value is added without updaing JobSubmission._get_error


### PR DESCRIPTION
Also refactor so that it is less likely that we
forget to associate new termination reasons with
retry events.

Fixes #2804