### PR TITLE
Add more events about users and projects

### DIFF
--- a/src/dstack/_internal/server/routers/runs.py
+++ b/src/dstack/_internal/server/routers/runs.py
@@ -118,7 +118,7 @@ async def get_plan(
     """
     user, project = user_project
     if not user.ssh_public_key and not body.run_spec.ssh_key_pub:
-        await users.refresh_ssh_key(session=session, user=user)
+        await users.refresh_ssh_key(session=session, actor=user)
     run_plan = await runs.get_plan(
         session=session,
         project=project,
@@ -148,7 +148,7 @@ async def apply_plan(
     """
     user, project = user_project
     if not user.ssh_public_key and not body.plan.run_spec.ssh_key_pub:
-        await users.refresh_ssh_key(session=session, user=user)
+        await users.refresh_ssh_key(session=session, actor=user)
     return CustomORJSONResponse(
         await runs.apply_plan(
             session=session,

--- a/src/dstack/_internal/server/routers/users.py
+++ b/src/dstack/_internal/server/routers/users.py
@@ -43,7 +43,7 @@ async def get_my_user(
 ):
     if user.ssh_private_key is None or user.ssh_public_key is None:
         # Generate keys for pre-0.19.33 users
-        await users.refresh_ssh_key(session=session, user=user)
+        await users.refresh_ssh_key(session=session, actor=user)
     return CustomORJSONResponse(users.user_model_to_user_with_creds(user))
 
 
@@ -86,6 +86,7 @@ async def update_user(
 ):
     res = await users.update_user(
         session=session,
+        actor=user,
         username=body.username,
         global_role=body.global_role,
         email=body.email,
@@ -102,7 +103,7 @@ async def refresh_ssh_key(
     session: AsyncSession = Depends(get_session),
     user: UserModel = Depends(Authenticated()),
 ):
-    res = await users.refresh_ssh_key(session=session, user=user, username=body.username)
+    res = await users.refresh_ssh_key(session=session, actor=user, username=body.username)
     if res is None:
         raise ResourceNotExistsError()
     return CustomORJSONResponse(users.user_model_to_user_with_creds(res))
@@ -114,7 +115,7 @@ async def refresh_token(
     session: AsyncSession = Depends(get_session),
     user: UserModel = Depends(Authenticated()),
 ):
-    res = await users.refresh_user_token(session=session, user=user, username=body.username)
+    res = await users.refresh_user_token(session=session, actor=user, username=body.username)
     if res is None:
         raise ResourceNotExistsError()
     return CustomORJSONResponse(users.user_model_to_user_with_creds(res))
@@ -128,6 +129,6 @@ async def delete_users(
 ):
     await users.delete_users(
         session=session,
-        user=user,
+        actor=user,
         usernames=body.users,
     )

--- a/src/tests/_internal/server/routers/test_projects.py
+++ b/src/tests/_internal/server/routers/test_projects.py
@@ -495,6 +495,16 @@ class TestDeleteProject:
         await session.refresh(project2)
         assert project1.deleted
         assert not project2.deleted
+        # Validate an event is emitted
+        response = await client.post(
+            "/api/events/list", headers=get_auth_headers(user.token), json={}
+        )
+        assert response.status_code == 200
+        assert len(response.json()) == 1
+        assert response.json()[0]["message"] == "Project deleted"
+        assert len(response.json()[0]["targets"]) == 1
+        assert response.json()[0]["targets"][0]["id"] == str(project1.id)
+        assert response.json()[0]["targets"][0]["name"] == project_name
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)


### PR DESCRIPTION
- User updated
- User token refreshed
- User SSH key refreshed
- User deleted
- Project updated
- Project deleted

Also refactor the implementation of the relevant
operations on users to enable more detailed event
messages and to avoid race conditions and longer
write transactions.

Part of #3290
Fixes #3383