### PR TITLE
Fix NVIDIA container toolkit bug in all backends

### DIFF
--- a/src/dstack/_internal/core/backends/lambdalabs/compute.py
+++ b/src/dstack/_internal/core/backends/lambdalabs/compute.py
@@ -1,4 +1,5 @@
 import hashlib
+import shlex
 import subprocess
 import tempfile
 from threading import Thread
@@ -98,7 +99,7 @@ class LambdaCompute(
                 arch=provisioning_data.instance_type.resources.cpu_arch,
             )
             # shim is assumed to be run under root
-            launch_command = "sudo sh -c '" + "&& ".join(commands) + "'"
+            launch_command = "sudo sh -c " + shlex.quote(" && ".join(commands))
             thread = Thread(
                 target=_start_runner,
                 kwargs={


### PR DESCRIPTION
Use cgroupfs as a Docker cgroup driver on all
backends by default to work around an NVIDIA
container toolkit bug where the container looses
access to the GPU.

The patch to `/etc/docker/daemon.json` is
automatically applied in all VM-based backends if
`/etc/docker/daemon.json` exists, has the NVIDIA
runtime, does not explicitly set another cgroup
driver, and `jq` is installed. This is not the
case in Nebius. Lambda, and CUDO, so they still
need custom code to apply the workaround - either
installing `jq` or just writing a hardcoded
`/etc/docker/daemon.json` that is known to work on this backend.

#2860