### PR TITLE
Support the local backend with the in-server proxy

### DIFF
--- a/src/dstack/_internal/server/services/proxy/repo.py
+++ b/src/dstack/_internal/server/services/proxy/repo.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import joinedload
 
 import dstack._internal.server.services.jobs as jobs_services
 from dstack._internal.core.consts import DSTACK_RUNNER_SSH_PORT
+from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.configurations import ServiceConfiguration
 from dstack._internal.core.models.instances import RemoteConnectionInfo, SSHConnectionParams
 from dstack._internal.core.models.runs import (
@@ -86,6 +87,8 @@ class ServerProxyRepo(BaseProxyRepo):
                     username=jpd.username,
                     port=jpd.ssh_port,
                 )
+                if jpd.backend == BackendType.LOCAL:
+                    ssh_proxy = None
             ssh_head_proxy: Optional[SSHConnectionParams] = None
             ssh_head_proxy_private_key: Optional[str] = None
             instance = get_or_error(job.instance)


### PR DESCRIPTION
Fix this error when requesting a service running
on the local backend and served by the in-server
proxy:

```python
  File "/dstack/src/dstack/_internal/proxy/lib/services/service_connection.py", line 82, in open
    await self._tunnel.aopen()
  File "/dstack/src/dstack/_internal/core/services/ssh/tunnel.py", line 204, in aopen
    raise get_ssh_error(stderr)
dstack._internal.core.errors.SSHError: Connection closed by UNKNOWN port 65535
```

If the replica runs on the local backend, connect
directly to the container, without proxy jumping
through the shim host. Similar to workarounds in
[`SSHAttach`](https://github.com/dstackai/dstack/blob/2cacada0d3251a7e9fb20c4c50969387e313dbdb/src/dstack/_internal/core/services/ssh/attach.py#L97) and [`runner_ssh_tunnel`](https://github.com/dstackai/dstack/blob/2cacada0d3251a7e9fb20c4c50969387e313dbdb/src/dstack/_internal/server/services/runner/ssh.py#L64).