### PR TITLE
Add AI Assistance Notice

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,19 @@
 
 We appreciate your interest in contributing to `dstack`! This document will help you get up to speed with `dstack` codebase and guide you through the contribution process.
 
+## AI Assistance Notice
+
+If you are using any kind of AI assistance while contributing to `dstack`,
+**this must be disclosed in the pull request**, along with the extent to
+which AI assistance was used.
+As an exception, tab-completions and trivial PRs don't need to be disclosed.
+
+An example disclosure:
+
+> This PR was written primarily by Claude Code.
+
+Failure to disclose this, makes it difficult to determine how much scrutiny to apply to the contribution. Please be respectful to maintainers and disclose AI assistance.
+
 ## Set up your development environment
 
 Follow [contributing/DEVELOPMENT.md](contributing/DEVELOPMENT.md).


### PR DESCRIPTION
Adding AI Assistance Notice taken from https://github.com/ghostty-org/ghostty/pull/8289

Disclosure of AI Assistance usage in PRs should make code reviews more efficient for maintainers.