### PR TITLE
Relax event message validation rules

### DIFF
--- a/src/dstack/_internal/server/services/events.py
+++ b/src/dstack/_internal/server/services/events.py
@@ -171,14 +171,9 @@ def emit(session: AsyncSession, message: str, actor: AnyActor, targets: list[Tar
     """
     if not targets:
         raise ValueError("At least one target must be specified")
+    message = message.strip().rstrip(".").replace("\n", " ")
     if not message:
         raise ValueError("Message cannot be empty")
-    if message.strip() != message:
-        raise ValueError("Message cannot have leading or trailing whitespace")
-    if "\n" in message:
-        raise ValueError("Message cannot contain newlines")
-    if message.endswith("."):
-        raise ValueError("Message cannot end with a period")
 
     logger.info(
         "Emitting event: %s. Event targets: %s. Actor: %s",


### PR DESCRIPTION
Replace some message validation rules with
implicit message transformations. Some event
messages may include extracts from external
sources (e.g., external error messages), that do
not pass the validation rules. Such cases may be
difficult to find during development, and we do
not want them to break dstack in production.

Part of #3290