### PR TITLE
Generate CoreModel dynamically when using custom configs

### DIFF
--- a/src/dstack/_internal/core/models/common.py
+++ b/src/dstack/_internal/core/models/common.py
@@ -30,7 +30,9 @@ class CoreConfig:
 # for permissive parsing of the server responses.
 #
 # We define a func to generate CoreModel dynamically that can be used
-# to define custom config for both __request__ and __response__ models.
+# to define custom Config for both __request__ and __response__ models.
+# Note: Defining config in the model class directly overrides
+# pydantic-duality's base config, breaking __response__.
 def generate_dual_core_model(
     custom_config: Union[type, Mapping],
 ) -> "type[CoreModel]":

--- a/src/dstack/_internal/core/models/common.py
+++ b/src/dstack/_internal/core/models/common.py
@@ -1,10 +1,10 @@
 import re
 from enum import Enum
-from typing import Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional, Union
 
 import orjson
 from pydantic import Field
-from pydantic_duality import DualBaseModel
+from pydantic_duality import generate_dual_base_model
 from typing_extensions import Annotated
 
 from dstack._internal.utils.json_utils import pydantic_orjson_dumps
@@ -17,46 +17,71 @@ IncludeExcludeDictType = dict[
 IncludeExcludeType = Union[IncludeExcludeSetType, IncludeExcludeDictType]
 
 
+class CoreConfig:
+    json_loads = orjson.loads
+    json_dumps = pydantic_orjson_dumps
+
+
+# All dstack models inherit from pydantic-duality's DualBaseModel.
 # DualBaseModel creates two classes for the model:
 # one with extra = "forbid" (CoreModel/CoreModel.__request__),
 # and another with extra = "ignore" (CoreModel.__response__).
-# This allows to use the same model both for a strict parsing of the user input and
-# for a permissive parsing of the server responses.
-class CoreModel(DualBaseModel):
-    class Config:
-        json_loads = orjson.loads
-        json_dumps = pydantic_orjson_dumps
+# This allows to use the same model both for strict parsing of the user input and
+# for permissive parsing of the server responses.
+#
+# We define a func to generate CoreModel dynamically that can be used
+# to define custom config for both __request__ and __response__ models.
+def generate_dual_core_model(
+    custom_config: Union[type, Mapping],
+) -> "type[CoreModel]":
+    class CoreModel(generate_dual_base_model(custom_config)):
+        def json(
+            self,
+            *,
+            include: Optional[IncludeExcludeType] = None,
+            exclude: Optional[IncludeExcludeType] = None,
+            by_alias: bool = False,
+            skip_defaults: Optional[bool] = None,  # ignore as it's deprecated
+            exclude_unset: bool = False,
+            exclude_defaults: bool = False,
+            exclude_none: bool = False,
+            encoder: Optional[Callable[[Any], Any]] = None,
+            models_as_dict: bool = True,  # does not seems to be needed by dstack or dependencies
+            **dumps_kwargs: Any,
+        ) -> str:
+            """
+            Override `json()` method so that it calls `dict()`.
+            Allows changing how models are serialized by overriding `dict()` only.
+            By default, `json()` won't call `dict()`, so changes applied in `dict()` won't take place.
+            """
+            data = self.dict(
+                by_alias=by_alias,
+                include=include,
+                exclude=exclude,
+                exclude_unset=exclude_unset,
+                exclude_defaults=exclude_defaults,
+                exclude_none=exclude_none,
+            )
+            if self.__custom_root_type__:
+                data = data["__root__"]
+            return self.__config__.json_dumps(data, default=encoder, **dumps_kwargs)
 
-    def json(
-        self,
-        *,
-        include: Optional[IncludeExcludeType] = None,
-        exclude: Optional[IncludeExcludeType] = None,
-        by_alias: bool = False,
-        skip_defaults: Optional[bool] = None,  # ignore as it's deprecated
-        exclude_unset: bool = False,
-        exclude_defaults: bool = False,
-        exclude_none: bool = False,
-        encoder: Optional[Callable[[Any], Any]] = None,
-        models_as_dict: bool = True,  # does not seems to be needed by dstack or dependencies
-        **dumps_kwargs: Any,
-    ) -> str:
-        """
-        Override `json()` method so that it calls `dict()`.
-        Allows changing how models are serialized by overriding `dict()` only.
-        By default, `json()` won't call `dict()`, so changes applied in `dict()` won't take place.
-        """
-        data = self.dict(
-            by_alias=by_alias,
-            include=include,
-            exclude=exclude,
-            exclude_unset=exclude_unset,
-            exclude_defaults=exclude_defaults,
-            exclude_none=exclude_none,
-        )
-        if self.__custom_root_type__:
-            data = data["__root__"]
-        return self.__config__.json_dumps(data, default=encoder, **dumps_kwargs)
+    return CoreModel
+
+
+if TYPE_CHECKING:
+
+    class CoreModel(generate_dual_base_model(CoreConfig)):
+        pass
+else:
+    CoreModel = generate_dual_core_model(CoreConfig)
+
+
+class FrozenConfig(CoreConfig):
+    frozen = True
+
+
+FrozenCoreModel = generate_dual_core_model(FrozenConfig)
 
 
 class Duration(int):
@@ -93,7 +118,7 @@ class Duration(int):
         raise ValueError(f"Cannot parse the duration {v}")
 
 
-class RegistryAuth(CoreModel):
+class RegistryAuth(FrozenCoreModel):
     """
     Credentials for pulling a private Docker image.
 
@@ -104,9 +129,6 @@ class RegistryAuth(CoreModel):
 
     username: Annotated[str, Field(description="The username")]
     password: Annotated[str, Field(description="The password or access token")]
-
-    class Config(CoreModel.Config):
-        frozen = True
 
 
 class ApplyAction(str, Enum):

--- a/src/dstack/_internal/core/models/fleets.py
+++ b/src/dstack/_internal/core/models/fleets.py
@@ -8,7 +8,12 @@ from pydantic import Field, root_validator, validator
 from typing_extensions import Annotated, Literal
 
 from dstack._internal.core.models.backends.base import BackendType
-from dstack._internal.core.models.common import ApplyAction, CoreModel
+from dstack._internal.core.models.common import (
+    ApplyAction,
+    CoreConfig,
+    CoreModel,
+    generate_dual_core_model,
+)
 from dstack._internal.core.models.envs import Env
 from dstack._internal.core.models.instances import Instance, InstanceOfferWithAvailability, SSHKey
 from dstack._internal.core.models.profiles import (
@@ -202,6 +207,21 @@ class FleetNodesSpec(CoreModel):
         return values
 
 
+class InstanceGroupParamsConfig(CoreConfig):
+    @staticmethod
+    def schema_extra(schema: Dict[str, Any]):
+        del schema["properties"]["termination_policy"]
+        del schema["properties"]["termination_idle_time"]
+        add_extra_schema_types(
+            schema["properties"]["nodes"],
+            extra_types=[{"type": "integer"}, {"type": "string"}],
+        )
+        add_extra_schema_types(
+            schema["properties"]["idle_duration"],
+            extra_types=[{"type": "string"}],
+        )
+
+
 class InstanceGroupParams(CoreModel):
     env: Annotated[
         Env,
@@ -297,20 +317,6 @@ class InstanceGroupParams(CoreModel):
     termination_policy: Annotated[Optional[TerminationPolicy], Field(exclude=True)] = None
     termination_idle_time: Annotated[Optional[Union[str, int]], Field(exclude=True)] = None
 
-    class Config(CoreModel.Config):
-        @staticmethod
-        def schema_extra(schema: Dict[str, Any], model: Type):
-            del schema["properties"]["termination_policy"]
-            del schema["properties"]["termination_idle_time"]
-            add_extra_schema_types(
-                schema["properties"]["nodes"],
-                extra_types=[{"type": "integer"}, {"type": "string"}],
-            )
-            add_extra_schema_types(
-                schema["properties"]["idle_duration"],
-                extra_types=[{"type": "string"}],
-            )
-
     @validator("nodes", pre=True)
     def parse_nodes(cls, v: Optional[Union[dict, str]]) -> Optional[dict]:
         if isinstance(v, str) and ".." in v:
@@ -331,7 +337,17 @@ class FleetProps(CoreModel):
     name: Annotated[Optional[str], Field(description="The fleet name")] = None
 
 
-class FleetConfiguration(InstanceGroupParams, FleetProps):
+class FleetConfigurationConfig(InstanceGroupParamsConfig):
+    @staticmethod
+    def schema_extra(schema: Dict[str, Any]):
+        InstanceGroupParamsConfig.schema_extra(schema)
+
+
+class FleetConfiguration(
+    InstanceGroupParams,
+    FleetProps,
+    generate_dual_core_model(FleetConfigurationConfig),
+):
     tags: Annotated[
         Optional[Dict[str, str]],
         Field(
@@ -346,7 +362,14 @@ class FleetConfiguration(InstanceGroupParams, FleetProps):
     _validate_tags = validator("tags", pre=True, allow_reuse=True)(tags_validator)
 
 
-class FleetSpec(CoreModel):
+class FleetSpecConfig(CoreConfig):
+    @staticmethod
+    def schema_extra(schema: Dict[str, Any], model: Type) -> None:
+        prop = schema.get("properties", {})
+        prop.pop("merged_profile", None)
+
+
+class FleetSpec(generate_dual_core_model(FleetSpecConfig)):
     configuration: FleetConfiguration
     configuration_path: Optional[str] = None
     profile: Profile
@@ -355,12 +378,6 @@ class FleetSpec(CoreModel):
     # Read profile parameters from merged_profile instead of profile directly.
     # TODO: make merged_profile a computed field after migrating to pydanticV2
     merged_profile: Annotated[Profile, Field(exclude=True)] = None
-
-    class Config(CoreModel.Config):
-        @staticmethod
-        def schema_extra(schema: Dict[str, Any], model: Type) -> None:
-            prop = schema.get("properties", {})
-            prop.pop("merged_profile", None)
 
     @root_validator
     def _merged_profile(cls, values) -> Dict:

--- a/src/dstack/_internal/core/models/fleets.py
+++ b/src/dstack/_internal/core/models/fleets.py
@@ -2,7 +2,7 @@ import ipaddress
 import uuid
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import Field, root_validator, validator
 from typing_extensions import Annotated, Literal
@@ -364,7 +364,7 @@ class FleetConfiguration(
 
 class FleetSpecConfig(CoreConfig):
     @staticmethod
-    def schema_extra(schema: Dict[str, Any], model: Type) -> None:
+    def schema_extra(schema: Dict[str, Any]):
         prop = schema.get("properties", {})
         prop.pop("merged_profile", None)
 

--- a/src/dstack/_internal/core/models/instances.py
+++ b/src/dstack/_internal/core/models/instances.py
@@ -7,7 +7,10 @@ import gpuhunt
 from pydantic import root_validator
 
 from dstack._internal.core.models.backends.base import BackendType
-from dstack._internal.core.models.common import CoreModel
+from dstack._internal.core.models.common import (
+    CoreModel,
+    FrozenCoreModel,
+)
 from dstack._internal.core.models.envs import Env
 from dstack._internal.core.models.health import HealthStatus
 from dstack._internal.core.models.volumes import Volume
@@ -117,13 +120,10 @@ class InstanceType(CoreModel):
     resources: Resources
 
 
-class SSHConnectionParams(CoreModel):
+class SSHConnectionParams(FrozenCoreModel):
     hostname: str
     username: str
     port: int
-
-    class Config(CoreModel.Config):
-        frozen = True
 
 
 class SSHKey(CoreModel):

--- a/src/dstack/_internal/core/models/profiles.py
+++ b/src/dstack/_internal/core/models/profiles.py
@@ -228,7 +228,7 @@ class Schedule(CoreModel):
 
 class ProfileParamsConfig(CoreConfig):
     @staticmethod
-    def schema_extra(schema: Dict[str, Any]) -> None:
+    def schema_extra(schema: Dict[str, Any]):
         del schema["properties"]["pool_name"]
         del schema["properties"]["instance_name"]
         del schema["properties"]["retry_policy"]
@@ -413,7 +413,7 @@ class ProfileProps(CoreModel):
 
 class ProfileConfig(ProfileParamsConfig):
     @staticmethod
-    def schema_extra(schema: Dict[str, Any]) -> None:
+    def schema_extra(schema: Dict[str, Any]):
         ProfileParamsConfig.schema_extra(schema)
 
 

--- a/src/dstack/_internal/core/models/repos/remote.py
+++ b/src/dstack/_internal/core/models/repos/remote.py
@@ -26,7 +26,7 @@ class RepoError(DstackError):
 
 class RemoteRepoCredsConfig(CoreConfig):
     @staticmethod
-    def schema_extra(schema: Dict[str, Any]) -> None:
+    def schema_extra(schema: Dict[str, Any]):
         del schema["properties"]["protocol"]
 
 
@@ -41,7 +41,7 @@ class RemoteRepoCreds(generate_dual_core_model(RemoteRepoCredsConfig)):
 
 class RemoteRepoInfoConfig(CoreConfig):
     @staticmethod
-    def schema_extra(schema: Dict[str, Any]) -> None:
+    def schema_extra(schema: Dict[str, Any]):
         del schema["properties"]["repo_host_name"]
         del schema["properties"]["repo_port"]
         del schema["properties"]["repo_user_name"]

--- a/src/dstack/_internal/core/models/repos/remote.py
+++ b/src/dstack/_internal/core/models/repos/remote.py
@@ -11,7 +11,7 @@ from pydantic import Field
 from typing_extensions import Literal
 
 from dstack._internal.core.errors import DstackError
-from dstack._internal.core.models.common import CoreModel
+from dstack._internal.core.models.common import CoreConfig, generate_dual_core_model
 from dstack._internal.core.models.repos.base import BaseRepoInfo, Repo
 from dstack._internal.utils.hash import get_sha256, slugify
 from dstack._internal.utils.path import PathLike
@@ -24,21 +24,33 @@ class RepoError(DstackError):
     pass
 
 
-class RemoteRepoCreds(CoreModel):
+class RemoteRepoCredsConfig(CoreConfig):
+    @staticmethod
+    def schema_extra(schema: Dict[str, Any]) -> None:
+        del schema["properties"]["protocol"]
+
+
+class RemoteRepoCreds(generate_dual_core_model(RemoteRepoCredsConfig)):
     clone_url: str
-    private_key: Optional[str]
-    oauth_token: Optional[str]
+    private_key: Optional[str] = None
+    oauth_token: Optional[str] = None
 
     # TODO: remove in 0.20. Left for compatibility with CLI <=0.18.44
     protocol: Annotated[Optional[str], Field(exclude=True)] = None
 
-    class Config(CoreModel.Config):
-        @staticmethod
-        def schema_extra(schema: Dict[str, Any]) -> None:
-            del schema["properties"]["protocol"]
+
+class RemoteRepoInfoConfig(CoreConfig):
+    @staticmethod
+    def schema_extra(schema: Dict[str, Any]) -> None:
+        del schema["properties"]["repo_host_name"]
+        del schema["properties"]["repo_port"]
+        del schema["properties"]["repo_user_name"]
 
 
-class RemoteRepoInfo(BaseRepoInfo):
+class RemoteRepoInfo(
+    BaseRepoInfo,
+    generate_dual_core_model(RemoteRepoInfoConfig),
+):
     repo_type: Literal["remote"] = "remote"
     repo_name: str
 
@@ -46,13 +58,6 @@ class RemoteRepoInfo(BaseRepoInfo):
     repo_host_name: Annotated[Optional[str], Field(exclude=True)] = None
     repo_port: Annotated[Optional[int], Field(exclude=True)] = None
     repo_user_name: Annotated[Optional[str], Field(exclude=True)] = None
-
-    class Config(BaseRepoInfo.Config):
-        @staticmethod
-        def schema_extra(schema: Dict[str, Any]) -> None:
-            del schema["properties"]["repo_host_name"]
-            del schema["properties"]["repo_port"]
-            del schema["properties"]["repo_user_name"]
 
 
 class RemoteRunRepoData(RemoteRepoInfo):

--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional, Type
+from typing import Any, Dict, List, Literal, Optional
 from urllib.parse import urlparse
 
 from pydantic import UUID4, Field, root_validator
@@ -394,7 +394,7 @@ class Job(CoreModel):
 
 class RunSpecConfig(CoreConfig):
     @staticmethod
-    def schema_extra(schema: Dict[str, Any], model: Type) -> None:
+    def schema_extra(schema: Dict[str, Any]):
         prop = schema.get("properties", {})
         prop.pop("merged_profile", None)
 

--- a/src/dstack/_internal/server/models.py
+++ b/src/dstack/_internal/server/models.py
@@ -24,7 +24,7 @@ from sqlalchemy_utils import UUIDType
 
 from dstack._internal.core.errors import DstackError
 from dstack._internal.core.models.backends.base import BackendType
-from dstack._internal.core.models.common import CoreModel
+from dstack._internal.core.models.common import CoreConfig, generate_dual_core_model
 from dstack._internal.core.models.fleets import FleetStatus
 from dstack._internal.core.models.gateways import GatewayStatus
 from dstack._internal.core.models.health import HealthStatus
@@ -71,7 +71,11 @@ class NaiveDateTime(TypeDecorator):
         return value.replace(tzinfo=timezone.utc)
 
 
-class DecryptedString(CoreModel):
+class DecryptedStringConfig(CoreConfig):
+    arbitrary_types_allowed = True
+
+
+class DecryptedString(generate_dual_core_model(DecryptedStringConfig)):
     """
     A type for representing plaintext strings encrypted with `EncryptedString`.
     Besides the string, stores information if the decryption was successful.
@@ -83,9 +87,6 @@ class DecryptedString(CoreModel):
     plaintext: Optional[str]
     decrypted: bool = True
     exc: Optional[Exception] = None
-
-    class Config(CoreModel.Config):
-        arbitrary_types_allowed = True
 
     def get_plaintext_or_error(self) -> str:
         if self.decrypted and self.plaintext is not None:

--- a/src/dstack/_internal/server/schemas/gateways.py
+++ b/src/dstack/_internal/server/schemas/gateways.py
@@ -9,7 +9,7 @@ from dstack._internal.core.models.gateways import GatewayConfiguration
 
 class CreateGatewayRequestConfig(CoreConfig):
     @staticmethod
-    def schema_extra(schema: Dict[str, Any]) -> None:
+    def schema_extra(schema: Dict[str, Any]):
         del schema["properties"]["name"]
         del schema["properties"]["backend_type"]
         del schema["properties"]["region"]

--- a/src/dstack/_internal/server/schemas/gateways.py
+++ b/src/dstack/_internal/server/schemas/gateways.py
@@ -3,23 +3,24 @@ from typing import Annotated, Any, Dict, List, Optional
 from pydantic import Field
 
 from dstack._internal.core.models.backends.base import BackendType
-from dstack._internal.core.models.common import CoreModel
+from dstack._internal.core.models.common import CoreConfig, CoreModel, generate_dual_core_model
 from dstack._internal.core.models.gateways import GatewayConfiguration
 
 
-class CreateGatewayRequest(CoreModel):
+class CreateGatewayRequestConfig(CoreConfig):
+    @staticmethod
+    def schema_extra(schema: Dict[str, Any]) -> None:
+        del schema["properties"]["name"]
+        del schema["properties"]["backend_type"]
+        del schema["properties"]["region"]
+
+
+class CreateGatewayRequest(generate_dual_core_model(CreateGatewayRequestConfig)):
     configuration: GatewayConfiguration
     # Deprecated and unused. Left for compatibility with 0.18 clients.
     name: Annotated[Optional[str], Field(exclude=True)] = None
     backend_type: Annotated[Optional[BackendType], Field(exclude=True)] = None
     region: Annotated[Optional[str], Field(exclude=True)] = None
-
-    class Config(CoreModel.Config):
-        @staticmethod
-        def schema_extra(schema: Dict[str, Any]) -> None:
-            del schema["properties"]["name"]
-            del schema["properties"]["backend_type"]
-            del schema["properties"]["region"]
 
 
 class GetGatewayRequest(CoreModel):

--- a/src/dstack/_internal/server/services/docker.py
+++ b/src/dstack/_internal/server/services/docker.py
@@ -9,7 +9,11 @@ from pydantic import Field, ValidationError, validator
 from typing_extensions import Annotated
 
 from dstack._internal.core.errors import DockerRegistryError
-from dstack._internal.core.models.common import CoreModel, RegistryAuth
+from dstack._internal.core.models.common import (
+    CoreModel,
+    FrozenCoreModel,
+    RegistryAuth,
+)
 from dstack._internal.server.utils.common import join_byte_stream_checked
 from dstack._internal.utils.dxf import PatchedDXF
 
@@ -31,15 +35,12 @@ class DXFAuthAdapter:
         )
 
 
-class DockerImage(CoreModel):
+class DockerImage(FrozenCoreModel):
     image: str
-    registry: Optional[str]
+    registry: Optional[str] = None
     repo: str
     tag: str
-    digest: Optional[str]
-
-    class Config(CoreModel.Config):
-        frozen = True
+    digest: Optional[str] = None
 
 
 class ImageConfig(CoreModel):


### PR DESCRIPTION
Fixes #3066 

The PR introduces `generate_dual_core_model()` that generates CoreModel with a custom config on the fly. This allows models to have custom configs and pyndatic-duality's behavior at the same time. Previously, models that defined custom Configs had `__response__.extra == "forbid"`, breaking pyndatic-duality's behavior. To use custom configs in `generate_dual_core_model()`, they are moved from model classes to the top level.

* [x] schema_extra (usual case for custom config) works as before and modifies json schema appropriately.
* [x] models with custom configs have `__response__.extra == "ignore"` as expected.