### PR TITLE
[runner] Ensure `working_dir` exists

### DIFF
--- a/runner/internal/executor/executor_test.go
+++ b/runner/internal/executor/executor_test.go
@@ -28,7 +28,7 @@ func TestExecutor_WorkingDir_Set(t *testing.T) {
 
 	ex.jobSpec.WorkingDir = &workingDir
 	ex.jobSpec.Commands = append(ex.jobSpec.Commands, "pwd")
-	err = ex.setJobWorkingDir(context.TODO())
+	err = ex.prepareJobWorkingDir(context.TODO())
 	require.NoError(t, err)
 	require.Equal(t, workingDir, ex.jobWorkingDir)
 	err = os.MkdirAll(workingDir, 0o755)
@@ -47,7 +47,7 @@ func TestExecutor_WorkingDir_NotSet(t *testing.T) {
 	require.NoError(t, err)
 	ex.jobSpec.WorkingDir = nil
 	ex.jobSpec.Commands = append(ex.jobSpec.Commands, "pwd")
-	err = ex.setJobWorkingDir(context.TODO())
+	err = ex.prepareJobWorkingDir(context.TODO())
 	require.NoError(t, err)
 	require.Equal(t, cwd, ex.jobWorkingDir)
 
@@ -158,7 +158,7 @@ func TestExecutor_RemoteRepo(t *testing.T) {
 	err := os.WriteFile(ex.codePath, []byte{}, 0o600) // empty diff
 	require.NoError(t, err)
 
-	err = ex.setJobWorkingDir(context.TODO())
+	err = ex.prepareJobWorkingDir(context.TODO())
 	require.NoError(t, err)
 	err = ex.setupRepo(context.TODO())
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes: https://github.com/dstackai/dstack/issues/3051