### PR TITLE
Run frontend-pre-commit only on frontend files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,4 @@ repos:
         entry: bash -c "cd frontend && npm install && npm run pre-commit"
         language: system
         pass_filenames: false
+        files: ^frontend/


### PR DESCRIPTION
The PR skips running frontend-pre-commit on non-frontend files so that each commit does not trigger npm install.