### PR TITLE
[Docker] Update the CUDA version in the default Docker image to 12.8 (from 12.1)

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -2,7 +2,7 @@
 ARG UBUNTU_VERSION
 
 # Build stage
-FROM nvidia/cuda:12.1.1-base-ubuntu${UBUNTU_VERSION}.04 AS builder
+FROM nvidia/cuda:12.8.1-base-ubuntu${UBUNTU_VERSION}.04 AS builder
 
 ENV NCCL_HOME=/opt/nccl
 ENV CUDA_HOME=/usr/local/cuda

--- a/docker/base/Dockerfile.common
+++ b/docker/base/Dockerfile.common
@@ -1,6 +1,6 @@
 ARG UBUNTU_VERSION
 
-FROM nvidia/cuda:12.1.1-base-ubuntu${UBUNTU_VERSION}.04
+FROM nvidia/cuda:12.8.1-base-ubuntu${UBUNTU_VERSION}.04
 
 ARG _UV_HOME="/opt/uv"
 

--- a/scripts/packer/azure-image-grid.json
+++ b/scripts/packer/azure-image-grid.json
@@ -24,7 +24,6 @@
     "image_publisher": "canonical",
     "image_offer": "ubuntu-24_04-lts",
     "image_sku": "server",
-    "image_version": "24.04.202509170",
     "azure_tags": {
         "Name": "DSTACK-GRID"
     },
@@ -63,6 +62,15 @@
         "chmod +x install-docker.sh",
         "./install-docker.sh --version {{user `docker_version`}}"
       ]
+    },
+    {
+      "type": "shell",
+      "script": "provisioners/downgrade-azure-kernel.sh"
+    },
+    {
+      "type": "shell",
+      "inline": ["sudo reboot"],
+      "expect_disconnect": true
     },
     {
       "type": "shell",

--- a/scripts/packer/azure-image-grid.json
+++ b/scripts/packer/azure-image-grid.json
@@ -24,6 +24,7 @@
     "image_publisher": "canonical",
     "image_offer": "ubuntu-24_04-lts",
     "image_sku": "server",
+    "image_version": "24.04.202509170",
     "azure_tags": {
         "Name": "DSTACK-GRID"
     },

--- a/scripts/packer/provisioners/downgrade-azure-kernel.sh
+++ b/scripts/packer/provisioners/downgrade-azure-kernel.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# based on https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/hpccompute-gpu-linux#known-issues
+# this is a temporary solution only required until the issue is fixed
+
+set -e
+
+# Install 6.8 kernel
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive sudo apt install linux-image-6.8.0-1015-azure linux-headers-6.8.0-1015-azure -y
+
+# Update the Grub entry name
+sudo grub_entry_name=$(sudo grep -Po "menuentry '\KUbuntu, with Linux 6.8[^(']+" /boot/grub/grub.cfg | sort -V | head -1)
+sudo sed -i "s/^\s*GRUB_DEFAULT=.*$/GRUB_DEFAULT='Advanced options for Ubuntu>$grub_entry_name'/" /etc/default/grub
+sudo update-grub
+
+# Disable the kernel package upgrade
+sudo apt-mark hold $(dpkg --get-selections | grep -Po "^linux[^\t]+${grub_entry_name##* }")

--- a/scripts/packer/provisioners/downgrade-azure-kernel.sh
+++ b/scripts/packer/provisioners/downgrade-azure-kernel.sh
@@ -7,10 +7,10 @@ set -e
 
 # Install 6.8 kernel
 sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive sudo apt install linux-image-6.8.0-1015-azure linux-headers-6.8.0-1015-azure -y
+sudo DEBIAN_FRONTEND=noninteractive apt install linux-image-6.8.0-1015-azure linux-headers-6.8.0-1015-azure -y
 
 # Update the Grub entry name
-sudo grub_entry_name=$(sudo grep -Po "menuentry '\KUbuntu, with Linux 6.8[^(']+" /boot/grub/grub.cfg | sort -V | head -1)
+grub_entry_name="$(sudo grep -Po "menuentry '\KUbuntu, with Linux 6\.8[^(']+" /boot/grub/grub.cfg | sort -V | head -1)"
 sudo sed -i "s/^\s*GRUB_DEFAULT=.*$/GRUB_DEFAULT='Advanced options for Ubuntu>$grub_entry_name'/" /etc/default/grub
 sudo update-grub
 

--- a/src/dstack/_internal/core/backends/vastai/compute.py
+++ b/src/dstack/_internal/core/backends/vastai/compute.py
@@ -47,7 +47,7 @@ class VastAICompute(
                     "reliability2": {"gte": 0.9},
                     "inet_down": {"gt": 128},
                     "verified": {"eq": True},
-                    "cuda_max_good": {"gte": 12.1},
+                    "cuda_max_good": {"gte": 12.8},
                     "compute_cap": {"gte": 600},
                 }
             )

--- a/src/dstack/version.py
+++ b/src/dstack/version.py
@@ -5,5 +5,5 @@
 
 __version__ = "0.0.0"
 __is_release__ = False
-base_image = "0.11rc2"
+base_image = "0.11"
 base_image_ubuntu_version = "22.04"

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -333,7 +333,7 @@ def get_dev_env_run_dict(
                 " && tail -f /dev/null"
             ),
         ]
-        image_name = "dstackai/base:0.11rc2-base-ubuntu22.04"
+        image_name = "dstackai/base:0.11-base-ubuntu22.04"
 
     return {
         "id": run_id,


### PR DESCRIPTION
Fixes #3163

- [x] Build 0.11rc3 on staging and do a minimum test
- [x] Build 0.11 on production
- [x] Update the image version in sources to 0.11