### PR TITLE
Switch to `e2-medium` for GCP gateways

### DIFF
--- a/src/dstack/_internal/core/backends/gcp/compute.py
+++ b/src/dstack/_internal/core/backends/gcp/compute.py
@@ -499,7 +499,7 @@ class GCPCompute(
         request.instance_resource = gcp_resources.create_instance_struct(
             disk_size=10,
             image_id=_get_gateway_image_id(),
-            machine_type="e2-small",
+            machine_type="e2-medium",
             accelerators=[],
             spot=False,
             user_data=get_gateway_user_data(configuration.ssh_key_pub),


### PR DESCRIPTION
Switching from `e2-small` to `e2-medium` decreases
provisioning time from about 5 minutes to about 2
minutes. The bottleneck is the snap, apt, and pip
package installation, which takes too long on
`e2-small`, likely because of the burstable CPU -
`e2-small` comes with 0.5-2 vCPU, while
`e2-medium` comes with 1-2 vCPU, depending on the
burst.

Fixes #2885