### PR TITLE
Fix autocreated fleets warning

### DIFF
--- a/src/dstack/_internal/cli/services/configurators/run.py
+++ b/src/dstack/_internal/cli/services/configurators/run.py
@@ -941,7 +941,7 @@ def _warn_fleet_autocreated(api: APIClient, run: Run):
     if not fleet.spec.autocreated:
         return
     warn(
-        f"\nNo existing fleet matched, so the run created a new fleet [code]{fleet.name}[/code].\n"
+        f"\nThe run is using automatically created fleet [code]{fleet.name}[/code].\n"
         "Future dstack versions won't create fleets automatically.\n"
         "Create a fleet explicitly: https://dstack.ai/docs/concepts/fleets/"
     )


### PR DESCRIPTION
The warning was misleading because it could appear when reusing old autocreated fleets (no new fleets created).

Reverts https://github.com/dstackai/dstack/pull/3060/commits/9e19d51c0e310ebe975d34e744e6dfe87b89012d