### PR TITLE
Fix: Lambda backend instance unreachable after dstack server restart

### DIFF
--- a/src/dstack/_internal/core/backends/lambdalabs/compute.py
+++ b/src/dstack/_internal/core/backends/lambdalabs/compute.py
@@ -206,10 +206,11 @@ def _launch_runner(
     ssh_private_key: str,
     launch_command: str,
 ):
+    daemonized_command = f"{launch_command.rstrip('&')} >/tmp/dstack-shim.log 2>&1 & disown"
     _run_ssh_command(
         hostname=hostname,
         ssh_private_key=ssh_private_key,
-        command=launch_command,
+        command=daemonized_command,
     )
 
 


### PR DESCRIPTION
This PR fixes issue https://github.com/dstackai/dstack/issues/2669, where the shim launched via SSH gets terminated when the dstack server restarts.

**Issue Cause:**
dstack's local daemon thread creates an SSH connection to the VM. The shim installation command runs on the VM via this SSH connection, unlike cloud-init setup.Even though the shim runs on the VM, it's still a child of the SSH session.When dstack server restarts → daemon thread dies → SSH connection closes.When SSH session closes, the remote shell session ends, and any processes started by that session (including the shim) get terminated.

**Fix:**
The shim launch_command is daemonized as daemonized_command = f"{launch_command.rstrip('&')} >/tmp/dstack-shim.log 2>&1 & disown"