### PR TITLE
Introduce job_submissions_limit for /api/runs/list 

### DIFF
--- a/frontend/src/pages/Runs/List/index.tsx
+++ b/frontend/src/pages/Runs/List/index.tsx
@@ -48,7 +48,7 @@ export const RunList: React.FC = () => {
 
     const { data, isLoading, refreshList, isLoadingMore } = useInfiniteScroll<IRun, TRunsRequestParams>({
         useLazyQuery: useLazyGetRunsQuery,
-        args: { ...filteringRequestParams, limit: DEFAULT_TABLE_PAGE_SIZE },
+        args: { ...filteringRequestParams, limit: DEFAULT_TABLE_PAGE_SIZE, job_submissions_limit: 1 },
         getPaginationParams: (lastRun) => ({ prev_submitted_at: lastRun.submitted_at }),
     });
 

--- a/frontend/src/types/run.d.ts
+++ b/frontend/src/types/run.d.ts
@@ -7,6 +7,7 @@ declare type TRunsRequestParams = {
     prev_run_id?: string;
     limit?: number;
     ascending?: boolean;
+    job_submissions_limit?: number;
 };
 
 declare type TDeleteRunsRequestParams = {

--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -556,6 +556,10 @@ class Run(CoreModel):
 
     @root_validator
     def _status_message(cls, values) -> Dict:
+        # FIXME: status_message should not require all job submissions for status calculation
+        # since it's very expensive and is not required for anything else.
+        # May return a different status if not all job submissions requested.
+        # TODO: Calculate status_message by looking at job models directly instead job submissions.
         try:
             status = values["status"]
             jobs: List[Job] = values["jobs"]

--- a/src/dstack/_internal/server/routers/runs.py
+++ b/src/dstack/_internal/server/routers/runs.py
@@ -54,6 +54,7 @@ async def list_runs(
         repo_id=body.repo_id,
         username=body.username,
         only_active=body.only_active,
+        job_submissions_limit=body.job_submissions_limit,
         prev_submitted_at=body.prev_submitted_at,
         prev_run_id=body.prev_run_id,
         limit=body.limit,

--- a/src/dstack/_internal/server/routers/runs.py
+++ b/src/dstack/_internal/server/routers/runs.py
@@ -54,6 +54,7 @@ async def list_runs(
         repo_id=body.repo_id,
         username=body.username,
         only_active=body.only_active,
+        include_jobs=body.include_jobs,
         job_submissions_limit=body.job_submissions_limit,
         prev_submitted_at=body.prev_submitted_at,
         prev_run_id=body.prev_run_id,

--- a/src/dstack/_internal/server/schemas/runs.py
+++ b/src/dstack/_internal/server/schemas/runs.py
@@ -13,12 +13,16 @@ class ListRunsRequest(CoreModel):
     repo_id: Optional[str] = None
     username: Optional[str] = None
     only_active: bool = False
+    include_jobs: bool = Field(
+        True,
+        description=("Whether to include `jobs` in the response"),
+    )
     job_submissions_limit: Optional[int] = Field(
         None,
         ge=0,
         description=(
             "Limit number of job submissions returned per job to avoid large responses."
-            "Drops old job submissions"
+            "Drops older job submissions. No effect with `include_jobs: false`"
         ),
     )
     prev_submitted_at: Optional[datetime] = None

--- a/src/dstack/_internal/server/schemas/runs.py
+++ b/src/dstack/_internal/server/schemas/runs.py
@@ -9,12 +9,20 @@ from dstack._internal.core.models.runs import ApplyRunPlanInput, RunSpec
 
 
 class ListRunsRequest(CoreModel):
-    project_name: Optional[str]
-    repo_id: Optional[str]
-    username: Optional[str]
+    project_name: Optional[str] = None
+    repo_id: Optional[str] = None
+    username: Optional[str] = None
     only_active: bool = False
-    prev_submitted_at: Optional[datetime]
-    prev_run_id: Optional[UUID]
+    job_submissions_limit: Optional[int] = Field(
+        None,
+        ge=0,
+        description=(
+            "Limit number of job submissions returned per job to avoid large responses."
+            "Drops old job submissions"
+        ),
+    )
+    prev_submitted_at: Optional[datetime] = None
+    prev_run_id: Optional[UUID] = None
     limit: int = Field(100, ge=0, le=100)
     ascending: bool = False
 

--- a/src/dstack/_internal/server/services/runs.py
+++ b/src/dstack/_internal/server/services/runs.py
@@ -668,7 +668,7 @@ def run_model_to_run(
 ) -> Run:
     jobs: List[Job] = []
     if include_jobs:
-        jobs = _get_run_job_with_submissions(
+        jobs = _get_run_jobs_with_submissions(
             run_model=run_model,
             job_submissions_limit=job_submissions_limit,
             return_in_api=return_in_api,
@@ -705,7 +705,7 @@ def run_model_to_run(
     return run
 
 
-def _get_run_job_with_submissions(
+def _get_run_jobs_with_submissions(
     run_model: RunModel,
     job_submissions_limit: Optional[int],
     return_in_api: bool = False,

--- a/src/dstack/_internal/server/services/runs.py
+++ b/src/dstack/_internal/server/services/runs.py
@@ -105,6 +105,7 @@ async def list_user_runs(
     repo_id: Optional[str],
     username: Optional[str],
     only_active: bool,
+    include_jobs: bool,
     job_submissions_limit: Optional[int],
     prev_submitted_at: Optional[datetime],
     prev_run_id: Optional[uuid.UUID],
@@ -151,7 +152,10 @@ async def list_user_runs(
         try:
             runs.append(
                 run_model_to_run(
-                    r, return_in_api=True, job_submissions_limit=job_submissions_limit
+                    r,
+                    return_in_api=True,
+                    include_jobs=include_jobs,
+                    job_submissions_limit=job_submissions_limit,
                 )
             )
         except pydantic.ValidationError:
@@ -657,52 +661,26 @@ async def delete_runs(
 
 def run_model_to_run(
     run_model: RunModel,
-    include_job_submissions: bool = True,
+    include_jobs: bool = True,
     job_submissions_limit: Optional[int] = None,
     return_in_api: bool = False,
     include_sensitive: bool = False,
 ) -> Run:
     jobs: List[Job] = []
-    run_jobs = sorted(run_model.jobs, key=lambda j: (j.replica_num, j.job_num, j.submission_num))
-    for replica_num, replica_submissions in itertools.groupby(
-        run_jobs, key=lambda j: j.replica_num
-    ):
-        for job_num, job_submissions in itertools.groupby(
-            replica_submissions, key=lambda j: j.job_num
-        ):
-            submissions = []
-            job_model = None
-            if job_submissions_limit is not None:
-                if job_submissions_limit == 0:
-                    job_submissions = []
-                else:
-                    job_submissions = list(job_submissions)[-job_submissions_limit:]
-            for job_model in job_submissions:
-                if include_job_submissions:
-                    job_submission = job_model_to_job_submission(job_model)
-                    if return_in_api:
-                        # Set default non-None values for 0.18 backward-compatibility
-                        # Remove in 0.19
-                        if job_submission.job_provisioning_data is not None:
-                            if job_submission.job_provisioning_data.hostname is None:
-                                job_submission.job_provisioning_data.hostname = ""
-                            if job_submission.job_provisioning_data.ssh_port is None:
-                                job_submission.job_provisioning_data.ssh_port = 22
-                    submissions.append(job_submission)
-            if job_model is not None:
-                # Use the spec from the latest submission. Submissions can have different specs
-                job_spec = JobSpec.__response__.parse_raw(job_model.job_spec_data)
-                if not include_sensitive:
-                    _remove_job_spec_sensitive_info(job_spec)
-                jobs.append(Job(job_spec=job_spec, job_submissions=submissions))
+    if include_jobs:
+        jobs = _get_run_job_with_submissions(
+            run_model=run_model,
+            job_submissions_limit=job_submissions_limit,
+            return_in_api=return_in_api,
+            include_sensitive=include_sensitive,
+        )
 
     run_spec = RunSpec.__response__.parse_raw(run_model.run_spec)
 
     latest_job_submission = None
-    if include_job_submissions:
+    if len(jobs) > 0 and len(jobs[0].job_submissions) > 0:
         # TODO(egor-s): does it make sense with replicas and multi-node?
-        if jobs:
-            latest_job_submission = jobs[0].job_submissions[-1]
+        latest_job_submission = jobs[0].job_submissions[-1]
 
     service_spec = None
     if run_model.service_spec is not None:
@@ -725,6 +703,47 @@ def run_model_to_run(
     )
     run.cost = _get_run_cost(run)
     return run
+
+
+def _get_run_job_with_submissions(
+    run_model: RunModel,
+    job_submissions_limit: Optional[int],
+    return_in_api: bool = False,
+    include_sensitive: bool = False,
+) -> List[Job]:
+    jobs: List[Job] = []
+    run_jobs = sorted(run_model.jobs, key=lambda j: (j.replica_num, j.job_num, j.submission_num))
+    for replica_num, replica_submissions in itertools.groupby(
+        run_jobs, key=lambda j: j.replica_num
+    ):
+        for job_num, job_models in itertools.groupby(replica_submissions, key=lambda j: j.job_num):
+            submissions = []
+            job_model = None
+            if job_submissions_limit is not None:
+                if job_submissions_limit == 0:
+                    # Take latest job submission to return its job_spec
+                    job_models = list(job_models)[-1:]
+                else:
+                    job_models = list(job_models)[-job_submissions_limit:]
+            for job_model in job_models:
+                if job_submissions_limit != 0:
+                    job_submission = job_model_to_job_submission(job_model)
+                    if return_in_api:
+                        # Set default non-None values for 0.18 backward-compatibility
+                        # Remove in 0.19
+                        if job_submission.job_provisioning_data is not None:
+                            if job_submission.job_provisioning_data.hostname is None:
+                                job_submission.job_provisioning_data.hostname = ""
+                            if job_submission.job_provisioning_data.ssh_port is None:
+                                job_submission.job_provisioning_data.ssh_port = 22
+                    submissions.append(job_submission)
+            if job_model is not None:
+                # Use the spec from the latest submission. Submissions can have different specs
+                job_spec = JobSpec.__response__.parse_raw(job_model.job_spec_data)
+                if not include_sensitive:
+                    _remove_job_spec_sensitive_info(job_spec)
+                jobs.append(Job(job_spec=job_spec, job_submissions=submissions))
+    return jobs
 
 
 async def _get_pool_offers(

--- a/src/dstack/api/_public/runs.py
+++ b/src/dstack/api/_public/runs.py
@@ -748,6 +748,7 @@ class RunCollection:
             repo_id=None,
             only_active=only_active,
             limit=limit or 100,
+            job_submissions_limit=1,  # no need to return more than 1 submission per job
         )
         if only_active and len(runs) == 0:
             runs = self._api_client.runs.list(

--- a/src/dstack/api/server/_runs.py
+++ b/src/dstack/api/server/_runs.py
@@ -33,6 +33,7 @@ class RunsAPIClient(APIClientGroup):
         prev_run_id: Optional[UUID] = None,
         limit: int = 100,
         ascending: bool = False,
+        include_jobs: bool = True,
         job_submissions_limit: Optional[int] = None,
     ) -> List[Run]:
         body = ListRunsRequest(
@@ -40,6 +41,7 @@ class RunsAPIClient(APIClientGroup):
             repo_id=repo_id,
             username=username,
             only_active=only_active,
+            include_jobs=include_jobs,
             job_submissions_limit=job_submissions_limit,
             prev_submitted_at=prev_submitted_at,
             prev_run_id=prev_run_id,

--- a/src/dstack/api/server/_runs.py
+++ b/src/dstack/api/server/_runs.py
@@ -33,12 +33,14 @@ class RunsAPIClient(APIClientGroup):
         prev_run_id: Optional[UUID] = None,
         limit: int = 100,
         ascending: bool = False,
+        job_submissions_limit: Optional[int] = None,
     ) -> List[Run]:
         body = ListRunsRequest(
             project_name=project_name,
             repo_id=repo_id,
             username=username,
             only_active=only_active,
+            job_submissions_limit=job_submissions_limit,
             prev_submitted_at=prev_submitted_at,
             prev_run_id=prev_run_id,
             limit=limit,

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -707,6 +707,108 @@ class TestListRuns:
         assert len(response2_json) == 1
         assert response2_json[0]["id"] == str(run2.id)
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_limits_job_submissions(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        user = await create_user(session=session, global_role=GlobalRole.USER)
+        project = await create_project(session=session, owner=user)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.USER
+        )
+        repo = await create_repo(
+            session=session,
+            project_id=project.id,
+        )
+        run_submitted_at = datetime(2023, 1, 2, 3, 4, tzinfo=timezone.utc)
+        run = await create_run(
+            session=session,
+            project=project,
+            repo=repo,
+            user=user,
+            submitted_at=run_submitted_at,
+        )
+        run_spec = RunSpec.parse_raw(run.run_spec)
+        await create_job(
+            session=session,
+            run=run,
+            submitted_at=run_submitted_at,
+            last_processed_at=run_submitted_at,
+        )
+        job2 = await create_job(
+            session=session,
+            run=run,
+            submitted_at=run_submitted_at,
+            last_processed_at=run_submitted_at,
+        )
+        job2_spec = JobSpec.parse_raw(job2.job_spec_data)
+        response = await client.post(
+            "/api/runs/list",
+            headers=get_auth_headers(user.token),
+            json={"job_submissions_limit": 1},
+        )
+        assert response.status_code == 200, response.json()
+        assert response.json() == [
+            {
+                "id": str(run.id),
+                "project_name": project.name,
+                "user": user.name,
+                "submitted_at": run_submitted_at.isoformat(),
+                "last_processed_at": run_submitted_at.isoformat(),
+                "status": "submitted",
+                "status_message": "submitted",
+                "run_spec": run_spec.dict(),
+                "jobs": [
+                    {
+                        "job_spec": job2_spec.dict(),
+                        "job_submissions": [
+                            {
+                                "id": str(job2.id),
+                                "submission_num": 0,
+                                "deployment_num": 0,
+                                "submitted_at": run_submitted_at.isoformat(),
+                                "last_processed_at": run_submitted_at.isoformat(),
+                                "finished_at": None,
+                                "inactivity_secs": None,
+                                "status": "submitted",
+                                "status_message": "submitted",
+                                "termination_reason": None,
+                                "termination_reason_message": None,
+                                "error": None,
+                                "exit_status": None,
+                                "job_provisioning_data": None,
+                                "job_runtime_data": None,
+                            }
+                        ],
+                    }
+                ],
+                "latest_job_submission": {
+                    "id": str(job2.id),
+                    "submission_num": 0,
+                    "deployment_num": 0,
+                    "submitted_at": run_submitted_at.isoformat(),
+                    "last_processed_at": run_submitted_at.isoformat(),
+                    "finished_at": None,
+                    "inactivity_secs": None,
+                    "status": "submitted",
+                    "status_message": "submitted",
+                    "termination_reason_message": None,
+                    "termination_reason": None,
+                    "error": None,
+                    "exit_status": None,
+                    "job_provisioning_data": None,
+                    "job_runtime_data": None,
+                },
+                "cost": 0,
+                "service": None,
+                "deployment_num": 0,
+                "termination_reason": None,
+                "error": None,
+                "deleted": False,
+            },
+        ]
+
 
 class TestGetRun:
     @pytest.mark.asyncio


### PR DESCRIPTION
This PR introduces `job_submissions_limit` parameter for /api/runs/list endpoint that allows returning less job_submission per job, reducing response sizes significantly and speeding up the API / server. The CLI/UI are updated to request job_submissions_limit: 1 when listing runs – no need for all the submission there.

The only downside so far: status_message calculation requires all the job submissions to be returned, so it may not return "retrying" if fewer job submission requested. This will be fixed in a separate PR since status_message calculation requires a revision.

**Update**: also adds `include_jobs` parameter to include no jobs at all (no job specs). `job_submissions_limit: 0` still returns job specs but without jobs submissions.

Speedups should stack nicely with #2880.

`"job_submissions_limit": null`:

```
(venvt) ➜  stuff wrk http://localhost:8000/api/runs/list -H 'Authorization: Bearer-' -s bench_list.lua
Running 10s test @ http://localhost:8000/api/runs/list
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   655.67ms  185.66ms   1.21s    73.65%
    Req/Sec     8.41      4.51    29.00     83.96%
  148 requests in 10.10s, 19.30MB read
Requests/sec:     14.66
Transfer/sec:      1.91MB
```

`"job_submissions_limit": 1`:

```
(venvt) ➜  stuff wrk http://localhost:8000/api/runs/list -H 'Authorization: Bearer -' -s bench_list.lua
Running 10s test @ http://localhost:8000/api/runs/list
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   570.31ms  146.76ms   1.00s    70.41%
    Req/Sec    10.12      6.94    30.00     67.33%
  169 requests in 10.10s, 17.35MB read
Requests/sec:     16.74
Transfer/sec:      1.72MB
```

`"include_jobs": false`:

```
(venvt) ➜  stuff wrk http://localhost:8000/api/runs/list -H 'Authorization: Bearer -' -s bench_list.lua
Running 10s test @ http://localhost:8000/api/runs/list
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   333.30ms   83.78ms 662.51ms   75.50%
    Req/Sec    15.30      7.13    39.00     85.88%
  298 requests in 10.09s, 8.90MB read
Requests/sec:     29.54
Transfer/sec:      0.88MB
```

Speedups will be more significant if there are lots of submission per job (retrying), in my benchmarks there are at most 2-3 submissions per job.