### PR TITLE
Fix LEGACY_REPO_DIR_DISABLED feature flag

### DIFF
--- a/src/dstack/_internal/server/services/runs/spec.py
+++ b/src/dstack/_internal/server/services/runs/spec.py
@@ -114,7 +114,12 @@ def validate_run_spec_and_set_defaults(
             raise ServerClientError("ssh_key_pub must be set if the user has no ssh_public_key")
     if run_spec.configuration.working_dir is None and legacy_repo_dir:
         run_spec.configuration.working_dir = LEGACY_REPO_DIR
-    if run_spec.repo_dir is None and FeatureFlags.LEGACY_REPO_DIR_DISABLED and not legacy_repo_dir:
+    if (
+        run_spec.configuration.repos
+        and run_spec.repo_dir is None
+        and FeatureFlags.LEGACY_REPO_DIR_DISABLED
+        and not legacy_repo_dir
+    ):
         raise ServerClientError("Repo path is not set")
 
 


### PR DESCRIPTION
RunSpec.repo_dir = None is valid if there are no repos in the configuration