### PR TITLE
Fix idle duration: off and forbid negative durations

### DIFF
--- a/src/dstack/_internal/core/models/profiles.py
+++ b/src/dstack/_internal/core/models/profiles.py
@@ -85,9 +85,13 @@ def parse_off_duration(v: Optional[Union[int, str, bool]]) -> Optional[Union[Lit
     return parse_duration(v)
 
 
-def parse_idle_duration(v: Optional[Union[int, str]]) -> Optional[int]:
-    if v == "off" or v == -1:
+def parse_idle_duration(v: Optional[Union[int, str, bool]]) -> Optional[int]:
+    # Differs from `parse_off_duration`` to accept negative durations as `off`
+    # for backward compatibility.
+    if v == "off" or v is False or v == -1:
         return -1
+    if v is True:
+        return None
     return parse_duration(v)
 
 

--- a/src/dstack/_internal/core/models/profiles.py
+++ b/src/dstack/_internal/core/models/profiles.py
@@ -80,13 +80,16 @@ def parse_stop_duration(
 def parse_off_duration(v: Optional[Union[int, str, bool]]) -> Optional[Union[Literal["off"], int]]:
     if v == "off" or v is False:
         return "off"
-    if v is True:
+    if v is True or v is None:
         return None
-    return parse_duration(v)
+    duration = parse_duration(v)
+    if duration < 0:
+        raise ValueError("Duration cannot be negative")
+    return duration
 
 
 def parse_idle_duration(v: Optional[Union[int, str, bool]]) -> Optional[int]:
-    # Differs from `parse_off_duration`` to accept negative durations as `off`
+    # Differs from `parse_off_duration` to accept negative durations as `off`
     # for backward compatibility.
     if v == "off" or v is False or v == -1:
         return -1


### PR DESCRIPTION
Fixes #3125 
Fixes #3150

Now all duration parameters that accept `off` do not allow negative values since this was not handled properly and led to bugs. `idle_duration` continues to accept negative values and treats them the same as `off` for backward compatibility. `idle_duration: off` parsing is fixed.