### PR TITLE
Rolling deployments for repo updates

### DIFF
--- a/runner/internal/executor/executor.go
+++ b/runner/internal/executor/executor.go
@@ -276,6 +276,14 @@ func (ex *RunExecutor) SetRunnerState(state string) {
 	ex.state = state
 }
 
+func (ex *RunExecutor) getRepoData() schemas.RepoData {
+	if ex.jobSpec.RepoData == nil {
+		// jobs submitted before 0.19.17 do not have jobSpec.RepoData
+		return ex.run.RunSpec.RepoData
+	}
+	return *ex.jobSpec.RepoData
+}
+
 func (ex *RunExecutor) execJob(ctx context.Context, jobLogFile io.Writer) error {
 	node_rank := ex.jobSpec.JobNum
 	nodes_num := ex.jobSpec.JobsPerReplica

--- a/runner/internal/executor/executor_test.go
+++ b/runner/internal/executor/executor_test.go
@@ -132,7 +132,7 @@ func TestExecutor_RemoteRepo(t *testing.T) {
 
 	var b bytes.Buffer
 	ex := makeTestExecutor(t)
-	ex.run.RunSpec.RepoData = schemas.RepoData{
+	ex.jobSpec.RepoData = &schemas.RepoData{
 		RepoType:        "remote",
 		RepoBranch:      "main",
 		RepoHash:        "2b83592e506ed6fe8e49f4eaa97c3866bc9402b1",
@@ -148,7 +148,7 @@ func TestExecutor_RemoteRepo(t *testing.T) {
 
 	err = ex.execJob(context.TODO(), io.Writer(&b))
 	assert.NoError(t, err)
-	expected := fmt.Sprintf("%s\r\n%s\r\n%s\r\n", ex.run.RunSpec.RepoData.RepoHash, ex.run.RunSpec.RepoData.RepoConfigName, ex.run.RunSpec.RepoData.RepoConfigEmail)
+	expected := fmt.Sprintf("%s\r\n%s\r\n%s\r\n", ex.getRepoData().RepoHash, ex.getRepoData().RepoConfigName, ex.getRepoData().RepoConfigEmail)
 	assert.Equal(t, expected, b.String())
 }
 
@@ -178,6 +178,7 @@ func makeTestExecutor(t *testing.T) *RunExecutor {
 			Env:         make(map[string]string),
 			MaxDuration: 0, // no timeout
 			WorkingDir:  &workingDir,
+			RepoData:    &schemas.RepoData{RepoType: "local"},
 		},
 		Secrets: make(map[string]string),
 		RepoCredentials: &schemas.RepoCredentials{

--- a/runner/internal/executor/repo.go
+++ b/runner/internal/executor/repo.go
@@ -40,7 +40,7 @@ func (ex *RunExecutor) setupRepo(ctx context.Context) error {
 			err = gerrors.Wrap(err_)
 		}
 	}()
-	switch ex.run.RunSpec.RepoData.RepoType {
+	switch ex.getRepoData().RepoType {
 	case "remote":
 		log.Trace(ctx, "Fetching git repository")
 		if err := ex.prepareGit(ctx); err != nil {
@@ -52,7 +52,7 @@ func (ex *RunExecutor) setupRepo(ctx context.Context) error {
 			return gerrors.Wrap(err)
 		}
 	default:
-		return gerrors.Newf("unknown RepoType: %s", ex.run.RunSpec.RepoData.RepoType)
+		return gerrors.Newf("unknown RepoType: %s", ex.getRepoData().RepoType)
 	}
 	return err
 }
@@ -61,8 +61,8 @@ func (ex *RunExecutor) prepareGit(ctx context.Context) error {
 	repoManager := repo.NewManager(
 		ctx,
 		ex.repoCredentials.CloneURL,
-		ex.run.RunSpec.RepoData.RepoBranch,
-		ex.run.RunSpec.RepoData.RepoHash,
+		ex.getRepoData().RepoBranch,
+		ex.getRepoData().RepoHash,
 		ex.jobSpec.SingleBranch,
 	).WithLocalPath(ex.workingDir)
 	if ex.repoCredentials != nil {
@@ -92,7 +92,7 @@ func (ex *RunExecutor) prepareGit(ctx context.Context) error {
 	if err := repoManager.Checkout(); err != nil {
 		return gerrors.Wrap(err)
 	}
-	if err := repoManager.SetConfig(ex.run.RunSpec.RepoData.RepoConfigName, ex.run.RunSpec.RepoData.RepoConfigEmail); err != nil {
+	if err := repoManager.SetConfig(ex.getRepoData().RepoConfigName, ex.getRepoData().RepoConfigEmail); err != nil {
 		return gerrors.Wrap(err)
 	}
 

--- a/runner/internal/schemas/schemas.go
+++ b/runner/internal/schemas/schemas.go
@@ -68,6 +68,10 @@ type JobSpec struct {
 	MaxDuration    int               `json:"max_duration"`
 	SSHKey         *SSHKey           `json:"ssh_key"`
 	WorkingDir     *string           `json:"working_dir"`
+	// `RepoData` is optional for compatibility with jobs submitted before 0.19.17.
+	// Use `RunExecutor.getRepoData()` to get non-nil `RepoData`.
+	// TODO: make required when supporting jobs submitted before 0.19.17 is no longer relevant.
+	RepoData *RepoData `json:"repo_data"`
 }
 
 type ClusterInfo struct {

--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -218,6 +218,14 @@ class JobSpec(CoreModel):
     volumes: Optional[List[MountPoint]] = None
     ssh_key: Optional[JobSSHKey] = None
     working_dir: Optional[str]
+    # `repo_data` is optional for client compatibility with pre-0.19.17 servers and for compatibility
+    # with jobs submitted before 0.19.17. All new jobs are expected to have non-None `repo_data`.
+    # For --no-repo runs, `repo_data` is `VirtualRunRepoData()`.
+    repo_data: Annotated[Optional[AnyRunRepoData], Field(discriminator="repo_type")] = None
+    # `repo_code_hash` can be None because it is not used for the repo or because the job was
+    # submitted before 0.19.17. See `_get_repo_code_hash` on how to get the correct `repo_code_hash`
+    # TODO: drop this comment when supporting jobs submitted before 0.19.17 is no longer relevant.
+    repo_code_hash: Optional[str] = None
 
 
 class JobProvisioningData(CoreModel):

--- a/src/dstack/_internal/server/background/tasks/process_running_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_running_jobs.py
@@ -241,7 +241,7 @@ async def _process_running_job(session: AsyncSession, job_model: JobModel):
                     session=session,
                     project=project,
                     repo=repo_model,
-                    code_hash=run.run_spec.repo_code_hash,
+                    code_hash=_get_repo_code_hash(run, job),
                 )
 
                 success = await common_utils.run_async(
@@ -293,7 +293,7 @@ async def _process_running_job(session: AsyncSession, job_model: JobModel):
                 session=session,
                 project=project,
                 repo=repo_model,
-                code_hash=run.run_spec.repo_code_hash,
+                code_hash=_get_repo_code_hash(run, job),
             )
             success = await common_utils.run_async(
                 _process_pulling_with_shim,
@@ -847,6 +847,19 @@ def _get_cluster_info(
         gpus_per_job=gpus_per_job,
     )
     return cluster_info
+
+
+def _get_repo_code_hash(run: Run, job: Job) -> Optional[str]:
+    # TODO: drop this function when supporting jobs submitted before 0.19.17 is no longer relevant.
+    if (
+        job.job_spec.repo_code_hash is None
+        and run.run_spec.repo_code_hash is not None
+        and job.job_submissions[-1].deployment_num == run.deployment_num
+    ):
+        # The job spec does not have `repo_code_hash`, because it was submitted before 0.19.17.
+        # Use `repo_code_hash` from the run.
+        return run.run_spec.repo_code_hash
+    return job.job_spec.repo_code_hash
 
 
 async def _get_job_code(

--- a/src/dstack/_internal/server/schemas/runner.py
+++ b/src/dstack/_internal/server/schemas/runner.py
@@ -78,6 +78,7 @@ class SubmitBody(CoreModel):
                 "max_duration",
                 "ssh_key",
                 "working_dir",
+                "repo_data",
             }
         ),
     ]

--- a/src/dstack/_internal/server/services/jobs/configurators/base.py
+++ b/src/dstack/_internal/server/services/jobs/configurators/base.py
@@ -134,6 +134,8 @@ class JobConfigurator(ABC):
             working_dir=self._working_dir(),
             volumes=self._volumes(job_num),
             ssh_key=self._ssh_key(jobs_per_replica),
+            repo_data=self.run_spec.repo_data,
+            repo_code_hash=self.run_spec.repo_code_hash,
         )
         return job_spec
 

--- a/src/dstack/_internal/server/services/runs.py
+++ b/src/dstack/_internal/server/services/runs.py
@@ -898,7 +898,14 @@ def _validate_run_spec_and_set_defaults(run_spec: RunSpec):
     set_resources_defaults(run_spec.configuration.resources)
 
 
-_UPDATABLE_SPEC_FIELDS = ["repo_code_hash", "configuration"]
+_UPDATABLE_SPEC_FIELDS = ["configuration"]
+_TYPE_SPECIFIC_UPDATABLE_SPEC_FIELDS = {
+    "service": [
+        # rolling deployment
+        "repo_data",
+        "repo_code_hash",
+    ],
+}
 _CONF_UPDATABLE_FIELDS = ["priority"]
 _TYPE_SPECIFIC_CONF_UPDATABLE_FIELDS = {
     "dev-environment": ["inactivity_duration"],
@@ -935,11 +942,14 @@ def _can_update_run_spec(current_run_spec: RunSpec, new_run_spec: RunSpec) -> bo
 def _check_can_update_run_spec(current_run_spec: RunSpec, new_run_spec: RunSpec):
     spec_diff = diff_models(current_run_spec, new_run_spec)
     changed_spec_fields = list(spec_diff.keys())
+    updatable_spec_fields = _UPDATABLE_SPEC_FIELDS + _TYPE_SPECIFIC_UPDATABLE_SPEC_FIELDS.get(
+        new_run_spec.configuration.type, []
+    )
     for key in changed_spec_fields:
-        if key not in _UPDATABLE_SPEC_FIELDS:
+        if key not in updatable_spec_fields:
             raise ServerClientError(
                 f"Failed to update fields {changed_spec_fields}."
-                f" Can only update {_UPDATABLE_SPEC_FIELDS}."
+                f" Can only update {updatable_spec_fields}."
             )
     _check_can_update_configuration(current_run_spec.configuration, new_run_spec.configuration)
 

--- a/src/dstack/_internal/server/testing/common.py
+++ b/src/dstack/_internal/server/testing/common.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from collections.abc import Callable
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import Dict, List, Literal, Optional, Union
@@ -252,18 +253,19 @@ async def create_file_archive(
 def get_run_spec(
     run_name: str,
     repo_id: str,
-    profile: Optional[Profile] = None,
+    configuration_path: str = "dstack.yaml",
+    profile: Union[Profile, Callable[[], Profile], None] = lambda: Profile(name="default"),
     configuration: Optional[AnyRunConfiguration] = None,
 ) -> RunSpec:
-    if profile is None:
-        profile = Profile(name="default")
+    if callable(profile):
+        profile = profile()
     return RunSpec(
         run_name=run_name,
         repo_id=repo_id,
         repo_data=LocalRunRepoData(repo_dir="/"),
         repo_code_hash=None,
         working_dir=".",
-        configuration_path="dstack.yaml",
+        configuration_path=configuration_path,
         configuration=configuration or DevEnvironmentConfiguration(ide="vscode"),
         profile=profile,
         ssh_key_pub="user_ssh_key",

--- a/src/dstack/_internal/utils/nested_list.py
+++ b/src/dstack/_internal/utils/nested_list.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class NestedListItem:
+    label: str
+    children: list["NestedListItem"] = field(default_factory=list)
+
+    def render(self, indent: int = 0, visited: Optional[set[int]] = None) -> str:
+        if visited is None:
+            visited = set()
+
+        item_id = id(self)
+        if item_id in visited:
+            raise ValueError(f"Cycle detected at item: {self.label}")
+
+        visited.add(item_id)
+        prefix = "  " * indent + "- "
+        output = f"{prefix}{self.label}\n"
+        for child in self.children:
+            # `visited.copy()` so that we only detect cycles within each path,
+            # rather than duplicate items in unrelated paths
+            output += child.render(indent + 1, visited.copy())
+        return output
+
+
+@dataclass
+class NestedList:
+    """
+    A nested list that can be rendered in Markdown-like format:
+
+    - Item 1
+    - Item 2
+      - Item 2.1
+      - Item 2.2
+        - Item 2.2.1
+    - Item 3
+    """
+
+    children: list[NestedListItem] = field(default_factory=list)
+
+    def render(self) -> str:
+        output = ""
+        for child in self.children:
+            output += child.render()
+        return output

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -244,6 +244,8 @@ def get_dev_env_run_plan_dict(
                     "volumes": volumes,
                     "ssh_key": None,
                     "working_dir": ".",
+                    "repo_code_hash": None,
+                    "repo_data": {"repo_dir": "/repo", "repo_type": "local"},
                 },
                 "offers": [json.loads(o.json()) for o in offers],
                 "total_offers": total_offers,
@@ -436,6 +438,8 @@ def get_dev_env_run_dict(
                     "volumes": [],
                     "ssh_key": None,
                     "working_dir": ".",
+                    "repo_code_hash": None,
+                    "repo_data": {"repo_dir": "/repo", "repo_type": "local"},
                 },
                 "job_submissions": [
                     {

--- a/src/tests/_internal/utils/test_nested_list.py
+++ b/src/tests/_internal/utils/test_nested_list.py
@@ -1,0 +1,56 @@
+from textwrap import dedent
+
+import pytest
+
+from dstack._internal.utils.nested_list import NestedList, NestedListItem
+
+
+def test_render_flat_list():
+    nested = NestedList(
+        children=[NestedListItem("Item 1"), NestedListItem("Item 2"), NestedListItem("Item 3")]
+    )
+    expected = "- Item 1\n- Item 2\n- Item 3\n"
+    assert nested.render() == expected
+
+
+def test_render_nested_list():
+    nested = NestedList(
+        children=[
+            NestedListItem("Item 1"),
+            NestedListItem(
+                "Item 2",
+                [
+                    NestedListItem("Item 2.1"),
+                    NestedListItem("Item 2.2", [NestedListItem("Item 2.2.1")]),
+                ],
+            ),
+            NestedListItem("Item 3"),
+        ]
+    )
+    expected = dedent(
+        """
+        - Item 1
+        - Item 2
+          - Item 2.1
+          - Item 2.2
+            - Item 2.2.1
+        - Item 3
+        """
+    ).lstrip()
+    assert nested.render() == expected
+
+
+def test_render_empty_list():
+    nested = NestedList()
+    assert nested.render() == ""
+
+
+def test_cycle_detection():
+    a = NestedListItem("A")
+    b = NestedListItem("B", [a])
+    a.children.append(b)  # Introduce a cycle: A → B → A
+
+    nested = NestedList(children=[a])
+
+    with pytest.raises(ValueError, match="Cycle detected at item: A"):
+        nested.render()


### PR DESCRIPTION
- Support rolling deployments for services when
  the run repo is updated: new commits are added,
  the branch is changed, uncommitted files are
  updated, etc. Switching from one repo to another
  is not yet supported.

  > **Note**: A side effect of this change is that
  if the run configuration file is stored in the
  same repo that is used for the run, any changes
  to the configuration file will also be
  considered a change to the repo
  (`repo_code_hash`), and hence require a rolling
  deployment for services or a full restart for
  tasks and dev environments. Previously, this was
  not the case, since changes to `repo_code_hash`
  were ignored for existing jobs. This new
  behavior makes it more difficult to avoid
  redeployment when changing some configuration
  properties, namely `priority`,
  `inactivity_duration`, `replicas`, and
  `scaling`. However, we consider this acceptable,
  since changing these properties in-place is an
  advanced use case and can still be achieved by
  moving the configuration file out of the repo.

- Improve run plan output in `dstack apply` when
  attempting an in-place update:

  - Show not only the list of changed
    configuration properties, but also other
    changes from the run spec, such as
    repo-related changes.

    ```shell
    $ dstack apply -f test-service.dstack.yml

    Active run test-service already exists. Detected changes that can be updated in-place:
    - Repo state (branch, commit, or other)
    - Repo files
    - Configuration properties:
      - env

    Update the run? [y/n]:
    ```

  - Show the list of changes not only when
    in-place update is possible, but also when it
    is not. This will help users understand why a
    run cannot be updated in-place.

    ```shell
    $ dstack apply -f test-service.dstack.yml

    Active run test-service already exists. Detected changes that cannot be updated in-place:
    - Repo files
    - Configuration properties:
      - gateway

    Stop and override the run? [y/n]:
    ```

    Currently, all detected changes are listed
    together. An area for future improvement is
    highlighting the changes that prevent an
    in-place update.

#2180