### PR TITLE
increase the secrets max character length

### DIFF
--- a/src/dstack/_internal/server/services/secrets.py
+++ b/src/dstack/_internal/server/services/secrets.py
@@ -18,7 +18,7 @@ logger = get_logger(__name__)
 
 
 _SECRET_NAME_REGEX = "^[A-Za-z0-9-_]{1,200}$"
-_SECRET_VALUE_MAX_LENGTH = 2000
+_SECRET_VALUE_MAX_LENGTH = 3000
 
 
 async def list_secrets(

--- a/src/tests/_internal/server/routers/test_secrets.py
+++ b/src/tests/_internal/server/routers/test_secrets.py
@@ -171,7 +171,7 @@ class TestCreateOrUpdateSecret:
     @pytest.mark.parametrize(
         "name, value",
         [
-            ("too_long_secret_value", "a" * 2001),
+            ("too_long_secret_value", "a" * 3001),
             ("", "empty_name"),
             ("@7&.", "wierd_name_chars"),
         ],


### PR DESCRIPTION
Closes: #2970 
ECR password is longer than 2000 characters. Increasing to the limit so ECR passwords can be stored. 