### PR TITLE
Fix project loading in _check_instance()

### DIFF
--- a/src/dstack/_internal/server/background/tasks/process_instances.py
+++ b/src/dstack/_internal/server/background/tasks/process_instances.py
@@ -738,10 +738,10 @@ async def _check_instance(session: AsyncSession, instance: InstanceModel) -> Non
     if job_provisioning_data.hostname is None:
         res = await session.execute(
             select(ProjectModel)
-            .where(ProjectModel.id == instance.id)
+            .where(ProjectModel.id == instance.project_id)
             .options(joinedload(ProjectModel.backends))
         )
-        project = res.scalar_one()
+        project = res.unique().scalar_one()
         await _wait_for_instance_provisioning_data(
             project=project,
             instance=instance,


### PR DESCRIPTION
Fixes instance provisioning for backends that may have `job_provisioning_data.hostname is None` (introduced in #2928)