### PR TITLE
[Internal] Allow passing `AnyActor` to `update_user`

### DIFF
--- a/src/dstack/_internal/server/routers/users.py
+++ b/src/dstack/_internal/server/routers/users.py
@@ -15,7 +15,7 @@ from dstack._internal.server.schemas.users import (
     UpdateUserRequest,
 )
 from dstack._internal.server.security.permissions import Authenticated, GlobalAdmin
-from dstack._internal.server.services import users
+from dstack._internal.server.services import events, users
 from dstack._internal.server.utils.routers import (
     CustomORJSONResponse,
     get_base_api_additional_responses,
@@ -86,7 +86,7 @@ async def update_user(
 ):
     res = await users.update_user(
         session=session,
-        actor=user,
+        actor=events.UserActor.from_user(user),
         username=body.username,
         global_role=body.global_role,
         email=body.email,

--- a/src/dstack/_internal/server/services/users.py
+++ b/src/dstack/_internal/server/services/users.py
@@ -130,7 +130,7 @@ async def create_user(
 
 async def update_user(
     session: AsyncSession,
-    actor: UserModel,
+    actor: events.AnyActor,
     username: str,
     global_role: GlobalRole,
     email: Optional[str] = None,
@@ -152,7 +152,7 @@ async def update_user(
         events.emit(
             session,
             f"User updated. Updated fields: {', '.join(updated_fields) or '<none>'}",
-            actor=events.UserActor.from_user(actor),
+            actor=actor,
             targets=[events.Target.from_model(user)],
         )
         await session.commit()


### PR DESCRIPTION
Motivation:

- `update_user` can be invoked on behalf of the system
