### PR TITLE
Add sglang router minimal/experimental support

### DIFF
--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
     # release builds of dstack-gateway depend on a PyPI version of dstack instead
-    "dstack[gateway] @ git+https://github.com/Bihan/dstack.git@add_sglang_router_minimal_support",
+    "dstack[gateway] @ git+https://github.com/dstackai/dstack.git@master",
 ]
 
 [tool.setuptools.package-data]

--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
     # release builds of dstack-gateway depend on a PyPI version of dstack instead
-    "dstack[gateway] @ git+https://github.com/dstackai/dstack.git@master",
+    "dstack[gateway] @ git+https://github.com/Bihan/dstack.git@add_sglang_router_minimal_support",
 ]
 
 [tool.setuptools.package-data]

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -840,6 +840,7 @@ def get_gateway_user_data(authorized_key: str) -> str:
         packages=[
             "nginx",
             "python3.10-venv",
+            "python3-pip",  # Add pip for sglang-router installation
         ],
         snap={"commands": [["install", "--classic", "certbot"]]},
         runcmd=[
@@ -850,6 +851,8 @@ def get_gateway_user_data(authorized_key: str) -> str:
                 "s/# server_names_hash_bucket_size 64;/server_names_hash_bucket_size 128;/",
                 "/etc/nginx/nginx.conf",
             ],
+            # Install sglang-router system-wide. Can be conditionally installed in the future.
+            ["pip", "install", "sglang-router"],
             ["su", "ubuntu", "-c", " && ".join(get_dstack_gateway_commands())],
         ],
         ssh_authorized_keys=[authorized_key],

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -982,7 +982,8 @@ def get_dstack_gateway_wheel(build: str) -> str:
         r.raise_for_status()
         build = r.text.strip()
         logger.debug("Found the latest gateway build: %s", build)
-    return f"{base_url}/dstack_gateway-{build}-py3-none-any.whl"
+    # return f"{base_url}/dstack_gateway-{build}-py3-none-any.whl"
+    return "https://bihan-test-bucket.s3.eu-west-1.amazonaws.com/dstack_gateway-0.0.0-py3-none-any.whl"
 
 
 def get_dstack_gateway_commands() -> List[str]:

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -979,7 +979,12 @@ def get_dstack_gateway_wheel(build: str) -> str:
         r.raise_for_status()
         build = r.text.strip()
         logger.debug("Found the latest gateway build: %s", build)
-    return f"{base_url}/dstack_gateway-{build}-py3-none-any.whl"
+    # return f"{base_url}/dstack_gateway-{build}-py3-none-any.whl"
+    # For testing
+    logger.debug(
+        "Using test gateway wheel: https://bihan-test-bucket.s3.eu-west-1.amazonaws.com/dstack_gateway-0.0.0-py3-none-any.whl"
+    )
+    return "https://bihan-test-bucket.s3.eu-west-1.amazonaws.com/dstack_gateway-0.0.0-py3-none-any.whl"
 
 
 def get_dstack_gateway_commands() -> List[str]:

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -982,12 +982,7 @@ def get_dstack_gateway_wheel(build: str) -> str:
         r.raise_for_status()
         build = r.text.strip()
         logger.debug("Found the latest gateway build: %s", build)
-    # return f"{base_url}/dstack_gateway-{build}-py3-none-any.whl"
-    # For testing
-    logger.debug(
-        "Using test gateway wheel: https://bihan-test-bucket.s3.eu-west-1.amazonaws.com/dstack_gateway-0.0.0-py3-none-any.whl"
-    )
-    return "https://bihan-test-bucket.s3.eu-west-1.amazonaws.com/dstack_gateway-0.0.0-py3-none-any.whl"
+    return f"{base_url}/dstack_gateway-{build}-py3-none-any.whl"
 
 
 def get_dstack_gateway_commands() -> List[str]:

--- a/src/dstack/_internal/core/models/gateways.py
+++ b/src/dstack/_internal/core/models/gateways.py
@@ -44,12 +44,14 @@ class GatewayCertificate(CoreModel):
     ]
 
 
+# https://github.com/dstackai/dstack/blob/master/src/dstack/_internal/proxy/gateway/resources/nginx/service.jinja2
 class GatewayConfiguration(CoreModel):
     type: Literal["gateway"] = "gateway"
     name: Annotated[Optional[str], Field(description="The gateway name")] = None
     default: Annotated[bool, Field(description="Make the gateway default")] = False
     backend: Annotated[BackendType, Field(description="The gateway backend")]
     region: Annotated[str, Field(description="The gateway region")]
+    router: Annotated[Optional[str], Field(description="The router type, e.g. `sglang`")] = None
     domain: Annotated[
         Optional[str], Field(description="The gateway domain, e.g. `example.com`")
     ] = None

--- a/src/dstack/_internal/core/models/gateways.py
+++ b/src/dstack/_internal/core/models/gateways.py
@@ -44,7 +44,6 @@ class GatewayCertificate(CoreModel):
     ]
 
 
-# https://github.com/dstackai/dstack/blob/master/src/dstack/_internal/proxy/gateway/resources/nginx/service.jinja2
 class GatewayConfiguration(CoreModel):
     type: Literal["gateway"] = "gateway"
     name: Annotated[Optional[str], Field(description="The gateway name")] = None

--- a/src/dstack/_internal/proxy/gateway/resources/nginx/service.jinja2
+++ b/src/dstack/_internal/proxy/gateway/resources/nginx/service.jinja2
@@ -4,9 +4,13 @@ limit_req_zone {{ zone.key }} zone={{ zone.name }}:10m rate={{ zone.rpm }}r/m;
 
 {% if replicas %}
 upstream {{ domain }}.upstream {
+    {% if router == "sglang" %}
+    server 127.0.0.1:3000;  # SGLang router on the gateway
+    {% else %}
     {% for replica in replicas %}
-    server unix:{{ replica.socket }};  # replica {{ replica.id }} router={{ router }}
+    server unix:{{ replica.socket }};  # replica {{ replica.id }}
     {% endfor %}
+    {% endif %}
 }
 {% else %}
 

--- a/src/dstack/_internal/proxy/gateway/resources/nginx/service.jinja2
+++ b/src/dstack/_internal/proxy/gateway/resources/nginx/service.jinja2
@@ -5,7 +5,7 @@ limit_req_zone {{ zone.key }} zone={{ zone.name }}:10m rate={{ zone.rpm }}r/m;
 {% if replicas %}
 upstream {{ domain }}.upstream {
     {% for replica in replicas %}
-    server unix:{{ replica.socket }};  # replica {{ replica.id }}
+    server unix:{{ replica.socket }};  # replica {{ replica.id }} router={{ router }}
     {% endfor %}
 }
 {% else %}

--- a/src/dstack/_internal/proxy/gateway/resources/nginx/sglang_workers.jinja2
+++ b/src/dstack/_internal/proxy/gateway/resources/nginx/sglang_workers.jinja2
@@ -1,0 +1,23 @@
+{% for replica in replicas %}
+# Worker {{ loop.index }}
+upstream sglang_worker_{{ loop.index }}_upstream {
+    server unix:{{ replica.socket }};
+}
+
+server {
+    listen 127.0.0.1:{{ 10000 + loop.index }};
+    access_log off; # disable access logs for this internal endpoint
+
+    proxy_read_timeout 300s;
+    proxy_send_timeout 300s;
+
+    location / {
+        proxy_pass http://sglang_worker_{{ loop.index }}_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Connection "";
+        proxy_set_header Upgrade $http_upgrade;
+    }
+}
+{% endfor %}

--- a/src/dstack/_internal/proxy/gateway/routers/registry.py
+++ b/src/dstack/_internal/proxy/gateway/routers/registry.py
@@ -13,8 +13,10 @@ from dstack._internal.proxy.gateway.schemas.registry import (
 from dstack._internal.proxy.gateway.services.nginx import Nginx
 from dstack._internal.proxy.lib.deps import get_service_connection_pool
 from dstack._internal.proxy.lib.services.service_connection import ServiceConnectionPool
+from dstack._internal.utils.logging import get_logger
 
 router = APIRouter(prefix="/{project_name}")
+logger = get_logger(__name__)
 
 
 @router.post("/services/register")
@@ -25,6 +27,7 @@ async def register_service(
     nginx: Annotated[Nginx, Depends(get_nginx)],
     service_conn_pool: Annotated[ServiceConnectionPool, Depends(get_service_connection_pool)],
 ) -> OkResponse:
+    logger.debug(f"[SglangRouterTesting] Gateway API Reception Router: {body.router}")
     await registry_services.register_service(
         project_name=project_name.lower(),
         run_name=body.run_name.lower(),
@@ -36,6 +39,7 @@ async def register_service(
         model=body.options.openai.model if body.options.openai is not None else None,
         ssh_private_key=body.ssh_private_key,
         repo=repo,
+        router=body.router,
         nginx=nginx,
         service_conn_pool=service_conn_pool,
     )

--- a/src/dstack/_internal/proxy/gateway/routers/registry.py
+++ b/src/dstack/_internal/proxy/gateway/routers/registry.py
@@ -13,10 +13,8 @@ from dstack._internal.proxy.gateway.schemas.registry import (
 from dstack._internal.proxy.gateway.services.nginx import Nginx
 from dstack._internal.proxy.lib.deps import get_service_connection_pool
 from dstack._internal.proxy.lib.services.service_connection import ServiceConnectionPool
-from dstack._internal.utils.logging import get_logger
 
 router = APIRouter(prefix="/{project_name}")
-logger = get_logger(__name__)
 
 
 @router.post("/services/register")
@@ -27,7 +25,6 @@ async def register_service(
     nginx: Annotated[Nginx, Depends(get_nginx)],
     service_conn_pool: Annotated[ServiceConnectionPool, Depends(get_service_connection_pool)],
 ) -> OkResponse:
-    logger.debug(f"[SglangRouterTesting] Gateway API Reception Router: {body.router}")
     await registry_services.register_service(
         project_name=project_name.lower(),
         run_name=body.run_name.lower(),

--- a/src/dstack/_internal/proxy/gateway/schemas/registry.py
+++ b/src/dstack/_internal/proxy/gateway/schemas/registry.py
@@ -44,6 +44,7 @@ class RegisterServiceRequest(BaseModel):
     options: Options
     ssh_private_key: str
     rate_limits: tuple[RateLimit, ...] = ()
+    router: Optional[str] = None
 
 
 class RegisterReplicaRequest(BaseModel):

--- a/src/dstack/_internal/proxy/gateway/services/nginx.py
+++ b/src/dstack/_internal/proxy/gateway/services/nginx.py
@@ -64,6 +64,7 @@ class ServiceConfig(SiteConfig):
     limit_req_zones: list[LimitReqZoneConfig]
     locations: list[LocationConfig]
     replicas: list[ReplicaConfig]
+    router: Optional[str] = None
 
 
 class ModelEntrypointConfig(SiteConfig):

--- a/src/dstack/_internal/proxy/gateway/services/nginx.py
+++ b/src/dstack/_internal/proxy/gateway/services/nginx.py
@@ -106,6 +106,7 @@ class Nginx:
         async with self._lock:
             await run_async(sudo_rm, conf_path)
             workers_conf_path = self._conf_dir / f"sglang-workers.{domain}.conf"
+            logger.debug(f"[SglangRouterTesting] Workers conf path: {workers_conf_path}")
             if workers_conf_path.exists():
                 await run_async(sudo_rm, workers_conf_path)
                 await run_async(self.stop_sglang_router)

--- a/src/dstack/_internal/proxy/gateway/services/nginx.py
+++ b/src/dstack/_internal/proxy/gateway/services/nginx.py
@@ -146,7 +146,16 @@ class Nginx:
                     "--worker-urls",
                 ]
                 + worker_urls
-                + ["--host", "0.0.0.0", "--port", "3000"]
+                + [
+                    "--host",
+                    "0.0.0.0",
+                    "--port",
+                    "3000",
+                    "--log-level",
+                    "debug",
+                    "--log-dir",
+                    "./router_logs",
+                ]
             )
             subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 

--- a/src/dstack/_internal/proxy/gateway/services/nginx.py
+++ b/src/dstack/_internal/proxy/gateway/services/nginx.py
@@ -126,11 +126,11 @@ class Nginx:
         try:
             # Kill existing sglang-router if running
             result = subprocess.run(
-                ["pgrep", "-f", "sglang_router.launch_router"], capture_output=True, timeout=5
+                ["pgrep", "-f", "sglang::router"], capture_output=True, timeout=5
             )
             if result.returncode == 0:
                 logger.info("Killing existing sglang-router...")
-                subprocess.run(["pkill", "-f", "sglang_router.launch_router"], timeout=5)
+                subprocess.run(["pkill", "-f", "sglang::router"], timeout=5)
                 # Wait a moment for the process to terminate
                 import time
 
@@ -173,11 +173,11 @@ class Nginx:
     def stop_sglang_router() -> None:
         try:
             result = subprocess.run(
-                ["pgrep", "-f", "sglang_router.launch_router"], capture_output=True, timeout=5
+                ["pgrep", "-f", "sglang::router"], capture_output=True, timeout=5
             )
             if result.returncode == 0:
                 logger.info("Stopping sglang-router process...")
-                subprocess.run(["pkill", "-f", "sglang_router.launch_router"], timeout=5)
+                subprocess.run(["pkill", "-f", "sglang::router"], timeout=5)
             else:
                 logger.debug("No sglang-router process found to stop")
 

--- a/src/dstack/_internal/proxy/gateway/services/nginx.py
+++ b/src/dstack/_internal/proxy/gateway/services/nginx.py
@@ -147,7 +147,7 @@ class Nginx:
                 [
                     "python3",
                     "-m",
-                    "sglang_router.launch_router",  # Use system python3
+                    "sglang_router.launch_router",
                     "--worker-urls",
                 ]
                 + worker_urls
@@ -160,6 +160,8 @@ class Nginx:
                     "debug",
                     "--log-dir",
                     "./router_logs",
+                    "--request-timeout-secs",
+                    "1800",
                 ]
             )
             subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/src/dstack/_internal/proxy/gateway/services/nginx.py
+++ b/src/dstack/_internal/proxy/gateway/services/nginx.py
@@ -87,6 +87,13 @@ class Nginx:
             if conf.https:
                 await run_async(self.run_certbot, conf.domain, acme)
             await run_async(self.write_conf, conf.render(), conf_name)
+            # Start sglang-router if router is sglang
+            if hasattr(conf, "router") and conf.router == "sglang":
+                replicas = len(conf.replicas) if hasattr(conf, "replicas") and conf.replicas else 1
+                logger.debug(
+                    f"[SglangRouterTesting] Starting sglang-router with {replicas} replicas"
+                )
+                await run_async(self.start_sglang_router, replicas)
 
         logger.info("Registered %s domain %s", conf.type, conf.domain)
 

--- a/src/dstack/_internal/proxy/gateway/services/registry.py
+++ b/src/dstack/_internal/proxy/gateway/services/registry.py
@@ -44,6 +44,7 @@ async def register_service(
     repo: GatewayProxyRepo,
     nginx: Nginx,
     service_conn_pool: ServiceConnectionPool,
+    router: Optional[str] = None,
 ) -> None:
     service = models.Service(
         project_name=project_name,
@@ -54,6 +55,7 @@ async def register_service(
         auth=auth,
         client_max_body_size=client_max_body_size,
         replicas=(),
+        router=router,
     )
 
     async with lock:
@@ -335,6 +337,7 @@ async def get_nginx_service_config(
         limit_req_zones=limit_req_zones,
         locations=locations,
         replicas=sorted(replicas, key=lambda r: r.id),  # sort for reproducible configs
+        router=service.router,
     )
 
 

--- a/src/dstack/_internal/proxy/lib/models.py
+++ b/src/dstack/_internal/proxy/lib/models.py
@@ -57,6 +57,7 @@ class Service(ImmutableModel):
     client_max_body_size: int  # only enforced on gateways
     strip_prefix: bool = True  # only used in-server
     replicas: tuple[Replica, ...]
+    router: Optional[str] = None
 
     @property
     def domain_safe(self) -> str:

--- a/src/dstack/_internal/server/services/gateways/client.py
+++ b/src/dstack/_internal/server/services/gateways/client.py
@@ -45,6 +45,7 @@ class GatewayClient:
         options: dict,
         rate_limits: list[RateLimit],
         ssh_private_key: str,
+        router: Optional[str] = None,
     ):
         if "openai" in options:
             entrypoint = f"gateway.{domain.split('.', maxsplit=1)[1]}"
@@ -59,6 +60,7 @@ class GatewayClient:
             "options": options,
             "rate_limits": [limit.dict() for limit in rate_limits],
             "ssh_private_key": ssh_private_key,
+            "router": router,
         }
         resp = await self._client.post(
             self._url(f"/api/registry/{project}/services/register"), json=payload

--- a/src/dstack/_internal/server/services/services/__init__.py
+++ b/src/dstack/_internal/server/services/services/__init__.py
@@ -83,10 +83,6 @@ async def _register_service_in_gateway(
     gateway_configuration = get_gateway_configuration(gateway)
     service_https = _get_service_https(run_spec, gateway_configuration)
     router = gateway_configuration.router
-    logger.debug(f"[SglangRouterTesting] Configuration parsing: {router}")
-    logger.debug(
-        f"[SglangRouterTesting] Configuration parsing dict: {gateway_configuration.dict()}"
-    )
     service_protocol = "https" if service_https else "http"
 
     if service_https and gateway_configuration.certificate is None:
@@ -112,7 +108,6 @@ async def _register_service_in_gateway(
     conn = await get_or_add_gateway_connection(session, gateway.id)
     try:
         logger.debug("%s: registering service as %s", fmt(run_model), service_spec.url)
-        logger.debug(f"[SglangRouterTesting] Service Registration Router: {router}")
         async with conn.client() as client:
             await client.register_service(
                 project=run_model.project.name,

--- a/src/dstack/_internal/server/services/services/__init__.py
+++ b/src/dstack/_internal/server/services/services/__init__.py
@@ -82,6 +82,11 @@ async def _register_service_in_gateway(
 
     gateway_configuration = get_gateway_configuration(gateway)
     service_https = _get_service_https(run_spec, gateway_configuration)
+    router = gateway_configuration.router
+    logger.debug(f"[SglangRouterTesting] Configuration parsing: {router}")
+    logger.debug(
+        f"[SglangRouterTesting] Configuration parsing dict: {gateway_configuration.dict()}"
+    )
     service_protocol = "https" if service_https else "http"
 
     if service_https and gateway_configuration.certificate is None:
@@ -107,6 +112,7 @@ async def _register_service_in_gateway(
     conn = await get_or_add_gateway_connection(session, gateway.id)
     try:
         logger.debug("%s: registering service as %s", fmt(run_model), service_spec.url)
+        logger.debug(f"[SglangRouterTesting] Service Registration Router: {router}")
         async with conn.client() as client:
             await client.register_service(
                 project=run_model.project.name,
@@ -119,6 +125,7 @@ async def _register_service_in_gateway(
                 options=service_spec.options,
                 rate_limits=run_spec.configuration.rate_limits,
                 ssh_private_key=run_model.project.ssh_private_key,
+                router=router,
             )
         logger.info("%s: service is registered as %s", fmt(run_model), service_spec.url)
     except SSHError:


### PR DESCRIPTION
Intro
We want to make it possible to create a gateway which extends the gateway functionality with additional features (all sgl-router features such as cache aware routing, etc) while keeping all the standard gateway features (such as authentication, rate limits).

For the user, using such gateway should be very simple, e.g. setting router to sglang in gateway configurations.  Eg:

```
type: gateway
name: sglang-gateway

backend: aws
region: eu-west-1

domain: example.com
router: sglang
```

The rest for the user should look the same - the `same service endpoint`, `authentication` and `rate limits working,` etc.

While this first `experimental version` should only bring minimum features - allow to route replicas traffic through the router (dstack’s gateway/ngnix -> sglang-router -> replica workers), in the future this may be extended with router-specific scaling metrics, such as ttft, e2e, Prefill-Decode Disaggregation, etc).

As the first experimental version, the most critical is to come up with the minimum changes that are tested thoroughly that would allow embedding the `router: sglang` without breaking any existing functionality.

Note:

1. In this version installation of pip & sglang-router is done in gateway machine, irrespective of whether `router:sglang` is in gateway config or not. To make it conditional in future, it should be implemented across backends that support gateway. 

2. Modified upstream block of `src/dstack/_internal/proxy/gateway/resources/nginx/service.jinja2` to respect `router: sglang` in gateway config.
```
upstream {{ domain }}.upstream {
    {% if router == "sglang" %}
    server 127.0.0.1:3000;  # SGLang router on the gateway
    {% else %}
    {% for replica in replicas %}
    server unix:{{ replica.socket }};  # replica {{ replica.id }}
    {% endfor %}
    {% endif %}
}
```

3. Created new nginx conf: `src/dstack/_internal/proxy/gateway/resources/nginx/sglang_workers.jinja2`

This nginx conf forwards HTTP to Unix socket. dstack workers listen on Unix sockets, while the sglang-router speaks HTTP, so this bridge lets the router reach each worker via local TCP ports.

```
# Worker 1
upstream sglang_worker_1_upstream {
    server unix:/tmp/tmpazynu7m5/replica.sock;
}

server {
    listen 127.0.0.1:10001;
    access_log off; # disable access logs for this internal endpoint

    proxy_read_timeout 300s;
    proxy_send_timeout 300s;

    location / {
        proxy_pass http://sglang_worker_1_upstream;
        proxy_http_version 1.1;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header Connection "";
        proxy_set_header Upgrade $http_upgrade;
    }
}

# Worker 2
upstream sglang_worker_2_upstream {
    server unix:/tmp/tmpazynu7m6/replica.sock;
}

server {
    listen 127.0.0.1:10002;
    access_log off; # disable access logs for this internal endpoint

    proxy_read_timeout 300s;
    proxy_send_timeout 300s;

    location / {
        proxy_pass http://sglang_worker_2_upstream;
        proxy_http_version 1.1;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header Connection "";
        proxy_set_header Upgrade $http_upgrade;
    }
}
```




