### PR TITLE
Do not lose `provisioning` gateways on restart

### DIFF
--- a/src/dstack/_internal/server/background/__init__.py
+++ b/src/dstack/_internal/server/background/__init__.py
@@ -4,8 +4,8 @@ from apscheduler.triggers.interval import IntervalTrigger
 from dstack._internal.server import settings
 from dstack._internal.server.background.tasks.process_fleets import process_fleets
 from dstack._internal.server.background.tasks.process_gateways import (
+    process_gateways,
     process_gateways_connections,
-    process_submitted_gateways,
 )
 from dstack._internal.server.background.tasks.process_instances import (
     process_instances,
@@ -70,9 +70,7 @@ def start_background_tasks() -> AsyncIOScheduler:
         )
         _scheduler.add_job(delete_prometheus_metrics, IntervalTrigger(minutes=5), max_instances=1)
     _scheduler.add_job(process_gateways_connections, IntervalTrigger(seconds=15))
-    _scheduler.add_job(
-        process_submitted_gateways, IntervalTrigger(seconds=10, jitter=2), max_instances=5
-    )
+    _scheduler.add_job(process_gateways, IntervalTrigger(seconds=10, jitter=2), max_instances=5)
     _scheduler.add_job(
         process_submitted_volumes, IntervalTrigger(seconds=10, jitter=2), max_instances=5
     )

--- a/src/dstack/_internal/server/services/logging.py
+++ b/src/dstack/_internal/server/services/logging.py
@@ -1,12 +1,14 @@
 from typing import Union
 
-from dstack._internal.server.models import JobModel, RunModel
+from dstack._internal.server.models import GatewayModel, JobModel, RunModel
 
 
-def fmt(model: Union[RunModel, JobModel]) -> str:
+def fmt(model: Union[RunModel, JobModel, GatewayModel]) -> str:
     """Consistent string representation of a model for logging."""
     if isinstance(model, RunModel):
         return f"run({model.id.hex[:6]}){model.run_name}"
     if isinstance(model, JobModel):
         return f"job({model.id.hex[:6]}){model.job_name}"
+    if isinstance(model, GatewayModel):
+        return f"gateway({model.id.hex[:6]}){model.name}"
     return str(model)

--- a/src/tests/_internal/server/background/tasks/test_process_gateways.py
+++ b/src/tests/_internal/server/background/tasks/test_process_gateways.py
@@ -5,56 +5,48 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from dstack._internal.core.errors import BackendError
 from dstack._internal.core.models.gateways import GatewayProvisioningData, GatewayStatus
-from dstack._internal.server.background.tasks.process_gateways import process_submitted_gateways
+from dstack._internal.server.background.tasks.process_gateways import process_gateways
 from dstack._internal.server.testing.common import (
     AsyncContextManager,
     ComputeMockSpec,
     create_backend,
     create_gateway,
+    create_gateway_compute,
     create_project,
 )
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
 class TestProcessSubmittedGateways:
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
-    async def test_provisions_gateway(self, test_db, session: AsyncSession):
+    async def test_submitted_to_provisioning(self, test_db, session: AsyncSession):
         project = await create_project(session=session)
         backend = await create_backend(session=session, project_id=project.id)
         gateway = await create_gateway(
             session=session,
             project_id=project.id,
             backend_id=backend.id,
+            status=GatewayStatus.SUBMITTED,
         )
-        with (
-            patch(
-                "dstack._internal.server.services.backends.get_project_backend_with_model_by_type_or_error"
-            ) as m,
-            patch(
-                "dstack._internal.server.services.gateways.gateway_connections_pool.get_or_add"
-            ) as pool_add,
-        ):
+        with patch(
+            "dstack._internal.server.services.backends.get_project_backend_with_model_by_type_or_error"
+        ) as m:
             aws = Mock()
             m.return_value = (backend, aws)
-            pool_add.return_value = MagicMock()
-            pool_add.return_value.client.return_value = MagicMock(AsyncContextManager())
             aws.compute.return_value = Mock(spec=ComputeMockSpec)
             aws.compute.return_value.create_gateway.return_value = GatewayProvisioningData(
                 instance_id="i-1234567890",
                 ip_address="2.2.2.2",
                 region="us",
             )
-            await process_submitted_gateways()
+            await process_gateways()
             m.assert_called_once()
             aws.compute.return_value.create_gateway.assert_called_once()
-            pool_add.assert_called_once()
         await session.refresh(gateway)
-        assert gateway.status == GatewayStatus.RUNNING
+        assert gateway.status == GatewayStatus.PROVISIONING
         assert gateway.gateway_compute is not None
         assert gateway.gateway_compute.ip_address == "2.2.2.2"
 
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
     async def test_marks_gateway_as_failed_if_gateway_creation_errors(
         self, test_db, session: AsyncSession
     ):
@@ -64,6 +56,7 @@ class TestProcessSubmittedGateways:
             session=session,
             project_id=project.id,
             backend_id=backend.id,
+            status=GatewayStatus.SUBMITTED,
         )
         with patch(
             "dstack._internal.server.services.backends.get_project_backend_with_model_by_type_or_error"
@@ -72,47 +65,57 @@ class TestProcessSubmittedGateways:
             m.return_value = (backend, aws)
             aws.compute.return_value = Mock(spec=ComputeMockSpec)
             aws.compute.return_value.create_gateway.side_effect = BackendError("Some error")
-            await process_submitted_gateways()
+            await process_gateways()
             m.assert_called_once()
             aws.compute.return_value.create_gateway.assert_called_once()
         await session.refresh(gateway)
         assert gateway.status == GatewayStatus.FAILED
         assert gateway.status_message == "Some error"
 
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+class TestProcessProvisioningGateways:
+    async def test_provisioning_to_running(self, test_db, session: AsyncSession):
+        project = await create_project(session=session)
+        backend = await create_backend(session=session, project_id=project.id)
+        gateway_compute = await create_gateway_compute(session)
+        gateway = await create_gateway(
+            session=session,
+            project_id=project.id,
+            backend_id=backend.id,
+            gateway_compute_id=gateway_compute.id,
+            status=GatewayStatus.PROVISIONING,
+        )
+        with patch(
+            "dstack._internal.server.services.gateways.gateway_connections_pool.get_or_add"
+        ) as pool_add:
+            pool_add.return_value = MagicMock()
+            pool_add.return_value.client.return_value = MagicMock(AsyncContextManager())
+            await process_gateways()
+            pool_add.assert_called_once()
+        await session.refresh(gateway)
+        assert gateway.status == GatewayStatus.RUNNING
+
     async def test_marks_gateway_as_failed_if_fails_to_connect(
         self, test_db, session: AsyncSession
     ):
         project = await create_project(session=session)
         backend = await create_backend(session=session, project_id=project.id)
+        gateway_compute = await create_gateway_compute(session)
         gateway = await create_gateway(
             session=session,
             project_id=project.id,
             backend_id=backend.id,
+            gateway_compute_id=gateway_compute.id,
+            status=GatewayStatus.PROVISIONING,
         )
-        with (
-            patch(
-                "dstack._internal.server.services.backends.get_project_backend_with_model_by_type_or_error"
-            ) as m,
-            patch(
-                "dstack._internal.server.services.gateways.connect_to_gateway_with_retry"
-            ) as connect_to_gateway_with_retry_mock,
-        ):
-            aws = Mock()
-            m.return_value = (backend, aws)
+        with patch(
+            "dstack._internal.server.services.gateways.connect_to_gateway_with_retry"
+        ) as connect_to_gateway_with_retry_mock:
             connect_to_gateway_with_retry_mock.return_value = None
-            aws.compute.return_value = Mock(spec=ComputeMockSpec)
-            aws.compute.return_value.create_gateway.return_value = GatewayProvisioningData(
-                instance_id="i-1234567890",
-                ip_address="2.2.2.2",
-                region="us",
-            )
-            await process_submitted_gateways()
-            m.assert_called_once()
-            aws.compute.return_value.create_gateway.assert_called_once()
+            await process_gateways()
             connect_to_gateway_with_retry_mock.assert_called_once()
         await session.refresh(gateway)
         assert gateway.status == GatewayStatus.FAILED
-        assert gateway.gateway_compute is not None
-        assert gateway.gateway_compute is not None
+        assert gateway.status_message == "Failed to connect to gateway"


### PR DESCRIPTION
- Split processing `submitted` and `provisioning` gateways into two processing iterations, so that gateways in the `provisioning` status are not lost on server restarts.
- Decrease the number of gateway configuration attempts during server startup. 50 attempts are only necessary when processing a provisioning gateway.
- Make gateway processing logging more comprehensive and consistent.

Fixes #2677