### PR TITLE
Support getting job metrics by run_id

### DIFF
--- a/frontend/src/pages/Runs/Details/Jobs/Metrics/index.tsx
+++ b/frontend/src/pages/Runs/Details/Jobs/Metrics/index.tsx
@@ -35,6 +35,7 @@ export const JobMetrics: React.FC = () => {
     const { cpuChartProps, memoryChartProps, eachGPUChartProps, eachGPUMemoryChartProps, isLoading } = useMetricsData({
         project_name: paramProjectName,
         run_name: runData?.run_spec.run_name ?? '',
+        run_id: runData?.id ?? '',
         job_num: jobData?.job_spec.job_num ?? 0,
         limit: 1000,
     });

--- a/frontend/src/types/run.d.ts
+++ b/frontend/src/types/run.d.ts
@@ -136,6 +136,7 @@ declare type TStopRunsRequestParams = {
 declare type TJobMetricsRequestParams = {
     project_name: IProject['project_name'];
     run_name: string;
+    run_id: string;
     replica_num?: number;
     job_num: number;
     limit?: number;

--- a/src/dstack/_internal/server/routers/metrics.py
+++ b/src/dstack/_internal/server/routers/metrics.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Optional, Tuple
+from uuid import UUID
 
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -29,6 +30,7 @@ router = APIRouter(
 )
 async def get_job_metrics(
     run_name: str,
+    run_id: Optional[UUID] = None,
     replica_num: int = 0,
     job_num: int = 0,
     limit: int = 1,
@@ -39,8 +41,9 @@ async def get_job_metrics(
 ):
     """
     Returns job-level metrics such as hardware utilization
-    given `run_name`, `replica_num`, and `job_num`.
-    If only `run_name` is specified, returns metrics of `(replica_num=0, job_num=0)`.
+    given `run_name`, `run_id`, `replica_num`, and `job_num`.
+    If only `run_name` is specified, returns metrics of `(replica_num=0, job_num=0)`
+    of the latest run with the given name.
     By default, returns one latest sample. To control time window/number of samples, use
     `limit`, `after`, `before`.
 
@@ -61,6 +64,7 @@ async def get_job_metrics(
         session=session,
         project=project,
         run_name=run_name,
+        run_id=run_id,
         replica_num=replica_num,
         job_num=job_num,
     )


### PR DESCRIPTION
Fixed #3196

Previously the metrics endpoint ` /api/project/{project_name}/metrics/job/{run_name}` allowed requesting job metrics only by run name since it was initially designed to return metrics of active runs. Now it support passing run_id query param optionally so that it's possible to request metrics for finished runs with the same name. The frontend is updated to pass run_id.