### PR TITLE
Restore `RunSpec.working_dir` field

### DIFF
--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -443,6 +443,9 @@ class RunSpec(generate_dual_core_model(RunSpecConfig)):
         list[FileArchiveMapping],
         Field(description="The list of file archive ID to container path mappings."),
     ] = []
+    # Server uses configuration.working_dir since 0.19.27 and ignores this field, but the field
+    # still exists for compatibility with old clients that send it.
+    working_dir: Optional[str] = None
     configuration_path: Annotated[
         Optional[str],
         Field(

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -232,6 +232,7 @@ def get_dev_env_run_plan_dict(
         "repo_dir": "~/repo",
         "run_name": run_name,
         "ssh_key_pub": "ssh_key",
+        "working_dir": None,
     }
     return {
         "project_name": project_name,
@@ -469,6 +470,7 @@ def get_dev_env_run_dict(
             "repo_dir": "~/repo",
             "run_name": run_name,
             "ssh_key_pub": "ssh_key",
+            "working_dir": None,
         },
         "jobs": [
             {
@@ -612,6 +614,7 @@ def get_service_run_spec(
         "repo_dir": "~/repo",
         "run_name": run_name,
         "ssh_key_pub": "ssh_key",
+        "working_dir": None,
     }
 
 


### PR DESCRIPTION
The field is not used by the server, but clients < 0.20 still send it

Fixes: https://github.com/dstackai/dstack/issues/3370