### PR TITLE
Fix SSHAttach.detach()

### DIFF
--- a/src/dstack/_internal/core/services/ssh/tunnel.py
+++ b/src/dstack/_internal/core/services/ssh/tunnel.py
@@ -174,11 +174,6 @@ class SSHTunnel:
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 timeout=SSH_TIMEOUT,
-                # We don't want the ssh process to receive SIGINT from the controlling terminal
-                # (e.g., when SSHTunnel is used via CLI->Python API's SSHAttach and the dstack CLI
-                # process is a foreground process group leader). Starting a new session ensures
-                # that we don't have the controlling terminal at all.
-                start_new_session=True,
             )
         except subprocess.TimeoutExpired as e:
             msg = f"SSH tunnel to {self.destination} did not open in {SSH_TIMEOUT} seconds"
@@ -209,6 +204,11 @@ class SSHTunnel:
         raise get_ssh_error(stderr)
 
     def close(self) -> None:
+        if not os.path.exists(self.control_sock_path):
+            logger.debug(
+                "Control socket does not exist, it seems that ssh process has already exited"
+            )
+            return
         proc = subprocess.run(
             self.close_command(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT
         )
@@ -220,6 +220,11 @@ class SSHTunnel:
             )
 
     async def aclose(self) -> None:
+        if not os.path.exists(self.control_sock_path):
+            logger.debug(
+                "Control socket does not exist, it seems that ssh process has already exited"
+            )
+            return
         proc = await asyncio.create_subprocess_exec(
             *self.close_command(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT
         )

--- a/src/dstack/_internal/core/services/ssh/tunnel.py
+++ b/src/dstack/_internal/core/services/ssh/tunnel.py
@@ -174,6 +174,11 @@ class SSHTunnel:
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 timeout=SSH_TIMEOUT,
+                # We don't want the ssh process to receive SIGINT from the controlling terminal
+                # (e.g., when SSHTunnel is used via CLI->Python API's SSHAttach and the dstack CLI
+                # process is a foreground process group leader). Starting a new session ensures
+                # that we don't have the controlling terminal at all.
+                start_new_session=True,
             )
         except subprocess.TimeoutExpired as e:
             msg = f"SSH tunnel to {self.destination} did not open in {SSH_TIMEOUT} seconds"


### PR DESCRIPTION
When error logging was added to SSHTunnel.close()[1], it was discovered that SSHAttach.detach() is called multiple times on detach. Although this is harmless as long as this method is idempotent (and it is), this patch ensures that detach() is no-op when called more than one time, removing ERROR level log noise.

As a side-effect, detaching SSHAttach that reuses SSHTunnel no longer kills "master" SSHAttach, meaning that one can `dstack attach` multiple times and detach independently (detaching from the "master" attach still kicks out all other attaches).

[1]: https://github.com/dstackai/dstack/pull/3296