### PR TITLE
Set WORKDIR in base Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,7 +67,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Build and upload to DockerHub
         run: |
-         if [ "${{ matrix.flavor }}" = "base" ]; then
+          if [ "${{ matrix.flavor }}" = "base" ]; then
             FILE="base/Dockerfile"
           elif [ "${{ matrix.flavor }}" = "devel" ]; then
             FILE="base/Dockerfile"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,6 +65,12 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+      - name: Free up some space
+        run: |
+          df -h /
+          du -hs /usr/share/dotnet
+          rm -rf /usr/share/dotnet
+          df -h /
       - name: Build and upload to DockerHub
         run: |
           if [ "${{ matrix.flavor }}" = "base" ]; then

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -77,3 +77,5 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && echo "${NCCL_HOME}/lib" >> /etc/ld.so.conf.d/nccl.conf \
     && ldconfig
+
+WORKDIR /dstack/run

--- a/docker/base/Dockerfile.common
+++ b/docker/base/Dockerfile.common
@@ -24,12 +24,21 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && dpkg-reconfigure --frontend noninteractive tzdata \
     && apt-get install -y bzip2 ca-certificates curl build-essential git libglib2.0-0 libsm6 libxext6 libxrender1 mercurial openssh-server subversion wget \
         libibverbs1 ibverbs-providers ibverbs-utils libibverbs-dev infiniband-diags \
-    && rm -rf /var/lib/apt/lists/* \
     && sed -i "s/.*PasswordAuthentication.*/PasswordAuthentication no/g" /etc/ssh/sshd_config \
     && mkdir /run/sshd \
     && mkdir ~/.ssh && chmod 700 ~/.ssh && touch ~/.ssh/authorized_keys \
     && chmod 600 ~/.ssh/authorized_keys \
-    && rm /etc/ssh/ssh_host_*
+    && rm /etc/ssh/ssh_host_* \
+    # User
+    && apt-get install -y sudo \
+    && groupadd -g 1000 dstack \
+    && useradd -u 1000 -g 1000 -G sudo -s /bin/bash -m dstack \
+    && echo 'dstack ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/dstack \
+    # Default working dir
+    && mkdir -p /dstack/run \
+    && chmod a+rwx /dstack/run \
+    # Cleanup
+    && rm -rf /var/lib/apt/lists/*
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | INSTALLER_NO_MODIFY_PATH=1 sh \
     && uv python install --preview --default

--- a/docker/base/efa/Dockerfile
+++ b/docker/base/efa/Dockerfile
@@ -74,3 +74,5 @@ RUN cd /opt \
         MPI_HOME=${OPEN_MPI_PATH} \
         CUDA_HOME=${CUDA_HOME} \
         NCCL_HOME=${NCCL_HOME}
+
+WORKDIR /dstack/run


### PR DESCRIPTION
Use /dstack/run (rwx for all) as a default working dir.

In addition, dstack:dstack user with passwordless sudo added, but not (yet) used as a default user.

Part-of: https://github.com/dstackai/dstack/issues/3124