### PR TITLE
Allow gpu.name as string in json schema

### DIFF
--- a/src/dstack/_internal/core/models/resources.py
+++ b/src/dstack/_internal/core/models/resources.py
@@ -226,6 +226,10 @@ class GPUSpec(CoreModel):
                 extra_types=[{"type": "integer"}, {"type": "string"}],
             )
             add_extra_schema_types(
+                schema["properties"]["name"],
+                extra_types=[{"type": "string"}],
+            )
+            add_extra_schema_types(
                 schema["properties"]["memory"],
                 extra_types=[{"type": "integer"}, {"type": "string"}],
             )


### PR DESCRIPTION
Fixes json schema errors when specifying resources.gpu.name as string

<img width="820" height="429" alt="Screenshot 2025-08-26 at 13 38 43" src="https://github.com/user-attachments/assets/7de31fb8-3aa3-44f9-bc48-2c76782046c0" />
