### PR TITLE
Support client-side proxies for apply command

### DIFF
--- a/src/dstack/_internal/cli/services/configurators/run.py
+++ b/src/dstack/_internal/cli/services/configurators/run.py
@@ -251,8 +251,10 @@ class BaseRunConfigurator(
                     )
                     # Map the attach.proxy settings to the original configuration
                     attach_proxy_config = SSHProxyConfig()
-                    if isinstance(conf, RunAttachConfiguration) and conf.attach is not None:
-                        attach: RunAttachParams = conf.attach
+                    if isinstance(conf, RunAttachConfiguration) and isinstance(
+                        conf.attach, RunAttachParams
+                    ):
+                        attach = conf.attach
                         if attach.proxy.type == "jump":
                             attach_proxy_config = SSHProxyJumpConfig(attach.proxy.proxy_jump)
                         elif attach.proxy.type == "command":

--- a/src/dstack/_internal/core/services/ssh/attach.py
+++ b/src/dstack/_internal/core/services/ssh/attach.py
@@ -61,7 +61,7 @@ class SSHProxyCommandConfig(SSHProxyConfig):
         host["ProxyCommand"] = self.command
 
 
-@dataclasses.dataclass(kw_only=True)
+@dataclasses.dataclass
 class SSHProxyAwsSSMConfig(SSHProxyConfig):
     """Add ProxyCommand to use AWS SSM"""
 


### PR DESCRIPTION
This is a concept implementation to support SSH proxy in `dstack apply` comand.
I think this can be a part of #2562 and #2554.

## Summary
- Add client-side SSH proxy configuration to dev/task/service configs
- Let `dstack apply` reuse those settings for ProxyJump, ProxyCommand, and AWS SSM

## Liimitations
- `dstack attach` still bypasses the new proxy controls, so detached runs cannot yet use them

## Next Steps
- Add cloud-specific helpers (e.g., GCP, Azure) on top of this structure

## Example configuration

```yaml
type: dev-environment
name: example
ide: vscode
attach:
  proxy:
    type: aws-ssm
    profile: sso-profile-name
```