### PR TITLE
Show Schedule and Next run on Run page

### DIFF
--- a/frontend/src/locale/en.json
+++ b/frontend/src/locale/en.json
@@ -417,6 +417,8 @@
       "backend": "Backend",
       "region": "Region",
       "instance_id": "Instance ID",
+      "schedule": "Schedule",
+      "next_run": "Next run",
       "resources": "Resources",
       "spot": "Spot",
       "termination_reason": "Termination reason",

--- a/frontend/src/pages/Runs/Details/RunDetails/index.tsx
+++ b/frontend/src/pages/Runs/Details/RunDetails/index.tsx
@@ -20,6 +20,7 @@ import {
     getRunListItemPrice,
     getRunListItemRegion,
     getRunListItemResources,
+    getRunListItemSchedule,
     getRunListItemServiceUrl,
     getRunListItemSpot,
 } from '../../List/helpers';
@@ -38,6 +39,8 @@ export const RunDetails = () => {
     });
 
     const serviceUrl = runData ? getRunListItemServiceUrl(runData) : null;
+    const schedule = runData ? getRunListItemSchedule(runData) : null;
+    const nextTriggeredAt = runData ? runData.next_triggered_at : null;
 
     if (isLoadingRun)
         return (
@@ -115,7 +118,7 @@ export const RunDetails = () => {
 
                     <div>
                         <Box variant="awsui-key-label">{t('projects.run.error')}</Box>
-                        <div>{getRunError(runData)}</div>
+                        <div>{getRunError(runData) ?? '-'}</div>
                     </div>
 
                     <div>
@@ -139,6 +142,11 @@ export const RunDetails = () => {
                     </div>
 
                     <div>
+                        <Box variant="awsui-key-label">{t('projects.run.backend')}</Box>
+                        <div>{getRunListItemBackend(runData)}</div>
+                    </div>
+
+                    <div>
                         <Box variant="awsui-key-label">{t('projects.run.region')}</Box>
                         <div>{getRunListItemRegion(runData)}</div>
                     </div>
@@ -152,11 +160,6 @@ export const RunDetails = () => {
                         <Box variant="awsui-key-label">{t('projects.run.spot')}</Box>
                         <div>{getRunListItemSpot(runData)}</div>
                     </div>
-
-                    <div>
-                        <Box variant="awsui-key-label">{t('projects.run.backend')}</Box>
-                        <div>{getRunListItemBackend(runData)}</div>
-                    </div>
                 </ColumnLayout>
 
                 {serviceUrl && (
@@ -166,6 +169,19 @@ export const RunDetails = () => {
                             <div>
                                 <a href={serviceUrl}>{serviceUrl}</a>
                             </div>
+                        </div>
+                    </ColumnLayout>
+                )}
+
+                {schedule && (
+                    <ColumnLayout columns={4} variant="text-grid">
+                        <div>
+                            <Box variant="awsui-key-label">{t('projects.run.schedule')}</Box>
+                            <div>{schedule}</div>
+                        </div>
+                        <div>
+                            <Box variant="awsui-key-label">{t('projects.run.next_run')}</Box>
+                            <div>{nextTriggeredAt ? format(new Date(nextTriggeredAt), DATE_TIME_FORMAT) : '-'}</div>
                         </div>
                     </ColumnLayout>
                 )}

--- a/frontend/src/pages/Runs/List/helpers.ts
+++ b/frontend/src/pages/Runs/List/helpers.ts
@@ -14,7 +14,7 @@ export const getRunListItemResources = (run: IRun) => {
         return '-';
     }
 
-    return run.latest_job_submission?.job_provisioning_data?.instance_type?.resources?.description;
+    return run.latest_job_submission?.job_provisioning_data?.instance_type?.resources?.description ?? '-';
 };
 
 export const getRunListItemSpotLabelKey = (run: IRun) => {
@@ -31,7 +31,7 @@ export const getRunListItemSpotLabelKey = (run: IRun) => {
 
 export const getRunListItemSpot = (run: IRun) => {
     if (run.jobs.length > 1) {
-        return '';
+        return '-';
     }
 
     return run.latest_job_submission?.job_provisioning_data?.instance_type?.resources?.spot?.toString() ?? '-';
@@ -57,7 +57,7 @@ export const getRunListItemPrice = (run: IRun) => {
 
 export const getRunListItemInstance = (run: IRun) => {
     if (run.jobs.length > 1) {
-        return '';
+        return '-';
     }
 
     return run.latest_job_submission?.job_provisioning_data?.instance_type?.name;
@@ -65,7 +65,7 @@ export const getRunListItemInstance = (run: IRun) => {
 
 export const getRunListItemInstanceId = (run: IRun) => {
     if (run.jobs.length > 1) {
-        return '';
+        return '-';
     }
 
     return run.latest_job_submission?.job_provisioning_data?.instance_id ?? '-';
@@ -73,7 +73,7 @@ export const getRunListItemInstanceId = (run: IRun) => {
 
 export const getRunListItemRegion = (run: IRun) => {
     if (run.jobs.length > 1) {
-        return '';
+        return '-';
     }
 
     return run.latest_job_submission?.job_provisioning_data?.region ?? '-';
@@ -81,7 +81,7 @@ export const getRunListItemRegion = (run: IRun) => {
 
 export const getRunListItemBackend = (run: IRun) => {
     if (run.jobs.length > 1) {
-        return '';
+        return '-';
     }
 
     return run.latest_job_submission?.job_provisioning_data?.backend ?? '-';
@@ -91,4 +91,10 @@ export const getRunListItemServiceUrl = (run: IRun) => {
     const url = run.service?.url;
     if (!url) return null;
     return url.startsWith('/') ? `${getBaseUrl()}${url}` : url;
+};
+
+export const getRunListItemSchedule = (run: IRun) => {
+    if (run.run_spec.configuration.type != 'task' || !run.run_spec.configuration.schedule) return null;
+
+    return run.run_spec.configuration.schedule.cron.join(', ');
 };

--- a/frontend/src/types/run.d.ts
+++ b/frontend/src/types/run.d.ts
@@ -240,9 +240,14 @@ declare interface IJob {
     job_submissions: IJobSubmission[];
 }
 
+declare interface ISchedule {
+    cron: string[];
+}
+
 declare interface ITaskConfiguration {
     type: 'task';
     priority?: number | null;
+    schedule?: ISchedule | null;
 }
 
 declare interface IServiceConfiguration {
@@ -250,6 +255,7 @@ declare interface IServiceConfiguration {
     gateway: string | null;
     priority?: number | null;
 }
+
 declare interface IRunSpec {
     configuration: TDevEnvironmentConfiguration | ITaskConfiguration | IServiceConfiguration;
     configuration_path: string;
@@ -286,6 +292,7 @@ declare interface IRun {
     cost: number;
     service: IRunService | null;
     status_message?: string | null;
+    next_triggered_at?: string | null;
 }
 
 declare interface IMetricsItem {

--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -553,6 +553,7 @@ class Run(CoreModel):
     deployment_num: int = 0  # default for compatibility with pre-0.19.14 servers
     error: Optional[str] = None
     deleted: Optional[bool] = None
+    next_triggered_at: Optional[datetime] = None
 
     def is_deployment_in_progress(self) -> bool:
         return any(

--- a/src/dstack/_internal/server/services/runs.py
+++ b/src/dstack/_internal/server/services/runs.py
@@ -715,6 +715,7 @@ def run_model_to_run(
     status_message = _get_run_status_message(run_model)
     error = _get_run_error(run_model)
     fleet = _get_run_fleet(run_model)
+    next_triggered_at = _get_next_triggered_at(run_spec)
     run = Run(
         id=run_model.id,
         project_name=run_model.project.name,
@@ -734,6 +735,7 @@ def run_model_to_run(
         deployment_num=run_model.deployment_num,
         error=error,
         deleted=run_model.deleted,
+        next_triggered_at=next_triggered_at,
     )
     run.cost = _get_run_cost(run)
     return run

--- a/src/dstack/_internal/server/services/runs.py
+++ b/src/dstack/_internal/server/services/runs.py
@@ -715,7 +715,9 @@ def run_model_to_run(
     status_message = _get_run_status_message(run_model)
     error = _get_run_error(run_model)
     fleet = _get_run_fleet(run_model)
-    next_triggered_at = _get_next_triggered_at(run_spec)
+    next_triggered_at = None
+    if not run_model.status.is_finished():
+        next_triggered_at = _get_next_triggered_at(run_spec)
     run = Run(
         id=run_model.id,
         project_name=run_model.project.name,

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -517,6 +517,7 @@ def get_dev_env_run_dict(
         "termination_reason": None,
         "error": None,
         "deleted": deleted,
+        "next_triggered_at": None,
     }
 
 
@@ -665,6 +666,7 @@ class TestListRuns:
                 "termination_reason": None,
                 "error": None,
                 "deleted": False,
+                "next_triggered_at": None,
             },
             {
                 "id": str(run2.id),
@@ -687,6 +689,7 @@ class TestListRuns:
                 "termination_reason": None,
                 "error": None,
                 "deleted": False,
+                "next_triggered_at": None,
             },
         ]
 
@@ -853,6 +856,7 @@ class TestListRuns:
                 "termination_reason": None,
                 "error": None,
                 "deleted": False,
+                "next_triggered_at": None,
             },
         ]
 


### PR DESCRIPTION
Closes #3102

The PR add `next_triggered_at` field to the Run response model and shows Schedule and Next run boxes on Run page UI for scheduled runs:

<img width="1188" height="584" alt="Screenshot 2025-10-17 at 14 17 23" src="https://github.com/user-attachments/assets/9dc37ce2-ba56-437b-839a-a110fcd98e21" />

`next_triggered_at` is not showed in the CLI since it'll require more thought where and if it should be displayed exactly.

Also made empty values for some boxes displayed as "-" instead of "" since "" led to broken layout if all values in the row are empty.