### PR TITLE
Support `gateway: true` in service configurations

### DIFF
--- a/src/dstack/_internal/core/models/configurations.py
+++ b/src/dstack/_internal/core/models/configurations.py
@@ -725,7 +725,8 @@ class ServiceConfigurationParams(CoreModel):
         Field(
             description=(
                 "The name of the gateway. Specify boolean `false` to run without a gateway."
-                " Omit to run with the default gateway"
+                " Specify boolean `true` to run with the default gateway."
+                " Omit to run with the default gateway if there is one, or without a gateway otherwise"
             ),
         ),
     ] = None
@@ -793,16 +794,6 @@ class ServiceConfigurationParams(CoreModel):
             v.min = 0
         if v.min < 0:
             raise ValueError("The minimum number of replicas must be greater than or equal to 0")
-        return v
-
-    @validator("gateway")
-    def validate_gateway(
-        cls, v: Optional[Union[bool, str]]
-    ) -> Optional[Union[Literal[False], str]]:
-        if v == True:
-            raise ValueError(
-                "The `gateway` property must be a string or boolean `false`, not boolean `true`"
-            )
         return v
 
     @root_validator()

--- a/src/dstack/_internal/server/services/services/__init__.py
+++ b/src/dstack/_internal/server/services/services/__init__.py
@@ -55,6 +55,10 @@ async def register_service(session: AsyncSession, run_model: RunModel, run_spec:
         gateway = await get_project_default_gateway_model(
             session=session, project=run_model.project
         )
+        if gateway is None and run_spec.configuration.gateway == True:
+            raise ResourceNotExistsError(
+                "The service requires a gateway, but there is no default gateway in the project"
+            )
 
     if gateway is not None:
         service_spec = await _register_service_in_gateway(session, run_model, run_spec, gateway)


### PR DESCRIPTION
Allow setting `gateway: true` in service
configurations, which will enforce that the
service runs on the default gateway or is rejected
if one isn't available.

**Compatibility**: pre-0.20.1 clients will not be
able to list (`dstack ps`), get, or update
(`dstack apply`) services that were created by
0.20.1+ clients with the `gateway: true` property.

Closes #3412