### PR TITLE
Deprecate local repos

### DIFF
--- a/docs/docs/concepts/repos.md
+++ b/docs/docs/concepts/repos.md
@@ -7,13 +7,13 @@ This allows accessing the directory files from within the run.
 ## Initialize a repo
 
 To use a directory with `dstack apply`, it must first be initialized as a repo by running [`dstack init`](../reference/cli/dstack/init.md).
-The directory can be either a regular local directory or a cloned Git repo.
+The directory must be a cloned Git repo.
 
 [`dstack init`](../reference/cli/dstack/init.md) is not required if you pass `-P` (or `--repo`) to [`dstack apply`](../reference/cli/dstack/apply.md) (see below).
 
 ### Git credentials
 
-If the directory is a cloned Git repo, [`dstack init`](../reference/cli/dstack/init.md) grants the `dstack` server access by uploading the current user's default
+[`dstack init`](../reference/cli/dstack/init.md) grants the `dstack` server access by uploading the current user's default
 Git credentials, ensuring that dstack can clone the Git repo when running the container.
 
 To use custom credentials, pass them directly with `--token` (GitHub token) or `--git-identity` (path to a private SSH
@@ -24,21 +24,19 @@ key).
 
 ### .gitignore and folder size
 
-If the directory is cloned Git repo, [`dstack apply`](../reference/cli/dstack/apply.md) uploads to the `dstack` server only local changes.
-If the directory is not a cloned Git repo, it uploads the entire directory.
+[`dstack apply`](../reference/cli/dstack/apply.md) uploads to the `dstack` server only local changes.
 
 Uploads are limited to 2MB. Use `.gitignore` to exclude unnecessary files from being uploaded.
 You can set the `DSTACK_SERVER_CODE_UPLOAD_LIMIT` environment variable to increase the default server limit.
 Increasing the limit is recommended only if you [configure an object storage](../guides/server-deployment.md).
 
-### Initialize as a local directory
+### Use a local directory instead of a Git repo
 
-If the directory is a cloned Git repo but you want to initialize it as a regular local directory,
-use `--local` with [`dstack init`](../reference/cli/dstack/init.md).
+If the directory is not a cloned Git repo, use [`files`](../reference/dstack.yml/task.md#_files).
 
 ## Specify the repo
 
-By default, `dstack apply` uses the current directory as a repo and requires `dstack init`.
+By default, `dstack apply` uses the current directory as a repo if it is already initialized.
 You can change this by explicitly specifying the repo to use for `dstack apply`.
 
 ### Pass the repo path
@@ -47,8 +45,8 @@ To use a specific directory as the repo, specify its path using `-P` (or `--repo
 
 <div class="termy">
 
-```shell    
-$ dstack apply -f .dstack.yml -P ../parent_dir 
+```shell
+$ dstack apply -f .dstack.yml -P ../parent_dir
 ```
 
 </div>
@@ -73,7 +71,7 @@ If you use a private Git repo, you can pass Git credentials to `dstack apply` us
 
 ### Do not use a repo
 
-To run a configuration without a repo (the `/workflow` directory inside the container will be empty), use `--no-repo`:
+To run a configuration without a repo (the `/workflow` directory inside the container will be empty) if it is already initialized, use `--no-repo`:
 
 <div class="termy">
 

--- a/docs/docs/reference/cli/dstack/apply.md
+++ b/docs/docs/reference/cli/dstack/apply.md
@@ -3,7 +3,7 @@
 This command applies a given configuration. If a resource does not exist, `dstack apply` creates the resource.
 If a resource exists, `dstack apply` updates the resource in-place or re-creates the resource if the update is not possible.
 
-When applying run configurations, `dstack apply` requires that you run `dstack init` first,
+To mount a Git repo to the run's container, `dstack apply` requires that you run `dstack init` first,
 or specify a repo to work with via `-P` (or `--repo`), or specify `--no-repo` if you don't need any repo for the run.
 
 ## Usage
@@ -16,5 +16,10 @@ $ dstack apply --help
 ```
 
 </div>
+
+## User SSH key
+
+By default, `dstack` uses its own SSH key to access runs (`~/.dstack/ssh/id_rsa`).
+It is possible to override this key via the `--ssh-identity` argument.
 
 [//]: # (TODO: Provide examples)

--- a/docs/docs/reference/cli/dstack/apply.md
+++ b/docs/docs/reference/cli/dstack/apply.md
@@ -19,7 +19,7 @@ $ dstack apply --help
 
 ## User SSH key
 
-By default, `dstack` uses its own SSH key to access runs (`~/.dstack/ssh/id_rsa`).
+By default, `dstack` uses its own SSH key to attach to runs (`~/.dstack/ssh/id_rsa`).
 It is possible to override this key via the `--ssh-identity` argument.
 
 [//]: # (TODO: Provide examples)

--- a/docs/docs/reference/cli/dstack/attach.md
+++ b/docs/docs/reference/cli/dstack/attach.md
@@ -13,4 +13,9 @@ $ dstack attach --help
 
 </div>
 
+## User SSH key
+
+By default, `dstack` uses its own SSH key to access runs (`~/.dstack/ssh/id_rsa`).
+It is possible to override this key via the `--ssh-identity` argument.
+
 [//]: # (TODO: Provide examples)

--- a/docs/docs/reference/cli/dstack/attach.md
+++ b/docs/docs/reference/cli/dstack/attach.md
@@ -15,7 +15,7 @@ $ dstack attach --help
 
 ## User SSH key
 
-By default, `dstack` uses its own SSH key to access runs (`~/.dstack/ssh/id_rsa`).
+By default, `dstack` uses its own SSH key to attach to runs (`~/.dstack/ssh/id_rsa`).
 It is possible to override this key via the `--ssh-identity` argument.
 
 [//]: # (TODO: Provide examples)

--- a/docs/docs/reference/cli/dstack/init.md
+++ b/docs/docs/reference/cli/dstack/init.md
@@ -1,11 +1,12 @@
 # dstack init
 
 This command initializes the current directory as a `dstack` [repo](../../../concepts/repos.md).
+The directory must be a cloned Git repository.
 
 **Git credentials**
 
-If the directory is a cloned Git repository, `dstack init` ensures that `dstack` can access it.
-By default, the command uses the user's default Git credentials. These can be overridden with 
+`dstack init` ensures that `dstack` can access a remote Git repository.
+By default, the command uses the user's default Git credentials. These can be overridden with
 `--git-identity` (private SSH key) or `--token` (OAuth token).
 
 <div class="termy">
@@ -16,10 +17,3 @@ $ dstack init --help
 ```
 
 </div>
-
-**User SSH key**
-
-By default, `dstack` uses its own SSH key to access instances (`~/.dstack/ssh/id_rsa`). 
-It is possible to override this key via the `--ssh-identity` argument.
-
-[//]: # (TODO: Mention that it's optional, provide reference to `dstack apply`)

--- a/src/dstack/_internal/cli/commands/init.py
+++ b/src/dstack/_internal/cli/commands/init.py
@@ -4,7 +4,10 @@ from pathlib import Path
 
 from dstack._internal.cli.commands import BaseCommand
 from dstack._internal.cli.services.repos import init_repo, register_init_repo_args
-from dstack._internal.cli.utils.common import configure_logging, console
+from dstack._internal.cli.utils.common import configure_logging, confirm_ask, console, warn
+from dstack._internal.core.errors import ConfigurationError
+from dstack._internal.core.models.repos.base import RepoType
+from dstack._internal.core.services.configs import ConfigManager
 from dstack.api import Client
 
 
@@ -19,12 +22,55 @@ class InitCommand(BaseCommand):
             default=os.getenv("DSTACK_PROJECT"),
         )
         register_init_repo_args(self._parser)
+        # Deprecated since 0.19.25, ignored
+        self._parser.add_argument(
+            "--ssh-identity",
+            metavar="SSH_PRIVATE_KEY",
+            help=argparse.SUPPRESS,
+            type=Path,
+            dest="ssh_identity_file",
+        )
+        # A hidden mode for transitional period only, remove it with local repos
+        self._parser.add_argument(
+            "--remove",
+            help=argparse.SUPPRESS,
+            action="store_true",
+        )
 
     def _command(self, args: argparse.Namespace):
         configure_logging()
+        if args.remove:
+            config_manager = ConfigManager()
+            repo_path = Path.cwd()
+            repo_config = config_manager.get_repo_config(repo_path)
+            if repo_config is None:
+                raise ConfigurationError("The repo is not initialized, nothing to remove")
+            if repo_config.repo_type != RepoType.LOCAL:
+                raise ConfigurationError("`dstack init --remove` is for local repos only")
+            console.print(
+                f"You are about to remove the local repo {repo_path}\n"
+                "Only the record about the repo will be removed,"
+                " the repo files will remain intact\n"
+            )
+            if not confirm_ask("Remove the local repo?"):
+                return
+            config_manager.delete_repo_config(repo_config.repo_id)
+            config_manager.save()
+            console.print("Local repo has been removed")
+            return
         api = Client.from_config(
             project_name=args.project, ssh_identity_file=args.ssh_identity_file
         )
+        if args.local:
+            warn(
+                "Local repos are deprecated since 0.19.25 and will be removed soon."
+                " Consider using `files` instead: https://dstack.ai/docs/concepts/tasks/#files"
+            )
+        if args.ssh_identity_file:
+            warn(
+                "`--ssh-identity` in `dstack init` is deprecated and ignored since 0.19.25."
+                " Use this option with `dstack apply` and `dstack attach` instead"
+            )
         init_repo(
             api=api,
             repo_path=Path.cwd(),
@@ -33,6 +79,5 @@ class InitCommand(BaseCommand):
             local=args.local,
             git_identity_file=args.git_identity_file,
             oauth_token=args.gh_token,
-            ssh_identity_file=args.ssh_identity_file,
         )
         console.print("OK")

--- a/src/dstack/_internal/cli/utils/common.py
+++ b/src/dstack/_internal/cli/utils/common.py
@@ -103,3 +103,10 @@ def add_row_from_dict(table: Table, data: Dict[Union[str, int], Any], **kwargs):
         else:
             row.append("")
     table.add_row(*row, **kwargs)
+
+
+def warn(message: str):
+    if not message.endswith("\n"):
+        # Additional blank line for better visibility if there are more than one warning
+        message = f"{message}\n"
+    console.print(f"[warning][bold]{message}[/]")

--- a/src/dstack/_internal/core/models/config.py
+++ b/src/dstack/_internal/core/models/config.py
@@ -16,7 +16,9 @@ class RepoConfig(CoreModel):
     path: str
     repo_id: str
     repo_type: RepoType
-    ssh_key_path: str
+    # Deprecated since 0.19.25, not used. Can be removed when most users update their `config.yml`
+    # (it's updated each time a project or repo is added)
+    ssh_key_path: Annotated[Optional[str], Field(exclude=True)] = None
 
 
 class GlobalConfig(CoreModel):

--- a/src/dstack/_internal/core/services/configs/__init__.py
+++ b/src/dstack/_internal/core/services/configs/__init__.py
@@ -71,19 +71,15 @@ class ConfigManager:
     def delete_project(self, name: str):
         self.config.projects = [p for p in self.config.projects if p.name != name]
 
-    def save_repo_config(
-        self, repo_path: PathLike, repo_id: str, repo_type: RepoType, ssh_key_path: PathLike
-    ):
+    def save_repo_config(self, repo_path: PathLike, repo_id: str, repo_type: RepoType):
         self.config_filepath.parent.mkdir(parents=True, exist_ok=True)
         with filelock.FileLock(str(self.config_filepath) + ".lock"):
             self.load()
             repo_path = os.path.abspath(repo_path)
-            ssh_key_path = os.path.abspath(ssh_key_path)
             for repo in self.config.repos:
                 if repo.path == repo_path:
                     repo.repo_id = repo_id
                     repo.repo_type = repo_type
-                    repo.ssh_key_path = ssh_key_path
                     break
             else:
                 self.config.repos.append(
@@ -91,7 +87,6 @@ class ConfigManager:
                         path=repo_path,
                         repo_id=repo_id,
                         repo_type=repo_type,
-                        ssh_key_path=ssh_key_path,
                     )
                 )
             self.save()
@@ -109,6 +104,9 @@ class ConfigManager:
         if repo_config is not None:
             return repo_config
         raise DstackError("No repo config found")
+
+    def delete_repo_config(self, repo_id: str):
+        self.config.repos = [p for p in self.config.repos if p.repo_id != repo_id]
 
     @property
     def dstack_ssh_dir(self) -> Path:


### PR DESCRIPTION
* `--local` is deprecated
* `--ssh-identity` in `dstack init` is deprecated and ignored
* Repo is no longer required by default, but a warning is emitted to inform users about this change
* A new transitional `dstack init --remove` subcommand removes a local repo from `~/.dstack/config.yml`

[![asciicast](https://asciinema.org/a/n8MyptYghecUZYmcx0oIynG85.svg)](https://asciinema.org/a/n8MyptYghecUZYmcx0oIynG85)



Closes: https://github.com/dstackai/dstack/issues/2974