### PR TITLE
Fix context usage in internal metrics package

### DIFF
--- a/runner/internal/runner/api/http.go
+++ b/runner/internal/runner/api/http.go
@@ -33,7 +33,7 @@ func (s *Server) metricsGetHandler(w http.ResponseWriter, r *http.Request) (inte
 	if err != nil {
 		return nil, &api.Error{Status: http.StatusInternalServerError, Err: err}
 	}
-	metrics, err := metricsCollector.GetSystemMetrics()
+	metrics, err := metricsCollector.GetSystemMetrics(r.Context())
 	if err != nil {
 		return nil, &api.Error{Status: http.StatusInternalServerError, Err: err}
 	}


### PR DESCRIPTION
Same as #3223 and #3224 - In this case I've also updated the runner API so that the request context is passed over.