### PR TITLE
Do not terminate fleet instances on idle_duration at nodes.min

### DIFF
--- a/src/dstack/_internal/core/models/fleets.py
+++ b/src/dstack/_internal/core/models/fleets.py
@@ -309,7 +309,12 @@ class InstanceGroupParams(CoreModel):
     idle_duration: Annotated[
         Optional[int],
         Field(
-            description="Time to wait before terminating idle instances. Defaults to `5m` for runs and `3d` for fleets. Use `off` for unlimited duration"
+            description=(
+                "Time to wait before terminating idle instances."
+                " Instances are not terminated if the fleet is already at `nodes.min`."
+                " Defaults to `5m` for runs and `3d` for fleets."
+                " Use `off` for unlimited duration"
+            )
         ),
     ] = None
 

--- a/src/dstack/_internal/core/models/profiles.py
+++ b/src/dstack/_internal/core/models/profiles.py
@@ -341,7 +341,9 @@ class ProfileParams(CoreModel):
         Field(
             description=(
                 "Time to wait before terminating idle instances."
-                " Defaults to `5m` for runs and `3d` for fleets. Use `off` for unlimited duration"
+                " Instances are not terminated if the fleet is already at `nodes.min`."
+                " Defaults to `5m` for runs and `3d` for fleets."
+                " Use `off` for unlimited duration"
             )
         ),
     ] = None

--- a/src/dstack/_internal/server/background/tasks/process_instances.py
+++ b/src/dstack/_internal/server/background/tasks/process_instances.py
@@ -286,7 +286,7 @@ def _can_terminate_fleet_instances_on_idle_duration(fleet_model: FleetModel) -> 
     # That's ok: in the worst case we go below `nodes.min`, but
     # the fleet consolidation logic will provision new nodes.
     fleet = fleet_model_to_fleet(fleet_model)
-    if fleet.spec.configuration.nodes is None:
+    if fleet.spec.configuration.nodes is None or fleet.spec.autocreated:
         return True
     active_instances = [i for i in fleet_model.instances if i.status.is_active()]
     active_instances_num = len(active_instances)


### PR DESCRIPTION
Fixes #3128

Optimization to avoid terminating instances on idle_duration and starting recreate loop when the fleet is already at `nodes.min`.