### PR TITLE
[chore]: Fix Alembic `path_separator` warning

### DIFF
--- a/src/dstack/_internal/server/alembic.ini
+++ b/src/dstack/_internal/server/alembic.ini
@@ -38,18 +38,14 @@ prepend_sys_path = .
 # version location specification; This defaults
 # to alembic/versions.  When using multiple version
 # directories, initial revisions must be specified with --version-path.
-# The path separator used here should be the separator specified by "version_path_separator" below.
+# The path separator used here should be the separator specified by "path_separator" below.
 # version_locations = %(here)s/bar:%(here)s/bat:alembic/versions
 
-# version path separator; As mentioned above, this is the character used to split
-# version_locations. The default within new alembic.ini files is "os", which uses os.pathsep.
-# If this key is omitted entirely, it falls back to the legacy behavior of splitting on spaces and/or commas.
-# Valid values for version_path_separator are:
+# path_separator; This indicates what character is used to split lists of file
+# paths, including version_locations and prepend_sys_path.
 #
-# version_path_separator = :
-# version_path_separator = ;
-# version_path_separator = space
-version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
+# Use os.pathsep. Default configuration used for new projects.
+path_separator = os
 
 # set to 'true' to search source files recursively
 # in each "version_locations" directory


### PR DESCRIPTION
Fixes this deprecation warning:

```
src/tests/_internal/server/test_migrations.py::test_sqlite_migrations
src/tests/_internal/server/test_migrations.py::test_sqlite_migrations
src/tests/_internal/server/test_migrations.py::test_sqlite_migrations
src/tests/_internal/server/test_migrations.py::test_postgres_migrations
src/tests/_internal/server/test_migrations.py::test_postgres_migrations
src/tests/_internal/server/test_migrations.py::test_postgres_migrations
  /home/runner/work/dstack/dstack/.venv/lib/python3.10/site-packages/alembic/config.py:598: DeprecationWarning: No path_separator found in configuration; falling back to legacy splitting on spaces, commas, and colons for prepend_sys_path.  Consider adding path_separator=os to Alembic config.
```

Context:
https://alembic.sqlalchemy.org/en/latest/changelog.html#change-1.16.0-usecase

Does not affect Alembic behavior for dstack.