### PR TITLE
[Bug]: Can't see the entire log of a run via UI #2832

### DIFF
--- a/src/dstack/_internal/server/schemas/logs.py
+++ b/src/dstack/_internal/server/schemas/logs.py
@@ -12,5 +12,5 @@ class PollLogsRequest(CoreModel):
     start_time: Optional[datetime]
     end_time: Optional[datetime]
     descending: bool = False
-    limit: int = Field(100, ge=0, le=1000)
+    limit: int = Field(100, ge=1, le=1000)
     diagnose: bool = False

--- a/src/dstack/_internal/server/services/logs/filelog.py
+++ b/src/dstack/_internal/server/services/logs/filelog.py
@@ -44,7 +44,7 @@ class FileLogStorage(LogStorage):
             with open(log_file_path) as f:
                 for line in f:
                     log_event = LogEvent.__response__.parse_raw(line)
-                    if request.start_time and log_event.timestamp < request.start_time:
+                    if request.start_time and log_event.timestamp <= request.start_time:
                         continue
                     if request.end_time is None or log_event.timestamp < request.end_time:
                         logs.append(log_event)

--- a/src/tests/_internal/server/services/test_logs.py
+++ b/src/tests/_internal/server/services/test_logs.py
@@ -115,7 +115,7 @@ class TestFileLogStorage:
         job_submission_logs = log_storage.poll_logs(project, poll_request)
         assert len(job_submission_logs.logs) == 1
         assert job_submission_logs.logs[0].message == base64.b64encode(
-            "Log4".encode("utf-8")
+            "Log5".encode("utf-8")
         ).decode("utf-8")
 
 


### PR DESCRIPTION
Fixes  #2832

- [x] Ensure the file logger's `poll_logs` function respects limit

Note, `descending` is prohibited due to potential memory problems

To be done by @olgenn:
- [ ] Ensure UI `polls` logs starting from the very beginning up the the end using `start_time` and `end_time`
