### PR TITLE
[Docker] Fix ssh zombie processes issue

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -10,7 +10,7 @@ fi
 DB_PATH="${HOME}/.dstack/server/data/sqlite.db"
 mkdir -p "$(dirname "$DB_PATH")"
 if [[ -z "${LITESTREAM_REPLICA_URL}" ]]; then
-  exec dstack server --host 0.0.0.0
+  dstack server --host 0.0.0.0
 else
   if [[ ! -f "$DB_PATH" ]]; then
     echo "Attempting Litestream restore..."
@@ -23,5 +23,5 @@ else
       fi
     fi
   fi
-  exec litestream replicate -exec "dstack server --host 0.0.0.0" "$DB_PATH" "$LITESTREAM_REPLICA_URL"
+  litestream replicate -exec "dstack server --host 0.0.0.0" "$DB_PATH" "$LITESTREAM_REPLICA_URL"
 fi


### PR DESCRIPTION
SSHTunnel.open() starts the ssh process with -f option, which causes it to become a daemon (it calls daemon(3) after authentication).

Then, SSHTunnel.close() uses `ssh -O exit` to ask that daemon process to exit (the processes communicate via the control socket, -S option).

The daemon exits, and then PID 1 should reap it.

Before https://github.com/dstackai/dstack/pull/3165, PID 1 was bash, which handles SIGCHLD, properly wait(2)ing children, but in that pull request exec was added, making `dstack server` PID 1. dstack does nothing with SIGCHLD (neither handles nor explicitly ignores it), thus the default disposition (ignore the signal but do not discard children) leads to an evergrowing number of unreaped zombies.

Fixes: https://github.com/dstackai/dstack/issues/3291