### PR TITLE
Rolling deployment for services

### DIFF
--- a/src/dstack/_internal/cli/commands/attach.py
+++ b/src/dstack/_internal/cli/commands/attach.py
@@ -54,7 +54,6 @@ class AttachCommand(APIBaseCommand):
             "--replica",
             help="The replica number. Defaults to any running replica.",
             type=int,
-            required=None,
         )
         self._parser.add_argument(
             "--job",
@@ -129,14 +128,15 @@ _IGNORED_PORTS = [DSTACK_RUNNER_HTTP_PORT]
 def _print_attached_message(
     run: Run,
     bind_address: Optional[str],
-    replica_num: int,
+    replica_num: Optional[int],
     job_num: int,
 ):
     if bind_address is None:
         bind_address = "localhost"
 
-    output = f"Attached to run [code]{run.name}[/] (replica={replica_num} job={job_num})\n"
     job = get_or_error(run._find_job(replica_num=replica_num, job_num=job_num))
+    replica_num = job.job_spec.replica_num
+    output = f"Attached to run [code]{run.name}[/] (replica={replica_num} job={job_num})\n"
     name = run.name
     if replica_num != 0 or job_num != 0:
         name = job.job_spec.job_name

--- a/src/dstack/_internal/cli/commands/attach.py
+++ b/src/dstack/_internal/cli/commands/attach.py
@@ -52,9 +52,9 @@ class AttachCommand(APIBaseCommand):
         )
         self._parser.add_argument(
             "--replica",
-            help="The replica number. Defaults to 0.",
+            help="The replica number. Defaults to any running replica.",
             type=int,
-            default=0,
+            required=None,
         )
         self._parser.add_argument(
             "--job",

--- a/src/dstack/_internal/cli/services/configurators/run.py
+++ b/src/dstack/_internal/cli/services/configurators/run.py
@@ -599,6 +599,7 @@ def _is_ready_to_attach(run: Run) -> bool:
         ]
         or run._run.jobs[0].job_submissions[-1].status
         in [JobStatus.SUBMITTED, JobStatus.PROVISIONING, JobStatus.PULLING]
+        or run._run.is_deployment_in_progress()
     )
 
 

--- a/src/dstack/_internal/cli/utils/run.py
+++ b/src/dstack/_internal/cli/utils/run.py
@@ -162,9 +162,16 @@ def get_runs_table(
 
     for run in runs:
         run = run._run  # TODO(egor-s): make public attribute
+        show_deployment_num = (
+            verbose
+            and run.run_spec.configuration.type == "service"
+            or run.is_deployment_in_progress()
+        )
+        merge_job_rows = len(run.jobs) == 1 and not show_deployment_num
 
         run_row: Dict[Union[str, int], Any] = {
-            "NAME": run.run_spec.run_name,
+            "NAME": run.run_spec.run_name
+            + (f" [secondary]deployment={run.deployment_num}[/]" if show_deployment_num else ""),
             "SUBMITTED": format_date(run.submitted_at),
             "STATUS": (
                 run.latest_job_submission.status_message
@@ -174,7 +181,7 @@ def get_runs_table(
         }
         if run.error:
             run_row["ERROR"] = run.error
-        if len(run.jobs) != 1:
+        if not merge_job_rows:
             add_row_from_dict(table, run_row)
 
         for job in run.jobs:
@@ -184,7 +191,12 @@ def get_runs_table(
                 inactive_for = format_duration_multiunit(latest_job_submission.inactivity_secs)
                 status += f" (inactive for {inactive_for})"
             job_row: Dict[Union[str, int], Any] = {
-                "NAME": f"  replica={job.job_spec.replica_num} job={job.job_spec.job_num}",
+                "NAME": f"  replica={job.job_spec.replica_num} job={job.job_spec.job_num}"
+                + (
+                    f" deployment={latest_job_submission.deployment_num}"
+                    if show_deployment_num
+                    else ""
+                ),
                 "STATUS": latest_job_submission.status_message,
                 "SUBMITTED": format_date(latest_job_submission.submitted_at),
                 "ERROR": latest_job_submission.error,
@@ -208,7 +220,7 @@ def get_runs_table(
                         "PRICE": f"${jpd.price:.4f}".rstrip("0").rstrip("."),
                     }
                 )
-            if len(run.jobs) == 1:
+            if merge_job_rows:
                 # merge rows
                 job_row.update(run_row)
             add_row_from_dict(table, job_row, style="secondary" if len(run.jobs) != 1 else None)

--- a/src/dstack/_internal/core/compatibility/runs.py
+++ b/src/dstack/_internal/core/compatibility/runs.py
@@ -19,6 +19,8 @@ def get_apply_plan_excludes(plan: ApplyRunPlanInput) -> Optional[Dict]:
     if current_resource is not None:
         current_resource_excludes = {}
         current_resource_excludes["status_message"] = True
+        if current_resource.deployment_num == 0:
+            current_resource_excludes["deployment_num"] = True
         apply_plan_excludes["current_resource"] = current_resource_excludes
         current_resource_excludes["run_spec"] = get_run_spec_excludes(current_resource.run_spec)
         job_submissions_excludes = {}
@@ -36,6 +38,8 @@ def get_apply_plan_excludes(plan: ApplyRunPlanInput) -> Optional[Dict]:
             }
         if all(js.exit_status is None for js in job_submissions):
             job_submissions_excludes["exit_status"] = True
+        if all(js.deployment_num == 0 for js in job_submissions):
+            job_submissions_excludes["deployment_num"] = True
         latest_job_submission = current_resource.latest_job_submission
         if latest_job_submission is not None:
             latest_job_submission_excludes = {}
@@ -50,6 +54,8 @@ def get_apply_plan_excludes(plan: ApplyRunPlanInput) -> Optional[Dict]:
                 }
             if latest_job_submission.exit_status is None:
                 latest_job_submission_excludes["exit_status"] = True
+            if latest_job_submission.deployment_num == 0:
+                latest_job_submission_excludes["deployment_num"] = True
     return {"plan": apply_plan_excludes}
 
 

--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -289,7 +289,7 @@ class ClusterInfo(CoreModel):
 class JobSubmission(CoreModel):
     id: UUID4
     submission_num: int
-    deployment_num: int = 0  # default for compatibility with pre-TODO servers
+    deployment_num: int = 0  # default for compatibility with pre-0.19.14 servers
     submitted_at: datetime
     last_processed_at: datetime
     finished_at: Optional[datetime]
@@ -517,7 +517,7 @@ class Run(CoreModel):
     latest_job_submission: Optional[JobSubmission]
     cost: float = 0
     service: Optional[ServiceSpec] = None
-    deployment_num: int = 0  # default for compatibility with pre-TODO servers
+    deployment_num: int = 0  # default for compatibility with pre-0.19.14 servers
     # TODO: make error a computed field after migrating to pydanticV2
     error: Optional[str] = None
     deleted: Optional[bool] = None

--- a/src/dstack/_internal/server/background/tasks/process_runs.py
+++ b/src/dstack/_internal/server/background/tasks/process_runs.py
@@ -385,7 +385,7 @@ async def _handle_run_replicas(
         )
         return
 
-    await _update_jobs_to_new_deployment_in_place(run_model)
+    await _update_jobs_to_new_deployment_in_place(run_model, run_spec)
     if _has_out_of_date_replicas(run_model):
         non_terminated_replica_count = len(
             {j.replica_num for j in run_model.jobs if not j.status.is_finished()}
@@ -425,7 +425,7 @@ async def _handle_run_replicas(
             )
 
 
-async def _update_jobs_to_new_deployment_in_place(run_model: RunModel) -> None:
+async def _update_jobs_to_new_deployment_in_place(run_model: RunModel, run_spec: RunSpec) -> None:
     """
     Bump deployment_num for jobs that do not require redeployment.
     """
@@ -436,7 +436,7 @@ async def _update_jobs_to_new_deployment_in_place(run_model: RunModel) -> None:
         if all(j.deployment_num == run_model.deployment_num for j in job_models):
             continue
         new_job_specs = await get_job_specs_from_run_spec(
-            run_spec=RunSpec.__response__.parse_raw(run_model.run_spec),
+            run_spec=run_spec,
             replica_num=replica_num,
         )
         assert len(new_job_specs) == len(job_models), (

--- a/src/dstack/_internal/server/background/tasks/process_runs.py
+++ b/src/dstack/_internal/server/background/tasks/process_runs.py
@@ -1,18 +1,17 @@
 import asyncio
 import datetime
-import itertools
 from typing import List, Optional, Set, Tuple
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload, selectinload
 
-import dstack._internal.server.services.gateways as gateways
 import dstack._internal.server.services.services.autoscalers as autoscalers
 from dstack._internal.core.errors import ServerError
 from dstack._internal.core.models.profiles import RetryEvent, StopCriteria
 from dstack._internal.core.models.runs import (
     Job,
+    JobSpec,
     JobStatus,
     JobTerminationReason,
     Run,
@@ -24,22 +23,23 @@ from dstack._internal.server.db import get_session_ctx
 from dstack._internal.server.models import JobModel, ProjectModel, RunModel
 from dstack._internal.server.services.jobs import (
     find_job,
-    get_jobs_from_run_spec,
+    get_job_specs_from_run_spec,
     group_jobs_by_replica_latest,
 )
 from dstack._internal.server.services.locking import get_locker
 from dstack._internal.server.services.runs import (
-    create_job_model_for_new_submission,
     fmt,
     process_terminating_run,
     retry_run_replica_jobs,
     run_model_to_run,
     scale_run_replicas,
 )
+from dstack._internal.server.services.services import update_service_desired_replica_count
 from dstack._internal.utils import common
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
+ROLLING_DEPLOYMENT_MAX_SURGE = 1  # at most one extra replica during rolling deployment
 
 
 async def process_runs(batch_size: int = 1):
@@ -133,46 +133,22 @@ async def _process_pending_run(session: AsyncSession, run_model: RunModel):
         logger.debug("%s: pending run is not yet ready for resubmission", fmt(run_model))
         return
 
-    # TODO(egor-s) consolidate with `scale_run_replicas` if possible
-    replicas = 1
+    run_model.desired_replica_count = 1
     if run.run_spec.configuration.type == "service":
-        replicas = run.run_spec.configuration.replicas.min or 0  # new default
-        scaler = autoscalers.get_service_scaler(run.run_spec.configuration)
-        stats = None
-        if run_model.gateway_id is not None:
-            conn = await gateways.get_or_add_gateway_connection(session, run_model.gateway_id)
-            stats = await conn.get_stats(run_model.project.name, run_model.run_name)
-        # replicas info doesn't matter for now
-        replicas = scaler.scale([], stats)
-    if replicas == 0:
+        run_model.desired_replica_count = run.run_spec.configuration.replicas.min or 0
+        await update_service_desired_replica_count(
+            session,
+            run_model,
+            run.run_spec.configuration,
+            # does not matter for pending services, since 0->n scaling should happen without delay
+            last_scaled_at=None,
+        )
+
+    if run_model.desired_replica_count == 0:
         # stay zero scaled
         return
 
-    scheduled_replicas = 0
-    # Resubmit existing replicas
-    for replica_num, replica_jobs in itertools.groupby(
-        run.jobs, key=lambda j: j.job_spec.replica_num
-    ):
-        if scheduled_replicas >= replicas:
-            break
-        scheduled_replicas += 1
-        for job in replica_jobs:
-            new_job_model = create_job_model_for_new_submission(
-                run_model=run_model,
-                job=job,
-                status=JobStatus.SUBMITTED,
-            )
-            session.add(new_job_model)
-    # Create missing replicas
-    for replica_num in range(scheduled_replicas, replicas):
-        jobs = await get_jobs_from_run_spec(run.run_spec, replica_num=replica_num)
-        for job in jobs:
-            job_model = create_job_model_for_new_submission(
-                run_model=run_model,
-                job=job,
-                status=JobStatus.SUBMITTED,
-            )
-            session.add(job_model)
+    await scale_run_replicas(session, run_model, replicas_diff=run_model.desired_replica_count)
 
     run_model.status = RunStatus.SUBMITTED
     logger.info("%s: run status has changed PENDING -> SUBMITTED", fmt(run_model))
@@ -340,27 +316,11 @@ async def _process_active_run(session: AsyncSession, run_model: RunModel):
                     job_model.termination_reason = JobTerminationReason.TERMINATED_BY_SERVER
 
     if new_status not in {RunStatus.TERMINATING, RunStatus.PENDING}:
-        # No need to retry if the run is terminating,
+        # No need to retry, scale, or redeploy replicas if the run is terminating,
         # pending run will retry replicas in `process_pending_run`
-        for _, replica_jobs in replicas_to_retry:
-            await retry_run_replica_jobs(
-                session, run_model, replica_jobs, only_failed=retry_single_job
-            )
-
-        if run_spec.configuration.type == "service":
-            scaler = autoscalers.get_service_scaler(run_spec.configuration)
-            stats = None
-            if run_model.gateway_id is not None:
-                conn = await gateways.get_or_add_gateway_connection(session, run_model.gateway_id)
-                stats = await conn.get_stats(run_model.project.name, run_model.run_name)
-            # use replicas_info from before retrying
-            replicas_diff = scaler.scale(replicas_info, stats)
-            if replicas_diff != 0:
-                # FIXME: potentially long write transaction
-                # Why do we flush here?
-                await session.flush()
-                await session.refresh(run_model)
-                await scale_run_replicas(session, run_model, replicas_diff)
+        await _handle_run_replicas(
+            session, run_model, run_spec, replicas_to_retry, retry_single_job, replicas_info
+        )
 
     if run_model.status != new_status:
         logger.info(
@@ -376,6 +336,130 @@ async def _process_active_run(session: AsyncSession, run_model: RunModel):
             run_model.resubmission_attempt = 0
         elif new_status == RunStatus.PENDING:
             run_model.resubmission_attempt += 1
+
+
+async def _handle_run_replicas(
+    session: AsyncSession,
+    run_model: RunModel,
+    run_spec: RunSpec,
+    replicas_to_retry: list[tuple[int, list[JobModel]]],
+    retry_single_job: bool,
+    replicas_info: list[autoscalers.ReplicaInfo],
+) -> None:
+    """
+    Does ONE of:
+    - replica retry
+    - replica scaling
+    - replica rolling deployment
+
+    Does not do everything at once to avoid conflicts between the stages and long DB transactions.
+    """
+
+    if replicas_to_retry:
+        for _, replica_jobs in replicas_to_retry:
+            await retry_run_replica_jobs(
+                session, run_model, replica_jobs, only_failed=retry_single_job
+            )
+        return
+
+    if run_spec.configuration.type == "service":
+        await update_service_desired_replica_count(
+            session,
+            run_model,
+            run_spec.configuration,
+            # FIXME: should only include scaling events, not retries and deployments
+            last_scaled_at=max((r.timestamp for r in replicas_info), default=None),
+        )
+
+    max_replica_count = run_model.desired_replica_count
+    if _has_out_of_date_replicas(run_model):
+        # allow extra replicas when deployment is in progress
+        max_replica_count += ROLLING_DEPLOYMENT_MAX_SURGE
+
+    active_replica_count = sum(1 for r in replicas_info if r.active)
+    if active_replica_count not in range(run_model.desired_replica_count, max_replica_count + 1):
+        await scale_run_replicas(
+            session,
+            run_model,
+            replicas_diff=run_model.desired_replica_count - active_replica_count,
+        )
+        return
+
+    await _update_jobs_to_new_deployment_in_place(run_model)
+    if _has_out_of_date_replicas(run_model):
+        non_terminated_replica_count = len(
+            {j.replica_num for j in run_model.jobs if not j.status.is_finished()}
+        )
+        # Avoid using too much hardware during a deployment - never have
+        # more than max_replica_count non-terminated replicas.
+        if non_terminated_replica_count < max_replica_count:
+            # Start more up-to-date replicas that will eventually replace out-of-date replicas.
+            await scale_run_replicas(
+                session,
+                run_model,
+                replicas_diff=max_replica_count - non_terminated_replica_count,
+            )
+
+        replicas_to_stop_count = 0
+        # stop any out-of-date replicas that are not running
+        replicas_to_stop_count += len(
+            {
+                j.replica_num
+                for j in run_model.jobs
+                if j.status
+                not in [JobStatus.RUNNING, JobStatus.TERMINATING] + JobStatus.finished_statuses()
+                and j.deployment_num < run_model.deployment_num
+            }
+        )
+        running_replica_count = len(
+            {j.replica_num for j in run_model.jobs if j.status == JobStatus.RUNNING}
+        )
+        if running_replica_count > run_model.desired_replica_count:
+            # stop excessive running out-of-date replicas
+            replicas_to_stop_count += running_replica_count - run_model.desired_replica_count
+        if replicas_to_stop_count:
+            await scale_run_replicas(
+                session,
+                run_model,
+                replicas_diff=-replicas_to_stop_count,
+            )
+
+
+async def _update_jobs_to_new_deployment_in_place(run_model: RunModel) -> None:
+    """
+    Bump deployment_num for jobs that do not require redeployment.
+    """
+
+    for replica_num, job_models in group_jobs_by_replica_latest(run_model.jobs):
+        if all(j.status.is_finished() for j in job_models):
+            continue
+        if all(j.deployment_num == run_model.deployment_num for j in job_models):
+            continue
+        new_job_specs = await get_job_specs_from_run_spec(
+            run_spec=RunSpec.__response__.parse_raw(run_model.run_spec),
+            replica_num=replica_num,
+        )
+        assert len(new_job_specs) == len(job_models), (
+            "Changing the number of jobs within a replica is not yet supported"
+        )
+        can_update_all_jobs = True
+        for old_job_model, new_job_spec in zip(job_models, new_job_specs):
+            old_job_spec = JobSpec.__response__.parse_raw(old_job_model.job_spec_data)
+            if new_job_spec != old_job_spec:
+                can_update_all_jobs = False
+                break
+        if can_update_all_jobs:
+            for job_model in job_models:
+                job_model.deployment_num = run_model.deployment_num
+
+
+def _has_out_of_date_replicas(run: RunModel) -> bool:
+    for job in run.jobs:
+        if job.deployment_num < run.deployment_num and not (
+            job.status.is_finished() or job.termination_reason == JobTerminationReason.SCALED_DOWN
+        ):
+            return True
+    return False
 
 
 def _should_retry_job(run: Run, job: Job, job_model: JobModel) -> Optional[datetime.timedelta]:

--- a/src/dstack/_internal/server/migrations/versions/35e90e1b0d3e_add_rolling_deployment_fields.py
+++ b/src/dstack/_internal/server/migrations/versions/35e90e1b0d3e_add_rolling_deployment_fields.py
@@ -1,0 +1,42 @@
+"""Add rolling deployment fields
+
+Revision ID: 35e90e1b0d3e
+Revises: 35f732ee4cf5
+Create Date: 2025-05-29 15:30:27.878569
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "35e90e1b0d3e"
+down_revision = "35f732ee4cf5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("jobs", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("deployment_num", sa.Integer(), nullable=True))
+    with op.batch_alter_table("jobs", schema=None) as batch_op:
+        batch_op.execute("UPDATE jobs SET deployment_num = 0")
+        batch_op.alter_column("deployment_num", nullable=False)
+
+    with op.batch_alter_table("runs", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("deployment_num", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("desired_replica_count", sa.Integer(), nullable=True))
+    with op.batch_alter_table("runs", schema=None) as batch_op:
+        batch_op.execute("UPDATE runs SET deployment_num = 0")
+        batch_op.execute("UPDATE runs SET desired_replica_count = 1")
+        batch_op.alter_column("deployment_num", nullable=False)
+        batch_op.alter_column("desired_replica_count", nullable=False)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("runs", schema=None) as batch_op:
+        batch_op.drop_column("deployment_num")
+        batch_op.drop_column("desired_replica_count")
+
+    with op.batch_alter_table("jobs", schema=None) as batch_op:
+        batch_op.drop_column("deployment_num")

--- a/src/dstack/_internal/server/models.py
+++ b/src/dstack/_internal/server/models.py
@@ -350,6 +350,8 @@ class RunModel(BaseModel):
     run_spec: Mapped[str] = mapped_column(Text)
     service_spec: Mapped[Optional[str]] = mapped_column(Text)
     priority: Mapped[int] = mapped_column(Integer, default=0)
+    deployment_num: Mapped[int] = mapped_column(Integer)
+    desired_replica_count: Mapped[int] = mapped_column(Integer)
 
     jobs: Mapped[List["JobModel"]] = relationship(
         back_populates="run", lazy="selectin", order_by="[JobModel.replica_num, JobModel.job_num]"
@@ -404,6 +406,7 @@ class JobModel(BaseModel):
     instance: Mapped[Optional["InstanceModel"]] = relationship(back_populates="jobs")
     used_instance_id: Mapped[Optional[uuid.UUID]] = mapped_column(UUIDType(binary=False))
     replica_num: Mapped[int] = mapped_column(Integer)
+    deployment_num: Mapped[int] = mapped_column(Integer)
     job_runtime_data: Mapped[Optional[str]] = mapped_column(Text)
 
 

--- a/src/dstack/_internal/server/services/jobs/__init__.py
+++ b/src/dstack/_internal/server/services/jobs/__init__.py
@@ -128,6 +128,7 @@ def job_model_to_job_submission(job_model: JobModel) -> JobSubmission:
     return JobSubmission(
         id=job_model.id,
         submission_num=job_model.submission_num,
+        deployment_num=job_model.deployment_num,
         submitted_at=job_model.submitted_at.replace(tzinfo=timezone.utc),
         last_processed_at=last_processed_at,
         finished_at=finished_at,

--- a/src/dstack/_internal/server/services/services/__init__.py
+++ b/src/dstack/_internal/server/services/services/__init__.py
@@ -30,6 +30,7 @@ from dstack._internal.server.services.gateways import (
     get_project_gateway_model_by_name,
 )
 from dstack._internal.server.services.logging import fmt
+from dstack._internal.server.services.services.autoscalers import get_service_scaler
 from dstack._internal.server.services.services.options import get_service_options
 from dstack._internal.utils.logging import get_logger
 
@@ -258,3 +259,21 @@ def _get_gateway_https(configuration: GatewayConfiguration) -> bool:
     if configuration.certificate is not None and configuration.certificate.type == "lets-encrypt":
         return True
     return False
+
+
+async def update_service_desired_replica_count(
+    session: AsyncSession,
+    run_model: RunModel,
+    configuration: ServiceConfiguration,
+    last_scaled_at: Optional[int],
+) -> None:
+    scaler = get_service_scaler(configuration)
+    stats = None
+    if run_model.gateway_id is not None:
+        conn = await get_or_add_gateway_connection(session, run_model.gateway_id)
+        stats = await conn.get_stats(run_model.project.name, run_model.run_name)
+    run_model.desired_replica_count = scaler.get_desired_count(
+        current_desired_count=run_model.desired_replica_count,
+        stats=stats,
+        last_scaled_at=last_scaled_at,
+    )

--- a/src/dstack/_internal/server/testing/common.py
+++ b/src/dstack/_internal/server/testing/common.py
@@ -286,6 +286,8 @@ async def create_run(
         last_processed_at=submitted_at,
         jobs=[],
         priority=priority,
+        deployment_num=0,
+        desired_replica_count=1,
     )
     session.add(run)
     await session.commit()
@@ -318,6 +320,7 @@ async def create_job(
         job_num=job_num,
         job_name=run.run_name + f"-{job_num}-{replica_num}",
         replica_num=replica_num,
+        deployment_num=run.deployment_num,
         submission_num=submission_num,
         submitted_at=submitted_at,
         last_processed_at=last_processed_at,

--- a/src/dstack/_internal/server/testing/common.py
+++ b/src/dstack/_internal/server/testing/common.py
@@ -265,6 +265,7 @@ async def create_run(
     run_id: Optional[UUID] = None,
     deleted: bool = False,
     priority: int = 0,
+    deployment_num: int = 0,
 ) -> RunModel:
     if run_spec is None:
         run_spec = get_run_spec(
@@ -286,7 +287,7 @@ async def create_run(
         last_processed_at=submitted_at,
         jobs=[],
         priority=priority,
-        deployment_num=0,
+        deployment_num=deployment_num,
         desired_replica_count=1,
     )
     session.add(run)
@@ -307,9 +308,12 @@ async def create_job(
     instance: Optional[InstanceModel] = None,
     job_num: int = 0,
     replica_num: int = 0,
+    deployment_num: Optional[int] = None,
     instance_assigned: bool = False,
     disconnected_at: Optional[datetime] = None,
 ) -> JobModel:
+    if deployment_num is None:
+        deployment_num = run.deployment_num
     run_spec = RunSpec.parse_raw(run.run_spec)
     job_spec = (await get_job_specs_from_run_spec(run_spec, replica_num=replica_num))[0]
     job_spec.job_num = job_num
@@ -320,7 +324,7 @@ async def create_job(
         job_num=job_num,
         job_name=run.run_name + f"-{job_num}-{replica_num}",
         replica_num=replica_num,
-        deployment_num=run.deployment_num,
+        deployment_num=deployment_num,
         submission_num=submission_num,
         submitted_at=submitted_at,
         last_processed_at=last_processed_at,

--- a/src/dstack/api/_public/runs.py
+++ b/src/dstack/api/_public/runs.py
@@ -185,7 +185,7 @@ class Run(ABC):
         self,
         start_time: Optional[datetime] = None,
         diagnose: bool = False,
-        replica_num: int = 0,
+        replica_num: Optional[int] = None,
         job_num: int = 0,
     ) -> Iterable[bytes]:
         """

--- a/src/tests/_internal/server/background/tasks/test_process_runs.py
+++ b/src/tests/_internal/server/background/tasks/test_process_runs.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Union
+from typing import Union, cast
 from unittest.mock import patch
 
 import pytest
@@ -12,8 +12,10 @@ from dstack._internal.core.models.instances import InstanceStatus
 from dstack._internal.core.models.profiles import Profile
 from dstack._internal.core.models.resources import Range
 from dstack._internal.core.models.runs import (
+    JobSpec,
     JobStatus,
     JobTerminationReason,
+    RunSpec,
     RunStatus,
     RunTerminationReason,
 )
@@ -33,7 +35,11 @@ pytestmark = pytest.mark.usefixtures("image_config_mock")
 
 
 async def make_run(
-    session: AsyncSession, status: RunStatus = RunStatus.SUBMITTED, replicas: Union[str, int] = 1
+    session: AsyncSession,
+    status: RunStatus = RunStatus.SUBMITTED,
+    replicas: Union[str, int] = 1,
+    deployment_num: int = 0,
+    image: str = "ubuntu:latest",
 ) -> RunModel:
     project = await create_project(session=session)
     user = await create_user(session=session)
@@ -54,6 +60,7 @@ async def make_run(
             commands=["echo hello"],
             port=8000,
             replicas=parse_obj_as(Range[int], replicas),
+            image=image,
         ),
     )
     run = await create_run(
@@ -64,6 +71,7 @@ async def make_run(
         run_name=run_name,
         run_spec=run_spec,
         status=status,
+        deployment_num=deployment_num,
     )
     run.project = project
     return run
@@ -334,6 +342,420 @@ class TestProcessRunsReplicas:
         assert run.jobs[1].replica_num == 0
         assert run.jobs[2].status == JobStatus.SUBMITTED
         assert run.jobs[2].replica_num == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+class TestRollingDeployment:
+    @pytest.mark.parametrize(
+        ("run_status", "job_statuses"),
+        [
+            (RunStatus.RUNNING, (JobStatus.RUNNING, JobStatus.RUNNING)),
+            (RunStatus.RUNNING, (JobStatus.RUNNING, JobStatus.PULLING)),
+            (RunStatus.PROVISIONING, (JobStatus.PROVISIONING, JobStatus.PULLING)),
+            (RunStatus.PROVISIONING, (JobStatus.PROVISIONING, JobStatus.PROVISIONING)),
+        ],
+    )
+    async def test_updates_deployment_num_in_place(
+        self,
+        test_db,
+        session: AsyncSession,
+        run_status: RunStatus,
+        job_statuses: tuple[JobStatus, JobStatus],
+    ) -> None:
+        run = await make_run(session, status=run_status, replicas=2, deployment_num=1)
+        for replica_num, job_status in enumerate(job_statuses):
+            await create_job(
+                session=session,
+                run=run,
+                status=job_status,
+                replica_num=replica_num,
+                deployment_num=0,  # out of date
+            )
+
+        await process_runs.process_runs()
+        await session.refresh(run)
+        assert run.status == run_status
+        assert len(run.jobs) == 2
+        assert run.jobs[0].status == job_statuses[0]
+        assert run.jobs[0].replica_num == 0
+        assert run.jobs[0].deployment_num == 1  # updated
+        assert run.jobs[1].status == job_statuses[1]
+        assert run.jobs[1].replica_num == 1
+        assert run.jobs[1].deployment_num == 1  # updated
+
+    async def test_not_updates_deployment_num_in_place_for_finished_replica(
+        self, test_db, session: AsyncSession
+    ) -> None:
+        run = await make_run(session, status=RunStatus.RUNNING, deployment_num=1)
+        await create_job(
+            session=session,
+            run=run,
+            status=JobStatus.RUNNING,
+            replica_num=0,
+            deployment_num=0,  # out of date
+        )
+        await create_job(
+            session=session,
+            run=run,
+            status=JobStatus.TERMINATED,
+            termination_reason=JobTerminationReason.SCALED_DOWN,
+            replica_num=1,
+            deployment_num=0,  # out of date
+        )
+
+        await process_runs.process_runs()
+        await session.refresh(run)
+        assert run.status == RunStatus.RUNNING
+        assert len(run.jobs) == 2
+        assert run.jobs[0].status == JobStatus.RUNNING
+        assert run.jobs[0].replica_num == 0
+        assert run.jobs[0].deployment_num == 1  # updated
+        assert run.jobs[1].status == JobStatus.TERMINATED
+        assert run.jobs[1].replica_num == 1
+        assert run.jobs[1].deployment_num == 0  # not updated
+
+    async def test_starts_new_replica(self, test_db, session: AsyncSession) -> None:
+        run = await make_run(session, status=RunStatus.RUNNING, replicas=2, image="old")
+        for replica_num in range(2):
+            await create_job(
+                session=session,
+                run=run,
+                status=JobStatus.RUNNING,
+                replica_num=replica_num,
+            )
+
+        run_spec: RunSpec = RunSpec.__response__.parse_raw(run.run_spec)
+        assert isinstance(run_spec.configuration, ServiceConfiguration)
+        run_spec.configuration.image = "new"
+        run.run_spec = run_spec.json()
+        run.deployment_num += 1
+        await session.commit()
+
+        await process_runs.process_runs()
+        await session.refresh(run)
+        assert run.status == RunStatus.RUNNING
+        assert len(run.jobs) == 3
+        # old replicas remain as-is
+        for replica_num in range(2):
+            assert run.jobs[replica_num].status == JobStatus.RUNNING
+            assert run.jobs[replica_num].replica_num == replica_num
+            assert run.jobs[replica_num].deployment_num == 0
+            assert (
+                cast(
+                    JobSpec, JobSpec.__response__.parse_raw(run.jobs[replica_num].job_spec_data)
+                ).image_name
+                == "old"
+            )
+        # an extra replica is submitted
+        assert run.jobs[2].status == JobStatus.SUBMITTED
+        assert run.jobs[2].replica_num == 2
+        assert run.jobs[2].deployment_num == 1
+        assert (
+            cast(JobSpec, JobSpec.__response__.parse_raw(run.jobs[2].job_spec_data)).image_name
+            == "new"
+        )
+
+    @pytest.mark.parametrize(
+        "new_replica_status", [JobStatus.SUBMITTED, JobStatus.PROVISIONING, JobStatus.PULLING]
+    )
+    async def test_not_stops_out_of_date_replica_until_new_replica_is_running(
+        self, test_db, session: AsyncSession, new_replica_status: JobStatus
+    ) -> None:
+        run = await make_run(session, status=RunStatus.RUNNING, replicas=2, image="old")
+        for replica_num in range(2):
+            await create_job(
+                session=session,
+                run=run,
+                status=JobStatus.RUNNING,
+                replica_num=replica_num,
+            )
+
+        run_spec: RunSpec = RunSpec.__response__.parse_raw(run.run_spec)
+        assert isinstance(run_spec.configuration, ServiceConfiguration)
+        run_spec.configuration.image = "new"
+        run.run_spec = run_spec.json()
+        run.deployment_num += 1
+        await create_job(
+            session=session,
+            run=run,
+            status=new_replica_status,
+            replica_num=2,
+        )
+        await session.commit()
+
+        await process_runs.process_runs()
+        await session.refresh(run)
+        assert run.status == RunStatus.RUNNING
+        assert len(run.jobs) == 3
+        # All replicas remain as-is:
+        # - cannot yet start a new replica - there are already 3 non-terminated replicas
+        #   (3 = 2 desired + 1 max_surge)
+        # - cannot yet stop an out-of-date replica - that would only leave one running replica,
+        #   which is less than the desired count (2)
+        for replica_num in range(2):
+            assert run.jobs[replica_num].status == JobStatus.RUNNING
+            assert run.jobs[replica_num].replica_num == replica_num
+            assert run.jobs[replica_num].deployment_num == 0
+            assert (
+                cast(
+                    JobSpec, JobSpec.__response__.parse_raw(run.jobs[replica_num].job_spec_data)
+                ).image_name
+                == "old"
+            )
+        assert run.jobs[2].status == new_replica_status
+        assert run.jobs[2].replica_num == 2
+        assert run.jobs[2].deployment_num == 1
+        assert (
+            cast(JobSpec, JobSpec.__response__.parse_raw(run.jobs[2].job_spec_data)).image_name
+            == "new"
+        )
+
+    async def test_stops_out_of_date_replica(self, test_db, session: AsyncSession) -> None:
+        run = await make_run(session, status=RunStatus.RUNNING, replicas=2, image="old")
+        for replica_num in range(2):
+            await create_job(
+                session=session,
+                run=run,
+                status=JobStatus.RUNNING,
+                replica_num=replica_num,
+            )
+
+        run_spec: RunSpec = RunSpec.__response__.parse_raw(run.run_spec)
+        assert isinstance(run_spec.configuration, ServiceConfiguration)
+        run_spec.configuration.image = "new"
+        run.run_spec = run_spec.json()
+        run.deployment_num += 1
+        await create_job(
+            session=session,
+            run=run,
+            status=JobStatus.RUNNING,
+            replica_num=2,
+        )
+        await session.commit()
+
+        await process_runs.process_runs()
+        await session.refresh(run)
+        assert run.status == RunStatus.RUNNING
+        assert len(run.jobs) == 3
+        # one old replica remains as-is
+        assert run.jobs[0].status == JobStatus.RUNNING
+        assert run.jobs[0].replica_num == 0
+        assert run.jobs[0].deployment_num == 0
+        assert (
+            cast(JobSpec, JobSpec.__response__.parse_raw(run.jobs[0].job_spec_data)).image_name
+            == "old"
+        )
+        # another old replica is terminated
+        assert run.jobs[1].status == JobStatus.TERMINATING
+        assert run.jobs[1].termination_reason == JobTerminationReason.SCALED_DOWN
+        assert run.jobs[1].replica_num == 1
+        assert run.jobs[1].deployment_num == 0
+        assert (
+            cast(JobSpec, JobSpec.__response__.parse_raw(run.jobs[1].job_spec_data)).image_name
+            == "old"
+        )
+        # the new replica remains as-is
+        assert run.jobs[2].status == JobStatus.RUNNING
+        assert run.jobs[2].replica_num == 2
+        assert run.jobs[2].deployment_num == 1
+        assert (
+            cast(JobSpec, JobSpec.__response__.parse_raw(run.jobs[2].job_spec_data)).image_name
+            == "new"
+        )
+
+    async def test_not_starts_new_replica_until_out_of_date_replica_terminated(
+        self, test_db, session: AsyncSession
+    ) -> None:
+        run = await make_run(session, status=RunStatus.RUNNING, replicas=2, image="old")
+        await create_job(
+            session=session,
+            run=run,
+            status=JobStatus.RUNNING,
+            replica_num=0,
+        )
+        await create_job(
+            session=session,
+            run=run,
+            status=JobStatus.TERMINATING,
+            termination_reason=JobTerminationReason.SCALED_DOWN,
+            replica_num=1,
+        )
+
+        run_spec: RunSpec = RunSpec.__response__.parse_raw(run.run_spec)
+        assert isinstance(run_spec.configuration, ServiceConfiguration)
+        run_spec.configuration.image = "new"
+        run.run_spec = run_spec.json()
+        run.deployment_num += 1
+        await create_job(
+            session=session,
+            run=run,
+            status=JobStatus.RUNNING,
+            replica_num=2,
+        )
+        await session.commit()
+
+        await process_runs.process_runs()
+        await session.refresh(run)
+        assert run.status == RunStatus.RUNNING
+        assert len(run.jobs) == 3
+        # All replicas remain as-is:
+        # - cannot yet start a new replica - there are already 3 non-terminated replicas
+        #   (3 = 2 desired + 1 max_surge)
+        # - cannot yet stop an out-of-date replica - that would only leave one running replica,
+        #   which is less than the desired count (2)
+        assert run.jobs[0].status == JobStatus.RUNNING
+        assert run.jobs[0].replica_num == 0
+        assert run.jobs[0].deployment_num == 0
+        assert (
+            cast(JobSpec, JobSpec.__response__.parse_raw(run.jobs[0].job_spec_data)).image_name
+            == "old"
+        )
+        assert run.jobs[1].status == JobStatus.TERMINATING
+        assert run.jobs[1].termination_reason == JobTerminationReason.SCALED_DOWN
+        assert run.jobs[1].replica_num == 1
+        assert run.jobs[1].deployment_num == 0
+        assert (
+            cast(JobSpec, JobSpec.__response__.parse_raw(run.jobs[1].job_spec_data)).image_name
+            == "old"
+        )
+        assert run.jobs[2].status == JobStatus.RUNNING
+        assert run.jobs[2].replica_num == 2
+        assert run.jobs[2].deployment_num == 1
+        assert (
+            cast(JobSpec, JobSpec.__response__.parse_raw(run.jobs[2].job_spec_data)).image_name
+            == "new"
+        )
+
+    async def test_reuses_vacant_replica_num_when_starting_new_replica(
+        self, test_db, session: AsyncSession
+    ) -> None:
+        run = await make_run(session, status=RunStatus.RUNNING, replicas=2, image="old")
+        await create_job(
+            session=session,
+            run=run,
+            status=JobStatus.RUNNING,
+            replica_num=0,
+        )
+        await create_job(
+            session=session,
+            run=run,
+            status=JobStatus.TERMINATED,
+            termination_reason=JobTerminationReason.SCALED_DOWN,
+            replica_num=1,
+        )
+
+        run_spec: RunSpec = RunSpec.__response__.parse_raw(run.run_spec)
+        assert isinstance(run_spec.configuration, ServiceConfiguration)
+        run_spec.configuration.image = "new"
+        run.run_spec = run_spec.json()
+        run.deployment_num += 1
+        await create_job(
+            session=session,
+            run=run,
+            status=JobStatus.RUNNING,
+            replica_num=2,
+        )
+        await session.commit()
+
+        await process_runs.process_runs()
+        await session.refresh(run)
+        run.jobs.sort(key=lambda j: (j.replica_num, j.submission_num))
+        assert run.status == RunStatus.RUNNING
+        assert len(run.jobs) == 4  # 3 active submissions, 1 terminated submission
+        # The running old replica remains as-is
+        assert run.jobs[0].status == JobStatus.RUNNING
+        assert run.jobs[0].replica_num == 0
+        assert run.jobs[0].deployment_num == 0
+        assert (
+            cast(JobSpec, JobSpec.__response__.parse_raw(run.jobs[0].job_spec_data)).image_name
+            == "old"
+        )
+        # The terminated old replica remains as-is
+        assert run.jobs[1].status == JobStatus.TERMINATED
+        assert run.jobs[1].termination_reason == JobTerminationReason.SCALED_DOWN
+        assert run.jobs[1].replica_num == 1
+        assert run.jobs[1].deployment_num == 0
+        assert run.jobs[1].submission_num == 0
+        assert (
+            cast(JobSpec, JobSpec.__response__.parse_raw(run.jobs[1].job_spec_data)).image_name
+            == "old"
+        )
+        # The replica_num of the terminated old replica (1) is reused for the new replica
+        assert run.jobs[2].status == JobStatus.SUBMITTED
+        assert run.jobs[2].replica_num == 1
+        assert run.jobs[2].deployment_num == 1
+        assert run.jobs[2].submission_num == 1
+        assert (
+            cast(JobSpec, JobSpec.__response__.parse_raw(run.jobs[2].job_spec_data)).image_name
+            == "new"
+        )
+        # The running new replica remains as-is
+        assert run.jobs[3].status == JobStatus.RUNNING
+        assert run.jobs[3].replica_num == 2
+        assert run.jobs[3].deployment_num == 1
+        assert (
+            cast(JobSpec, JobSpec.__response__.parse_raw(run.jobs[3].job_spec_data)).image_name
+            == "new"
+        )
+
+    @pytest.mark.parametrize(
+        "new_replica_status", [JobStatus.SUBMITTED, JobStatus.PROVISIONING, JobStatus.PULLING]
+    )
+    async def test_stops_non_running_out_of_date_replicas_unconditionally(
+        self, test_db, session: AsyncSession, new_replica_status: JobStatus
+    ) -> None:
+        run = await make_run(session, status=RunStatus.PROVISIONING, replicas=2, image="old")
+        for replica_num in range(2):
+            await create_job(
+                session=session,
+                run=run,
+                status=JobStatus.PULLING,
+                replica_num=replica_num,
+            )
+
+        run_spec: RunSpec = RunSpec.__response__.parse_raw(run.run_spec)
+        assert isinstance(run_spec.configuration, ServiceConfiguration)
+        run_spec.configuration.image = "new"
+        run.run_spec = run_spec.json()
+        run.deployment_num += 1
+        await create_job(
+            session=session,
+            run=run,
+            status=new_replica_status,
+            replica_num=2,
+        )
+        await session.commit()
+
+        await process_runs.process_runs()
+        await session.refresh(run)
+        assert run.status == RunStatus.PROVISIONING
+        assert len(run.jobs) == 3
+        # The two out of date replicas transition from pulling to terminating immediately.
+        # No need to keep these replicas - they don't contribute to reaching the desired count.
+        assert run.jobs[0].status == JobStatus.TERMINATING
+        assert run.jobs[0].replica_num == 0
+        assert run.jobs[0].deployment_num == 0
+        assert (
+            cast(JobSpec, JobSpec.__response__.parse_raw(run.jobs[0].job_spec_data)).image_name
+            == "old"
+        )
+        assert run.jobs[1].status == JobStatus.TERMINATING
+        assert run.jobs[1].termination_reason == JobTerminationReason.SCALED_DOWN
+        assert run.jobs[1].replica_num == 1
+        assert run.jobs[1].deployment_num == 0
+        assert (
+            cast(JobSpec, JobSpec.__response__.parse_raw(run.jobs[1].job_spec_data)).image_name
+            == "old"
+        )
+        # The new replica remains as-is
+        assert run.jobs[2].status == new_replica_status
+        assert run.jobs[2].replica_num == 2
+        assert run.jobs[2].deployment_num == 1
+        assert (
+            cast(JobSpec, JobSpec.__response__.parse_raw(run.jobs[2].job_spec_data)).image_name
+            == "new"
+        )
 
 
 # TODO(egor-s): TestProcessRunsMultiNode

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -1132,6 +1132,9 @@ class TestApplyPlan:
         assert response.status_code == 200, response.json()
         await session.refresh(run_model)
         updated_run = run_model_to_run(run_model)
+        assert run.deployment_num == 0
+        assert updated_run.deployment_num == 1
+        assert run.run_spec.configuration.replicas == Range(min=1, max=1)
         assert updated_run.run_spec.configuration.replicas == Range(min=2, max=2)
 
 

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -385,6 +385,7 @@ def get_dev_env_run_dict(
                     {
                         "id": job_id,
                         "submission_num": 0,
+                        "deployment_num": 0,
                         "submitted_at": submitted_at,
                         "last_processed_at": last_processed_at,
                         "finished_at": finished_at,
@@ -404,6 +405,7 @@ def get_dev_env_run_dict(
         "latest_job_submission": {
             "id": job_id,
             "submission_num": 0,
+            "deployment_num": 0,
             "submitted_at": submitted_at,
             "last_processed_at": last_processed_at,
             "inactivity_secs": None,
@@ -419,6 +421,7 @@ def get_dev_env_run_dict(
         },
         "cost": 0.0,
         "service": None,
+        "deployment_num": 0,
         "termination_reason": None,
         "error": None,
         "deleted": deleted,
@@ -520,6 +523,7 @@ class TestListRuns:
                             {
                                 "id": str(job.id),
                                 "submission_num": 0,
+                                "deployment_num": 0,
                                 "submitted_at": run1_submitted_at.isoformat(),
                                 "last_processed_at": run1_submitted_at.isoformat(),
                                 "finished_at": None,
@@ -539,6 +543,7 @@ class TestListRuns:
                 "latest_job_submission": {
                     "id": str(job.id),
                     "submission_num": 0,
+                    "deployment_num": 0,
                     "submitted_at": run1_submitted_at.isoformat(),
                     "last_processed_at": run1_submitted_at.isoformat(),
                     "finished_at": None,
@@ -554,6 +559,7 @@ class TestListRuns:
                 },
                 "cost": 0,
                 "service": None,
+                "deployment_num": 0,
                 "termination_reason": None,
                 "error": None,
                 "deleted": False,
@@ -571,6 +577,7 @@ class TestListRuns:
                 "latest_job_submission": None,
                 "cost": 0,
                 "service": None,
+                "deployment_num": 0,
                 "termination_reason": None,
                 "error": None,
                 "deleted": False,

--- a/src/tests/_internal/server/services/test_runs.py
+++ b/src/tests/_internal/server/services/test_runs.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic import parse_obj_as
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from dstack._internal.core.errors import ServerClientError, ServerError
+from dstack._internal.core.errors import ServerClientError
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.configurations import ScalingSpec, ServiceConfiguration
 from dstack._internal.core.models.profiles import Profile
@@ -175,32 +175,6 @@ class TestScaleRunReplicas:
         assert run.jobs[0].status == JobStatus.RUNNING
         assert run.jobs[1].status == JobStatus.TERMINATING
         assert run.jobs[1].termination_reason == JobTerminationReason.SCALED_DOWN
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
-    async def test_no_downscale_below_limit(self, test_db, session: AsyncSession):
-        run = await make_run(
-            session,
-            [
-                JobStatus.RUNNING,
-            ],
-            replicas="1..2",
-        )
-        with pytest.raises(ServerError):
-            await scale_wrapper(session, run, -1)
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
-    async def test_no_upscale_above_limit(self, test_db, session: AsyncSession):
-        run = await make_run(
-            session,
-            [
-                JobStatus.RUNNING,
-            ],
-            replicas="0..1",
-        )
-        with pytest.raises(ServerError):
-            await scale_wrapper(session, run, 1)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)


### PR DESCRIPTION
Support rolling deployment when some service
configuration properties are changed. During the
deployment, `dstack` updates service replicas one
by one. It first starts a new version of the
replica, then waits until it is running, then
stops the old version of the replica.

As part of the implementation, introduce a new run
and job property - `deployment_num`. When a new
configuration is applied, the `deployment_num` of
the run is incremented. Then, `dstack` gradually
updates the jobs so that their `deployment_num`
matches that of the run. Some jobs are updated
in-place, if the new configuration does not affect
their spec, others are redeployed as described
above.

```shell
> dstack apply

Active run test-service already exists. Detected configuration changes that can be updated in-place: ['image', 'env', 'commands']
Update the run? [y/n]: y
⠋ Launching test-service...
 NAME                            BACKEND          RESOURCES                        PRICE    STATUS       SUBMITTED
 test-service deployment=1                                                                  running      11 mins ago
   replica=0 job=0 deployment=0  aws (us-west-2)  cpu=2 mem=1GB disk=100GB (spot)  $0.0026  terminating  11 mins ago
   replica=1 job=0 deployment=1  aws (us-west-2)  cpu=2 mem=1GB disk=100GB (spot)  $0.0026  running      1 min ago
```

Initial and main part of #2180