### PR TITLE
Update alembic pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,7 @@ server = [
     "watchfiles",
     "sqlalchemy[asyncio]>=2.0.0",
     "sqlalchemy_utils>=0.40.0",
-    "alembic>=1.10.2",
+    "alembic>=1.16.0",
     "aiosqlite",
     "docker>=6.0.0",
     "python-dxf>=12.1.1",


### PR DESCRIPTION
alembic>=1.16.0 needed for alembic's [if_not_exis](https://alembic.sqlalchemy.org/en/latest/ops.html#alembic.operations.Operations.add_column.params.if_not_exists) used in #3330 