### PR TITLE
[GCP] Support G4 preview instance type

### DIFF
--- a/src/dstack/_internal/core/backends/base/offers.py
+++ b/src/dstack/_internal/core/backends/base/offers.py
@@ -23,6 +23,7 @@ SUPPORTED_GPUHUNT_FLAGS = [
     "oci-spot",
     "lambda-arm",
     "gcp-a4",
+    "gcp-g4-preview",
 ]
 
 

--- a/src/dstack/_internal/core/backends/gcp/compute.py
+++ b/src/dstack/_internal/core/backends/gcp/compute.py
@@ -130,13 +130,19 @@ class GCPCompute(
         offer_keys_to_offers = {}
         offers_with_availability = []
         for offer in offers:
+            preview = False
+            if offer.instance.name.startswith("g4-standard-"):
+                if self.config.preview_features and "g4" in self.config.preview_features:
+                    preview = True
+                else:
+                    continue
             region = offer.region[:-2]  # strip zone
             key = (_unique_instance_name(offer.instance), region)
             if key in offer_keys_to_offers:
                 offer_keys_to_offers[key].availability_zones.append(offer.region)
                 continue
             availability = InstanceAvailability.NO_QUOTA
-            if _has_gpu_quota(quotas[region], offer.instance.resources):
+            if preview or _has_gpu_quota(quotas[region], offer.instance.resources):
                 availability = InstanceAvailability.UNKNOWN
             # todo quotas: cpu, memory, global gpu, tpu
             offer_with_availability = InstanceOfferWithAvailability(

--- a/src/dstack/_internal/core/backends/gcp/models.py
+++ b/src/dstack/_internal/core/backends/gcp/models.py
@@ -89,6 +89,13 @@ class GCPBackendConfig(CoreModel):
             description="The tags (labels) that will be assigned to resources created by `dstack`"
         ),
     ] = None
+    preview_features: Annotated[
+        Optional[List[Literal["g4"]]],
+        Field(
+            description=("The list of preview GCP features to enable."),
+            max_items=1,
+        ),
+    ] = None
 
 
 class GCPBackendConfigWithCreds(GCPBackendConfig):

--- a/src/dstack/_internal/core/backends/gcp/models.py
+++ b/src/dstack/_internal/core/backends/gcp/models.py
@@ -92,7 +92,7 @@ class GCPBackendConfig(CoreModel):
     preview_features: Annotated[
         Optional[List[Literal["g4"]]],
         Field(
-            description=("The list of preview GCP features to enable."),
+            description=("The list of preview GCP features to enable. Supported values: `g4`"),
             max_items=1,
         ),
     ] = None

--- a/src/dstack/_internal/core/backends/gcp/resources.py
+++ b/src/dstack/_internal/core/backends/gcp/resources.py
@@ -26,6 +26,7 @@ supported_accelerators = [
     {"accelerator_name": "nvidia-tesla-t4", "gpu_name": "T4", "memory_mb": 1024 * 16},
     {"accelerator_name": "nvidia-tesla-v100", "gpu_name": "V100", "memory_mb": 1024 * 16},
     {"accelerator_name": "nvidia-tesla-p100", "gpu_name": "P100", "memory_mb": 1024 * 16},
+    {"accelerator_name": "nvidia-rtx-pro-6000", "gpu_name": "RTXPRO6000", "memory_mb": 1024 * 96},
 ]
 
 
@@ -499,5 +500,6 @@ def instance_type_supports_persistent_disk(instance_type_name: str) -> bool:
             "h3-",
             "v6e",
             "a4-",
+            "g4-",
         ]
     )


### PR DESCRIPTION
Fixes #3155

This PR adds preview (opt-in) support for `g4-standard-48`. In order to enable such offers, the `gcp` backend should be configured with `preview_features: [g4]`.

Depends on https://github.com/dstackai/gpuhunt/pull/182