### PR TITLE
Support --since arg for dstack attach --logs command

### DIFF
--- a/runner/internal/runner/api/ws.go
+++ b/runner/internal/runner/api/ws.go
@@ -2,12 +2,17 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
 	"github.com/dstackai/dstack/runner/internal/log"
 	"github.com/gorilla/websocket"
 )
+
+type logsWsRequestParams struct {
+	startTimestamp int64
+}
 
 var upgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool {
@@ -20,18 +25,54 @@ func (s *Server) logsWsGetHandler(w http.ResponseWriter, r *http.Request) (inter
 	if err != nil {
 		return nil, err
 	}
+	requestParams, err := parseRequestParams(r)
+	if err != nil {
+		_ = conn.WriteMessage(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseUnsupportedData, err.Error()),
+		)
+		_ = conn.Close()
+		return nil, nil
+	}
 	// todo memorize clientId?
-	go s.streamJobLogs(conn)
+	go s.streamJobLogs(r.Context(), conn, requestParams)
 	return nil, nil
 }
 
-func (s *Server) streamJobLogs(conn *websocket.Conn) {
-	currentPos := 0
+func parseRequestParams(r *http.Request) (logsWsRequestParams, error) {
+	query := r.URL.Query()
+	startTimeStr := query.Get("start_time")
+	var startTimestamp int64
+	if startTimeStr != "" {
+		t, err := time.Parse(time.RFC3339, startTimeStr)
+		if err != nil {
+			return logsWsRequestParams{}, errors.New("Failed to parse start_time value")
+		}
+		startTimestamp = t.Unix()
+	}
+	return logsWsRequestParams{startTimestamp: startTimestamp}, nil
+}
+
+func (s *Server) streamJobLogs(ctx context.Context, conn *websocket.Conn, params logsWsRequestParams) {
 	defer func() {
 		_ = conn.WriteMessage(websocket.CloseMessage, nil)
 		_ = conn.Close()
 	}()
-
+	currentPos := 0
+	startTimestampMs := params.startTimestamp * 1000
+	if startTimestampMs != 0 {
+		// TODO: Replace currentPos linear search with binary search
+		s.executor.RLock()
+		jobLogsWsHistory := s.executor.GetJobWsLogsHistory()
+		for _, logEntry := range jobLogsWsHistory {
+			if logEntry.Timestamp < startTimestampMs {
+				currentPos += 1
+			} else {
+				break
+			}
+		}
+		s.executor.RUnlock()
+	}
 	for {
 		s.executor.RLock()
 		jobLogsWsHistory := s.executor.GetJobWsLogsHistory()
@@ -52,7 +93,7 @@ func (s *Server) streamJobLogs(conn *websocket.Conn) {
 		for currentPos < len(jobLogsWsHistory) {
 			if err := conn.WriteMessage(websocket.BinaryMessage, jobLogsWsHistory[currentPos].Message); err != nil {
 				s.executor.RUnlock()
-				log.Error(context.TODO(), "Failed to write message", "err", err)
+				log.Error(ctx, "Failed to write message", "err", err)
 				return
 			}
 			currentPos++

--- a/runner/internal/schemas/schemas.go
+++ b/runner/internal/schemas/schemas.go
@@ -16,7 +16,7 @@ type JobStateEvent struct {
 
 type LogEvent struct {
 	Message   []byte `json:"message"`
-	Timestamp int64  `json:"timestamp"`
+	Timestamp int64  `json:"timestamp"` // milliseconds
 }
 
 type SubmitBody struct {

--- a/src/dstack/_internal/cli/commands/attach.py
+++ b/src/dstack/_internal/cli/commands/attach.py
@@ -11,7 +11,7 @@ from dstack._internal.cli.services.configurators.run import (
     get_run_exit_code,
     print_finished_message,
 )
-from dstack._internal.cli.utils.common import console
+from dstack._internal.cli.utils.common import console, get_start_time
 from dstack._internal.core.consts import DSTACK_RUNNER_HTTP_PORT
 from dstack._internal.core.errors import CLIError
 from dstack._internal.utils.common import get_or_error
@@ -61,6 +61,14 @@ class AttachCommand(APIBaseCommand):
             type=int,
             default=0,
         )
+        self._parser.add_argument(
+            "--since",
+            help=(
+                "Show only logs newer than the specified date."
+                " Can be a duration (e.g. 10s, 5m, 1d) or an RFC 3339 string (e.g. 2023-09-24T15:30:00Z)."
+            ),
+            type=str,
+        )
         self._parser.add_argument("run_name").completer = RunNameCompleter()  # type: ignore[attr-defined]
 
     def _command(self, args: argparse.Namespace):
@@ -86,7 +94,9 @@ class AttachCommand(APIBaseCommand):
                 job_num=args.job,
             )
             if args.logs:
+                start_time = get_start_time(args.since)
                 logs = run.logs(
+                    start_time=start_time,
                     replica_num=args.replica,
                     job_num=args.job,
                 )

--- a/src/dstack/_internal/cli/commands/logs.py
+++ b/src/dstack/_internal/cli/commands/logs.py
@@ -1,12 +1,10 @@
 import argparse
 import sys
-from datetime import datetime
-from typing import Optional
 
 from dstack._internal.cli.commands import APIBaseCommand
 from dstack._internal.cli.services.completion import RunNameCompleter
+from dstack._internal.cli.utils.common import get_start_time
 from dstack._internal.core.errors import CLIError
-from dstack._internal.utils.common import parse_since
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -49,7 +47,7 @@ class LogsCommand(APIBaseCommand):
         if run is None:
             raise CLIError(f"Run {args.run_name} not found")
 
-        start_time = _get_start_time(args.since)
+        start_time = get_start_time(args.since)
         logs = run.logs(
             start_time=start_time,
             diagnose=args.diagnose,
@@ -62,12 +60,3 @@ class LogsCommand(APIBaseCommand):
                 sys.stdout.buffer.flush()
         except KeyboardInterrupt:
             pass
-
-
-def _get_start_time(since: Optional[str]) -> Optional[datetime]:
-    if since is None:
-        return None
-    try:
-        return parse_since(since)
-    except ValueError as e:
-        raise CLIError(e.args[0])

--- a/src/dstack/_internal/cli/utils/common.py
+++ b/src/dstack/_internal/cli/utils/common.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
 from rich.console import Console
 from rich.prompt import Confirm
@@ -11,7 +11,7 @@ from rich.theme import Theme
 from dstack._internal import settings
 from dstack._internal.cli.utils.rich import DstackRichHandler
 from dstack._internal.core.errors import CLIError, DstackError
-from dstack._internal.utils.common import get_dstack_dir
+from dstack._internal.utils.common import get_dstack_dir, parse_since
 
 _colors = {
     "secondary": "grey58",
@@ -110,3 +110,12 @@ def warn(message: str):
         # Additional blank line for better visibility if there are more than one warning
         message = f"{message}\n"
     console.print(f"[warning][bold]{message}[/]")
+
+
+def get_start_time(since: Optional[str]) -> Optional[datetime]:
+    if since is None:
+        return None
+    try:
+        return parse_since(since)
+    except ValueError as e:
+        raise CLIError(e.args[0])


### PR DESCRIPTION
Closes #3035 

This PR adds the `--since` argument to the `dstack attach --logs` command that allows getting realtime logs without loading the full logs history first:

```
✗ dstack attach logs-task --logs --since 1m
Attached to run logs-task (replica=0 job=0)
To connect to the run via SSH, use `ssh logs-task`.
Press Ctrl+C to detach...
424
425
426
427
428
429
430
```

**Implementation**

Extended the logs websocket endpoint to accept a query param `start_time` to filter out the old logs.

**Backward compatibility**

If a new client sends `start_time` to the old runner, it's ignored. So `--since` simply has no effect when used with old runners, but otherwise logs work as before.