### PR TITLE
Resolve url for dstack login

### DIFF
--- a/src/dstack/_internal/cli/utils/common.py
+++ b/src/dstack/_internal/cli/utils/common.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
+import requests
 from rich.console import Console
 from rich.prompt import Confirm
 from rich.table import Table
@@ -128,3 +129,20 @@ def get_start_time(since: Optional[str]) -> Optional[datetime]:
         return parse_since(since)
     except ValueError as e:
         raise CLIError(e.args[0])
+
+
+def resolve_url(url: str, timeout: float = 5.0) -> str:
+    """
+    Starts with http:// and follows redirects. Returns the final URL (including scheme).
+    """
+    if not url.startswith("http://") and not url.startswith("https://"):
+        url = "http://" + url
+    try:
+        response = requests.get(
+            url,
+            allow_redirects=True,
+            timeout=timeout,
+        )
+    except requests.exceptions.ConnectionError as e:
+        raise ValueError(f"Failed to resolve url {url}") from e
+    return response.url

--- a/src/tests/_internal/cli/commands/test_login.py
+++ b/src/tests/_internal/cli/commands/test_login.py
@@ -13,8 +13,12 @@ class TestLogin:
             patch("dstack._internal.cli.commands.login.webbrowser") as webbrowser_mock,
             patch("dstack._internal.cli.commands.login.APIClient") as APIClientMock,
             patch("dstack._internal.cli.commands.login._LoginServer") as LoginServerMock,
+            patch(
+                "dstack._internal.cli.commands.login._normalize_url_or_error"
+            ) as _normalize_url_or_error_mock,
         ):
             webbrowser_mock.open.return_value = True
+            _normalize_url_or_error_mock.return_value = "http://127.0.0.1:31313"
             APIClientMock.return_value.auth.list_providers.return_value = [
                 SimpleNamespace(name="github", enabled=True)
             ]
@@ -49,7 +53,11 @@ class TestLogin:
             patch("dstack._internal.cli.commands.login.APIClient") as APIClientMock,
             patch("dstack._internal.cli.commands.login.ConfigManager") as ConfigManagerMock,
             patch("dstack._internal.cli.commands.login._LoginServer") as LoginServerMock,
+            patch(
+                "dstack._internal.cli.commands.login._normalize_url_or_error"
+            ) as _normalize_url_or_error_mock,
         ):
+            _normalize_url_or_error_mock.return_value = "http://127.0.0.1:31313"
             webbrowser_mock.open.return_value = True
             APIClientMock.return_value.auth.list_providers.return_value = [
                 SimpleNamespace(name="github", enabled=True)


### PR DESCRIPTION
The PR fixes a problem with `dstack login` not working with server urls with https:// omitted:

```
✗ dstack login --url sky-stage.dstack.ai
Status code 404 when requesting https://sky-stage.dstack.ai:443/api/auth/list_providers
```

This was due to client defaulting to http:// and then 301 redirect from the server causing the client to retry POST request as GET. This is now changed so that the client first determines the scheme and then makes POST.