### PR TITLE
Forbid running multinode tasks on non-cluster fleets

### DIFF
--- a/src/dstack/_internal/server/db.py
+++ b/src/dstack/_internal/server/db.py
@@ -103,6 +103,23 @@ def session_decorator(func):
     return new_func
 
 
+def is_db_sqlite() -> bool:
+    return get_db().dialect_name == "sqlite"
+
+
+def is_db_postgres() -> bool:
+    return get_db().dialect_name == "postgresql"
+
+
+async def sqlite_commit(session: AsyncSession):
+    """
+    Commit an sqlite transaction.
+    Should be used before taking locks in active sessions to see committed changes.
+    """
+    if is_db_sqlite():
+        await session.commit()
+
+
 def _run_alembic_upgrade(connection):
     alembic_cfg = config.Config()
     alembic_cfg.set_main_option("script_location", settings.ALEMBIC_MIGRATIONS_LOCATION)

--- a/src/dstack/_internal/server/services/gateways/__init__.py
+++ b/src/dstack/_internal/server/services/gateways/__init__.py
@@ -38,7 +38,7 @@ from dstack._internal.core.models.gateways import (
 )
 from dstack._internal.core.services import validate_dstack_resource_name
 from dstack._internal.server import settings
-from dstack._internal.server.db import get_db
+from dstack._internal.server.db import get_db, is_db_postgres, is_db_sqlite
 from dstack._internal.server.models import (
     GatewayComputeModel,
     GatewayModel,
@@ -148,14 +148,13 @@ async def create_gateway(
     )
 
     lock_namespace = f"gateway_names_{project.name}"
-    if get_db().dialect_name == "sqlite":
+    if is_db_sqlite():
         # Start new transaction to see committed changes after lock
         await session.commit()
-    elif get_db().dialect_name == "postgresql":
+    elif is_db_postgres():
         await session.execute(
             select(func.pg_advisory_xact_lock(string_to_lock_id(lock_namespace)))
         )
-
     lock, _ = get_locker(get_db().dialect_name).get_lockset(lock_namespace)
     async with lock:
         if configuration.name is None:

--- a/src/dstack/_internal/server/services/volumes.py
+++ b/src/dstack/_internal/server/services/volumes.py
@@ -24,7 +24,7 @@ from dstack._internal.core.models.volumes import (
     VolumeStatus,
 )
 from dstack._internal.core.services import validate_dstack_resource_name
-from dstack._internal.server.db import get_db
+from dstack._internal.server.db import get_db, is_db_postgres, is_db_sqlite
 from dstack._internal.server.models import (
     InstanceModel,
     ProjectModel,
@@ -215,14 +215,13 @@ async def create_volume(
     _validate_volume_configuration(configuration)
 
     lock_namespace = f"volume_names_{project.name}"
-    if get_db().dialect_name == "sqlite":
+    if is_db_sqlite():
         # Start new transaction to see committed changes after lock
         await session.commit()
-    elif get_db().dialect_name == "postgresql":
+    elif is_db_postgres():
         await session.execute(
             select(func.pg_advisory_xact_lock(string_to_lock_id(lock_namespace)))
         )
-
     lock, _ = get_locker(get_db().dialect_name).get_lockset(lock_namespace)
     async with lock:
         if configuration.name is not None:

--- a/src/tests/_internal/server/background/tasks/test_process_submitted_jobs.py
+++ b/src/tests/_internal/server/background/tasks/test_process_submitted_jobs.py
@@ -546,6 +546,7 @@ class TestProcessSubmittedJobs:
         )
         offer = get_instance_offer_with_availability(gpu_count=8, cpu_count=64, memory_gib=128)
         fleet_spec = get_fleet_spec()
+        fleet_spec.configuration.placement = InstanceGroupPlacement.CLUSTER
         fleet_spec.configuration.nodes = FleetNodesSpec(min=1, target=1, max=None)
         fleet = await create_fleet(session=session, project=project, spec=fleet_spec)
         instance = await create_instance(


### PR DESCRIPTION
Fixes #3250 

This PR:
* Forbids running multinode tasks on non-cluster fleets.
* Fixes a bug when different clusters (instances from different backends/regions) could be provisioned in one cluster fleet.
* Simplifies process_submitted_jobs code and fixes minor bugs.
