### PR TITLE
Fix event target type rendering in server logs

### DIFF
--- a/src/dstack/_internal/server/services/events.py
+++ b/src/dstack/_internal/server/services/events.py
@@ -138,7 +138,7 @@ class Target:
         raise ValueError(f"Unsupported model type: {type(model)}")
 
     def fmt(self) -> str:
-        return fmt_entity(self.type, self.id, self.name)
+        return fmt_entity(self.type.value, self.id, self.name)
 
 
 def emit(session: AsyncSession, message: str, actor: AnyActor, targets: list[Target]) -> None:
@@ -389,7 +389,7 @@ async def list_events(
 def event_model_to_event(event_model: EventModel) -> Event:
     targets = [
         EventTarget(
-            type=target.entity_type,
+            type=target.entity_type.value,
             project_id=target.entity_project_id,
             project_name=target.entity_project.name if target.entity_project else None,
             id=target.entity_id,


### PR DESCRIPTION
Before:

```
Emitting event: Project deleted. Event targets: EventTargetType.PROJECT(65dce4)test
```

After:

```
Emitting event: Project deleted. Event targets: project(65dce4)test
```

The issue was only reproducible on [Python 3.11+](https://peps.python.org/pep-0663/)

Part of #3290