### PR TITLE
Include non-GPU offers on `gpu: 0..`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "python-multipart>=0.0.16",
     "filelock",
     "psutil",
-    "gpuhunt==0.1.11",
+    "gpuhunt==0.1.12",
     "argcomplete>=3.5.0",
     "ignore-python>=0.2.0",
     "orjson",


### PR DESCRIPTION
Previously, `dstack` did not return any non-GPU offers if GPU name, memory, or vendor requirements are set, regardless of the GPU count requirement.

```shell
> dstack offer --gpu 0..:nvidia
 #   BACKEND             RESOURCES                                   INSTANCE TYPE  PRICE
 1   aws (eu-west-2)     cpu=4 mem=16GB disk=100GB T4:16GB:1 (spot)  g4dn.xlarge    $0.1879
 2   aws (us-east-1)     cpu=4 mem=16GB disk=100GB T4:16GB:1 (spot)  g4dn.xlarge    $0.1914
 3   aws (ca-central-1)  cpu=4 mem=16GB disk=100GB T4:16GB:1 (spot)  g4dn.xlarge    $0.1931
 <...>
```

Now, it Includes non-GPU offers if the lower GPU count bound is set to `0`.

```shell
> dstack offer --gpu 0..:nvidia
 #     BACKEND             RESOURCES                                         INSTANCE TYPE  PRICE
 1     aws (eu-north-1)    cpu=2 mem=8GB disk=100GB (spot)                   t3.large       $0.0281
 2     aws (us-west-1)     cpu=2 mem=8GB disk=100GB (spot)                   t3.large       $0.0297
 3     aws (eu-west-2)     cpu=2 mem=8GB disk=100GB (spot)                   t3.large       $0.0298
 <...>
 1752  aws (ca-central-1)  cpu=192 mem=2048GB disk=100GB H100:80GB:8 (spot)  p5.48xlarge    $63.296
 1753  aws (us-west-1)     cpu=192 mem=2048GB disk=100GB H100:80GB:8         p5.48xlarge    $68.8
 1754  aws (eu-west-2)     cpu=192 mem=2048GB disk=100GB H100:80GB:8         p5.48xlarge    $71.552
```

Fixes #3249
See https://github.com/dstackai/gpuhunt/pull/197