### PR TITLE
Allow users to delete their only project

### DIFF
--- a/src/dstack/_internal/server/services/projects.py
+++ b/src/dstack/_internal/server/services/projects.py
@@ -199,8 +199,6 @@ async def delete_projects(
         for project in projects_to_delete:
             if not _is_project_admin(user=user, project=project):
                 raise ForbiddenError()
-        if all(name in projects_names for name in user_project_names):
-            raise ServerClientError("Cannot delete the only project")
 
     res = await session.execute(
         select(ProjectModel)

--- a/src/tests/_internal/server/routers/test_projects.py
+++ b/src/tests/_internal/server/routers/test_projects.py
@@ -453,7 +453,7 @@ class TestDeleteProject:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
-    async def test_cannot_delete_the_only_project(
+    async def test_deletes_the_only_project(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
@@ -466,9 +466,9 @@ class TestDeleteProject:
             headers=get_auth_headers(user.token),
             json={"projects_names": [project.name]},
         )
-        assert response.status_code == 400
+        assert response.status_code == 200
         await session.refresh(project)
-        assert not project.deleted
+        assert project.deleted
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)


### PR DESCRIPTION
The restriction preventing users from deleting
their only project was originally introduced in #972
because the UI could not function correctly
without projects, which is no longer the case.