### PR TITLE
[runner] Streamline authorized_keys management

### DIFF
--- a/runner/cmd/shim/main.go
+++ b/runner/cmd/shim/main.go
@@ -148,12 +148,6 @@ func mainInner() int {
 				Sources:     cli.EnvVars("DSTACK_DOCKER_PRIVILEGED"),
 			},
 			&cli.StringFlag{
-				Name:        "ssh-key",
-				Usage:       "Public SSH key",
-				Destination: &args.Docker.ConcatinatedPublicSSHKeys,
-				Sources:     cli.EnvVars("DSTACK_PUBLIC_SSH_KEY"),
-			},
-			&cli.StringFlag{
 				Name:        "pjrt-device",
 				Usage:       "Set the PJRT_DEVICE environment variable (e.g., TPU, GPU)",
 				Destination: &args.Docker.PJRTDevice,

--- a/runner/internal/executor/executor_test.go
+++ b/runner/internal/executor/executor_test.go
@@ -208,7 +208,7 @@ func makeTestExecutor(t *testing.T) *RunExecutor {
 	_ = os.Mkdir(temp, 0o700)
 	home := filepath.Join(baseDir, "home")
 	_ = os.Mkdir(home, 0o700)
-	ex, _ := NewRunExecutor(temp, home, 10022)
+	ex, _ := NewRunExecutor(temp, home, new(sshdMock))
 	ex.SetJob(body)
 	ex.SetCodePath(filepath.Join(baseDir, "code")) // note: create file before run
 	ex.setJobWorkingDir(context.Background())
@@ -339,6 +339,24 @@ func TestExecutor_LogsAnsiCodeHandling(t *testing.T) {
 	for i := 1; i < len(wsLogHistory); i++ {
 		assert.GreaterOrEqual(t, wsLogHistory[i].Timestamp, wsLogHistory[i-1].Timestamp)
 	}
+}
+
+type sshdMock struct{}
+
+func (d *sshdMock) Port() int {
+	return 0
+}
+
+func (d *sshdMock) Start(context.Context) error {
+	return nil
+}
+
+func (d *sshdMock) Stop(context.Context) error {
+	return nil
+}
+
+func (d *sshdMock) AddAuthorizedKeys(context.Context, ...string) error {
+	return nil
 }
 
 func combineLogMessages(logHistory []schemas.LogEvent) string {

--- a/runner/internal/runner/api/server.go
+++ b/runner/internal/runner/api/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dstackai/dstack/runner/internal/executor"
 	"github.com/dstackai/dstack/runner/internal/log"
 	"github.com/dstackai/dstack/runner/internal/metrics"
+	"github.com/dstackai/dstack/runner/internal/ssh"
 )
 
 type Server struct {
@@ -33,9 +34,9 @@ type Server struct {
 	version string
 }
 
-func NewServer(ctx context.Context, tempDir string, homeDir string, address string, sshPort int, version string) (*Server, error) {
+func NewServer(ctx context.Context, tempDir string, homeDir string, address string, sshd ssh.SshdManager, version string) (*Server, error) {
 	r := api.NewRouter()
-	ex, err := executor.NewRunExecutor(tempDir, homeDir, sshPort)
+	ex, err := executor.NewRunExecutor(tempDir, homeDir, sshd)
 	if err != nil {
 		return nil, err
 	}

--- a/runner/internal/shim/docker_test.go
+++ b/runner/internal/shim/docker_test.go
@@ -6,7 +6,6 @@ import (
 	"math/rand"
 	"os"
 	"runtime"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -112,10 +111,9 @@ func (c *dockerParametersMock) DockerPJRTDevice() string {
 }
 
 func (c *dockerParametersMock) DockerShellCommands(publicKeys []string) []string {
-	userPublicKey := strings.Join(publicKeys, "\n")
 	commands := make([]string, 0)
 	if c.sshShellCommands {
-		commands = append(commands, getSSHShellCommands(userPublicKey)...)
+		commands = append(commands, getSSHShellCommands()...)
 	}
 	commands = append(commands, c.commands...)
 	return commands

--- a/runner/internal/shim/models.go
+++ b/runner/internal/shim/models.go
@@ -39,9 +39,8 @@ type CLIArgs struct {
 	}
 
 	Docker struct {
-		ConcatinatedPublicSSHKeys string
-		Privileged                bool
-		PJRTDevice                string
+		Privileged bool
+		PJRTDevice string
 	}
 }
 
@@ -98,11 +97,10 @@ type TaskConfig struct {
 	InstanceMounts   []InstanceMountPoint `json:"instance_mounts"`
 	// GPUDevices allows the server to set gpu devices instead of relying on the runner default logic.
 	// E.g. passing nvidia devices directly instead of using nvidia-container-toolkit.
-	GPUDevices  []GPUDevice `json:"gpu_devices"`
-	HostSshUser string      `json:"host_ssh_user"`
-	HostSshKeys []string    `json:"host_ssh_keys"`
-	// TODO: submit keys to runner, not to shim
-	ContainerSshKeys []string `json:"container_ssh_keys"`
+	GPUDevices       []GPUDevice `json:"gpu_devices"`
+	HostSshUser      string      `json:"host_ssh_user"`
+	HostSshKeys      []string    `json:"host_ssh_keys"`
+	ContainerSshKeys []string    `json:"container_ssh_keys"`
 }
 
 type TaskListItem struct {

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -1,6 +1,7 @@
 import os
 import random
 import re
+import shlex
 import string
 import threading
 from abc import ABC, abstractmethod
@@ -683,7 +684,6 @@ def get_user_data(
     firewall_allow_from_subnets: Iterable[str] = DEFAULT_PRIVATE_SUBNETS,
 ) -> str:
     shim_commands = get_shim_commands(
-        authorized_keys=authorized_keys,
         base_path=base_path,
         bin_path=bin_path,
         backend_shim_env=backend_shim_env,
@@ -698,7 +698,6 @@ def get_user_data(
 
 
 def get_shim_env(
-    authorized_keys: List[str],
     base_path: Optional[PathLike] = None,
     bin_path: Optional[PathLike] = None,
     backend_shim_env: Optional[Dict[str, str]] = None,
@@ -714,7 +713,6 @@ def get_shim_env(
         "DSTACK_RUNNER_HTTP_PORT": str(DSTACK_RUNNER_HTTP_PORT),
         "DSTACK_RUNNER_SSH_PORT": str(DSTACK_RUNNER_SSH_PORT),
         "DSTACK_RUNNER_LOG_LEVEL": log_level,
-        "DSTACK_PUBLIC_SSH_KEY": "\n".join(authorized_keys),
     }
     if backend_shim_env is not None:
         envs |= backend_shim_env
@@ -722,7 +720,6 @@ def get_shim_env(
 
 
 def get_shim_commands(
-    authorized_keys: List[str],
     *,
     is_privileged: bool = False,
     pjrt_device: Optional[str] = None,
@@ -743,7 +740,6 @@ def get_shim_commands(
         arch=arch,
     )
     shim_env = get_shim_env(
-        authorized_keys=authorized_keys,
         base_path=base_path,
         bin_path=bin_path,
         backend_shim_env=backend_shim_env,
@@ -942,7 +938,6 @@ def get_docker_commands(
     bin_path: Optional[PathLike] = None,
 ) -> list[str]:
     dstack_runner_binary_path = get_dstack_runner_binary_path(bin_path)
-    authorized_keys_content = "\n".join(authorized_keys).strip()
     commands = [
         "( :",
         # See https://github.com/dstackai/dstack/issues/1769
@@ -960,27 +955,31 @@ def get_docker_commands(
         "if ! exists sshd; then install_pkg openssh-server; fi",
         # install curl if necessary
         "if ! exists curl; then install_pkg curl; fi",
-        # create ssh dirs and add public key
-        "mkdir -p ~/.ssh",
-        "chmod 700 ~/.ssh",
-        f"echo '{authorized_keys_content}' > ~/.ssh/authorized_keys",
-        "chmod 600 ~/.ssh/authorized_keys",
         ": )",
     ]
+
+    runner_command = [
+        dstack_runner_binary_path,
+        "--log-level",
+        "6",
+        "start",
+        "--home-dir",
+        "/root",
+        "--temp-dir",
+        "/tmp/runner",
+        "--http-port",
+        str(DSTACK_RUNNER_HTTP_PORT),
+        "--ssh-port",
+        str(DSTACK_RUNNER_SSH_PORT),
+    ]
+    for authorized_key in authorized_keys:
+        runner_command += ["--ssh-authorized-key", authorized_key]
 
     url = get_dstack_runner_download_url()
     commands += [
         f"curl --connect-timeout 60 --max-time 240 --retry 1 --output {dstack_runner_binary_path} {url}",
         f"chmod +x {dstack_runner_binary_path}",
-        (
-            f"{dstack_runner_binary_path}"
-            " --log-level 6"
-            " start"
-            f" --http-port {DSTACK_RUNNER_HTTP_PORT}"
-            f" --ssh-port {DSTACK_RUNNER_SSH_PORT}"
-            " --temp-dir /tmp/runner"
-            " --home-dir /root"
-        ),
+        shlex.join(runner_command),
     ]
 
     return commands

--- a/src/dstack/_internal/core/backends/cloudrift/compute.py
+++ b/src/dstack/_internal/core/backends/cloudrift/compute.py
@@ -73,7 +73,7 @@ class CloudRiftCompute(
         instance_config: InstanceConfiguration,
         placement_group: Optional[PlacementGroup],
     ) -> JobProvisioningData:
-        commands = get_shim_commands(authorized_keys=instance_config.get_public_keys())
+        commands = get_shim_commands()
         startup_script = " ".join([" && ".join(commands)])
         logger.debug(
             f"Creating instance for offer {instance_offer.instance.name} in region {instance_offer.region} with commands: {startup_script}"

--- a/src/dstack/_internal/core/backends/cudo/compute.py
+++ b/src/dstack/_internal/core/backends/cudo/compute.py
@@ -75,7 +75,7 @@ class CudoCompute(
             commands = install_jq_commands()
         else:
             commands = install_docker_commands()
-        commands += get_shim_commands(authorized_keys=public_keys)
+        commands += get_shim_commands()
 
         try:
             resp_data = self.api_client.create_virtual_machine(

--- a/src/dstack/_internal/core/backends/gcp/compute.py
+++ b/src/dstack/_internal/core/backends/gcp/compute.py
@@ -304,7 +304,7 @@ class GCPCompute(
         )
         if is_tpu:
             instance_id = instance_name
-            startup_script = _get_tpu_startup_script(authorized_keys)
+            startup_script = _get_tpu_startup_script()
             # GCP does not allow attaching disks while TPUs is creating,
             # so we need to attach the disks on creation.
             data_disks = _get_tpu_data_disks(self.config.project_id, instance_config.volumes)
@@ -1178,10 +1178,8 @@ def _get_volume_price(size: int) -> float:
     return size * 0.12
 
 
-def _get_tpu_startup_script(authorized_keys: List[str]) -> str:
-    commands = get_shim_commands(
-        authorized_keys=authorized_keys, is_privileged=True, pjrt_device="TPU"
-    )
+def _get_tpu_startup_script() -> str:
+    commands = get_shim_commands(is_privileged=True, pjrt_device="TPU")
     startup_script = " ".join([" && ".join(commands)])
     startup_script = "#! /bin/bash\n" + startup_script
     return startup_script

--- a/src/dstack/_internal/core/backends/hotaisle/compute.py
+++ b/src/dstack/_internal/core/backends/hotaisle/compute.py
@@ -103,10 +103,7 @@ class HotAisleCompute(
             if provisioning_data.hostname is None and provisioning_data.backend_data:
                 backend_data = HotAisleInstanceBackendData.load(provisioning_data.backend_data)
                 provisioning_data.hostname = backend_data.ip_address
-            commands = get_shim_commands(
-                authorized_keys=[project_ssh_public_key],
-                arch=provisioning_data.instance_type.resources.cpu_arch,
-            )
+            commands = get_shim_commands(arch=provisioning_data.instance_type.resources.cpu_arch)
             launch_command = "sudo sh -c " + shlex.quote(" && ".join(commands))
             thread = Thread(
                 target=_start_runner,

--- a/src/dstack/_internal/core/backends/lambdalabs/compute.py
+++ b/src/dstack/_internal/core/backends/lambdalabs/compute.py
@@ -95,10 +95,7 @@ class LambdaCompute(
         instance_info = _get_instance_info(self.api_client, provisioning_data.instance_id)
         if instance_info is not None and instance_info["status"] != "booting":
             provisioning_data.hostname = instance_info["ip"]
-            commands = get_shim_commands(
-                authorized_keys=[project_ssh_public_key],
-                arch=provisioning_data.instance_type.resources.cpu_arch,
-            )
+            commands = get_shim_commands(arch=provisioning_data.instance_type.resources.cpu_arch)
             # shim is assumed to be run under root
             launch_command = "sudo sh -c " + shlex.quote(" && ".join(commands))
             thread = Thread(

--- a/src/dstack/_internal/core/backends/verda/compute.py
+++ b/src/dstack/_internal/core/backends/verda/compute.py
@@ -112,7 +112,7 @@ class VerdaCompute(
                 )
             )
 
-        commands = get_shim_commands(authorized_keys=public_keys)
+        commands = get_shim_commands()
         startup_script = " ".join([" && ".join(commands)])
         script_name = f"dstack-{instance_config.instance_name}.sh"
         startup_script_ids = _get_or_create_startup_scrpit(

--- a/src/dstack/_internal/server/background/tasks/process_instances.py
+++ b/src/dstack/_internal/server/background/tasks/process_instances.py
@@ -503,7 +503,7 @@ def _deploy_instance(
         logger.debug("The script for installing dstack has been executed")
 
         # Upload envs
-        shim_envs = get_shim_env(authorized_keys, arch=arch)
+        shim_envs = get_shim_env(arch=arch)
         try:
             fleet_configuration_envs = remote_details.env.as_dict()
         except ValueError as e:


### PR DESCRIPTION
* Add keys by the runner, not the shell script
* Don't touch user's ~/.ssh/authorized_keys, use our own file
* Share that file between all users

Part-of: https://github.com/dstackai/dstack/issues/3419