### PR TITLE
[Internal] Packer: apt-upgrade.sh: autoaccept conffiles changes

### DIFF
--- a/scripts/packer/provisioners/kernel/apt-upgrade.sh
+++ b/scripts/packer/provisioners/kernel/apt-upgrade.sh
@@ -40,4 +40,9 @@ apt_update_with_retry() {
 }
 
 apt_update_with_retry
-sudo DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=60 dist-upgrade -y -q
+# See https://man7.org/linux/man-pages/man1/dpkg.1.html#OPTIONS for confold/confdef
+sudo DEBIAN_FRONTEND=noninteractive apt-get \
+    -o DPkg::Lock::Timeout=60 \
+    -o Dpkg::Options::=--force-confold \
+    -o Dpkg::Options::=--force-confdef \
+    dist-upgrade -y -q


### PR DESCRIPTION
Fixes such errors:

```
Configuration file '/etc/systemd/resolved.conf.d/gce-resolved.conf'
 ==> Modified (by you or by a script) since installation.
 ==> Package distributor has shipped an updated version.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** gce-resolved.conf (Y/I/N/O/D/Z) [default=N] ?

dpkg: error processing package google-compute-engine (--configure):
 end of file on stdin at conffile prompt
```