### PR TITLE
[shim] Log successful API calls with trace level

### DIFF
--- a/runner/internal/api/common.go
+++ b/runner/internal/api/common.go
@@ -113,11 +113,13 @@ func JSONResponseHandler(handler func(http.ResponseWriter, *http.Request) (inter
 			if errors.As(err, &apiErr) {
 				status = apiErr.Status
 				errMsg = apiErr.Error()
-				log.Warning(r.Context(), "API error", "err", errMsg, "status", status)
+				log.Warning(r.Context(), "API error", "err", errMsg, "method", r.Method, "endpoint", r.URL.Path, "status", status)
 			} else {
 				status = http.StatusInternalServerError
-				log.Error(r.Context(), "Unexpected API error", "err", err, "status", status)
+				log.Error(r.Context(), "Unexpected API error", "err", err, "method", r.Method, "endpoint", r.URL.Path, "status", status)
 			}
+		} else {
+			log.Trace(r.Context(), "", "method", r.Method, "endpoint", r.URL.Path, "status", status)
 		}
 
 		if status != 500 && body != nil {
@@ -127,7 +129,5 @@ func JSONResponseHandler(handler func(http.ResponseWriter, *http.Request) (inter
 		} else {
 			http.Error(w, errMsg, status)
 		}
-
-		log.Debug(r.Context(), "", "method", r.Method, "endpoint", r.URL.Path, "status", status)
 	}
 }

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -699,7 +699,7 @@ def get_shim_env(
     backend_shim_env: Optional[Dict[str, str]] = None,
     arch: Optional[str] = None,
 ) -> Dict[str, str]:
-    log_level = "6"  # Trace
+    log_level = "5"  # Debug
     envs = {
         "DSTACK_SHIM_HOME": get_dstack_working_dir(base_path),
         "DSTACK_SHIM_HTTP_PORT": str(DSTACK_SHIM_HTTP_PORT),


### PR DESCRIPTION
Reduces log noise when `DSTACK_SHIM_LOG_LEVEL` is set to 5 (debug) or lower

Such messages are gone:

```
Oct 29 13:41:15 defpc dstack-shim[389812]: time=2025-10-29T13:41:15.1726Z level=debug endpoint=/api/healthcheck status=200 method=GET
Oct 29 13:41:15 defpc dstack-shim[389812]: time=2025-10-29T13:41:15.174582Z level=debug method=GET endpoint=/api/tasks status=200
Oct 29 13:41:29 defpc dstack-shim[389812]: time=2025-10-29T13:41:29.307652Z level=debug method=GET endpoint=/api/healthcheck status=200
Oct 29 13:41:29 defpc dstack-shim[389812]: time=2025-10-29T13:41:29.309535Z level=debug method=GET endpoint=/api/tasks status=200
Oct 29 13:41:40 defpc dstack-shim[389812]: time=2025-10-29T13:41:40.535613Z level=debug method=GET endpoint=/api/healthcheck status=200
```