### PR TITLE
feat(docker): upgrade litestream to v0.5.0

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -7,9 +7,21 @@ if [ -n "${GOOGLE_APPLICATION_CREDENTIALS_JSON}" ]; then
   echo "${GOOGLE_APPLICATION_CREDENTIALS_JSON}" > "${GOOGLE_APPLICATION_CREDENTIALS_DIR}/application_default_credentials.json"
 fi
 
+DB_PATH="${HOME}/.dstack/server/data/sqlite.db"
+mkdir -p "$(dirname "$DB_PATH")"
 if [[ -z "${LITESTREAM_REPLICA_URL}" ]]; then
-  dstack server --host 0.0.0.0
+  exec dstack server --host 0.0.0.0
 else
-  litestream restore -if-replica-exists -o ${HOME}/.dstack/server/data/sqlite.db ${LITESTREAM_REPLICA_URL}
-  litestream replicate -exec "dstack server --host 0.0.0.0" ${HOME}/.dstack/server/data/sqlite.db ${LITESTREAM_REPLICA_URL}
+  if [[ ! -f "$DB_PATH" ]]; then
+    echo "Attempting Litestream restore..."
+    if ! output=$(litestream restore -o "$DB_PATH" "$LITESTREAM_REPLICA_URL" 2>&1); then
+      if echo "$output" | grep -qiE "cannot calc restore plan"; then
+        echo "No replica snapshots found; starting with empty database."
+      else
+        echo "$output" >&2
+        exit 1
+      fi
+    fi
+  fi
+  exec litestream replicate -exec "dstack server --host 0.0.0.0" "$DB_PATH" "$LITESTREAM_REPLICA_URL"
 fi

--- a/docker/server/release/Dockerfile
+++ b/docker/server/release/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y \
     sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN if [ $(uname -m) = "aarch64" ]; then ARCH="arm64"; else ARCH="amd64"; fi && \
+RUN if [ $(uname -m) = "aarch64" ]; then ARCH="arm64"; else ARCH="x86_64"; fi && \
     curl https://github.com/benbjohnson/litestream/releases/download/v0.5.0/litestream-0.5.0-linux-$ARCH.deb -O -L && \
     dpkg -i litestream-0.5.0-linux-$ARCH.deb
 

--- a/docker/server/release/Dockerfile
+++ b/docker/server/release/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN if [ $(uname -m) = "aarch64" ]; then ARCH="arm64"; else ARCH="amd64"; fi && \
-    curl https://github.com/benbjohnson/litestream/releases/download/v0.3.9/litestream-v0.3.9-linux-$ARCH.deb -O -L && \
-    dpkg -i litestream-v0.3.9-linux-$ARCH.deb
+    curl https://github.com/benbjohnson/litestream/releases/download/v0.3.9/litestream-v0.5.0-linux-$ARCH.deb -O -L && \
+    dpkg -i litestream-v0.5.0-linux-$ARCH.deb
 
 ADD https://astral.sh/uv/install.sh /uv-installer.sh
 RUN sh /uv-installer.sh && rm /uv-installer.sh

--- a/docker/server/release/Dockerfile
+++ b/docker/server/release/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN if [ $(uname -m) = "aarch64" ]; then ARCH="arm64"; else ARCH="amd64"; fi && \
     curl https://github.com/benbjohnson/litestream/releases/download/v0.5.0/litestream-0.5.0-linux-$ARCH.deb -O -L && \
-    dpkg -i litestream-v0.5.0-linux-$ARCH.deb
+    dpkg -i litestream-0.5.0-linux-$ARCH.deb
 
 ADD https://astral.sh/uv/install.sh /uv-installer.sh
 RUN sh /uv-installer.sh && rm /uv-installer.sh

--- a/docker/server/release/Dockerfile
+++ b/docker/server/release/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN if [ $(uname -m) = "aarch64" ]; then ARCH="arm64"; else ARCH="amd64"; fi && \
-    curl https://github.com/benbjohnson/litestream/releases/download/v0.3.9/litestream-v0.5.0-linux-$ARCH.deb -O -L && \
+    curl https://github.com/benbjohnson/litestream/releases/download/v0.5.0/litestream-0.5.0-linux-$ARCH.deb -O -L && \
     dpkg -i litestream-v0.5.0-linux-$ARCH.deb
 
 ADD https://astral.sh/uv/install.sh /uv-installer.sh

--- a/docker/server/stgn/Dockerfile
+++ b/docker/server/stgn/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
     sqlite3 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN if [ $(uname -m) = "aarch64" ]; then ARCH="arm64"; else ARCH="amd64"; fi && \
+RUN if [ $(uname -m) = "aarch64" ]; then ARCH="arm64"; else ARCH="x86_64"; fi && \
     curl https://github.com/benbjohnson/litestream/releases/download/v0.5.0/litestream-0.5.0-linux-$ARCH.deb -O -L && \
     dpkg -i litestream-0.5.0-linux-$ARCH.deb
 

--- a/docker/server/stgn/Dockerfile
+++ b/docker/server/stgn/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN if [ $(uname -m) = "aarch64" ]; then ARCH="arm64"; else ARCH="amd64"; fi && \
-    curl https://github.com/benbjohnson/litestream/releases/download/v0.3.9/litestream-v0.3.9-linux-$ARCH.deb -O -L && \
-    dpkg -i litestream-v0.3.9-linux-$ARCH.deb
+    curl https://github.com/benbjohnson/litestream/releases/download/v0.3.9/litestream-v0.5.0-linux-$ARCH.deb -O -L && \
+    dpkg -i litestream-v0.5.0-linux-$ARCH.deb
 
 ADD https://astral.sh/uv/install.sh /uv-installer.sh
 RUN sh /uv-installer.sh && rm /uv-installer.sh

--- a/docker/server/stgn/Dockerfile
+++ b/docker/server/stgn/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN if [ $(uname -m) = "aarch64" ]; then ARCH="arm64"; else ARCH="amd64"; fi && \
-    curl https://github.com/benbjohnson/litestream/releases/download/v0.3.9/litestream-v0.5.0-linux-$ARCH.deb -O -L && \
-    dpkg -i litestream-v0.5.0-linux-$ARCH.deb
+    curl https://github.com/benbjohnson/litestream/releases/download/v0.5.0/litestream-0.5.0-linux-$ARCH.deb -O -L && \
+    dpkg -i litestream-0.5.0-linux-$ARCH.deb
 
 ADD https://astral.sh/uv/install.sh /uv-installer.sh
 RUN sh /uv-installer.sh && rm /uv-installer.sh


### PR DESCRIPTION
The SRE team at TableCheck is attempting to deploy dstack for our GPU workloads, but we are currently blocked due to an issue we have identified with EKS Pod Identity (OIDC) support and Litestream.

This pull request in Litestream adds support https://github.com/benbjohnson/litestream/pull/683, but the version of litestream used in dstack's Docker images is quite old (v0.3.9) and doesn't include this support.

As a result, the Docker image will start with the following error from Litestream:
```
cannot fetch generations: cannot lookup bucket region: NoCredentialProviders: no valid providers in chain. Deprecated.
	For verbose messaging see aws.Config.CredentialsChainVerboseErrors
```

This pull request updates the version of Litestream to the latest version available in https://github.com/benbjohnson/litestream/releases.