### PR TITLE
Handle BackendAuthError when getting project backends

### DIFF
--- a/src/dstack/_internal/server/services/backends/__init__.py
+++ b/src/dstack/_internal/server/services/backends/__init__.py
@@ -23,6 +23,7 @@ from dstack._internal.core.backends.models import (
     AnyBackendConfigWithoutCreds,
 )
 from dstack._internal.core.errors import (
+    BackendAuthError,
     BackendError,
     BackendInvalidCredentialsError,
     BackendNotAvailable,
@@ -224,7 +225,7 @@ async def get_project_backends_with_models(project: ProjectModel) -> List[Backen
             try:
                 backend_record = get_stored_backend_record(backend_model)
                 backend = await run_async(configurator.get_backend, backend_record)
-            except BackendInvalidCredentialsError:
+            except (BackendInvalidCredentialsError, BackendAuthError):
                 logger.warning(
                     "Credentials for %s backend are invalid. Backend will be ignored.",
                     backend_model.type.value,


### PR DESCRIPTION
For some backends (e.g. Azure), `configurator.get_backend()` raises `BackendAuthError`, which wasn't handled previously. 