### PR TITLE
[Docs] Fix typo in fleets.md comment

### DIFF
--- a/docs/docs/concepts/fleets.md
+++ b/docs/docs/concepts/fleets.md
@@ -383,7 +383,7 @@ By default, a job uses the entire instance—e.g., all 8 GPUs. To allow multiple
           # As many as possible, according to numbers of GPUs and CPUs
           blocks: auto
         - hostname: 3.255.177.53
-          # Do not sclice. This is the default value, may be omitted
+          # Do not slice. This is the default value, may be omitted
           blocks: 1
     ```
 


### PR DESCRIPTION
Fix a typo in the [Blocks section of the Fleets documentation](https://dstack.ai/docs/concepts/fleets/#configuration-options), meant to be slice instead of sclice. 

```
# Do not sclice. This is the default value, may be omitted
blocks: 1
```