### PR TITLE
Add more probe request configuration options

### DIFF
--- a/docs/docs/concepts/services.md
+++ b/docs/docs/concepts/services.md
@@ -230,7 +230,34 @@ $ dstack ps --verbose
 
     If multiple probes are configured for the service, their statuses are displayed in the order in which the probes appear in the configuration.
 
-Probes are executed for each service replica while the replica is `running`. Probe statuses do not affect how `dstack` handles replicas, except during [rolling deployments](#rolling-deployment).
+Probes are executed for each service replica while the replica is `running`. A probe execution is considered successful if the replica responds with a `2xx` status code. Probe statuses do not affect how `dstack` handles replicas, except during [rolling deployments](#rolling-deployment).
+
+??? info "HTTP request configuration"
+    You can configure the HTTP request method, headers, and other properties. To include secret values in probe requests, use environment variable interpolation, which is enabled for the `url`, `headers[i].value`, and `body` properties.
+
+    <div editor-title="service.dstack.yml">
+
+    ```yaml
+    type: service
+    name: my-service
+    port: 80
+    image: my-app:latest
+    env:
+    - PROBES_API_KEY
+    probes:
+    - type: http
+      method: post
+      url: /check-health
+      headers:
+      - name: X-API-Key
+        value: ${{ env.PROBES_API_KEY }}
+      - name: Content-Type
+        value: application/json
+      body: '{"level": 2}'
+      timeout: 20s
+    ```
+
+    </div>
 
 See the [reference](../reference/dstack.yml/service.md#probes) for more probe configuration options.
 

--- a/docs/docs/reference/dstack.yml/service.md
+++ b/docs/docs/reference/dstack.yml/service.md
@@ -116,6 +116,17 @@ The `service` configuration type allows running [services](../../concepts/servic
       type:
         required: true
 
+##### `probes[n].headers`
+
+###### `probes[n].headers[m]`
+
+#SCHEMA# dstack._internal.core.models.configurations.HTTPHeaderSpec
+    overrides:
+      show_root_heading: false
+      type:
+        required: true
+
+
 ### `retry`
 
 #SCHEMA# dstack._internal.core.models.profiles.ProfileRetry

--- a/src/dstack/_internal/cli/services/configurators/run.py
+++ b/src/dstack/_internal/cli/services/configurators/run.py
@@ -341,6 +341,14 @@ class BaseRunConfigurator(ApplyEnvVarsConfiguratorMixin, BaseApplyConfigurator):
                     username=interpolator.interpolate_or_error(conf.registry_auth.username),
                     password=interpolator.interpolate_or_error(conf.registry_auth.password),
                 )
+            if isinstance(conf, ServiceConfiguration):
+                for probe in conf.probes:
+                    for header in probe.headers:
+                        header.value = interpolator.interpolate_or_error(header.value)
+                    if probe.url:
+                        probe.url = interpolator.interpolate_or_error(probe.url)
+                    if probe.body:
+                        probe.body = interpolator.interpolate_or_error(probe.body)
         except InterpolatorError as e:
             raise ConfigurationError(e.args[0])
 

--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -8,8 +8,11 @@ from typing_extensions import Annotated
 from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.common import ApplyAction, CoreModel, NetworkMode, RegistryAuth
 from dstack._internal.core.models.configurations import (
+    DEFAULT_PROBE_METHOD,
     DEFAULT_REPO_DIR,
     AnyRunConfiguration,
+    HTTPHeaderSpec,
+    HTTPMethod,
     RunConfiguration,
     ServiceConfiguration,
 )
@@ -226,6 +229,9 @@ class JobSSHKey(CoreModel):
 class ProbeSpec(CoreModel):
     type: Literal["http"]  # expect other probe types in the future, namely `exec`
     url: str
+    method: HTTPMethod = DEFAULT_PROBE_METHOD
+    headers: list[HTTPHeaderSpec] = []
+    body: Optional[str] = None
     timeout: int
     interval: int
     ready_after: int

--- a/src/dstack/_internal/server/background/tasks/process_probes.py
+++ b/src/dstack/_internal/server/background/tasks/process_probes.py
@@ -116,9 +116,13 @@ async def _execute_probe(probe: ProbeModel, probe_spec: ProbeSpec) -> bool:
 
     try:
         async with _get_service_replica_client(probe.job) as client:
-            resp = await client.get(
-                "http://dstack" + probe_spec.url,
+            resp = await client.request(
+                method=probe_spec.method,
+                url="http://dstack" + probe_spec.url,
+                headers=[(h.name, h.value) for h in probe_spec.headers],
+                data=probe_spec.body,
                 timeout=probe_spec.timeout,
+                follow_redirects=False,
             )
             logger.debug("%s: probe status code: %s", fmt(probe), resp.status_code)
             return resp.is_success

--- a/src/dstack/_internal/server/services/jobs/configurators/base.py
+++ b/src/dstack/_internal/server/services/jobs/configurators/base.py
@@ -12,6 +12,7 @@ from dstack._internal.core.errors import DockerRegistryError, ServerClientError
 from dstack._internal.core.models.common import RegistryAuth
 from dstack._internal.core.models.configurations import (
     DEFAULT_PROBE_INTERVAL,
+    DEFAULT_PROBE_METHOD,
     DEFAULT_PROBE_READY_AFTER,
     DEFAULT_PROBE_TIMEOUT,
     DEFAULT_PROBE_URL,
@@ -372,6 +373,9 @@ def _probe_config_to_spec(c: ProbeConfig) -> ProbeSpec:
         timeout=c.timeout if c.timeout is not None else DEFAULT_PROBE_TIMEOUT,
         interval=c.interval if c.interval is not None else DEFAULT_PROBE_INTERVAL,
         ready_after=c.ready_after if c.ready_after is not None else DEFAULT_PROBE_READY_AFTER,
+        method=c.method if c.method is not None else DEFAULT_PROBE_METHOD,
+        headers=c.headers,
+        body=c.body,
     )
 
 

--- a/src/dstack/_internal/utils/common.py
+++ b/src/dstack/_internal/utils/common.py
@@ -222,6 +222,21 @@ def remove_prefix(text: str, prefix: str) -> str:
     return text
 
 
+def has_duplicates(iterable: Iterable[Any]) -> bool:
+    """
+    Checks if there are any duplicate items in the given iterable.
+
+    O(n^2) implementation, but works with iterables with unhashable items.
+    For iterables with hashable items, prefer len(set(iterable)) != len(iterable).
+    """
+    seen = []
+    for item in iterable:
+        if item in seen:
+            return True
+        seen.append(item)
+    return False
+
+
 T = TypeVar("T")
 
 

--- a/src/tests/_internal/utils/test_common.py
+++ b/src/tests/_internal/utils/test_common.py
@@ -8,6 +8,7 @@ from dstack._internal.utils.common import (
     batched,
     concat_url_path,
     format_duration_multiunit,
+    has_duplicates,
     local_time,
     make_proxy_url,
     parse_memory,
@@ -122,6 +123,30 @@ class TestFormatDurationMultiunit:
     def test_forbids_negative(self) -> None:
         with pytest.raises(ValueError):
             format_duration_multiunit(-1)
+
+
+@pytest.mark.parametrize(
+    "iterable, expected",
+    [
+        ([1, 2, 3, 4], False),
+        ([1, 2, 3, 4, 2], True),
+        (iter([1, 2, 3, 4]), False),
+        (iter([1, 2, 3, 4, 2]), True),
+        ("abcde", False),
+        ("hello", True),
+        ([1, "a"], False),
+        ([1, "a", 1], True),
+        ([[1, 2], [3, 4]], False),
+        ([[1, 2], [1, 2]], True),
+        ([{"a": "b"}, {"a": "c"}], False),
+        ([{"a": "b"}, {"a": "b"}], True),
+        ([{}, {}], True),
+        ([], False),
+        ([1], False),
+    ],
+)
+def test_has_duplicates(iterable, expected):
+    assert has_duplicates(iterable) == expected
 
 
 class TestParseMemory:


### PR DESCRIPTION
- Add `method`, `headers`, and `body` properties
- Support interpolation from `${{ env.* }}` (but not `${{ secrets.* }}` yet)

#2181