### PR TITLE
Support placement groups for elastic fleets

### DIFF
--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -111,6 +111,7 @@ class Compute(ABC):
         project_ssh_public_key: str,
         project_ssh_private_key: str,
         volumes: List[Volume],
+        placement_group: Optional[PlacementGroup],
     ) -> JobProvisioningData:
         """
         Launches a new instance for the job. It should return `JobProvisioningData` ASAP.
@@ -287,6 +288,7 @@ class ComputeWithCreateInstanceSupport(ABC):
         project_ssh_public_key: str,
         project_ssh_private_key: str,
         volumes: List[Volume],
+        placement_group: Optional[PlacementGroup],
     ) -> JobProvisioningData:
         """
         The default `run_job()` implementation for all backends that support `create_instance()`.
@@ -303,7 +305,9 @@ class ComputeWithCreateInstanceSupport(ABC):
         )
         instance_offer = instance_offer.copy()
         self._restrict_instance_offer_az_to_volumes_az(instance_offer, volumes)
-        return self.create_instance(instance_offer, instance_config, placement_group=None)
+        return self.create_instance(
+            instance_offer, instance_config, placement_group=placement_group
+        )
 
     def _restrict_instance_offer_az_to_volumes_az(
         self,
@@ -335,6 +339,7 @@ class ComputeWithGroupProvisioningSupport(ABC):
         instance_offer: InstanceOfferWithAvailability,
         project_ssh_public_key: str,
         project_ssh_private_key: str,
+        placement_group: Optional[PlacementGroup],
     ) -> ComputeGroupProvisioningData:
         pass
 

--- a/src/dstack/_internal/core/backends/kubernetes/compute.py
+++ b/src/dstack/_internal/core/backends/kubernetes/compute.py
@@ -49,6 +49,7 @@ from dstack._internal.core.models.instances import (
     Resources,
     SSHConnectionParams,
 )
+from dstack._internal.core.models.placement import PlacementGroup
 from dstack._internal.core.models.resources import CPUSpec, GPUSpec, Memory
 from dstack._internal.core.models.runs import Job, JobProvisioningData, Requirements, Run
 from dstack._internal.core.models.volumes import Volume
@@ -131,6 +132,7 @@ class KubernetesCompute(
         project_ssh_public_key: str,
         project_ssh_private_key: str,
         volumes: list[Volume],
+        placement_group: Optional[PlacementGroup],
     ) -> JobProvisioningData:
         instance_name = generate_unique_instance_name_for_job(run, job)
         assert run.run_spec.ssh_key_pub is not None

--- a/src/dstack/_internal/core/backends/local/compute.py
+++ b/src/dstack/_internal/core/backends/local/compute.py
@@ -79,6 +79,7 @@ class LocalCompute(
         project_ssh_public_key: str,
         project_ssh_private_key: str,
         volumes: List[Volume],
+        placement_group: Optional[PlacementGroup],
     ) -> JobProvisioningData:
         return JobProvisioningData(
             backend=instance_offer.backend,

--- a/src/dstack/_internal/core/backends/runpod/compute.py
+++ b/src/dstack/_internal/core/backends/runpod/compute.py
@@ -36,6 +36,7 @@ from dstack._internal.core.models.instances import (
     InstanceOfferWithAvailability,
     SSHKey,
 )
+from dstack._internal.core.models.placement import PlacementGroup
 from dstack._internal.core.models.resources import Memory, Range
 from dstack._internal.core.models.runs import Job, JobProvisioningData, Requirements, Run
 from dstack._internal.core.models.volumes import Volume, VolumeProvisioningData
@@ -109,6 +110,7 @@ class RunpodCompute(
         project_ssh_public_key: str,
         project_ssh_private_key: str,
         volumes: List[Volume],
+        placement_group: Optional[PlacementGroup],
     ) -> JobProvisioningData:
         assert run.run_spec.ssh_key_pub is not None
         instance_config = InstanceConfiguration(

--- a/src/dstack/_internal/core/backends/runpod/compute.py
+++ b/src/dstack/_internal/core/backends/runpod/compute.py
@@ -218,6 +218,7 @@ class RunpodCompute(
         instance_offer: InstanceOfferWithAvailability,
         project_ssh_public_key: str,
         project_ssh_private_key: str,
+        placement_group: Optional[PlacementGroup],
     ) -> ComputeGroupProvisioningData:
         master_job_configuration = job_configurations[0]
         master_job = master_job_configuration.job

--- a/src/dstack/_internal/core/backends/template/compute.py.jinja
+++ b/src/dstack/_internal/core/backends/template/compute.py.jinja
@@ -83,6 +83,7 @@ class {{ backend_name }}Compute(
         project_ssh_public_key: str,
         project_ssh_private_key: str,
         volumes: List[Volume],
+        placement_group: Optional[PlacementGroup],
     ) -> JobProvisioningData:
         # TODO: Implement if create_instance() is not implemented. Delete otherwise.
         raise NotImplementedError()

--- a/src/dstack/_internal/core/backends/vastai/compute.py
+++ b/src/dstack/_internal/core/backends/vastai/compute.py
@@ -20,6 +20,7 @@ from dstack._internal.core.models.instances import (
     InstanceOfferWithAvailability,
     InstanceRuntime,
 )
+from dstack._internal.core.models.placement import PlacementGroup
 from dstack._internal.core.models.runs import Job, JobProvisioningData, Requirements, Run
 from dstack._internal.core.models.volumes import Volume
 from dstack._internal.utils.logging import get_logger
@@ -82,6 +83,7 @@ class VastAICompute(
         project_ssh_public_key: str,
         project_ssh_private_key: str,
         volumes: List[Volume],
+        placement_group: Optional[PlacementGroup],
     ) -> JobProvisioningData:
         instance_name = generate_unique_instance_name_for_job(
             run, job, max_length=MAX_INSTANCE_NAME_LEN

--- a/src/dstack/_internal/server/background/tasks/process_runs.py
+++ b/src/dstack/_internal/server/background/tasks/process_runs.py
@@ -32,6 +32,7 @@ from dstack._internal.server.services.jobs import (
     find_job,
     get_job_specs_from_run_spec,
     group_jobs_by_replica_latest,
+    is_master_job,
 )
 from dstack._internal.server.services.locking import get_locker
 from dstack._internal.server.services.prometheus.client_metrics import run_metrics
@@ -606,6 +607,6 @@ def _should_stop_on_master_done(run: Run) -> bool:
     if run.run_spec.merged_profile.stop_criteria != StopCriteria.MASTER_DONE:
         return False
     for job in run.jobs:
-        if job.job_spec.job_num == 0 and job.job_submissions[-1].status == JobStatus.DONE:
+        if is_master_job(job) and job.job_submissions[-1].status == JobStatus.DONE:
             return True
     return False

--- a/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
@@ -802,11 +802,12 @@ async def _fetch_fleet_with_master_instance_provisioning_data(
             else:
                 res = await session.execute(
                     select(FleetModel)
+                    .join(FleetModel.instances)
                     .where(
                         FleetModel.id == fleet_model.id,
                         InstanceModel.deleted == False,
                     )
-                    .options(joinedload(FleetModel.instances))
+                    .options(contains_eager(FleetModel.instances))
                     .execution_options(populate_existing=True)
                 )
                 fleet_model = res.unique().scalar_one()

--- a/src/dstack/_internal/server/services/fleets.py
+++ b/src/dstack/_internal/server/services/fleets.py
@@ -643,6 +643,18 @@ def is_fleet_empty(fleet_model: FleetModel) -> bool:
     return len(active_instances) == 0
 
 
+def is_cloud_cluster(fleet_model: FleetModel) -> bool:
+    fleet = fleet_model_to_fleet(fleet_model)
+    return (
+        fleet.spec.configuration.placement == InstanceGroupPlacement.CLUSTER
+        and fleet.spec.configuration.ssh_config is None
+    )
+
+
+def is_fleet_master_instance(instance: InstanceModel) -> bool:
+    return instance.fleet is not None and instance.id == instance.fleet.instances[0].id
+
+
 def get_fleet_requirements(fleet_spec: FleetSpec) -> Requirements:
     profile = fleet_spec.merged_profile
     requirements = Requirements(

--- a/src/dstack/_internal/server/services/jobs/__init__.py
+++ b/src/dstack/_internal/server/services/jobs/__init__.py
@@ -202,6 +202,14 @@ def delay_job_instance_termination(job_model: JobModel):
     job_model.remove_at = common.get_current_datetime() + timedelta(seconds=15)
 
 
+def is_multinode_job(job: Job) -> bool:
+    return job.job_spec.jobs_per_replica > 1
+
+
+def is_master_job(job: Job) -> bool:
+    return job.job_spec.job_num == 0
+
+
 def _get_job_configurator(run_spec: RunSpec, secrets: Dict[str, str]) -> JobConfigurator:
     configuration_type = RunConfigurationType(run_spec.configuration.type)
     configurator_class = _configuration_type_to_configurator_class_map[configuration_type]

--- a/src/dstack/_internal/server/services/offers.py
+++ b/src/dstack/_internal/server/services/offers.py
@@ -220,3 +220,22 @@ def generate_shared_offer(
         blocks=blocks,
         total_blocks=total_blocks,
     )
+
+
+def get_instance_offer_with_restricted_az(
+    instance_offer: InstanceOfferWithAvailability,
+    master_job_provisioning_data: Optional[JobProvisioningData],
+) -> InstanceOfferWithAvailability:
+    instance_offer = instance_offer.copy()
+    if (
+        master_job_provisioning_data is not None
+        and master_job_provisioning_data.availability_zone is not None
+    ):
+        if instance_offer.availability_zones is None:
+            instance_offer.availability_zones = [master_job_provisioning_data.availability_zone]
+        instance_offer.availability_zones = [
+            z
+            for z in instance_offer.availability_zones
+            if z == master_job_provisioning_data.availability_zone
+        ]
+    return instance_offer

--- a/src/dstack/_internal/server/services/placement.py
+++ b/src/dstack/_internal/server/services/placement.py
@@ -6,43 +6,23 @@ from git import List
 from sqlalchemy import and_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from dstack._internal.core.backends.base.compute import (
+    ComputeWithPlacementGroupSupport,
+    generate_unique_placement_group_name,
+)
+from dstack._internal.core.errors import BackendError, PlacementGroupNotSupportedError
+from dstack._internal.core.models.instances import InstanceOffer
 from dstack._internal.core.models.placement import (
     PlacementGroup,
     PlacementGroupConfiguration,
     PlacementGroupProvisioningData,
+    PlacementStrategy,
 )
-from dstack._internal.server.models import PlacementGroupModel
+from dstack._internal.server.models import FleetModel, InstanceModel, PlacementGroupModel
+from dstack._internal.utils.common import run_async
+from dstack._internal.utils.logging import get_logger
 
-
-async def get_fleet_placement_group_models(
-    session: AsyncSession,
-    fleet_id: UUID,
-) -> List[PlacementGroupModel]:
-    res = await session.execute(
-        select(PlacementGroupModel).where(
-            and_(
-                PlacementGroupModel.fleet_id == fleet_id,
-                PlacementGroupModel.deleted == False,
-                PlacementGroupModel.fleet_deleted == False,
-            )
-        )
-    )
-    return list(res.scalars().all())
-
-
-async def schedule_fleet_placement_groups_deletion(
-    session: AsyncSession, fleet_id: UUID, except_placement_group_ids: Iterable[UUID] = ()
-) -> None:
-    await session.execute(
-        update(PlacementGroupModel)
-        .where(
-            and_(
-                PlacementGroupModel.fleet_id == fleet_id,
-                PlacementGroupModel.id.not_in(except_placement_group_ids),
-            )
-        )
-        .values(fleet_deleted=True)  # TODO: rename `fleet_deleted` -> `to_be_deleted`
-    )
+logger = get_logger(__name__)
 
 
 def placement_group_model_to_placement_group(
@@ -56,6 +36,14 @@ def placement_group_model_to_placement_group(
         configuration=configuration,
         provisioning_data=provisioning_data,
     )
+
+
+def placement_group_model_to_placement_group_optional(
+    placement_group_model: Optional[PlacementGroupModel],
+) -> Optional[PlacementGroup]:
+    if placement_group_model is None:
+        return None
+    return placement_group_model_to_placement_group(placement_group_model)
 
 
 def get_placement_group_configuration(
@@ -72,3 +60,178 @@ def get_placement_group_provisioning_data(
     return PlacementGroupProvisioningData.__response__.parse_raw(
         placement_group_model.provisioning_data
     )
+
+
+async def get_fleet_placement_group_models(
+    session: AsyncSession,
+    fleet_id: Optional[UUID],
+) -> List[PlacementGroupModel]:
+    if fleet_id is None:
+        return []
+    res = await session.execute(
+        select(PlacementGroupModel).where(
+            and_(
+                PlacementGroupModel.fleet_id == fleet_id,
+                PlacementGroupModel.deleted == False,
+                PlacementGroupModel.fleet_deleted == False,
+            )
+        )
+    )
+    return list(res.scalars().all())
+
+
+async def schedule_fleet_placement_groups_deletion(
+    session: AsyncSession, fleet_id: UUID, except_placement_group_ids: Iterable[UUID] = ()
+):
+    await session.execute(
+        update(PlacementGroupModel)
+        .where(
+            and_(
+                PlacementGroupModel.fleet_id == fleet_id,
+                PlacementGroupModel.id.not_in(except_placement_group_ids),
+            )
+        )
+        .values(fleet_deleted=True)  # TODO: rename `fleet_deleted` -> `to_be_deleted`
+    )
+
+
+def get_placement_group_model_for_instance(
+    placement_group_models: list[PlacementGroupModel],
+    instance_model: InstanceModel,
+) -> Optional[PlacementGroupModel]:
+    placement_group_model = None
+    if not _is_fleet_master_instance(instance_model):
+        if placement_group_models:
+            placement_group_model = placement_group_models[0]
+        if len(placement_group_models) > 1:
+            logger.error(
+                (
+                    "Expected 0 or 1 placement groups associated with fleet %s, found %s."
+                    " An incorrect placement group might have been selected for instance %s"
+                ),
+                instance_model.fleet_id,
+                len(placement_group_models),
+                instance_model.name,
+            )
+    return placement_group_model
+
+
+def get_placement_group_model_for_job(
+    placement_group_models: list[PlacementGroupModel],
+    fleet_model: Optional[FleetModel],
+) -> Optional[PlacementGroupModel]:
+    """
+    Returns any fleet placement group for jobs that provision
+    in non-empty fleets and `None` for empty fleets.
+    This is so that only the first job creates placement groups.
+    """
+    placement_group_model = None
+    active_instances = []
+    if fleet_model is not None:
+        active_instances = [i for i in fleet_model.instances if not i.deleted]
+    if len(active_instances) > 0 and len(placement_group_models) > 0:
+        placement_group_model = placement_group_models[0]
+    return placement_group_model
+
+
+async def find_or_create_suitable_placement_group(
+    fleet_model: FleetModel,
+    placement_groups: List[PlacementGroupModel],
+    instance_offer: InstanceOffer,
+    compute: ComputeWithPlacementGroupSupport,
+) -> Optional[PlacementGroupModel]:
+    placement_group_model = find_suitable_placement_group(
+        placement_groups=placement_groups,
+        instance_offer=instance_offer,
+        compute=compute,
+    )
+    if placement_group_model is None:
+        placement_group_model = await create_placement_group(
+            fleet_model=fleet_model,
+            master_instance_offer=instance_offer,
+            compute=compute,
+        )
+    return placement_group_model
+
+
+def find_suitable_placement_group(
+    placement_groups: List[PlacementGroupModel],
+    instance_offer: InstanceOffer,
+    compute: ComputeWithPlacementGroupSupport,
+) -> Optional[PlacementGroupModel]:
+    for pg in placement_groups:
+        if compute.is_suitable_placement_group(
+            placement_group_model_to_placement_group(pg), instance_offer
+        ):
+            return pg
+    return None
+
+
+async def create_placement_group(
+    fleet_model: FleetModel,
+    master_instance_offer: InstanceOffer,
+    compute: ComputeWithPlacementGroupSupport,
+) -> Optional[PlacementGroupModel]:
+    placement_group_model = PlacementGroupModel(
+        # TODO: generate the name in Compute.create_placement_group to allow
+        # backend-specific name length limits
+        name=generate_unique_placement_group_name(
+            project_name=fleet_model.project.name,
+            fleet_name=fleet_model.name,
+        ),
+        project=fleet_model.project,
+        fleet=fleet_model,
+        configuration=PlacementGroupConfiguration(
+            backend=master_instance_offer.backend,
+            region=master_instance_offer.region,
+            placement_strategy=PlacementStrategy.CLUSTER,
+        ).json(),
+    )
+    placement_group = placement_group_model_to_placement_group(placement_group_model)
+    logger.debug(
+        "Creating placement group %s in %s/%s",
+        placement_group.name,
+        placement_group.configuration.backend.value,
+        placement_group.configuration.region,
+    )
+    try:
+        pgpd = await run_async(
+            compute.create_placement_group,
+            placement_group_model_to_placement_group(placement_group_model),
+            master_instance_offer,
+        )
+    except PlacementGroupNotSupportedError:
+        logger.debug(
+            "Skipping offer %s because placement group not supported",
+            master_instance_offer.instance.name,
+        )
+        return None
+    except BackendError as e:
+        logger.warning(
+            "Failed to create placement group %s in %s/%s: %r",
+            placement_group.name,
+            placement_group.configuration.backend.value,
+            placement_group.configuration.region,
+            e,
+        )
+        return None
+    except Exception:
+        logger.exception(
+            "Got exception when creating placement group %s in %s/%s",
+            placement_group.name,
+            placement_group.configuration.backend.value,
+            placement_group.configuration.region,
+        )
+        return None
+    logger.info(
+        "Created placement group %s in %s/%s",
+        placement_group.name,
+        placement_group.configuration.backend.value,
+        placement_group.configuration.region,
+    )
+    placement_group_model.provisioning_data = pgpd.json()
+    return placement_group_model
+
+
+def _is_fleet_master_instance(instance: InstanceModel) -> bool:
+    return instance.fleet is not None and instance.id == instance.fleet.instances[0].id

--- a/src/dstack/_internal/server/services/runs.py
+++ b/src/dstack/_internal/server/services/runs.py
@@ -84,6 +84,7 @@ from dstack._internal.server.services.jobs import (
     get_job_configured_volumes,
     get_jobs_from_run_spec,
     group_jobs_by_replica_latest,
+    is_multinode_job,
     job_model_to_job_submission,
     stop_runner,
 )
@@ -862,7 +863,7 @@ async def _get_pool_offers(
     detaching_instances_ids = await get_instances_ids_with_detaching_volumes(session)
     pool_instances = await get_pool_instances(session, project)
     pool_instances = [i for i in pool_instances if i.id not in detaching_instances_ids]
-    multinode = job.job_spec.jobs_per_replica > 1
+    multinode = is_multinode_job(job)
 
     shared_instances_with_offers = get_shared_pool_instances_with_offers(
         pool_instances=pool_instances,

--- a/src/tests/_internal/server/background/tasks/test_process_submitted_jobs.py
+++ b/src/tests/_internal/server/background/tasks/test_process_submitted_jobs.py
@@ -17,7 +17,6 @@ from dstack._internal.core.models.instances import (
 )
 from dstack._internal.core.models.placement import PlacementGroup
 from dstack._internal.core.models.profiles import Profile
-from dstack._internal.core.models.resources import Range, ResourcesSpec
 from dstack._internal.core.models.runs import (
     JobStatus,
     JobTerminationReason,
@@ -817,17 +816,6 @@ class TestProcessSubmittedJobs:
         fleet_spec = get_fleet_spec()
         fleet_spec.configuration.nodes = FleetNodesSpec(min=0, target=0, max=1)
         await create_fleet(session=session, project=project, spec=fleet_spec, name="fleet")
-        # Need a second non-empty fleet to have two-stage processing
-        fleet2 = await create_fleet(
-            session=session, project=project, spec=fleet_spec, name="fleet2"
-        )
-        await create_instance(
-            session=session,
-            project=project,
-            fleet=fleet2,
-            instance_num=0,
-            status=InstanceStatus.BUSY,
-        )
         run = await create_run(
             session=session,
             project=project,
@@ -858,20 +846,6 @@ class TestProcessSubmittedJobs:
         fleet_spec1.configuration.nodes = FleetNodesSpec(min=0, target=0, max=1)
         fleet1 = await create_fleet(
             session=session, project=project, spec=fleet_spec1, name="fleet"
-        )
-        # Need a second non-empty fleet to have two-stage processing
-        fleet_spec2 = get_fleet_spec()
-        # Empty resources intersection to return no backend offers
-        fleet_spec2.configuration.resources = ResourcesSpec(cpu=Range(min=0, max=0))
-        fleet2 = await create_fleet(
-            session=session, project=project, spec=fleet_spec2, name="fleet2"
-        )
-        await create_instance(
-            session=session,
-            project=project,
-            fleet=fleet2,
-            instance_num=0,
-            status=InstanceStatus.BUSY,
         )
         run = await create_run(
             session=session,


### PR DESCRIPTION
Closes #3256 

Previously, placement groups were created and used for instances provisioned for static cloud fleets (with `nodes: n`). This PR adds placement group support for any instances provisioned in cluster fleets. It repeats placement group logic from create_instance in process_submitted_jobs. Also fixes several fleet-related bugs introduced in previous PRs.

**Important**: Provisioning even one instance in a cluster fleet (e.g. for a dev env) now creates a placement group for that instance since more instances can be provisioned later due to fleet elasticity and all the instances should be in the placement group.