### PR TITLE
Kubernetes: support IP based load balancers

### DIFF
--- a/gateway/pyproject.toml
+++ b/gateway/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
     # release builds of dstack-gateway depend on a PyPI version of dstack instead
-    "dstack[gateway] @ git+https://github.com/dstackai/dstack.git@master",
+    "dstack[gateway] @ https://github.com/dstackai/dstack/archive/refs/heads/master.tar.gz",
 ]
 
 [tool.setuptools.package-data]

--- a/src/dstack/_internal/server/settings.py
+++ b/src/dstack/_internal/server/settings.py
@@ -14,7 +14,7 @@ logger = get_logger(__name__)
 
 DSTACK_DIR_PATH = Path("~/.dstack/").expanduser()
 
-SERVER_DIR_PATH = Path(os.getenv("DSTACK_SERVER_DIR", DSTACK_DIR_PATH / "server"))
+SERVER_DIR_PATH = Path(os.getenv("DSTACK_SERVER_DIR", DSTACK_DIR_PATH / "server")).resolve()
 
 SERVER_CONFIG_FILE_PATH = SERVER_DIR_PATH / "config.yml"
 


### PR DESCRIPTION
Extends Kubernetes backend gateway support to providers that provide IPs, not domain names, for externally-accessible Services.

Tested on Nebius (mk8s) and Google Cloud (GKE).

Part-of: https://github.com/dstackai/dstack/issues/3126