### PR TITLE
Add a script to automatically generate expanded release notes using an LLM

### DIFF
--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -92,7 +92,15 @@ Examples of good release notes:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Generate release notes from draft release")
+    # TODO: When the script is sufficiently polished, we may automate draft release generation and its update,
+    # and integrate the script into the CI.
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate expanded `dstack` release notes from a release draft using LLM."
+            " The script accepts a release tag for which you must generate automatic release notes beforehand."
+            " The script does not publish or change anything on GitHub and only outputs the generated release notes."
+        )
+    )
     parser.add_argument("tag", help="Release tag (e.g., 0.19.25)")
     args = parser.parse_args()
 

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -6,6 +6,7 @@
 # ]
 # ///
 
+import argparse
 import os
 import re
 from pathlib import Path
@@ -91,9 +92,13 @@ Examples of good release notes:
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate release notes from draft release")
+    parser.add_argument("tag", help="Release tag (e.g., 0.19.25)")
+    args = parser.parse_args()
+
     with open(Path(__file__).parent / "release_notes_examples.md") as f:
         examples = f.read()
-    draft_release = get_draft_release_by_tag("0.19.25rc1")
+    draft_release = get_draft_release_by_tag(args.tag)
     draft_body = draft_release["body"]
     prs = get_prs_from_draft(draft_body)
     notes = generate_release_notes(draft_body, prs, examples)

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -1,0 +1,100 @@
+# /// script
+# dependencies = [
+#   "requests",
+#   "litellm",
+#   "boto3", # for AWS Bedrock
+# ]
+# ///
+
+import os
+import re
+from pathlib import Path
+
+import requests
+from litellm import completion
+
+REPO = "dstackai/dstack"
+BRANCH = "master"
+
+# GITHUB_TOKEN to avoid rate limiting
+GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+
+# Model can be any supported by LiteLLM: https://docs.litellm.ai/docs/providers
+# Prover-specific credentials are picked up from env
+# e.g. AWS_REGION=us-east-1 AWS_PROFILE=... for AWS Bedrock
+MODEL = os.getenv("LLM_MODEL", "bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0")
+
+
+def get_draft_release_by_tag(tag: str) -> dict:
+    r = requests.get(
+        f"https://api.github.com/repos/{REPO}/releases",
+        headers={"Authorization": f"token {GITHUB_TOKEN}"},
+        timeout=10,
+    )
+    for release in r.json():
+        if release["tag_name"] == tag and release["draft"]:
+            return release
+    # May error if the draft not on the first page - we assume draft was created recently
+    raise ValueError(f"Release for tag {tag} not found")
+
+
+def get_prs_from_draft(draft_body: str) -> list[dict]:
+    prs = []
+    pr_numbers = extract_pr_numbers_from_draft(draft_body)
+    for pr_number in pr_numbers:
+        r = requests.get(
+            f"https://api.github.com/repos/{REPO}/pulls/{pr_number}",
+            headers={"Authorization": f"token {GITHUB_TOKEN}"},
+            timeout=10,
+        )
+        prs.append(r.json())
+    return prs
+
+
+def extract_pr_numbers_from_draft(notes: str) -> list[int]:
+    return [int(num) for num in re.findall(r"/pull/(\d+)", notes)]
+
+
+def generate_release_notes(
+    draft_body: str,
+    prs: list[dict],
+    examples: str,
+) -> str:
+    pr_summaries = "\n\n".join(f"PR #{pr['number']}: {pr['title']}\n{pr['body']}" for pr in prs)
+    prompt = f"""
+You are a release notes generator.
+
+Here are the draft GitHub release notes:
+{draft_body}
+
+Here are the PR details (titles + descriptions):
+{pr_summaries}
+
+Task:
+* Keep the 'What's Changed' and 'Contributors' sections as they are.
+* Add expanded sections in the beginning for major features and changes. Do not mention minor fixes.
+* Use clear, user-friendly prose. Avoid emojis.
+* Use the PR descriptions to enrich the expanded sections.
+* Include examples of how to use the new features when they are available in the PR descriptions.
+* Do not group sections based on functionality (like "New features"). Instead, group by domain (e.g. "Runs", "Backends", "Examples") or do not group at all.
+* Include "Deprecations" and "Breaking changes" sections if there are any.
+
+Examples of good release notes:
+{examples}
+
+"""
+    response = completion(
+        model=MODEL,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response["choices"][0]["message"]["content"]
+
+
+if __name__ == "__main__":
+    with open(Path(__file__).parent / "release_notes_examples.md") as f:
+        examples = f.read()
+    draft_release = get_draft_release_by_tag("0.19.25rc1")
+    draft_body = draft_release["body"]
+    prs = get_prs_from_draft(draft_body)
+    notes = generate_release_notes(draft_body, prs, examples)
+    print(notes)

--- a/scripts/release_notes_examples.md
+++ b/scripts/release_notes_examples.md
@@ -1,0 +1,112 @@
+## Run configurations
+
+### Repo directory
+
+It's now possible to specify the directory in the container where the repo is mounted:
+
+```yaml
+type: dev-environment
+
+ide: vscode
+
+repos:
+  - local_path: .
+    path: my_repo
+
+  # or using short syntax:
+  # - .:my_repo
+```
+
+The `path` property can be an absolute path or a relative path (with respect to `working_dir`). It's available inside run as the `$DSTACK_REPO_DIR` environment variable. If `path` is not set, the `/workflow` path is used.
+
+### Working directory
+
+Previously, the `working_dir` property had complicated semantics: it defaulted to the repo path (`/workflow`), but for tasks and services without `commands`, the image working directory was used. You could also specify custom `working_dir` relative to the repo directory. This is now reversed: you specify `working_dir` as absolute path, and the repo path can be specified relative to it. 
+
+> [!NOTE]
+> During transitioning period, the legacy behavior of using `/workflow` is preserved if `working_dir` is not set. In future releases, this will be simplified, and `working_dir`  will always default to the image working directory.
+
+## Fleet configuration
+
+###  Nodes, retry, and target
+
+`dstack` now indefinitely maintains `nodes.min` specified for cloud fleets. If instances get terminated for any reason and there are fewer instances than `nodes.min`, `dstack` will provision new fleet instances in the background.
+
+There is also a new `nodes.target` property that specifies the number of instances to provision on fleet apply. Since now `nodes.min` is always maintained, you may specify `nodes.target` different from `nodes.min` to provision more instances than needs to be maintained.
+
+Example:
+
+```yaml
+type: fleet
+name: default-fleet
+nodes:
+  min: 1 # Maintain one instance
+  target: 2 # Provision two instances initially
+  max: 3
+```
+
+`dstack` will provision two instances. After deleting one instance, there will be one instances left. Deleting the last instance will trigger `dstack` to re-create the instance.
+
+## Offers
+
+The UI now has a dedicated page showing GPU offers available across all configured backends.
+
+<img width="750" src="https://github.com/user-attachments/assets/827b56d9-2b92-43d0-bb27-a7e6926b1b80" />
+
+## Digital Ocean and AMD Developer Cloud
+
+The release adds native integration with [DigitalOcean](https://www.digitalocean.com/products/gradient/gpu-droplets) and 
+[AMD Developer Cloud](https://www.amd.com/en/developer/resources/cloud-access/amd-developer-cloud.html).
+
+A backend configuration example:
+
+```yaml
+projects:
+- name: main
+  backends:
+  - type: amddevcloud
+    project_name: TestProject
+    creds:
+        type: api_key
+        api_key: ...
+```
+
+For DigitalOcean, set `type` to `digitalocean`.
+
+The `digitalocean` and `amddevcloud` backends support NVIDIA and AMD GPU VMs, respectively, and allow you to run 
+[dev environments](../../docs/concepts/dev-environments.md) (interactive development), [tasks](../../docs/concepts/tasks.md) 
+(training, fine-tuning, or other batch jobs), and [services](../../docs/concepts/services.md) (inference).
+
+## Security
+
+> [!IMPORTANT]
+> This update fixes a vulnerability in the `cloudrift`, `cudo`, and `datacrunch` backends. Instances created with earlier `dstack` versions lack proper firewall rules, potentially exposing internal APIs and allowing unauthorized access.
+>
+> Users of these backends are advised to update to the latest version and re-create any running instances.
+
+## What's changed
+
+* Minor Hot Aisle Cleanup by @Bihan in https://github.com/dstackai/dstack/pull/2978
+* UI for offers #3004 by @olgenn in https://github.com/dstackai/dstack/pull/3042
+* Add `repos[].path` property by @un-def in https://github.com/dstackai/dstack/pull/3041
+* style(frontend): Add missing final newline by @un-def in https://github.com/dstackai/dstack/pull/3044
+* Implement fleet state-spec consolidation to maintain `nodes.min` by @r4victor in https://github.com/dstackai/dstack/pull/3047
+* Add digital ocean and amd dev backend by @Bihan in https://github.com/dstackai/dstack/pull/3030
+* test: include amddevcloud and digitalocean in backend types by @Bihan in https://github.com/dstackai/dstack/pull/3053
+* Fix missing digitaloceanbase configurator methods by @Bihan in https://github.com/dstackai/dstack/pull/3055
+* Expose job working dir via environment variable by @un-def in https://github.com/dstackai/dstack/pull/3049
+* [runner] Ensure `working_dir` exists by @un-def in https://github.com/dstackai/dstack/pull/3052
+* Fix server compatibility with pre-0.19.27 runners by @un-def in https://github.com/dstackai/dstack/pull/3054
+* Bind shim and exposed container ports to localhost by @jvstme in https://github.com/dstackai/dstack/pull/3057
+* Fix client compatibility with pre-0.19.27 servers by @un-def in https://github.com/dstackai/dstack/pull/3063
+* [Docs] Reflect the repo and working directory changes (#3041) by @peterschmidt85 in https://github.com/dstackai/dstack/pull/3064
+* Show a CLI warning when using autocreated fleets by @r4victor in https://github.com/dstackai/dstack/pull/3060
+* Improve UX with private repos by @un-def in https://github.com/dstackai/dstack/pull/3065
+* Set up instance-level firewall on all backends by @jvstme in https://github.com/dstackai/dstack/pull/3058
+* Exclude target when equal to min for responses by @r4victor in https://github.com/dstackai/dstack/pull/3070
+* [Docs] Shorten the default `working_dir` warning by @peterschmidt85 in https://github.com/dstackai/dstack/pull/3072
+* Do not issue empty update for deleted_fleets_placement_groups by @r4victor in https://github.com/dstackai/dstack/pull/3071
+* Exclude target when equal to min for responses (attempt 2) by @r4victor in https://github.com/dstackai/dstack/pull/3074
+
+
+**Full changelog**: https://github.com/dstackai/dstack/compare/0.19.26...0.19.27


### PR DESCRIPTION
The PR adds a script to generate release notes that we used to prepare by hand with an LLM. It takes a draft release with automatic release notes and expands it. The LLM gets all the relevant PR descriptions in the context and is able to produce good results given the PR descriptions are sufficient.

Currently adding to be used manually – then we can automatic draft generation and editing and add to the CI on release.

Example:

"""
python scripts/release_notes.py 0.19.25rc1
## Service Probes

When deploying services with rolling updates, new replicas are only registered to receive traffic after all their probes pass, preventing service disruptions during deployments.

## Elastic Fleets

Fleet configuration now supports elastic scaling with improved instance selection logic. The system now prioritizes fleets that can accommodate runs without requiring additional provisioning, falling back to fleets specified in configuration when no idle instances are available. This improves resource utilization and reduces startup times for runs.

## GPU Offer Aggregation

The `dstack offer` command now supports aggregating GPU information for better resource planning:

```bash
dstack offer --group-by backend,region,count
```

This groups available GPU offers by backend, region, and GPU count, making it easier to understand resource availability across your infrastructure.

## Deprecations

- The `--local` flag is now deprecated
- The `--ssh-identity` option in `dstack init` is deprecated and ignored
- Repository configuration is no longer required by default, though a warning will be displayed to inform users of this change
- A new transitional command `dstack init --remove` is available to remove local repo configurations from `~/.dstack/config.yml`

## What's Changed
* Document Deployment-compatible migrations by @r4victor in https://github.com/dstackai/dstack/pull/2987
* [Bug]: Server Docker image fails because of Unable to locate package … by @peterschmidt85 in https://github.com/dstackai/dstack/pull/2983
* Only register service replicas after probes pass by @jvstme in https://github.com/dstackai/dstack/pull/2986
* [Changelog] Introducing service probes by @peterschmidt85 in https://github.com/dstackai/dstack/pull/2988
* Deprecate local repos by @un-def in https://github.com/dstackai/dstack/pull/2984
* Support elastic fleets by @r4victor in https://github.com/dstackai/dstack/pull/2967
* fix typo config.yml.md by @jspablo in https://github.com/dstackai/dstack/pull/2991
* Check if kapa.ai can also be integrated into dstack Sky #296 by @olgenn in https://github.com/dstackai/dstack/pull/2990
* Typo in URLs by @mashcroft3 in https://github.com/dstackai/dstack/pull/2995
* [shim] Fix `DCGMWrapperInterface` nil check (bis) by @un-def in https://github.com/dstackai/dstack/pull/3001
* The logs section is too short in the UI  by @olgenn in https://github.com/dstackai/dstack/pull/2989
* [Feature]: Allow `dstack offer` to aggregate GPU information by @peterschmidt85 in https://github.com/dstackai/dstack/pull/2992

## New Contributors
* @mashcroft3 made their first contribution in https://github.com/dstackai/dstack/pull/2995

**Full Changelog**: https://github.com/dstackai/dstack/compare/0.19.24...0.19.25rc1
"""