### PR TITLE
Return plan offers wrt fleets

### DIFF
--- a/docs/docs/reference/cli/dstack/offer.md
+++ b/docs/docs/reference/cli/dstack/offer.md
@@ -4,6 +4,9 @@ Displays available offers (hardware configurations) from configured backends or 
 
 The output shows backend, region, instance type, resources, spot availability, and pricing.
 
+!!! info "Experimental"
+    `dstack offer` command is currently an experimental feature. Backward compatibility is not guaranteed across releases.
+
 ## Usage
 
 This command accepts most of the same arguments as [`dstack apply`](apply.md).

--- a/src/dstack/_internal/server/background/tasks/process_runs.py
+++ b/src/dstack/_internal/server/background/tasks/process_runs.py
@@ -38,10 +38,12 @@ from dstack._internal.server.services.locking import get_locker
 from dstack._internal.server.services.prometheus.client_metrics import run_metrics
 from dstack._internal.server.services.runs import (
     fmt,
-    is_replica_registered,
     process_terminating_run,
-    retry_run_replica_jobs,
     run_model_to_run,
+)
+from dstack._internal.server.services.runs.replicas import (
+    is_replica_registered,
+    retry_run_replica_jobs,
     scale_run_replicas,
 )
 from dstack._internal.server.services.secrets import get_project_secrets_mapping

--- a/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
+++ b/src/dstack/_internal/server/background/tasks/process_submitted_jobs.py
@@ -327,6 +327,7 @@ async def _process_submitted_job(
             job=job,
             master_job_provisioning_data=master_job_provisioning_data,
             volumes=volumes,
+            exclude_not_available=True,
         )
         if fleet_model is None:
             if run_spec.merged_profile.fleets is not None:

--- a/src/dstack/_internal/server/services/jobs/__init__.py
+++ b/src/dstack/_internal/server/services/jobs/__init__.py
@@ -735,6 +735,10 @@ async def get_job_attached_volumes(
     return job_volumes
 
 
+def remove_job_spec_sensitive_info(spec: JobSpec):
+    spec.ssh_key = None
+
+
 def _get_job_mount_point_attached_volume(
     volumes: List[Volume],
     job_provisioning_data: JobProvisioningData,

--- a/src/dstack/_internal/server/services/runs.py
+++ b/src/dstack/_internal/server/services/runs.py
@@ -352,7 +352,6 @@ async def get_plan(
         secrets=secrets,
         replica_num=0,
     )
-
     volumes = await get_job_configured_volumes(
         session=session,
         project=project,
@@ -1324,6 +1323,18 @@ def is_job_ready(probes: Iterable[ProbeModel], probe_specs: Iterable[ProbeSpec])
 def is_replica_registered(jobs: list[JobModel]) -> bool:
     # Only job_num=0 is supposed to receive service requests
     return jobs[0].registered
+
+
+def get_nodes_required_num_for_run(run_spec: RunSpec) -> int:
+    nodes_required_num = 1
+    if run_spec.configuration.type == "task":
+        nodes_required_num = run_spec.configuration.nodes
+    elif (
+        run_spec.configuration.type == "service"
+        and run_spec.configuration.replicas.min is not None
+    ):
+        nodes_required_num = run_spec.configuration.replicas.min
+    return nodes_required_num
 
 
 def _remove_job_spec_sensitive_info(spec: JobSpec):

--- a/src/dstack/_internal/server/services/runs/__init__.py
+++ b/src/dstack/_internal/server/services/runs/__init__.py
@@ -83,7 +83,6 @@ from dstack._internal.server.services.jobs import (
     get_instances_ids_with_detaching_volumes,
     get_job_configured_volumes,
     get_jobs_from_run_spec,
-    group_jobs_by_replica_latest,
     is_multinode_job,
     job_model_to_job_submission,
     stop_runner,
@@ -752,6 +751,18 @@ def run_model_to_run(
     return run
 
 
+def get_nodes_required_num_for_run(run_spec: RunSpec) -> int:
+    nodes_required_num = 1
+    if run_spec.configuration.type == "task":
+        nodes_required_num = run_spec.configuration.nodes
+    elif (
+        run_spec.configuration.type == "service"
+        and run_spec.configuration.replicas.min is not None
+    ):
+        nodes_required_num = run_spec.configuration.replicas.min
+    return nodes_required_num
+
+
 def _get_run_jobs_with_submissions(
     run_model: RunModel,
     job_submissions_limit: Optional[int],
@@ -1199,142 +1210,8 @@ async def process_terminating_run(session: AsyncSession, run_model: RunModel):
         )
 
 
-async def scale_run_replicas(session: AsyncSession, run_model: RunModel, replicas_diff: int):
-    if replicas_diff == 0:
-        # nothing to do
-        return
-
-    logger.info(
-        "%s: scaling %s %s replica(s)",
-        fmt(run_model),
-        "UP" if replicas_diff > 0 else "DOWN",
-        abs(replicas_diff),
-    )
-
-    # lists of (importance, is_out_of_date, replica_num, jobs)
-    active_replicas = []
-    inactive_replicas = []
-
-    for replica_num, replica_jobs in group_jobs_by_replica_latest(run_model.jobs):
-        statuses = set(job.status for job in replica_jobs)
-        deployment_num = replica_jobs[0].deployment_num  # same for all jobs
-        is_out_of_date = deployment_num < run_model.deployment_num
-        if {JobStatus.TERMINATING, *JobStatus.finished_statuses()} & statuses:
-            # if there are any terminating or finished jobs, the replica is inactive
-            inactive_replicas.append((0, is_out_of_date, replica_num, replica_jobs))
-        elif JobStatus.SUBMITTED in statuses:
-            # if there are any submitted jobs, the replica is active and has the importance of 0
-            active_replicas.append((0, is_out_of_date, replica_num, replica_jobs))
-        elif {JobStatus.PROVISIONING, JobStatus.PULLING} & statuses:
-            # if there are any provisioning or pulling jobs, the replica is active and has the importance of 1
-            active_replicas.append((1, is_out_of_date, replica_num, replica_jobs))
-        elif not is_replica_registered(replica_jobs):
-            # all jobs are running, but not receiving traffic, the replica is active and has the importance of 2
-            active_replicas.append((2, is_out_of_date, replica_num, replica_jobs))
-        else:
-            # all jobs are running and ready, the replica is active and has the importance of 3
-            active_replicas.append((3, is_out_of_date, replica_num, replica_jobs))
-
-    # sort by is_out_of_date (up-to-date first), importance (desc), and replica_num (asc)
-    active_replicas.sort(key=lambda r: (r[1], -r[0], r[2]))
-    run_spec = RunSpec.__response__.parse_raw(run_model.run_spec)
-
-    if replicas_diff < 0:
-        for _, _, _, replica_jobs in reversed(active_replicas[-abs(replicas_diff) :]):
-            # scale down the less important replicas first
-            for job in replica_jobs:
-                if job.status.is_finished() or job.status == JobStatus.TERMINATING:
-                    continue
-                job.status = JobStatus.TERMINATING
-                job.termination_reason = JobTerminationReason.SCALED_DOWN
-                # background task will process the job later
-    else:
-        scheduled_replicas = 0
-
-        # rerun inactive replicas
-        for _, _, _, replica_jobs in inactive_replicas:
-            if scheduled_replicas == replicas_diff:
-                break
-            await retry_run_replica_jobs(session, run_model, replica_jobs, only_failed=False)
-            scheduled_replicas += 1
-
-        secrets = await get_project_secrets_mapping(
-            session=session,
-            project=run_model.project,
-        )
-
-        for replica_num in range(
-            len(active_replicas) + scheduled_replicas, len(active_replicas) + replicas_diff
-        ):
-            # FIXME: Handle getting image configuration errors or skip it.
-            jobs = await get_jobs_from_run_spec(
-                run_spec=run_spec,
-                secrets=secrets,
-                replica_num=replica_num,
-            )
-            for job in jobs:
-                job_model = create_job_model_for_new_submission(
-                    run_model=run_model,
-                    job=job,
-                    status=JobStatus.SUBMITTED,
-                )
-                session.add(job_model)
-
-
-async def retry_run_replica_jobs(
-    session: AsyncSession, run_model: RunModel, latest_jobs: List[JobModel], *, only_failed: bool
-):
-    # FIXME: Handle getting image configuration errors or skip it.
-    secrets = await get_project_secrets_mapping(
-        session=session,
-        project=run_model.project,
-    )
-    new_jobs = await get_jobs_from_run_spec(
-        run_spec=RunSpec.__response__.parse_raw(run_model.run_spec),
-        secrets=secrets,
-        replica_num=latest_jobs[0].replica_num,
-    )
-    assert len(new_jobs) == len(latest_jobs), (
-        "Changing the number of jobs within a replica is not yet supported"
-    )
-    for job_model, new_job in zip(latest_jobs, new_jobs):
-        if not (job_model.status.is_finished() or job_model.status == JobStatus.TERMINATING):
-            if only_failed:
-                # No need to resubmit, skip
-                continue
-            # The job is not finished, but we have to retry all jobs. Terminate it
-            job_model.status = JobStatus.TERMINATING
-            job_model.termination_reason = JobTerminationReason.TERMINATED_BY_SERVER
-
-        new_job_model = create_job_model_for_new_submission(
-            run_model=run_model,
-            job=new_job,
-            status=JobStatus.SUBMITTED,
-        )
-        # dirty hack to avoid passing all job submissions
-        new_job_model.submission_num = job_model.submission_num + 1
-        session.add(new_job_model)
-
-
 def is_job_ready(probes: Iterable[ProbeModel], probe_specs: Iterable[ProbeSpec]) -> bool:
     return all(is_probe_ready(probe, probe_spec) for probe, probe_spec in zip(probes, probe_specs))
-
-
-def is_replica_registered(jobs: list[JobModel]) -> bool:
-    # Only job_num=0 is supposed to receive service requests
-    return jobs[0].registered
-
-
-def get_nodes_required_num_for_run(run_spec: RunSpec) -> int:
-    nodes_required_num = 1
-    if run_spec.configuration.type == "task":
-        nodes_required_num = run_spec.configuration.nodes
-    elif (
-        run_spec.configuration.type == "service"
-        and run_spec.configuration.replicas.min is not None
-    ):
-        nodes_required_num = run_spec.configuration.replicas.min
-    return nodes_required_num
 
 
 def _remove_job_spec_sensitive_info(spec: JobSpec):

--- a/src/dstack/_internal/server/services/runs/plan.py
+++ b/src/dstack/_internal/server/services/runs/plan.py
@@ -1,0 +1,265 @@
+import math
+from typing import List, Optional
+
+from dstack._internal.core.backends.base.backend import Backend
+from dstack._internal.core.models.fleets import Fleet, InstanceGroupPlacement
+from dstack._internal.core.models.instances import InstanceOfferWithAvailability, InstanceStatus
+from dstack._internal.core.models.profiles import Profile
+from dstack._internal.core.models.runs import Job, JobProvisioningData, Requirements, RunSpec
+from dstack._internal.core.models.volumes import Volume
+from dstack._internal.server.models import FleetModel, InstanceModel, ProjectModel, RunModel
+from dstack._internal.server.services.fleets import (
+    check_can_create_new_cloud_instance_in_fleet,
+    fleet_model_to_fleet,
+    get_fleet_master_instance_provisioning_data,
+    get_fleet_requirements,
+)
+from dstack._internal.server.services.instances import (
+    filter_pool_instances,
+    get_instance_offer,
+    get_shared_pool_instances_with_offers,
+)
+from dstack._internal.server.services.jobs import is_multinode_job
+from dstack._internal.server.services.offers import get_offers_by_requirements
+from dstack._internal.server.services.requirements.combine import (
+    combine_fleet_and_run_profiles,
+    combine_fleet_and_run_requirements,
+)
+from dstack._internal.server.services.runs.spec import (
+    check_run_spec_requires_instance_mounts,
+    get_nodes_required_num,
+)
+from dstack._internal.settings import FeatureFlags
+from dstack._internal.utils import common as common_utils
+from dstack._internal.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+async def find_optimal_fleet_with_offers(
+    project: ProjectModel,
+    fleet_models: list[FleetModel],
+    run_model: Optional[RunModel],
+    run_spec: RunSpec,
+    job: Job,
+    master_job_provisioning_data: Optional[JobProvisioningData],
+    volumes: Optional[list[list[Volume]]],
+) -> tuple[
+    Optional[FleetModel],
+    list[tuple[InstanceModel, InstanceOfferWithAvailability]],
+    list[tuple[Backend, InstanceOfferWithAvailability]],
+]:
+    """
+    Finds the optimal fleet for the run among the given fleet models and returns
+    the fleet model, pool offers with instances, and backend offers.
+    Returns empty backend offers if run_model.fleet is set since
+    backend offer from this function are needed only for run plan.
+    """
+    if run_model is not None and run_model.fleet is not None:
+        # Using the fleet that was already chosen by the master job
+        fleet_instance_offers = _get_run_fleet_instance_offers(
+            fleet_model=run_model.fleet,
+            run_spec=run_spec,
+            job=job,
+            master_job_provisioning_data=master_job_provisioning_data,
+            volumes=volumes,
+        )
+        return run_model.fleet, fleet_instance_offers, []
+
+    nodes_required_num = get_nodes_required_num(run_spec)
+    # The current strategy is first to consider fleets that can accommodate
+    # the run without additional provisioning and choose the one with the cheapest pool offer.
+    # Then choose a fleet with the cheapest pool offer among all fleets with pool offers.
+    # If there are no fleets with pool offers, choose a fleet with a cheapest backend offer.
+    # Fallback to autocreated fleet if fleets have no pool or backend offers.
+    # TODO: Consider trying all backend offers and then choosing a fleet.
+    candidate_fleets_with_offers: list[
+        tuple[
+            Optional[FleetModel],
+            list[tuple[InstanceModel, InstanceOfferWithAvailability]],
+            list[tuple[Backend, InstanceOfferWithAvailability]],
+            int,
+            int,
+            tuple[int, float, float],
+        ]
+    ] = []
+    for candidate_fleet_model in fleet_models:
+        candidate_fleet = fleet_model_to_fleet(candidate_fleet_model)
+        if (
+            is_multinode_job(job)
+            and candidate_fleet.spec.configuration.placement != InstanceGroupPlacement.CLUSTER
+        ):
+            # Limit multinode runs to cluster fleets to guarantee best connectivity.
+            continue
+
+        fleet_instance_offers = _get_run_fleet_instance_offers(
+            fleet_model=candidate_fleet_model,
+            run_spec=run_spec,
+            job=job,
+            # No need to pass master_job_provisioning_data for master job
+            # as all pool offers are suitable.
+            master_job_provisioning_data=None,
+            volumes=volumes,
+        )
+        fleet_has_pool_capacity = nodes_required_num <= len(fleet_instance_offers)
+        fleet_cheapest_instance_offer = math.inf
+        if len(fleet_instance_offers) > 0:
+            fleet_cheapest_instance_offer = fleet_instance_offers[0][1].price
+
+        try:
+            check_can_create_new_cloud_instance_in_fleet(candidate_fleet)
+            profile, requirements = get_run_profile_and_requirements_in_fleet(
+                job=job,
+                run_spec=run_spec,
+                fleet=candidate_fleet,
+            )
+        except ValueError:
+            fleet_backend_offers = []
+        else:
+            # Master job offers must be in the same cluster as existing instances.
+            master_instance_provisioning_data = get_fleet_master_instance_provisioning_data(
+                fleet_model=candidate_fleet_model,
+                fleet_spec=candidate_fleet.spec,
+            )
+            # Handle multinode for old jobs that don't have requirements.multinode set.
+            # TODO: Drop multinode param.
+            multinode = requirements.multinode or is_multinode_job(job)
+            fleet_backend_offers = await get_offers_by_requirements(
+                project=project,
+                profile=profile,
+                requirements=requirements,
+                exclude_not_available=True,
+                multinode=multinode,
+                master_job_provisioning_data=master_instance_provisioning_data,
+                volumes=volumes,
+                privileged=job.job_spec.privileged,
+                instance_mounts=check_run_spec_requires_instance_mounts(run_spec),
+            )
+
+        fleet_cheapest_backend_offer = math.inf
+        if len(fleet_backend_offers) > 0:
+            fleet_cheapest_backend_offer = fleet_backend_offers[0][1].price
+
+        if not _run_can_fit_into_fleet(run_spec, candidate_fleet):
+            logger.debug("Skipping fleet %s from consideration: run cannot fit into fleet")
+            continue
+
+        fleet_priority = (
+            not fleet_has_pool_capacity,
+            fleet_cheapest_instance_offer,
+            fleet_cheapest_backend_offer,
+        )
+        candidate_fleets_with_offers.append(
+            (
+                candidate_fleet_model,
+                fleet_instance_offers,
+                fleet_backend_offers,
+                len(fleet_instance_offers),
+                len(fleet_backend_offers),
+                fleet_priority,
+            )
+        )
+    if len(candidate_fleets_with_offers) == 0:
+        return None, [], []
+    if (
+        not FeatureFlags.AUTOCREATED_FLEETS_DISABLED
+        and run_spec.merged_profile.fleets is None
+        and all(t[3] == 0 and t[4] == 0 for t in candidate_fleets_with_offers)
+    ):
+        # If fleets are not specified and no fleets have available pool
+        # or backend offers, create a new fleet.
+        # This is for compatibility with non-fleet-first UX when runs created new fleets
+        # if there are no instances to reuse.
+        return None, [], []
+    candidate_fleets_with_offers.sort(key=lambda t: t[-1])
+    return candidate_fleets_with_offers[0][:3]
+
+
+def get_run_profile_and_requirements_in_fleet(
+    job: Job,
+    run_spec: RunSpec,
+    fleet: Fleet,
+) -> tuple[Profile, Requirements]:
+    profile = combine_fleet_and_run_profiles(fleet.spec.merged_profile, run_spec.merged_profile)
+    if profile is None:
+        raise ValueError("Cannot combine fleet profile")
+    fleet_requirements = get_fleet_requirements(fleet.spec)
+    requirements = combine_fleet_and_run_requirements(
+        fleet_requirements, job.job_spec.requirements
+    )
+    if requirements is None:
+        raise ValueError("Cannot combine fleet requirements")
+    return profile, requirements
+
+
+def _get_run_fleet_instance_offers(
+    fleet_model: FleetModel,
+    run_spec: RunSpec,
+    job: Job,
+    master_job_provisioning_data: Optional[JobProvisioningData] = None,
+    volumes: Optional[List[List[Volume]]] = None,
+) -> list[tuple[InstanceModel, InstanceOfferWithAvailability]]:
+    pool_instances = fleet_model.instances
+    instances_with_offers: list[tuple[InstanceModel, InstanceOfferWithAvailability]]
+    profile = run_spec.merged_profile
+    multinode = is_multinode_job(job)
+    nonshared_instances = filter_pool_instances(
+        pool_instances=pool_instances,
+        profile=profile,
+        requirements=job.job_spec.requirements,
+        status=InstanceStatus.IDLE,
+        fleet_model=fleet_model,
+        multinode=multinode,
+        master_job_provisioning_data=master_job_provisioning_data,
+        volumes=volumes,
+        shared=False,
+    )
+    instances_with_offers = [
+        (instance, common_utils.get_or_error(get_instance_offer(instance)))
+        for instance in nonshared_instances
+    ]
+    shared_instances_with_offers = get_shared_pool_instances_with_offers(
+        pool_instances=pool_instances,
+        profile=profile,
+        requirements=job.job_spec.requirements,
+        idle_only=True,
+        fleet_model=fleet_model,
+        multinode=multinode,
+        volumes=volumes,
+    )
+    instances_with_offers.extend(shared_instances_with_offers)
+    instances_with_offers.sort(key=lambda instance_with_offer: instance_with_offer[0].price or 0)
+    return instances_with_offers
+
+
+def _run_can_fit_into_fleet(run_spec: RunSpec, fleet: Fleet) -> bool:
+    """
+    Returns `False` if the run cannot fit into fleet for sure.
+    This is helpful heuristic to avoid even considering fleets too small for a run.
+    A run may not fit even if this function returns `True`.
+    This will lead to some jobs failing due to exceeding `nodes.max`
+    or more than `nodes.max` instances being provisioned
+    and eventually removed by the fleet consolidation logic.
+    """
+    # No check for cloud fleets with blocks > 1 since we don't know
+    # how many jobs such fleets can accommodate.
+    nodes_required_num = get_nodes_required_num(run_spec)
+    if (
+        fleet.spec.configuration.nodes is not None
+        and fleet.spec.configuration.blocks == 1
+        and fleet.spec.configuration.nodes.max is not None
+    ):
+        busy_instances = [i for i in fleet.instances if i.busy_blocks > 0]
+        fleet_available_capacity = fleet.spec.configuration.nodes.max - len(busy_instances)
+        if fleet_available_capacity < nodes_required_num:
+            return False
+    elif fleet.spec.configuration.ssh_config is not None:
+        # Currently assume that each idle block can run a job.
+        # TODO: Take resources / eligible offers into account.
+        total_idle_blocks = 0
+        for instance in fleet.instances:
+            total_blocks = instance.total_blocks or 1
+            total_idle_blocks += total_blocks - instance.busy_blocks
+        if total_idle_blocks < nodes_required_num:
+            return False
+    return True

--- a/src/dstack/_internal/server/services/runs/replicas.py
+++ b/src/dstack/_internal/server/services/runs/replicas.py
@@ -1,0 +1,135 @@
+from typing import List
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dstack._internal.core.models.runs import JobStatus, JobTerminationReason, RunSpec
+from dstack._internal.server.models import JobModel, RunModel
+from dstack._internal.server.services.jobs import (
+    get_jobs_from_run_spec,
+    group_jobs_by_replica_latest,
+)
+from dstack._internal.server.services.logging import fmt
+from dstack._internal.server.services.runs import create_job_model_for_new_submission, logger
+from dstack._internal.server.services.secrets import get_project_secrets_mapping
+
+
+async def retry_run_replica_jobs(
+    session: AsyncSession, run_model: RunModel, latest_jobs: List[JobModel], *, only_failed: bool
+):
+    # FIXME: Handle getting image configuration errors or skip it.
+    secrets = await get_project_secrets_mapping(
+        session=session,
+        project=run_model.project,
+    )
+    new_jobs = await get_jobs_from_run_spec(
+        run_spec=RunSpec.__response__.parse_raw(run_model.run_spec),
+        secrets=secrets,
+        replica_num=latest_jobs[0].replica_num,
+    )
+    assert len(new_jobs) == len(latest_jobs), (
+        "Changing the number of jobs within a replica is not yet supported"
+    )
+    for job_model, new_job in zip(latest_jobs, new_jobs):
+        if not (job_model.status.is_finished() or job_model.status == JobStatus.TERMINATING):
+            if only_failed:
+                # No need to resubmit, skip
+                continue
+            # The job is not finished, but we have to retry all jobs. Terminate it
+            job_model.status = JobStatus.TERMINATING
+            job_model.termination_reason = JobTerminationReason.TERMINATED_BY_SERVER
+
+        new_job_model = create_job_model_for_new_submission(
+            run_model=run_model,
+            job=new_job,
+            status=JobStatus.SUBMITTED,
+        )
+        # dirty hack to avoid passing all job submissions
+        new_job_model.submission_num = job_model.submission_num + 1
+        session.add(new_job_model)
+
+
+def is_replica_registered(jobs: list[JobModel]) -> bool:
+    # Only job_num=0 is supposed to receive service requests
+    return jobs[0].registered
+
+
+async def scale_run_replicas(session: AsyncSession, run_model: RunModel, replicas_diff: int):
+    if replicas_diff == 0:
+        # nothing to do
+        return
+
+    logger.info(
+        "%s: scaling %s %s replica(s)",
+        fmt(run_model),
+        "UP" if replicas_diff > 0 else "DOWN",
+        abs(replicas_diff),
+    )
+
+    # lists of (importance, is_out_of_date, replica_num, jobs)
+    active_replicas = []
+    inactive_replicas = []
+
+    for replica_num, replica_jobs in group_jobs_by_replica_latest(run_model.jobs):
+        statuses = set(job.status for job in replica_jobs)
+        deployment_num = replica_jobs[0].deployment_num  # same for all jobs
+        is_out_of_date = deployment_num < run_model.deployment_num
+        if {JobStatus.TERMINATING, *JobStatus.finished_statuses()} & statuses:
+            # if there are any terminating or finished jobs, the replica is inactive
+            inactive_replicas.append((0, is_out_of_date, replica_num, replica_jobs))
+        elif JobStatus.SUBMITTED in statuses:
+            # if there are any submitted jobs, the replica is active and has the importance of 0
+            active_replicas.append((0, is_out_of_date, replica_num, replica_jobs))
+        elif {JobStatus.PROVISIONING, JobStatus.PULLING} & statuses:
+            # if there are any provisioning or pulling jobs, the replica is active and has the importance of 1
+            active_replicas.append((1, is_out_of_date, replica_num, replica_jobs))
+        elif not is_replica_registered(replica_jobs):
+            # all jobs are running, but not receiving traffic, the replica is active and has the importance of 2
+            active_replicas.append((2, is_out_of_date, replica_num, replica_jobs))
+        else:
+            # all jobs are running and ready, the replica is active and has the importance of 3
+            active_replicas.append((3, is_out_of_date, replica_num, replica_jobs))
+
+    # sort by is_out_of_date (up-to-date first), importance (desc), and replica_num (asc)
+    active_replicas.sort(key=lambda r: (r[1], -r[0], r[2]))
+    run_spec = RunSpec.__response__.parse_raw(run_model.run_spec)
+
+    if replicas_diff < 0:
+        for _, _, _, replica_jobs in reversed(active_replicas[-abs(replicas_diff) :]):
+            # scale down the less important replicas first
+            for job in replica_jobs:
+                if job.status.is_finished() or job.status == JobStatus.TERMINATING:
+                    continue
+                job.status = JobStatus.TERMINATING
+                job.termination_reason = JobTerminationReason.SCALED_DOWN
+                # background task will process the job later
+    else:
+        scheduled_replicas = 0
+
+        # rerun inactive replicas
+        for _, _, _, replica_jobs in inactive_replicas:
+            if scheduled_replicas == replicas_diff:
+                break
+            await retry_run_replica_jobs(session, run_model, replica_jobs, only_failed=False)
+            scheduled_replicas += 1
+
+        secrets = await get_project_secrets_mapping(
+            session=session,
+            project=run_model.project,
+        )
+
+        for replica_num in range(
+            len(active_replicas) + scheduled_replicas, len(active_replicas) + replicas_diff
+        ):
+            # FIXME: Handle getting image configuration errors or skip it.
+            jobs = await get_jobs_from_run_spec(
+                run_spec=run_spec,
+                secrets=secrets,
+                replica_num=replica_num,
+            )
+            for job in jobs:
+                job_model = create_job_model_for_new_submission(
+                    run_model=run_model,
+                    job=job,
+                    status=JobStatus.SUBMITTED,
+                )
+                session.add(job_model)

--- a/src/dstack/_internal/server/services/runs/spec.py
+++ b/src/dstack/_internal/server/services/runs/spec.py
@@ -1,0 +1,177 @@
+from dstack._internal.core.errors import ServerClientError
+from dstack._internal.core.models.configurations import RUN_PRIORITY_DEFAULT, ServiceConfiguration
+from dstack._internal.core.models.repos.virtual import DEFAULT_VIRTUAL_REPO_ID, VirtualRunRepoData
+from dstack._internal.core.models.runs import LEGACY_REPO_DIR, AnyRunConfiguration, RunSpec
+from dstack._internal.core.models.volumes import InstanceMountPoint
+from dstack._internal.core.services import validate_dstack_resource_name
+from dstack._internal.core.services.diff import diff_models
+from dstack._internal.server import settings
+from dstack._internal.server.models import UserModel
+from dstack._internal.server.services.docker import is_valid_docker_volume_target
+from dstack._internal.server.services.resources import set_resources_defaults
+from dstack._internal.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+_UPDATABLE_SPEC_FIELDS = ["configuration_path", "configuration"]
+_TYPE_SPECIFIC_UPDATABLE_SPEC_FIELDS = {
+    "service": [
+        # rolling deployment
+        "repo_data",
+        "repo_code_hash",
+        "file_archives",
+        "working_dir",
+    ],
+}
+_CONF_UPDATABLE_FIELDS = ["priority"]
+_TYPE_SPECIFIC_CONF_UPDATABLE_FIELDS = {
+    "dev-environment": ["inactivity_duration"],
+    "service": [
+        # in-place
+        "replicas",
+        "scaling",
+        # rolling deployment
+        # NOTE: keep this list in sync with the "Rolling deployment" section in services.md
+        "port",
+        "probes",
+        "resources",
+        "volumes",
+        "docker",
+        "files",
+        "image",
+        "user",
+        "privileged",
+        "entrypoint",
+        "working_dir",
+        "python",
+        "nvcc",
+        "single_branch",
+        "env",
+        "shell",
+        "commands",
+    ],
+}
+
+
+def validate_run_spec_and_set_defaults(
+    user: UserModel, run_spec: RunSpec, legacy_default_working_dir: bool = False
+):
+    # This function may set defaults for null run_spec values,
+    # although most defaults are resolved when building job_spec
+    # so that we can keep both the original user-supplied value (null in run_spec)
+    # and the default in job_spec.
+    # If a property is stored in job_spec - resolve the default there.
+    # Server defaults are preferable over client defaults so that
+    # the defaults depend on the server version, not the client version.
+    if run_spec.run_name is not None:
+        validate_dstack_resource_name(run_spec.run_name)
+    for mount_point in run_spec.configuration.volumes:
+        if not is_valid_docker_volume_target(mount_point.path):
+            raise ServerClientError(f"Invalid volume mount path: {mount_point.path}")
+    if run_spec.repo_id is None and run_spec.repo_data is not None:
+        raise ServerClientError("repo_data must not be set if repo_id is not set")
+    if run_spec.repo_id is not None and run_spec.repo_data is None:
+        raise ServerClientError("repo_id must not be set if repo_data is not set")
+    # Some run_spec parameters have to be set here and not in the model defaults since
+    # the client may not pass them or pass null, but they must be always present, e.g. for runner.
+    if run_spec.repo_id is None:
+        run_spec.repo_id = DEFAULT_VIRTUAL_REPO_ID
+    if run_spec.repo_data is None:
+        run_spec.repo_data = VirtualRunRepoData()
+    if (
+        run_spec.merged_profile.utilization_policy is not None
+        and run_spec.merged_profile.utilization_policy.time_window
+        > settings.SERVER_METRICS_RUNNING_TTL_SECONDS
+    ):
+        raise ServerClientError(
+            f"Maximum utilization_policy.time_window is {settings.SERVER_METRICS_RUNNING_TTL_SECONDS}s"
+        )
+    if isinstance(run_spec.configuration, ServiceConfiguration):
+        if run_spec.merged_profile.schedule and run_spec.configuration.replicas.min == 0:
+            raise ServerClientError(
+                "Scheduled services with autoscaling to zero are not supported"
+            )
+        if len(run_spec.configuration.probes) > settings.MAX_PROBES_PER_JOB:
+            raise ServerClientError(
+                f"Cannot configure more than {settings.MAX_PROBES_PER_JOB} probes"
+            )
+        if any(
+            p.timeout is not None and p.timeout > settings.MAX_PROBE_TIMEOUT
+            for p in run_spec.configuration.probes
+        ):
+            raise ServerClientError(
+                f"Probe timeout cannot be longer than {settings.MAX_PROBE_TIMEOUT}s"
+            )
+    if run_spec.configuration.priority is None:
+        run_spec.configuration.priority = RUN_PRIORITY_DEFAULT
+    set_resources_defaults(run_spec.configuration.resources)
+    if run_spec.ssh_key_pub is None:
+        if user.ssh_public_key:
+            run_spec.ssh_key_pub = user.ssh_public_key
+        else:
+            raise ServerClientError("ssh_key_pub must be set if the user has no ssh_public_key")
+    if run_spec.configuration.working_dir is None and legacy_default_working_dir:
+        run_spec.configuration.working_dir = LEGACY_REPO_DIR
+
+
+def check_can_update_run_spec(current_run_spec: RunSpec, new_run_spec: RunSpec):
+    spec_diff = diff_models(current_run_spec, new_run_spec)
+    changed_spec_fields = list(spec_diff.keys())
+    updatable_spec_fields = _UPDATABLE_SPEC_FIELDS + _TYPE_SPECIFIC_UPDATABLE_SPEC_FIELDS.get(
+        new_run_spec.configuration.type, []
+    )
+    for key in changed_spec_fields:
+        if key not in updatable_spec_fields:
+            raise ServerClientError(
+                f"Failed to update fields {changed_spec_fields}."
+                f" Can only update {updatable_spec_fields}."
+            )
+    _check_can_update_configuration(current_run_spec.configuration, new_run_spec.configuration)
+
+
+def can_update_run_spec(current_run_spec: RunSpec, new_run_spec: RunSpec) -> bool:
+    try:
+        check_can_update_run_spec(current_run_spec, new_run_spec)
+    except ServerClientError as e:
+        logger.debug("Run cannot be updated: %s", repr(e))
+        return False
+    return True
+
+
+def get_nodes_required_num(run_spec: RunSpec) -> int:
+    nodes_required_num = 1
+    if run_spec.configuration.type == "task":
+        nodes_required_num = run_spec.configuration.nodes
+    elif (
+        run_spec.configuration.type == "service"
+        and run_spec.configuration.replicas.min is not None
+    ):
+        nodes_required_num = run_spec.configuration.replicas.min
+    return nodes_required_num
+
+
+def check_run_spec_requires_instance_mounts(run_spec: RunSpec) -> bool:
+    return any(
+        isinstance(mp, InstanceMountPoint) and not mp.optional
+        for mp in run_spec.configuration.volumes
+    )
+
+
+def _check_can_update_configuration(
+    current: AnyRunConfiguration, new: AnyRunConfiguration
+) -> None:
+    if current.type != new.type:
+        raise ServerClientError(
+            f"Configuration type changed from {current.type} to {new.type}, cannot update"
+        )
+    updatable_fields = _CONF_UPDATABLE_FIELDS + _TYPE_SPECIFIC_CONF_UPDATABLE_FIELDS.get(
+        new.type, []
+    )
+    diff = diff_models(current, new)
+    changed_fields = list(diff.keys())
+    for key in changed_fields:
+        if key not in updatable_fields:
+            raise ServerClientError(
+                f"Failed to update fields {changed_fields}. Can only update {updatable_fields}"
+            )

--- a/src/tests/_internal/server/services/test_runs.py
+++ b/src/tests/_internal/server/services/test_runs.py
@@ -17,7 +17,7 @@ from dstack._internal.server.models import (
     RunModel,
 )
 from dstack._internal.server.services.jobs import check_can_attach_job_volumes
-from dstack._internal.server.services.runs import scale_run_replicas
+from dstack._internal.server.services.runs.replicas import scale_run_replicas
 from dstack._internal.server.testing.common import (
     create_job,
     create_project,


### PR DESCRIPTION
Closes #3294

The PR changes run plan logic to return offers wrt to an optimal fleet. Effectively, run plan offers are now the same as the offers used for provisioning + non-available (e.g. busy, no quota) offers. If there is no suitable fleet for the run, the run plan includes offers across all project backends (as before, to show offers for autocreated fleets flow). If `FeatureFlags.DSTACK_FF_AUTOCREATED_FLEETS_DISABLED` is set, then no suitable fleet for the run means no offers (future behavior).

There is an extensive refactoring so that the same `find_optimal_fleet_with_offers()` function is used for getting optimal fleet and its offers both for run plan and during provisioning. Also split services/runs.py into modules since it became too big.

`dstack offer` command works the same as before returning all offers irrespective of fleets. This case is handled separately when generating run plan offers.

**Performance**

Getting run plan now involves getting offers for every fleet (to select an optimal fleet), and the time of getting run plan now increases linearly with the number of suitable fleets when offers in cache. For example, with aws+gcp across all regions and 10 fleets, get offers becomes 15-20s from 1.5s-2s.

Peak memory also increases linearly with the number of suitable fleets. With aws+gcp across all regions and 10 fleets, it's ~1.3GB vs 0.5GB with one fleet / before.

A possible time/memory optimization is to limit the number of offers process by a backend so that backends do not need to modify thousands of offers for every fleet to set disk, availability zones, etc. A caveat is that there is post filtering that can filter out all/most of returned offers, and the offers left out by the limit may be needed then.