### PR TITLE
[Backward incompatible] Rename properties in Kubernetes backend config

### DIFF
--- a/docs/docs/concepts/backends.md
+++ b/docs/docs/concepts/backends.md
@@ -1049,18 +1049,18 @@ In case of a self-managed cluster, also specify the IP address of any node in th
         - type: kubernetes
           kubeconfig:
             filename: ~/.kube/config
-          networking:
-            ssh_host: localhost # The external IP address of any node
-            ssh_port: 32000 # Any port accessible outside of the cluster
+          proxy_jump:
+            hostname: localhost # The external IP address of any node
+            port: 32000 # Any port accessible outside of the cluster
     ```
 
     </div>
 
-    The port specified to `ssh_port` must be accessible outside of the cluster.
+    The port specified to `port` must be accessible outside of the cluster.
 
     ??? info "Kind"
         If you are using [Kind](https://kind.sigs.k8s.io/), make sure to make 
-        to set up `ssh_port` via `extraPortMappings` for proxying SSH traffic:
+        to set up `port` via `extraPortMappings` for proxying SSH traffic:
     
         ```yaml
         kind: Cluster
@@ -1068,8 +1068,8 @@ In case of a self-managed cluster, also specify the IP address of any node in th
         nodes:
           - role: control-plane
             extraPortMappings:
-              - containerPort: 32000 # Must be same as `ssh_port`
-                hostPort: 32000 # Must be same as `ssh_port`
+              - containerPort: 32000 # Must be same as `port`
+                hostPort: 32000 # Must be same as `port`
         ```
     
         Go ahead and create the cluster like this: 
@@ -1092,13 +1092,13 @@ In case of a self-managed cluster, also specify the IP address of any node in th
           - type: kubernetes
             kubeconfig:
               filename: ~/.kube/config
-            networking:
-              ssh_port: 32000 # Any port accessible outside of the cluster
+            proxy_jump:
+              port: 32000 # Any port accessible outside of the cluster
     ```
 
     </div>
 
-    The port specified to `ssh_port` must be accessible outside of the cluster.
+    The port specified to `port` must be accessible outside of the cluster.
 
     ??? info "EKS"
         For example, if you are using EKS, make sure to add it via an ingress rule

--- a/docs/docs/reference/server/config.yml.md
+++ b/docs/docs/reference/server/config.yml.md
@@ -293,7 +293,7 @@ to configure [backends](../../concepts/backends.md) and other [server-level sett
     cat my-service-account-file.json | jq -c | jq -R
     ```
 
-###### `projects[n].backends[type=kubernetes].networking` { #kubernetes-networking data-toc-label="networking" }
+###### `projects[n].backends[type=kubernetes].proxy_jump` { #kubernetes-proxy_jump data-toc-label="proxy_jump" }
 
 #SCHEMA# dstack._internal.core.backends.kubernetes.models.KubernetesProxyJumpConfig
     overrides:

--- a/docs/docs/reference/server/config.yml.md
+++ b/docs/docs/reference/server/config.yml.md
@@ -295,7 +295,7 @@ to configure [backends](../../concepts/backends.md) and other [server-level sett
 
 ###### `projects[n].backends[type=kubernetes].networking` { #kubernetes-networking data-toc-label="networking" }
 
-#SCHEMA# dstack._internal.core.backends.kubernetes.models.KubernetesNetworkingConfig
+#SCHEMA# dstack._internal.core.backends.kubernetes.models.KubernetesProxyJumpConfig
     overrides:
         show_root_heading: false
 

--- a/src/dstack/_internal/core/backends/kubernetes/models.py
+++ b/src/dstack/_internal/core/backends/kubernetes/models.py
@@ -8,11 +8,11 @@ from dstack._internal.core.models.common import CoreModel
 DEFAULT_NAMESPACE = "default"
 
 
-class KubernetesNetworkingConfig(CoreModel):
-    ssh_host: Annotated[
-        Optional[str], Field(description="The external IP address of any node")
+class KubernetesProxyJumpConfig(CoreModel):
+    hostname: Annotated[
+        Optional[str], Field(description="The external IP address or hostname of any node")
     ] = None
-    ssh_port: Annotated[
+    port: Annotated[
         Optional[int], Field(description="Any port accessible outside of the cluster")
     ] = None
 
@@ -24,8 +24,8 @@ class KubeconfigConfig(CoreModel):
 
 class KubernetesBackendConfig(CoreModel):
     type: Annotated[Literal["kubernetes"], Field(description="The type of backend")] = "kubernetes"
-    networking: Annotated[
-        Optional[KubernetesNetworkingConfig], Field(description="The networking configuration")
+    proxy_jump: Annotated[
+        Optional[KubernetesProxyJumpConfig], Field(description="The SSH proxy jump configuration")
     ] = None
     namespace: Annotated[
         str, Field(description="The namespace for resources managed by `dstack`")

--- a/src/tests/_internal/core/backends/kubernetes/test_configurator.py
+++ b/src/tests/_internal/core/backends/kubernetes/test_configurator.py
@@ -8,7 +8,7 @@ from dstack._internal.core.backends.kubernetes.configurator import (
 from dstack._internal.core.backends.kubernetes.models import (
     KubeconfigConfig,
     KubernetesBackendConfigWithCreds,
-    KubernetesNetworkingConfig,
+    KubernetesProxyJumpConfig,
 )
 from dstack._internal.core.errors import BackendInvalidCredentialsError
 
@@ -17,7 +17,7 @@ class TestKubernetesConfigurator:
     def test_validate_config_valid(self):
         config = KubernetesBackendConfigWithCreds(
             kubeconfig=KubeconfigConfig(data="valid", filename="-"),
-            networking=KubernetesNetworkingConfig(ssh_host=None, ssh_port=None),
+            proxy_jump=KubernetesProxyJumpConfig(hostname=None, port=None),
         )
         with patch(
             "dstack._internal.core.backends.kubernetes.utils.get_api_from_config_data"
@@ -30,7 +30,7 @@ class TestKubernetesConfigurator:
     def test_validate_config_invalid_config(self):
         config = KubernetesBackendConfigWithCreds(
             kubeconfig=KubeconfigConfig(data="invalid", filename="-"),
-            networking=KubernetesNetworkingConfig(ssh_host=None, ssh_port=None),
+            proxy_jump=KubernetesProxyJumpConfig(hostname=None, port=None),
         )
         with (
             patch(


### PR DESCRIPTION
* networking -> proxy_jump
* ssh_host -> hostname
* ssh_port -> port

In addition, `dstack-` prefix has been added to jump pod and service names for consistency with jobs pods and services.

Closes: https://github.com/dstackai/dstack/issues/3136