### PR TITLE
fix gateway docs url

### DIFF
--- a/examples/accelerators/tenstorrent/README.md
+++ b/examples/accelerators/tenstorrent/README.md
@@ -124,7 +124,7 @@ Additionally, the model is available via `dstack`'s control plane UI:
 
 ![](https://dstack.ai/static-assets/static-assets/images/dstack-tenstorrent-model-ui.png){ width=800 }
 
-When a [gateway](https://dstack.ai/docs/concepts/gateways.md) is configured, the service endpoint 
+When a [gateway](https://dstack.ai/docs/concepts/gateways/) is configured, the service endpoint 
 is available at `https://<run name>.<gateway domain>/`.
 
 > Services support many options, including authentication, auto-scaling policies, etc. To learn more, refer to [Services](https://dstack.ai/docs/concepts/services).

--- a/examples/inference/nim/README.md
+++ b/examples/inference/nim/README.md
@@ -107,7 +107,7 @@ $ curl http://127.0.0.1:3000/proxy/models/main/chat/completions \
 
 </div>
 
-When a [gateway](https://dstack.ai/docs/concepts/gateways.md) is configured, the OpenAI-compatible endpoint 
+When a [gateway](https://dstack.ai/docs/concepts/gateways/) is configured, the OpenAI-compatible endpoint 
 is available at `https://gateway.<gateway domain>/`.
 
 ## Source code

--- a/examples/inference/sglang/README.md
+++ b/examples/inference/sglang/README.md
@@ -119,7 +119,7 @@ curl http://127.0.0.1:3000/proxy/models/main/chat/completions \
 ```
 </div>
 
-When a [gateway](https://dstack.ai/docs/concepts/gateways.md) is configured, the OpenAI-compatible endpoint 
+When a [gateway](https://dstack.ai/docs/concepts/gateways/) is configured, the OpenAI-compatible endpoint 
 is available at `https://gateway.<gateway domain>/`.
 
 ## Source code

--- a/examples/inference/tgi/README.md
+++ b/examples/inference/tgi/README.md
@@ -111,7 +111,7 @@ $ curl http://127.0.0.1:3000/proxy/models/main/chat/completions \
 
 </div>
 
-When a [gateway](https://dstack.ai/docs/concepts/gateways.md) is configured, the OpenAI-compatible endpoint 
+When a [gateway](https://dstack.ai/docs/concepts/gateways/) is configured, the OpenAI-compatible endpoint 
 is available at `https://gateway.<gateway domain>/`.
 
 ## Source code

--- a/examples/inference/trtllm/README.md
+++ b/examples/inference/trtllm/README.md
@@ -360,7 +360,7 @@ $ curl http://127.0.0.1:3000/proxy/models/main/chat/completions \
 
 </div>
 
-When a [gateway](https://dstack.ai/docs/concepts/gateways.md) is configured, the OpenAI-compatible endpoint 
+When a [gateway](https://dstack.ai/docs/concepts/gateways/) is configured, the OpenAI-compatible endpoint 
 is available at `https://gateway.<gateway domain>/`.
 
 ## Source code

--- a/examples/inference/vllm/README.md
+++ b/examples/inference/vllm/README.md
@@ -107,7 +107,7 @@ $ curl http://127.0.0.1:3000/proxy/models/main/chat/completions \
 
 </div>
 
-When a [gateway](https://dstack.ai/docs/concepts/gateways.md) is configured, the OpenAI-compatible endpoint 
+When a [gateway](https://dstack.ai/docs/concepts/gateways/) is configured, the OpenAI-compatible endpoint 
 is available at `https://gateway.<gateway domain>/`.
 
 ## Source code

--- a/examples/llms/deepseek/README.md
+++ b/examples/llms/deepseek/README.md
@@ -291,7 +291,7 @@ curl http://127.0.0.1:3000/proxy/models/main/chat/completions \
 ```
 </div>
 
-When a [gateway](https://dstack.ai/docs/concepts/gateways.md) is configured, the OpenAI-compatible endpoint 
+When a [gateway](https://dstack.ai/docs/concepts/gateways/) is configured, the OpenAI-compatible endpoint 
 is available at `https://gateway.<gateway domain>/`.
 
 ## Fine-tuning

--- a/examples/llms/llama/README.md
+++ b/examples/llms/llama/README.md
@@ -195,7 +195,7 @@ curl http://127.0.0.1:3000/proxy/models/main/chat/completions \
 
 </div>
 
-When a [gateway](https://dstack.ai/docs/concepts/gateways.md) is configured, the service endpoint 
+When a [gateway](https://dstack.ai/docs/concepts/gateways/) is configured, the service endpoint 
 is available at `https://<run name>.<gateway domain>/`.
 
 [//]: # (TODO: https://github.com/dstackai/dstack/issues/1777)

--- a/examples/llms/llama31/README.md
+++ b/examples/llms/llama31/README.md
@@ -208,7 +208,7 @@ $ curl http://127.0.0.1:3000/proxy/models/main/chat/completions \
 
 </div>
 
-When a [gateway](https://dstack.ai/docs/concepts/gateways.md) is configured, the OpenAI-compatible endpoint 
+When a [gateway](https://dstack.ai/docs/concepts/gateways/) is configured, the OpenAI-compatible endpoint 
 is available at `https://gateway.<gateway domain>/`.
 
 [//]: # (TODO: How to prompting and tool calling)

--- a/examples/llms/llama32/README.md
+++ b/examples/llms/llama32/README.md
@@ -115,7 +115,7 @@ $ curl http://127.0.0.1:3000/proxy/services/main/llama32/v1/chat/completions \
 
 </div>
 
-When a [gateway](https://dstack.ai/docs/concepts/gateways.md) is configured, the service endpoint 
+When a [gateway](https://dstack.ai/docs/concepts/gateways/) is configured, the service endpoint 
 is available at `https://<run name>.<gateway domain>/`.
 
 [//]: # (TODO: https://github.com/dstackai/dstack/issues/1777)


### PR DESCRIPTION
While reading the docs found that the gateways link is not correct and when I tried to access got `404 - Not found` error.