### PR TITLE
[Docs]: Fix TensorDock still present in reference

### DIFF
--- a/docs/docs/reference/server/config.yml.md
+++ b/docs/docs/reference/server/config.yml.md
@@ -195,7 +195,9 @@ to configure [backends](../../concepts/backends.md) and other [server-level sett
         type:
             required: true
 
-<!-- ##### `projects[n].backends[type=tensordock]` { #tensordock data-toc-label="tensordock" }
+<!--
+
+##### `projects[n].backends[type=tensordock]` { #tensordock data-toc-label="tensordock" }
 
 #SCHEMA# dstack._internal.core.backends.tensordock.models.TensorDockBackendConfigWithCreds
     overrides:
@@ -210,7 +212,9 @@ to configure [backends](../../concepts/backends.md) and other [server-level sett
     overrides:
         show_root_heading: false
         type:
-            required: true -->
+            required: true
+
+-->
 
 ##### `projects[n].backends[type=oci]` { #oci data-toc-label="oci" }
 


### PR DESCRIPTION
<img width="820" height="421" alt="image" src="https://github.com/user-attachments/assets/b16cc191-5bf9-4665-8cb8-df8fa78a9804" />
