### PR TITLE
Add `InstanceOffer.backend_data` + reserved GCP A4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "python-multipart>=0.0.16",
     "filelock",
     "psutil",
-    "gpuhunt @ https://github.com/dstackai/gpuhunt/archive/refs/heads/provider_data_typed_dict.zip",
+    "gpuhunt==0.1.11",
     "argcomplete>=3.5.0",
     "ignore-python>=0.2.0",
     "orjson",
@@ -66,9 +66,6 @@ artifacts = [
 artifacts = [
     "src/dstack/_internal/server/statics/**",
 ]
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.hatch.metadata.hooks.fancy-pypi-readme]
 content-type = "text/markdown"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "python-multipart>=0.0.16",
     "filelock",
     "psutil",
-    "gpuhunt==0.1.10",
+    "gpuhunt @ https://github.com/dstackai/gpuhunt/archive/refs/heads/provider_data_typed_dict.zip",
     "argcomplete>=3.5.0",
     "ignore-python>=0.2.0",
     "orjson",
@@ -66,6 +66,9 @@ artifacts = [
 artifacts = [
     "src/dstack/_internal/server/statics/**",
 ]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.metadata.hooks.fancy-pypi-readme]
 content-type = "text/markdown"

--- a/src/dstack/_internal/core/backends/base/offers.py
+++ b/src/dstack/_internal/core/backends/base/offers.py
@@ -24,6 +24,7 @@ SUPPORTED_GPUHUNT_FLAGS = [
     "lambda-arm",
     "gcp-a4",
     "gcp-g4-preview",
+    "gcp-dws-calendar-mode",
 ]
 
 
@@ -94,6 +95,7 @@ def catalog_item_to_offer(
         ),
         region=item.location,
         price=item.price,
+        backend_data=item.provider_data,
     )
 
 

--- a/src/dstack/_internal/core/models/instances.py
+++ b/src/dstack/_internal/core/models/instances.py
@@ -1,6 +1,6 @@
 import datetime
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 import gpuhunt
@@ -184,6 +184,7 @@ class InstanceOffer(CoreModel):
     instance: InstanceType
     region: str
     price: float
+    backend_data: dict[str, Any] = {}
 
 
 class InstanceOfferWithAvailability(InstanceOffer):

--- a/src/dstack/_internal/server/services/offers.py
+++ b/src/dstack/_internal/server/services/offers.py
@@ -215,6 +215,7 @@ def generate_shared_offer(
         ),
         region=offer.region,
         price=offer.price,
+        backend_data=offer.backend_data,
         availability=offer.availability,
         blocks=blocks,
         total_blocks=total_blocks,


### PR DESCRIPTION
Add an offer field for holding arbitrary
backend-specific data. As an example, use this
field to mark reserved GCP A4 instances.

Depends on https://github.com/dstackai/gpuhunt/pull/184

**Before merging**:
- [x] Revert `pyproject.toml` and bump `gpuhunt` version