### PR TITLE
Use uvloop by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ gateway = [
 server = [
     "fastapi",
     "starlette>=0.26.0",
-    "uvicorn",
+    "uvicorn[standard]",
     "aiorwlock",
     "aiocache",
     "httpx",

--- a/src/dstack/_internal/server/app.py
+++ b/src/dstack/_internal/server/app.py
@@ -99,7 +99,6 @@ def create_app() -> FastAPI:
 async def lifespan(app: FastAPI):
     configure_logging()
     server_executor = ThreadPoolExecutor(max_workers=settings.SERVER_EXECUTOR_MAX_WORKERS)
-    print(asyncio.get_running_loop())
     asyncio.get_running_loop().set_default_executor(server_executor)
     await migrate()
     _print_dstack_logo()

--- a/src/dstack/_internal/server/app.py
+++ b/src/dstack/_internal/server/app.py
@@ -99,6 +99,7 @@ def create_app() -> FastAPI:
 async def lifespan(app: FastAPI):
     configure_logging()
     server_executor = ThreadPoolExecutor(max_workers=settings.SERVER_EXECUTOR_MAX_WORKERS)
+    print(asyncio.get_running_loop())
     asyncio.get_running_loop().set_default_executor(server_executor)
     await migrate()
     _print_dstack_logo()


### PR DESCRIPTION
The PR installs uvicorn[standard], which includes uvloop and makes uvicorn use it by default when possible.

uvloop improves server performance 10-20% (throughput, latency), which is noticeable on fast endpoints:

without uv loop:

```
(venvt) ➜  stuff wrk http://localhost:8000/healthcheck
Running 10s test @ http://localhost:8000/healthcheck
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     9.61ms   26.02ms 223.25ms   93.55%
    Req/Sec     1.50k   433.86     1.95k    84.85%
  29731 requests in 10.02s, 4.11MB read
Requests/sec:   2966.66
Transfer/sec:    420.13KB
```

with uvloop:

```
(venvt) ➜  stuff wrk http://localhost:8000/healthcheck             
Running 10s test @ http://localhost:8000/healthcheck
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    11.63ms   32.02ms 265.65ms   91.91%
    Req/Sec     1.84k   537.20     2.36k    84.74%
  35526 requests in 10.02s, 4.91MB read
Requests/sec:   3544.50
Transfer/sec:    501.97KB
```

As expected, there is no effect for slow API endpoints (e.g. /api/runs/list).