### PR TITLE
Support --since arg for dstack logs command

### DIFF
--- a/src/dstack/_internal/cli/commands/logs.py
+++ b/src/dstack/_internal/cli/commands/logs.py
@@ -1,9 +1,12 @@
 import argparse
 import sys
+from datetime import datetime
+from typing import Optional
 
 from dstack._internal.cli.commands import APIBaseCommand
 from dstack._internal.cli.services.completion import RunNameCompleter
 from dstack._internal.core.errors import CLIError
+from dstack._internal.utils.common import parse_since
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -30,6 +33,14 @@ class LogsCommand(APIBaseCommand):
             type=int,
             default=0,
         )
+        self._parser.add_argument(
+            "--since",
+            help=(
+                "Show only logs newer than the specified date."
+                " Can be a duration (e.g. 10s, 5m, 1d) or an RFC 3339 string (e.g. 2023-09-24T15:30:00Z)."
+            ),
+            type=str,
+        )
         self._parser.add_argument("run_name").completer = RunNameCompleter(all=True)  # type: ignore[attr-defined]
 
     def _command(self, args: argparse.Namespace):
@@ -37,7 +48,10 @@ class LogsCommand(APIBaseCommand):
         run = self.api.runs.get(args.run_name)
         if run is None:
             raise CLIError(f"Run {args.run_name} not found")
+
+        start_time = _get_start_time(args.since)
         logs = run.logs(
+            start_time=start_time,
             diagnose=args.diagnose,
             replica_num=args.replica,
             job_num=args.job,
@@ -48,3 +62,12 @@ class LogsCommand(APIBaseCommand):
                 sys.stdout.buffer.flush()
         except KeyboardInterrupt:
             pass
+
+
+def _get_start_time(since: Optional[str]) -> Optional[datetime]:
+    if since is None:
+        return None
+    try:
+        return parse_since(since)
+    except ValueError as e:
+        raise CLIError(e.args[0])


### PR DESCRIPTION
#3035

The PR adds the `--since` argument to the `dstack logs` CLI command that allows showing only recent logs. It supports both relative duration and a timestamp:

```
✗ dstack logs logs-task --since 2025-11-05T08:54:15Z
348
349
350
351
352
353
```

```
✗ dstack logs logs-task --since 5m
350
351
352
353
```