### PR TITLE
Only register service replicas after probes pass

### DIFF
--- a/src/dstack/_internal/proxy/gateway/services/registry.py
+++ b/src/dstack/_internal/proxy/gateway/services/registry.py
@@ -152,6 +152,8 @@ async def register_replica(
             )
 
         if old_service.find_replica(replica_id) is not None:
+            # NOTE: as of 0.19.25, the dstack server relies on the exact text of this error.
+            # See dstack._internal.server.services.services.register_replica
             raise ProxyError(f"Replica {replica_id} already exists in service {old_service.fmt()}")
 
         service = old_service.with_replicas(old_service.replicas + (replica,))

--- a/src/dstack/_internal/server/background/tasks/process_running_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_running_jobs.py
@@ -32,6 +32,7 @@ from dstack._internal.core.models.runs import (
     JobSpec,
     JobStatus,
     JobTerminationReason,
+    ProbeSpec,
     Run,
     RunSpec,
     RunStatus,
@@ -70,6 +71,7 @@ from dstack._internal.server.services.repos import (
 from dstack._internal.server.services.runner import client
 from dstack._internal.server.services.runner.ssh import runner_ssh_tunnel
 from dstack._internal.server.services.runs import (
+    is_job_ready,
     run_model_to_run,
 )
 from dstack._internal.server.services.secrets import get_project_secrets_mapping
@@ -140,6 +142,7 @@ async def _process_running_job(session: AsyncSession, job_model: JobModel):
         select(JobModel)
         .where(JobModel.id == job_model.id)
         .options(joinedload(JobModel.instance).joinedload(InstanceModel.project))
+        .options(joinedload(JobModel.probes).load_only(ProbeModel.success_streak))
         .execution_options(populate_existing=True)
     )
     job_model = res.unique().scalar_one()
@@ -382,52 +385,21 @@ async def _process_running_job(session: AsyncSession, job_model: JobModel):
                         job_submission.age,
                     )
 
-    if (
-        initial_status != job_model.status
-        and job_model.status == JobStatus.RUNNING
-        and job_model.job_num == 0  # gateway connects only to the first node
-        and run.run_spec.configuration.type == "service"
-    ):
-        ssh_head_proxy: Optional[SSHConnectionParams] = None
-        ssh_head_proxy_private_key: Optional[str] = None
-        instance = common_utils.get_or_error(job_model.instance)
-        if instance.remote_connection_info is not None:
-            rci = RemoteConnectionInfo.__response__.parse_raw(instance.remote_connection_info)
-            if rci.ssh_proxy is not None:
-                ssh_head_proxy = rci.ssh_proxy
-                ssh_head_proxy_keys = common_utils.get_or_error(rci.ssh_proxy_keys)
-                ssh_head_proxy_private_key = ssh_head_proxy_keys[0].private
-        try:
-            await services.register_replica(
-                session,
-                run_model.gateway_id,
-                run,
-                job_model,
-                ssh_head_proxy,
-                ssh_head_proxy_private_key,
-            )
-        except GatewayError as e:
-            logger.warning(
-                "%s: failed to register service replica: %s, age=%s",
-                fmt(job_model),
-                e,
-                job_submission.age,
-            )
-            job_model.status = JobStatus.TERMINATING
-            job_model.termination_reason = JobTerminationReason.GATEWAY_ERROR
-        else:
-            for probe_num in range(len(job.job_spec.probes)):
-                session.add(
-                    ProbeModel(
-                        name=f"{job_model.job_name}-{probe_num}",
-                        job=job_model,
-                        probe_num=probe_num,
-                        due=common_utils.get_current_datetime(),
-                        success_streak=0,
-                        active=True,
-                    )
+    if initial_status != job_model.status and job_model.status == JobStatus.RUNNING:
+        job_model.probes = []
+        for probe_num in range(len(job.job_spec.probes)):
+            job_model.probes.append(
+                ProbeModel(
+                    name=f"{job_model.job_name}-{probe_num}",
+                    probe_num=probe_num,
+                    due=common_utils.get_current_datetime(),
+                    success_streak=0,
+                    active=True,
                 )
+            )
 
+    if job_model.status == JobStatus.RUNNING:
+        await _maybe_register_replica(session, run_model, run, job_model, job.job_spec.probes)
     if job_model.status == JobStatus.RUNNING:
         await _check_gpu_utilization(session, job_model, job)
 
@@ -820,6 +792,55 @@ def _should_terminate_job_due_to_disconnect(job_model: JobModel) -> bool:
         common_utils.get_current_datetime()
         > job_model.disconnected_at + JOB_DISCONNECTED_RETRY_TIMEOUT
     )
+
+
+async def _maybe_register_replica(
+    session: AsyncSession,
+    run_model: RunModel,
+    run: Run,
+    job_model: JobModel,
+    probe_specs: Iterable[ProbeSpec],
+) -> None:
+    """
+    Register the replica represented by this job to receive service requests if it is ready.
+    """
+
+    if (
+        run.run_spec.configuration.type != "service"
+        or job_model.registered
+        or job_model.job_num != 0  # only the first job in the replica receives service requests
+        or not is_job_ready(job_model.probes, probe_specs)
+    ):
+        return
+
+    ssh_head_proxy: Optional[SSHConnectionParams] = None
+    ssh_head_proxy_private_key: Optional[str] = None
+    instance = common_utils.get_or_error(job_model.instance)
+    if instance.remote_connection_info is not None:
+        rci: RemoteConnectionInfo = RemoteConnectionInfo.__response__.parse_raw(
+            instance.remote_connection_info
+        )
+        if rci.ssh_proxy is not None:
+            ssh_head_proxy = rci.ssh_proxy
+            ssh_head_proxy_keys = common_utils.get_or_error(rci.ssh_proxy_keys)
+            ssh_head_proxy_private_key = ssh_head_proxy_keys[0].private
+    try:
+        await services.register_replica(
+            session,
+            run_model.gateway_id,
+            run,
+            job_model,
+            ssh_head_proxy,
+            ssh_head_proxy_private_key,
+        )
+    except GatewayError as e:
+        logger.warning(
+            "%s: failed to register service replica: %s",
+            fmt(job_model),
+            e,
+        )
+        job_model.status = JobStatus.TERMINATING
+        job_model.termination_reason = JobTerminationReason.GATEWAY_ERROR
 
 
 async def _check_gpu_utilization(session: AsyncSession, job_model: JobModel, job: Job) -> None:

--- a/src/dstack/_internal/server/migrations/versions/3d7f6c2ec000_add_jobmodel_registered.py
+++ b/src/dstack/_internal/server/migrations/versions/3d7f6c2ec000_add_jobmodel_registered.py
@@ -1,0 +1,28 @@
+"""Add JobModel.registered
+
+Revision ID: 3d7f6c2ec000
+Revises: 74a1f55209bd
+Create Date: 2025-08-11 13:23:39.530103
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "3d7f6c2ec000"
+down_revision = "74a1f55209bd"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("jobs", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("registered", sa.Boolean(), server_default=sa.false(), nullable=False)
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("jobs", schema=None) as batch_op:
+        batch_op.drop_column("registered")

--- a/src/dstack/_internal/server/models.py
+++ b/src/dstack/_internal/server/models.py
@@ -430,6 +430,9 @@ class JobModel(BaseModel):
     probes: Mapped[list["ProbeModel"]] = relationship(
         back_populates="job", order_by="ProbeModel.probe_num"
     )
+    # Whether the replica is registered to receive service requests.
+    # Always `False` for non-service runs.
+    registered: Mapped[bool] = mapped_column(Boolean, server_default=false())
 
 
 class GatewayModel(BaseModel):

--- a/src/dstack/_internal/server/services/probes.py
+++ b/src/dstack/_internal/server/services/probes.py
@@ -1,6 +1,10 @@
-from dstack._internal.core.models.runs import Probe
+from dstack._internal.core.models.runs import Probe, ProbeSpec
 from dstack._internal.server.models import ProbeModel
 
 
 def probe_model_to_probe(probe_model: ProbeModel) -> Probe:
     return Probe(success_streak=probe_model.success_streak)
+
+
+def is_probe_ready(probe: ProbeModel, spec: ProbeSpec) -> bool:
+    return probe.success_streak >= spec.ready_after

--- a/src/dstack/_internal/server/services/proxy/repo.py
+++ b/src/dstack/_internal/server/services/proxy/repo.py
@@ -54,6 +54,7 @@ class ServerProxyRepo(BaseProxyRepo):
                 RunModel.gateway_id.is_(None),
                 JobModel.run_name == run_name,
                 JobModel.status == JobStatus.RUNNING,
+                JobModel.registered == True,
                 JobModel.job_num == 0,
             )
             .options(

--- a/src/dstack/_internal/server/testing/common.py
+++ b/src/dstack/_internal/server/testing/common.py
@@ -343,6 +343,7 @@ async def create_job(
     deployment_num: Optional[int] = None,
     instance_assigned: bool = False,
     disconnected_at: Optional[datetime] = None,
+    registered: bool = False,
 ) -> JobModel:
     if deployment_num is None:
         deployment_num = run.deployment_num
@@ -372,6 +373,7 @@ async def create_job(
         used_instance_id=instance.id if instance is not None else None,
         disconnected_at=disconnected_at,
         probes=[],
+        registered=registered,
     )
     session.add(job)
     await session.commit()


### PR DESCRIPTION
To avoid service disruptions during rolling deployments, only register a newly started replica to receive requests after all its probes pass, not immediately after it becomes `running`.

Fixes #2985