### PR TITLE
Support GCP A4 clusters

### DIFF
--- a/src/dstack/_internal/core/backends/gcp/configurator.py
+++ b/src/dstack/_internal/core/backends/gcp/configurator.py
@@ -202,5 +202,5 @@ class GCPConfigurator(
             )
         except BackendError as e:
             raise ServerClientError(e.args[0])
-        # Not checking config.extra_vpc so that users are not required to configure subnets for all regions
+        # Not checking config.extra_vpcs and config.roce_vpcs so that users are not required to configure subnets for all regions
         # but only for regions they intend to use. Validation will be done on provisioning.

--- a/src/dstack/_internal/core/backends/gcp/models.py
+++ b/src/dstack/_internal/core/backends/gcp/models.py
@@ -41,9 +41,22 @@ class GCPBackendConfig(CoreModel):
         Optional[List[str]],
         Field(
             description=(
-                "The names of additional VPCs used for GPUDirect. Specify eight VPCs to maximize bandwidth."
+                "The names of additional VPCs used for multi-NIC instances, such as those that support GPUDirect."
+                " Specify eight VPCs to maximize bandwidth in clusters with eight-GPU instances."
                 " Each VPC must have a subnet and a firewall rule allowing internal traffic across all subnets"
             )
+        ),
+    ] = None
+    roce_vpcs: Annotated[
+        Optional[List[str]],
+        Field(
+            description=(
+                "The names of additional VPCs with the RoCE network profile."
+                " Used for RDMA on GPU instances that support the MRDMA interface type."
+                " A VPC should have eight subnets to maximize the bandwidth in clusters"
+                " with eight-GPU instances."
+            ),
+            max_items=1,  # The currently supported instance types only need one VPC with eight subnets.
         ),
     ] = None
     vpc_project_id: Annotated[


### PR DESCRIPTION
This commit implements provisioning GCP A4 clusters with high-performance RoCE networking.

```shell
> dstack fleet
 FLEET  INSTANCE  BACKEND         RESOURCES                                          PRICE    STATUS  CREATED
 gpu    0         gcp (us-west2)  cpu=224 mem=3968GB disk=100GB B200:180GB:8 (spot)  $51.552  idle    21 mins ago
        1         gcp (us-west2)  cpu=224 mem=3968GB disk=100GB B200:180GB:8 (spot)  $51.552  idle    17 mins ago
```

To enable high-performance networking, users need to create the [appropriate networks](https://cloud.google.com/ai-hypercomputer/docs/create/create-vm#setup-network) and configure them in the backend settings.

```yaml
projects:
- name: main
  backends:
  - type: gcp
    project_id: my-project
    creds:
      type: default
    vpc_name: my-vpc-0  # regular, 1 subnet
    extra_vpcs:
    - my-vpc-1  # regular, 1 subnet
    roce_vpcs:
    - my-vpc-mrdma  # RoCE profile, 8 subnets
```

Then apply a fleet configuration.

```yaml
type: fleet
nodes: 2
placement: cluster
availability_zones: [us-west2-c]
backends: [gcp]
resources:
  gpu: 8:b200
```

Each instance in the cluster will then have 10 network interfaces:
- 1 regular interface in the main VPC (`default` or the one configured in `vpc_name`).
- 1 regular interface in a VPC configured in `extra_vpcs`.
- 8 RDMA interfaces in the VPC configured in `roce_vpcs`.

Additionally, this commit optimizes the fetching and caching of subnets, so that they are fetched from the API only once, and not separately for each item in `extra_vpcs`. For some instance types, this reduces the number of API requests from 9 to 1, which cuts about 16 seconds from each offer provisioning attempt.

#3088