### PR TITLE
Indicate deleted actors and projects in Events API

### DIFF
--- a/src/dstack/_internal/core/models/events.py
+++ b/src/dstack/_internal/core/models/events.py
@@ -46,6 +46,15 @@ class EventTarget(CoreModel):
             )
         ),
     ]
+    is_project_deleted: Annotated[
+        Optional[bool],
+        Field(
+            description=(
+                "Whether the project the target entity belongs to is deleted,"
+                " or `null` for target types not bound to a project (e.g., users)"
+            )
+        ),
+    ] = None  # default for client compatibility with older servers that don't return this field
     id: Annotated[uuid.UUID, Field(description="ID of the target entity")]
     name: Annotated[str, Field(description="Name of the target entity")]
 
@@ -72,6 +81,15 @@ class Event(CoreModel):
             )
         ),
     ]
+    is_actor_user_deleted: Annotated[
+        Optional[bool],
+        Field(
+            description=(
+                "Whether the user who performed the action that triggered the event is deleted,"
+                " or `null` if the action was performed by the system"
+            )
+        ),
+    ] = None  # default for client compatibility with older servers that don't return this field
     targets: Annotated[
         list[EventTarget], Field(description="List of entities affected by the event")
     ]

--- a/src/dstack/_internal/core/models/events.py
+++ b/src/dstack/_internal/core/models/events.py
@@ -54,7 +54,7 @@ class EventTarget(CoreModel):
                 " or `null` for target types not bound to a project (e.g., users)"
             )
         ),
-    ] = None  # default for client compatibility with older servers that don't return this field
+    ] = None  # default for client compatibility with pre-0.20.1 servers
     id: Annotated[uuid.UUID, Field(description="ID of the target entity")]
     name: Annotated[str, Field(description="Name of the target entity")]
 
@@ -89,7 +89,7 @@ class Event(CoreModel):
                 " or `null` if the action was performed by the system"
             )
         ),
-    ] = None  # default for client compatibility with older servers that don't return this field
+    ] = None  # default for client compatibility with pre-0.20.1 servers
     targets: Annotated[
         list[EventTarget], Field(description="List of entities affected by the event")
     ]


### PR DESCRIPTION
In `/api/events/list`:

- Instead of `_deleted_*` placeholders, return original names of deleted projects and actors
- Add the `is_project_deleted` and `is_actor_user_deleted` properties to indicate deleted projects and actors

Part of #3420