### PR TITLE
[GCP] Support G4 instance type GA

### DIFF
--- a/src/dstack/_internal/core/backends/base/offers.py
+++ b/src/dstack/_internal/core/backends/base/offers.py
@@ -23,6 +23,7 @@ SUPPORTED_GPUHUNT_FLAGS = [
     "oci-spot",
     "lambda-arm",
     "gcp-a4",
+    "gcp-g4",
     "gcp-dws-calendar-mode",
 ]
 

--- a/src/dstack/_internal/core/backends/base/offers.py
+++ b/src/dstack/_internal/core/backends/base/offers.py
@@ -23,7 +23,6 @@ SUPPORTED_GPUHUNT_FLAGS = [
     "oci-spot",
     "lambda-arm",
     "gcp-a4",
-    "gcp-g4-preview",
     "gcp-dws-calendar-mode",
 ]
 

--- a/src/dstack/_internal/core/backends/gcp/models.py
+++ b/src/dstack/_internal/core/backends/gcp/models.py
@@ -92,7 +92,10 @@ class GCPBackendConfig(CoreModel):
     preview_features: Annotated[
         Optional[List[Literal["g4"]]],
         Field(
-            description=("The list of preview GCP features to enable. Supported values: `g4`"),
+            description=(
+                "The list of preview GCP features to enable."
+                " There are currently no preview features"
+            ),
             max_items=1,
         ),
     ] = None


### PR DESCRIPTION
GCP G4 instances with the NVIDIA RTX PRO 6000 GPU are now generally available without the `preview_features: [g4]` backend setting.

```shell
> dstack offer -b gcp --gpu RTXPRO6000                                          

 #  BACKEND            RESOURCES                                        INSTANCE TYPE    PRICE      
 1  gcp (us-central1)  cpu=48 mem=180GB disk=100GB RTXPRO6000:96GB:1    g4-standard-48   $4.5001    
 2  gcp (us-central1)  cpu=96 mem=360GB disk=100GB RTXPRO6000:96GB:2    g4-standard-96   $9.0002    
 3  gcp (us-central1)  cpu=192 mem=720GB disk=100GB RTXPRO6000:96GB:4   g4-standard-192  $18.0003   
 4  gcp (us-central1)  cpu=384 mem=1440GB disk=100GB RTXPRO6000:96GB:8  g4-standard-384  $36.0006
 ```

Fixes #3212

Depends on https://github.com/dstackai/gpuhunt/pull/186