### PR TITLE
Return logs external_url for AWS and GCP

### DIFF
--- a/src/dstack/_internal/core/models/logs.py
+++ b/src/dstack/_internal/core/models/logs.py
@@ -23,4 +23,5 @@ class LogEvent(CoreModel):
 
 class JobSubmissionLogs(CoreModel):
     logs: List[LogEvent]
-    next_token: Optional[str]
+    external_url: Optional[str] = None
+    next_token: Optional[str] = None

--- a/src/tests/_internal/server/routers/test_logs.py
+++ b/src/tests/_internal/server/routers/test_logs.py
@@ -75,6 +75,7 @@ class TestPollLogs:
                     "message": "IQ==",
                 },
             ],
+            "external_url": None,
             "next_token": None,
         }
         response = await client.post(
@@ -96,5 +97,6 @@ class TestPollLogs:
                     "message": "IQ==",
                 },
             ],
+            "external_url": None,
             "next_token": None,
         }


### PR DESCRIPTION
API support for #2926 

The PR adds external_url field to the logs/poll endpoint that includes a url to view job submission logs in the external storage (AWS CloudWatch or GCP Logging).

Returning a url to run logs (logs of all job submission) will be more involved since it would probably require a new API endpoint or extending runs/get.