### PR TITLE
Automatically remove dangling tasks from shim

### DIFF
--- a/runner/docs/shim.openapi.yaml
+++ b/runner/docs/shim.openapi.yaml
@@ -404,8 +404,7 @@ components:
               id:
                 $ref: "#/components/schemas/TaskID"
               status:
-                allOf:
-                  - $ref: "#/components/schemas/TaskStatus"
+                $ref: "#/components/schemas/TaskStatus"
             required:
               - id
               - status

--- a/runner/docs/shim.openapi.yaml
+++ b/runner/docs/shim.openapi.yaml
@@ -396,13 +396,22 @@ components:
       title: shim.api.TaskListResponse
       type: object
       properties:
-        ids:
+        tasks:
           type: array
           items:
-            $ref: "#/components/schemas/TaskID"
-          description: A list of all task IDs tracked by shim
+            type: object
+            properties:
+              id:
+                $ref: "#/components/schemas/TaskID"
+              status:
+                allOf:
+                  - $ref: "#/components/schemas/TaskStatus"
+            required:
+              - id
+              - status
+          description: A list of all tasks tracked by shim, each with its ID and status
       required:
-        - ids
+        - tasks
       additionalProperties: false
 
     TaskInfoResponse:

--- a/runner/internal/shim/api/api_test.go
+++ b/runner/internal/shim/api/api_test.go
@@ -34,8 +34,8 @@ func (ds *DummyRunner) Remove(context.Context, string) error {
 	return nil
 }
 
-func (ds *DummyRunner) TaskIDs() []string {
-	return []string{}
+func (ds *DummyRunner) TaskList() []*shim.TaskListItem {
+	return []*shim.TaskListItem{}
 }
 
 func (ds *DummyRunner) TaskInfo(taskID string) shim.TaskInfo {

--- a/runner/internal/shim/api/handlers.go
+++ b/runner/internal/shim/api/handlers.go
@@ -36,7 +36,8 @@ func (s *ShimServer) InstanceHealthHandler(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *ShimServer) TaskListHandler(w http.ResponseWriter, r *http.Request) (interface{}, error) {
-	return &TaskListResponse{IDs: s.runner.TaskIDs()}, nil
+	tasks := s.runner.TaskList()
+	return &TaskListResponse{tasks}, nil
 }
 
 func (s *ShimServer) TaskInfoHandler(w http.ResponseWriter, r *http.Request) (interface{}, error) {

--- a/runner/internal/shim/api/schemas.go
+++ b/runner/internal/shim/api/schemas.go
@@ -15,7 +15,7 @@ type InstanceHealthResponse struct {
 }
 
 type TaskListResponse struct {
-	IDs []string `json:"ids"`
+	Tasks []*shim.TaskListItem `json:"tasks"`
 }
 
 type TaskInfoResponse struct {

--- a/runner/internal/shim/api/server.go
+++ b/runner/internal/shim/api/server.go
@@ -19,7 +19,7 @@ type TaskRunner interface {
 	Remove(ctx context.Context, taskID string) error
 
 	Resources(context.Context) shim.Resources
-	TaskIDs() []string
+	TaskList() []*shim.TaskListItem
 	TaskInfo(taskID string) shim.TaskInfo
 }
 

--- a/runner/internal/shim/docker.go
+++ b/runner/internal/shim/docker.go
@@ -216,8 +216,13 @@ func (d *DockerRunner) Resources(ctx context.Context) Resources {
 	}
 }
 
-func (d *DockerRunner) TaskIDs() []string {
-	return d.tasks.IDs()
+func (d *DockerRunner) TaskList() []*TaskListItem {
+	tasks := d.tasks.List()
+	result := make([]*TaskListItem, 0, len(tasks))
+	for _, task := range tasks {
+		result = append(result, &TaskListItem{ID: task.ID, Status: task.Status})
+	}
+	return result
 }
 
 func (d *DockerRunner) TaskInfo(taskID string) TaskInfo {

--- a/runner/internal/shim/models.go
+++ b/runner/internal/shim/models.go
@@ -104,6 +104,11 @@ type TaskConfig struct {
 	ContainerSshKeys []string `json:"container_ssh_keys"`
 }
 
+type TaskListItem struct {
+	ID     string     `json:"id"`
+	Status TaskStatus `json:"status"`
+}
+
 type TaskInfo struct {
 	ID                 string
 	Status             TaskStatus

--- a/runner/internal/shim/task.go
+++ b/runner/internal/shim/task.go
@@ -148,14 +148,15 @@ type TaskStorage struct {
 	mu    sync.RWMutex
 }
 
-func (ts *TaskStorage) IDs() []string {
+// Get a _copy_ of all tasks. To "commit" changes, use Update()
+func (ts *TaskStorage) List() []Task {
 	ts.mu.RLock()
 	defer ts.mu.RUnlock()
-	ids := make([]string, 0, len(ts.tasks))
-	for id := range ts.tasks {
-		ids = append(ids, id)
+	tasks := make([]Task, 0, len(ts.tasks))
+	for _, task := range ts.tasks {
+		tasks = append(tasks, task)
 	}
-	return ids
+	return tasks
 }
 
 // Get a _copy_ of the task. To "commit" changes, use Update()

--- a/src/dstack/_internal/server/schemas/runner.py
+++ b/src/dstack/_internal/server/schemas/runner.py
@@ -159,6 +159,16 @@ class GPUDevice(CoreModel):
     path_in_container: str
 
 
+class TaskListItem(CoreModel):
+    id: str
+    status: TaskStatus
+
+
+class TaskListResponse(CoreModel):
+    ids: Optional[list[str]] = None  # returned by pre-TODO shim
+    tasks: Optional[list[TaskListItem]] = None  # returned by TODO+ shim
+
+
 class TaskInfoResponse(CoreModel):
     id: str
     status: TaskStatus

--- a/src/dstack/_internal/server/schemas/runner.py
+++ b/src/dstack/_internal/server/schemas/runner.py
@@ -165,8 +165,8 @@ class TaskListItem(CoreModel):
 
 
 class TaskListResponse(CoreModel):
-    ids: Optional[list[str]] = None  # returned by pre-TODO shim
-    tasks: Optional[list[TaskListItem]] = None  # returned by TODO+ shim
+    ids: Optional[list[str]] = None  # returned by pre-0.19.26 shim
+    tasks: Optional[list[TaskListItem]] = None  # returned by 0.19.26+ shim
 
 
 class TaskInfoResponse(CoreModel):

--- a/src/dstack/_internal/server/services/instances.py
+++ b/src/dstack/_internal/server/services/instances.py
@@ -647,7 +647,7 @@ def remove_dangling_tasks_from_instance(shim_client: ShimClient, instance: Insta
     if task_list_response.tasks is not None:
         tasks = [(t.id, t.status) for t in task_list_response.tasks]
     elif task_list_response.ids is not None:
-        # compatibility with pre-TODO shim
+        # compatibility with pre-0.19.26 shim
         tasks = [(t_id, None) for t_id in task_list_response.ids]
     else:
         raise ValueError("Unexpected task list response, neither `tasks` nor `ids` is set")

--- a/src/dstack/_internal/server/services/instances.py
+++ b/src/dstack/_internal/server/services/instances.py
@@ -39,6 +39,7 @@ from dstack._internal.core.models.profiles import (
 from dstack._internal.core.models.runs import JobProvisioningData, Requirements
 from dstack._internal.core.models.volumes import Volume
 from dstack._internal.core.services.profiles import get_termination
+from dstack._internal.server import settings as server_settings
 from dstack._internal.server.models import (
     FleetModel,
     InstanceHealthCheckModel,
@@ -47,9 +48,11 @@ from dstack._internal.server.models import (
     UserModel,
 )
 from dstack._internal.server.schemas.health.dcgm import DCGMHealthResponse
-from dstack._internal.server.schemas.runner import InstanceHealthResponse
+from dstack._internal.server.schemas.runner import InstanceHealthResponse, TaskStatus
+from dstack._internal.server.services.logging import fmt
 from dstack._internal.server.services.offers import generate_shared_offer
 from dstack._internal.server.services.projects import list_user_project_models
+from dstack._internal.server.services.runner.client import ShimClient
 from dstack._internal.utils import common as common_utils
 from dstack._internal.utils.logging import get_logger
 
@@ -633,3 +636,40 @@ async def create_ssh_instance_model(
         busy_blocks=0,
     )
     return im
+
+
+def remove_dangling_tasks_from_instance(shim_client: ShimClient, instance: InstanceModel) -> None:
+    if not shim_client.is_api_v2_supported():
+        return
+    assigned_to_instance_job_ids = {str(j.id) for j in instance.jobs}
+    task_list_response = shim_client.list_tasks()
+    tasks: list[tuple[str, Optional[TaskStatus]]]
+    if task_list_response.tasks is not None:
+        tasks = [(t.id, t.status) for t in task_list_response.tasks]
+    elif task_list_response.ids is not None:
+        # compatibility with pre-TODO shim
+        tasks = [(t_id, None) for t_id in task_list_response.ids]
+    else:
+        raise ValueError("Unexpected task list response, neither `tasks` nor `ids` is set")
+    for task_id, task_status in tasks:
+        if task_id in assigned_to_instance_job_ids:
+            continue
+        should_terminate = task_status != TaskStatus.TERMINATED
+        should_remove = not server_settings.SERVER_KEEP_SHIM_TASKS
+        if not (should_terminate or should_remove):
+            continue
+        logger.warning(
+            "%s: dangling task found, id=%s, status=%s. Terminating and/or removing",
+            fmt(instance),
+            task_id,
+            task_status or "<unknown>",
+        )
+        if should_terminate:
+            shim_client.terminate_task(
+                task_id=task_id,
+                reason=None,
+                message=None,
+                timeout=0,
+            )
+        if should_remove:
+            shim_client.remove_task(task_id=task_id)

--- a/src/dstack/_internal/server/services/logging.py
+++ b/src/dstack/_internal/server/services/logging.py
@@ -1,14 +1,22 @@
 from typing import Union
 
-from dstack._internal.server.models import GatewayModel, JobModel, ProbeModel, RunModel
+from dstack._internal.server.models import (
+    GatewayModel,
+    InstanceModel,
+    JobModel,
+    ProbeModel,
+    RunModel,
+)
 
 
-def fmt(model: Union[RunModel, JobModel, GatewayModel, ProbeModel]) -> str:
+def fmt(model: Union[RunModel, JobModel, InstanceModel, GatewayModel, ProbeModel]) -> str:
     """Consistent string representation of a model for logging."""
     if isinstance(model, RunModel):
         return f"run({model.id.hex[:6]}){model.run_name}"
     if isinstance(model, JobModel):
         return f"job({model.id.hex[:6]}){model.job_name}"
+    if isinstance(model, InstanceModel):
+        return f"instance({model.id.hex[:6]}){model.name}"
     if isinstance(model, GatewayModel):
         return f"gateway({model.id.hex[:6]}){model.name}"
     if isinstance(model, ProbeModel):

--- a/src/dstack/_internal/server/services/runner/client.py
+++ b/src/dstack/_internal/server/services/runner/client.py
@@ -26,6 +26,7 @@ from dstack._internal.server.schemas.runner import (
     ShimVolumeInfo,
     SubmitBody,
     TaskInfoResponse,
+    TaskListResponse,
     TaskSubmitRequest,
     TaskTerminateRequest,
 )
@@ -244,6 +245,12 @@ class ShimClient:
             return None
         self._raise_for_status(resp)
         return self._response(InstanceHealthResponse, resp)
+
+    def list_tasks(self) -> TaskListResponse:
+        if not self.is_api_v2_supported():
+            raise ShimAPIVersionError()
+        resp = self._request("GET", "/api/tasks", raise_for_status=True)
+        return self._response(TaskListResponse, resp)
 
     def get_task(self, task_id: "_TaskID") -> TaskInfoResponse:
         if not self.is_api_v2_supported():


### PR DESCRIPTION
- Terminate and remove dangling tasks from shim when processing the instance. Tasks can become dangling because shim was unavailable when the job was in the `terminating` status.
- Adjust the shim API to return task statuses to avoid redundant termination. Dangling task termination and removal works with the old API too, but may result in redundant termination requests and warnings if the task is already terminated, but not removed. This is particularly noticeable if `DSTACK_SERVER_KEEP_SHIM_TASKS` is set.

Fixes #2998


Before merging:
- [x] Set the release version in compatibility comments