### PR TITLE
Add DSTACK_FF_AUTOCREATED_FLEETS_DISABLED

### DIFF
--- a/src/dstack/_internal/settings.py
+++ b/src/dstack/_internal/settings.py
@@ -35,4 +35,4 @@ class FeatureFlags:
     development. Feature flags are environment variables of the form DSTACK_FF_*
     """
 
-    pass
+    AUTOCREATED_FLEETS_DISABLED = os.getenv("DSTACK_FF_AUTOCREATED_FLEETS_DISABLED") is not None


### PR DESCRIPTION
Feature flag to test #3059 internally.

Do `export DSTACK_FF_AUTOCREATED_FLEETS_DISABLED=` on the sever and the fleets won't be created automatically.