### PR TITLE
Support specifying kubeconfig directly as yaml

### DIFF
--- a/docs/docs/reference/server/config.yml.md
+++ b/docs/docs/reference/server/config.yml.md
@@ -287,10 +287,26 @@ to configure [backends](../../concepts/backends.md) and other [server-level sett
         show_root_heading: false
 
 ??? info "Specifying `data`"
-    To specify kubeconfig contents directly via `data`, convert it to a string:
+    To specify kubeconfig contents directly via `data`, you can convert it to a string:
 
     ```shell
     yq -o=json ~/.kube/config | jq -c | jq -R
+    ```
+
+    or copy kubeconfig contents under `data` as-is:
+
+    ```yaml
+    type: kubernetes
+    kubeconfig:
+      data:
+        apiVersion: v1
+        clusters:
+        - cluster:
+            # ...
+        contexts:
+        - context:
+            # ...
+        # ...
     ```
 
 ###### `projects[n].backends[type=kubernetes].proxy_jump` { #kubernetes-proxy_jump data-toc-label="proxy_jump" }

--- a/src/dstack/_internal/core/backends/kubernetes/compute.py
+++ b/src/dstack/_internal/core/backends/kubernetes/compute.py
@@ -27,7 +27,7 @@ from dstack._internal.core.backends.kubernetes.models import (
 )
 from dstack._internal.core.backends.kubernetes.utils import (
     call_api_method,
-    get_api_from_config_data,
+    get_api_from_config_dict,
     get_cluster_public_ip,
     get_value,
 )
@@ -99,7 +99,7 @@ class KubernetesCompute(
         if proxy_jump is None:
             proxy_jump = KubernetesProxyJumpConfig()
         self.proxy_jump = proxy_jump
-        self.api = get_api_from_config_data(config.kubeconfig.data)
+        self.api = get_api_from_config_dict(config.kubeconfig.data)
 
     def get_offers_by_requirements(
         self, requirements: Requirements

--- a/src/dstack/_internal/core/backends/kubernetes/configurator.py
+++ b/src/dstack/_internal/core/backends/kubernetes/configurator.py
@@ -30,7 +30,7 @@ class KubernetesConfigurator(
         self, config: KubernetesBackendConfigWithCreds, default_creds_enabled: bool
     ):
         try:
-            api = kubernetes_utils.get_api_from_config_data(config.kubeconfig.data)
+            api = kubernetes_utils.get_api_from_config_dict(config.kubeconfig.data)
             api.list_node()
         except Exception as e:
             logger.debug("Invalid kubeconfig: %s", str(e))

--- a/src/dstack/_internal/core/backends/kubernetes/models.py
+++ b/src/dstack/_internal/core/backends/kubernetes/models.py
@@ -50,7 +50,7 @@ class KubeconfigFileConfig(CoreModel):
         Optional[Union[str, dict]],
         Field(
             description=(
-                "The contents of the kubeconfig file."
+                "The contents of the kubeconfig file specified as yaml or a string."
                 " When configuring via `server/config.yml`, it's automatically filled from `filename`."
                 " When configuring via UI, it has to be specified explicitly"
             )

--- a/src/dstack/_internal/core/backends/kubernetes/utils.py
+++ b/src/dstack/_internal/core/backends/kubernetes/utils.py
@@ -1,18 +1,12 @@
 import ast
 from typing import Any, Callable, List, Literal, Optional, TypeVar, Union, get_origin, overload
 
-import yaml
 from kubernetes import client as kubernetes_client
 from kubernetes import config as kubernetes_config
 from typing_extensions import ParamSpec
 
 T = TypeVar("T")
 P = ParamSpec("P")
-
-
-def get_api_from_config_data(kubeconfig_data: str) -> kubernetes_client.CoreV1Api:
-    config_dict = yaml.load(kubeconfig_data, yaml.FullLoader)
-    return get_api_from_config_dict(config_dict)
 
 
 def get_api_from_config_dict(kubeconfig: dict) -> kubernetes_client.CoreV1Api:

--- a/src/tests/_internal/core/backends/kubernetes/test_configurator.py
+++ b/src/tests/_internal/core/backends/kubernetes/test_configurator.py
@@ -16,11 +16,11 @@ from dstack._internal.core.errors import BackendInvalidCredentialsError
 class TestKubernetesConfigurator:
     def test_validate_config_valid(self):
         config = KubernetesBackendConfigWithCreds(
-            kubeconfig=KubeconfigConfig(data="valid", filename="-"),
+            kubeconfig=KubeconfigConfig(data={"config": "valid"}, filename="-"),
             proxy_jump=KubernetesProxyJumpConfig(hostname=None, port=None),
         )
         with patch(
-            "dstack._internal.core.backends.kubernetes.utils.get_api_from_config_data"
+            "dstack._internal.core.backends.kubernetes.utils.get_api_from_config_dict"
         ) as get_api_mock:
             api_mock = Mock()
             api_mock.list_node.return_value = Mock()
@@ -29,12 +29,12 @@ class TestKubernetesConfigurator:
 
     def test_validate_config_invalid_config(self):
         config = KubernetesBackendConfigWithCreds(
-            kubeconfig=KubeconfigConfig(data="invalid", filename="-"),
+            kubeconfig=KubeconfigConfig(data={"config": "invalid"}, filename="-"),
             proxy_jump=KubernetesProxyJumpConfig(hostname=None, port=None),
         )
         with (
             patch(
-                "dstack._internal.core.backends.kubernetes.utils.get_api_from_config_data"
+                "dstack._internal.core.backends.kubernetes.utils.get_api_from_config_dict"
             ) as get_api_mock,
             pytest.raises(BackendInvalidCredentialsError) as exc_info,
         ):


### PR DESCRIPTION
Closes #3167 

It's now possible to specify kubeconfig for kubernetes backend directly as yaml via the `data` field:


```yaml
type: kubernetes
kubeconfig:
  data:
    apiVersion: v1
    clusters:
    - cluster:
        # ...
    contexts:
    - context:
        # ...
    # ...
```

Previously, `kubeconfig` contents have to be converted to a string first.