### PR TITLE
Fix configuring CLI logging on Python 3.9/3.10

### DIFF
--- a/src/dstack/_internal/settings.py
+++ b/src/dstack/_internal/settings.py
@@ -19,6 +19,9 @@ DSTACK_BASE_IMAGE_UBUNTU_VERSION = os.getenv(
 )
 DSTACK_DIND_IMAGE = os.getenv("DSTACK_DIND_IMAGE", "dstackai/dind")
 
+CLI_LOG_LEVEL = os.getenv("DSTACK_CLI_LOG_LEVEL", "INFO").upper()
+CLI_FILE_LOG_LEVEL = os.getenv("DSTACK_CLI_FILE_LOG_LEVEL", "DEBUG").upper()
+
 # Development settings
 
 LOCAL_BACKEND_ENABLED = os.getenv("DSTACK_LOCAL_BACKEND_ENABLED") is not None


### PR DESCRIPTION
Do not use `logging.getLevelNamesMapping`
introduced in 3.11.

No need to get the numeric levels at all - just
set the configured named levels on the handlers
and set DEBUG on the logger. This way, the logger
allows all messages, but level filtering is then
done by the handlers.

Fixes #2951