### PR TITLE
[CLI] Handle unrecognized arguments

### DIFF
--- a/src/dstack/_internal/cli/commands/__init__.py
+++ b/src/dstack/_internal/cli/commands/__init__.py
@@ -1,20 +1,22 @@
 import argparse
 import os
+import shlex
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import ClassVar, Optional
 
 from rich_argparse import RichHelpFormatter
 
 from dstack._internal.cli.services.completion import ProjectNameCompleter
-from dstack._internal.cli.utils.common import configure_logging
+from dstack._internal.core.errors import CLIError
 from dstack.api import Client
 
 
 class BaseCommand(ABC):
-    NAME: str = "name the command"
-    DESCRIPTION: str = "describe the command"
-    DEFAULT_HELP: bool = True
-    ALIASES: Optional[List[str]] = None
+    NAME: ClassVar[str] = "name the command"
+    DESCRIPTION: ClassVar[str] = "describe the command"
+    DEFAULT_HELP: ClassVar[bool] = True
+    ALIASES: ClassVar[Optional[list[str]]] = None
+    ACCEPT_EXTRA_ARGS: ClassVar[bool] = False
 
     def __init__(self, parser: argparse.ArgumentParser):
         self._parser = parser
@@ -50,7 +52,8 @@ class BaseCommand(ABC):
 
     @abstractmethod
     def _command(self, args: argparse.Namespace):
-        pass
+        if not self.ACCEPT_EXTRA_ARGS and args.extra_args:
+            raise CLIError(f"Unrecognized arguments: {shlex.join(args.extra_args)}")
 
 
 class APIBaseCommand(BaseCommand):
@@ -65,5 +68,5 @@ class APIBaseCommand(BaseCommand):
         ).completer = ProjectNameCompleter()  # type: ignore[attr-defined]
 
     def _command(self, args: argparse.Namespace):
-        configure_logging()
+        super()._command(args)
         self.api = Client.from_config(project_name=args.project)

--- a/src/dstack/_internal/cli/commands/completion.py
+++ b/src/dstack/_internal/cli/commands/completion.py
@@ -1,3 +1,5 @@
+import argparse
+
 import argcomplete
 
 from dstack._internal.cli.commands import BaseCommand
@@ -15,6 +17,6 @@ class CompletionCommand(BaseCommand):
             choices=["bash", "zsh"],
         )
 
-    def _command(self, args):
+    def _command(self, args: argparse.Namespace):
         super()._command(args)
         print(argcomplete.shellcode(["dstack"], shell=args.shell))  # type: ignore[attr-defined]

--- a/src/dstack/_internal/cli/commands/config.py
+++ b/src/dstack/_internal/cli/commands/config.py
@@ -40,6 +40,7 @@ class ConfigCommand(BaseCommand):
         )
 
     def _command(self, args: argparse.Namespace):
+        super()._command(args)
         config_manager = ConfigManager()
         if args.remove:
             config_manager.delete_project(args.project)

--- a/src/dstack/_internal/cli/commands/init.py
+++ b/src/dstack/_internal/cli/commands/init.py
@@ -9,7 +9,7 @@ from dstack._internal.cli.services.repos import (
     is_git_repo_url,
     register_init_repo_args,
 )
-from dstack._internal.cli.utils.common import configure_logging, confirm_ask, console, warn
+from dstack._internal.cli.utils.common import confirm_ask, console, warn
 from dstack._internal.core.errors import ConfigurationError
 from dstack._internal.core.models.repos.remote import RemoteRepo
 from dstack._internal.core.services.configs import ConfigManager
@@ -52,7 +52,7 @@ class InitCommand(BaseCommand):
         )
 
     def _command(self, args: argparse.Namespace):
-        configure_logging()
+        super()._command(args)
 
         repo_path: Optional[Path] = None
         repo_url: Optional[str] = None

--- a/src/dstack/_internal/cli/commands/offer.py
+++ b/src/dstack/_internal/cli/commands/offer.py
@@ -99,7 +99,7 @@ class OfferCommand(APIBaseCommand):
         conf = TaskConfiguration(commands=[":"])
 
         configurator = OfferConfigurator(api_client=self.api)
-        configurator.apply_args(conf, args, [])
+        configurator.apply_args(conf, args)
         profile = load_profile(Path.cwd(), profile_name=args.profile)
 
         run_spec = RunSpec(

--- a/src/dstack/_internal/cli/commands/project.py
+++ b/src/dstack/_internal/cli/commands/project.py
@@ -67,6 +67,7 @@ class ProjectCommand(BaseCommand):
         set_default_parser.set_defaults(subfunc=self._set_default)
 
     def _command(self, args: argparse.Namespace):
+        super()._command(args)
         if not hasattr(args, "subfunc"):
             args.subfunc = self._list
         args.subfunc(args)

--- a/src/dstack/_internal/cli/commands/server.py
+++ b/src/dstack/_internal/cli/commands/server.py
@@ -1,5 +1,5 @@
+import argparse
 import os
-from argparse import Namespace
 
 from dstack._internal import settings
 from dstack._internal.cli.commands import BaseCommand
@@ -53,7 +53,7 @@ class ServerCommand(BaseCommand):
         )
         self._parser.add_argument("--token", type=str, help="The admin user token")
 
-    def _command(self, args: Namespace):
+    def _command(self, args: argparse.Namespace):
         super()._command(args)
 
         if not UVICORN_INSTALLED:

--- a/src/dstack/_internal/cli/main.py
+++ b/src/dstack/_internal/cli/main.py
@@ -83,7 +83,7 @@ def main():
     argcomplete.autocomplete(parser, always_complete_options=False)
 
     args, unknown_args = parser.parse_known_args()
-    args.unknown = unknown_args
+    args.extra_args = unknown_args
 
     try:
         check_for_updates()

--- a/src/dstack/_internal/cli/services/configurators/base.py
+++ b/src/dstack/_internal/cli/services/configurators/base.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 from abc import ABC, abstractmethod
-from typing import Generic, List, TypeVar, Union, cast
+from typing import ClassVar, Generic, List, TypeVar, Union, cast
 
 from dstack._internal.cli.services.args import env_var
 from dstack._internal.core.errors import ConfigurationError
@@ -18,7 +18,7 @@ ApplyConfigurationT = TypeVar("ApplyConfigurationT", bound=AnyApplyConfiguration
 
 
 class BaseApplyConfigurator(ABC, Generic[ApplyConfigurationT]):
-    TYPE: ApplyConfigurationType
+    TYPE: ClassVar[ApplyConfigurationType]
 
     def __init__(self, api_client: Client):
         self.api = api_client
@@ -30,7 +30,6 @@ class BaseApplyConfigurator(ABC, Generic[ApplyConfigurationT]):
         configuration_path: str,
         command_args: argparse.Namespace,
         configurator_args: argparse.Namespace,
-        unknown_args: List[str],
     ):
         """
         Implements `dstack apply` for a given configuration type.
@@ -40,7 +39,6 @@ class BaseApplyConfigurator(ABC, Generic[ApplyConfigurationT]):
             configuration_path: The path to the configuration file.
             command_args: The args parsed by `dstack apply`.
             configurator_args: The known args parsed by `cls.get_parser()`.
-            unknown_args: The unknown args after parsing by `cls.get_parser()`.
         """
         pass
 

--- a/src/dstack/_internal/cli/services/configurators/fleet.py
+++ b/src/dstack/_internal/cli/services/configurators/fleet.py
@@ -1,7 +1,7 @@
 import argparse
 import time
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from rich.table import Table
 
@@ -46,7 +46,7 @@ logger = get_logger(__name__)
 
 
 class FleetConfigurator(ApplyEnvVarsConfiguratorMixin, BaseApplyConfigurator[FleetConfiguration]):
-    TYPE: ApplyConfigurationType = ApplyConfigurationType.FLEET
+    TYPE = ApplyConfigurationType.FLEET
 
     def apply_configuration(
         self,
@@ -54,9 +54,8 @@ class FleetConfigurator(ApplyEnvVarsConfiguratorMixin, BaseApplyConfigurator[Fle
         configuration_path: str,
         command_args: argparse.Namespace,
         configurator_args: argparse.Namespace,
-        unknown_args: List[str],
     ):
-        self.apply_args(conf, configurator_args, unknown_args)
+        self.apply_args(conf, configurator_args)
         profile = load_profile(Path.cwd(), None)
         spec = FleetSpec(
             configuration=conf,
@@ -309,7 +308,7 @@ class FleetConfigurator(ApplyEnvVarsConfiguratorMixin, BaseApplyConfigurator[Fle
         )
         cls.register_env_args(configuration_group)
 
-    def apply_args(self, conf: FleetConfiguration, args: argparse.Namespace, unknown: List[str]):
+    def apply_args(self, conf: FleetConfiguration, args: argparse.Namespace):
         if args.name:
             conf.name = args.name
         self.apply_env_vars(conf.env, args)

--- a/src/dstack/_internal/cli/services/configurators/gateway.py
+++ b/src/dstack/_internal/cli/services/configurators/gateway.py
@@ -1,6 +1,5 @@
 import argparse
 import time
-from typing import List
 
 from rich.table import Table
 
@@ -27,7 +26,7 @@ from dstack.api._public import Client
 
 
 class GatewayConfigurator(BaseApplyConfigurator[GatewayConfiguration]):
-    TYPE: ApplyConfigurationType = ApplyConfigurationType.GATEWAY
+    TYPE = ApplyConfigurationType.GATEWAY
 
     def apply_configuration(
         self,
@@ -35,9 +34,8 @@ class GatewayConfigurator(BaseApplyConfigurator[GatewayConfiguration]):
         configuration_path: str,
         command_args: argparse.Namespace,
         configurator_args: argparse.Namespace,
-        unknown_args: List[str],
     ):
-        self.apply_args(conf, configurator_args, unknown_args)
+        self.apply_args(conf, configurator_args)
         spec = GatewaySpec(
             configuration=conf,
             configuration_path=configuration_path,
@@ -179,7 +177,7 @@ class GatewayConfigurator(BaseApplyConfigurator[GatewayConfiguration]):
             help="The gateway name",
         )
 
-    def apply_args(self, conf: GatewayConfiguration, args: argparse.Namespace, unknown: List[str]):
+    def apply_args(self, conf: GatewayConfiguration, args: argparse.Namespace):
         if args.name:
             conf.name = args.name
 

--- a/src/dstack/_internal/cli/services/configurators/volume.py
+++ b/src/dstack/_internal/cli/services/configurators/volume.py
@@ -1,6 +1,5 @@
 import argparse
 import time
-from typing import List
 
 from rich.table import Table
 
@@ -26,7 +25,7 @@ from dstack.api._public import Client
 
 
 class VolumeConfigurator(BaseApplyConfigurator[VolumeConfiguration]):
-    TYPE: ApplyConfigurationType = ApplyConfigurationType.VOLUME
+    TYPE = ApplyConfigurationType.VOLUME
 
     def apply_configuration(
         self,
@@ -34,9 +33,8 @@ class VolumeConfigurator(BaseApplyConfigurator[VolumeConfiguration]):
         configuration_path: str,
         command_args: argparse.Namespace,
         configurator_args: argparse.Namespace,
-        unknown_args: List[str],
     ):
-        self.apply_args(conf, configurator_args, unknown_args)
+        self.apply_args(conf, configurator_args)
         spec = VolumeSpec(
             configuration=conf,
             configuration_path=configuration_path,
@@ -167,7 +165,7 @@ class VolumeConfigurator(BaseApplyConfigurator[VolumeConfiguration]):
             help="The volume name",
         )
 
-    def apply_args(self, conf: VolumeConfiguration, args: argparse.Namespace, unknown: List[str]):
+    def apply_args(self, conf: VolumeConfiguration, args: argparse.Namespace):
         if args.name:
             conf.name = args.name
 

--- a/src/tests/_internal/cli/services/configurators/test_fleet.py
+++ b/src/tests/_internal/cli/services/configurators/test_fleet.py
@@ -50,6 +50,6 @@ def apply_args(
     configurator = FleetConfigurator(Mock())
     configurator.register_args(parser)
     conf = conf.copy(deep=True)
-    configurator_args, unknown_args = parser.parse_known_args(args)
-    configurator.apply_args(conf, configurator_args, unknown_args)
+    configurator_args = parser.parse_args(args)
+    configurator.apply_args(conf, configurator_args)
     return conf, configurator_args

--- a/src/tests/_internal/cli/services/configurators/test_run.py
+++ b/src/tests/_internal/cli/services/configurators/test_run.py
@@ -34,9 +34,9 @@ class TestApplyArgs:
         configurator = configurator_class(Mock())
         configurator.register_args(parser)
         conf = conf.copy(deep=True)  # to avoid modifying the original configuration
-        known, unknown = parser.parse_known_args(args)
-        configurator.apply_args(conf, known, unknown)
-        return conf, known
+        parsed_args = parser.parse_args(args)
+        configurator.apply_args(conf, parsed_args)
+        return conf, parsed_args
 
     def test_env(self):
         conf = TaskConfiguration(commands=["whoami"])


### PR DESCRIPTION
* All commands now reject unrecognized arguments
* Undocumented `${{ run.args }}` for tasks and services is still supported but requires `--` pseudo-argument:

  > If you have positional arguments that must begin with `-`
  > and don’t look like negative numbers, you can insert
  > the pseudo-argument `'--'` which tells `parse_args()`
  > that everything after that is a positional argument

  ```
  dstack apply --reuse -- --some=arg --some-option
                       ^^
  ```

Fixes: https://github.com/dstackai/dstack/issues/3073

---

@peterschmidt85 not sure if we want to drop `${{ run.args }}` altogether or document it as a feature.

[![asciicast](https://asciinema.org/a/tEPx2ICbanEEUWR0SIPZLb7iI.svg)](https://asciinema.org/a/tEPx2ICbanEEUWR0SIPZLb7iI)

