### PR TITLE
Forbid deleting projects with active resources

### DIFF
--- a/src/dstack/_internal/server/background/tasks/process_fleets.py
+++ b/src/dstack/_internal/server/background/tasks/process_fleets.py
@@ -177,6 +177,14 @@ def _maintain_fleet_nodes_min(
 
 
 def _autodelete_fleet(fleet_model: FleetModel) -> bool:
+    if fleet_model.project.deleted:
+        # It used to be possible to delete project with active resources:
+        # https://github.com/dstackai/dstack/issues/3077
+        fleet_model.status = FleetStatus.TERMINATED
+        fleet_model.deleted = True
+        logger.info("Fleet %s deleted due to deleted project", fleet_model.name)
+        return True
+
     if is_fleet_in_use(fleet_model) or not is_fleet_empty(fleet_model):
         return False
 

--- a/src/dstack/_internal/server/services/backends/handlers.py
+++ b/src/dstack/_internal/server/services/backends/handlers.py
@@ -20,6 +20,8 @@ async def delete_backends_safe(
     error: bool = True,
 ):
     try:
+        # FIXME: The checks are not under lock,
+        # so there can be dangling active resources due to race conditions.
         await _check_active_instances(
             session=session,
             project=project,


### PR DESCRIPTION
Fixes #3077

The PR also terminates existing active fleets in deleted projects.