### PR TITLE
Do not issue empty update for deleted_fleets_placement_groups

### DIFF
--- a/src/dstack/_internal/server/background/tasks/process_fleets.py
+++ b/src/dstack/_internal/server/background/tasks/process_fleets.py
@@ -197,6 +197,8 @@ def _autodelete_fleet(fleet_model: FleetModel) -> bool:
 
 
 async def _update_deleted_fleets_placement_groups(session: AsyncSession, fleets_ids: list[UUID]):
+    if len(fleets_ids) == 0:
+        return
     await session.execute(
         update(PlacementGroupModel)
         .where(


### PR DESCRIPTION
This small fix makes #3068 less likely but does not fix the root cause, which is a long write transaction in process_instances.
