### PR TITLE
[Dev environments] Support windsurf IDE 

### DIFF
--- a/frontend/src/pages/Runs/CreateDevEnvironment/constants.tsx
+++ b/frontend/src/pages/Runs/CreateDevEnvironment/constants.tsx
@@ -23,3 +23,28 @@ export const FORM_FIELD_NAMES = {
     repo_path: 'repo_path',
     working_dir: 'working_dir',
 } as const satisfies Record<IRunEnvironmentFormKeys, IRunEnvironmentFormKeys>;
+
+export const IDE_OPTIONS = [
+    {
+        label: 'Cursor',
+        value: 'cursor',
+    },
+    {
+        label: 'VS Code',
+        value: 'vscode',
+    },
+    {
+        label: 'Windsurf',
+        value: 'windsurf',
+    },
+] as const;
+
+export const IDE_DISPLAY_NAMES: Record<string, string> = {
+    cursor: 'Cursor',
+    vscode: 'VS Code',
+    windsurf: 'Windsurf',
+};
+
+export const getIDEDisplayName = (ide: string): string => {
+    return IDE_DISPLAY_NAMES[ide] || 'IDE';
+};

--- a/frontend/src/pages/Runs/CreateDevEnvironment/index.tsx
+++ b/frontend/src/pages/Runs/CreateDevEnvironment/index.tsx
@@ -21,7 +21,7 @@ import { NoFleetProjectAlert } from 'pages/Project/components/NoFleetProjectAler
 
 import { useGenerateYaml } from './hooks/useGenerateYaml';
 import { useGetRunSpecFromYaml } from './hooks/useGetRunSpecFromYaml';
-import { FORM_FIELD_NAMES } from './constants';
+import { FORM_FIELD_NAMES, IDE_OPTIONS } from './constants';
 
 import { IRunEnvironmentFormKeys, IRunEnvironmentFormValues } from './types';
 
@@ -31,17 +31,6 @@ const requiredFieldError = 'This is a required field';
 const namesFieldError = 'Only latin characters, dashes, and digits';
 const urlFormatError = 'Only URLs';
 const workingDirFormatError = 'Must be an absolute path';
-
-const ideOptions = [
-    {
-        label: 'Cursor',
-        value: 'cursor',
-    },
-    {
-        label: 'VS Code',
-        value: 'vscode',
-    },
-];
 
 enum DockerPythonTabs {
     DOCKER = 'docker',
@@ -348,7 +337,7 @@ export const CreateDevEnvironment: React.FC = () => {
                                         description={t('runs.dev_env.wizard.ide_description')}
                                         control={control}
                                         name="ide"
-                                        options={ideOptions}
+                                        options={IDE_OPTIONS}
                                         disabled={loading}
                                     />
 

--- a/frontend/src/pages/Runs/CreateDevEnvironment/types.ts
+++ b/frontend/src/pages/Runs/CreateDevEnvironment/types.ts
@@ -1,7 +1,7 @@
 export interface IRunEnvironmentFormValues {
     offer: IGpu;
     name: string;
-    ide: 'cursor' | 'vscode';
+    ide: 'cursor' | 'vscode' | 'windsurf';
     config_yaml: string;
     docker: boolean;
     image?: string;

--- a/frontend/src/pages/Runs/Details/RunDetails/ConnectToRunWithDevEnvConfiguration/index.tsx
+++ b/frontend/src/pages/Runs/Details/RunDetails/ConnectToRunWithDevEnvConfiguration/index.tsx
@@ -19,6 +19,7 @@ import {
 import { copyToClipboard } from 'libs';
 
 import { useConfigProjectCliCommand } from 'pages/Project/hooks/useConfigProjectCliComand';
+import { getIDEDisplayName } from 'pages/Runs/CreateDevEnvironment/constants';
 
 import styles from './styles.module.scss';
 
@@ -52,7 +53,9 @@ export const ConnectToRunWithDevEnvConfiguration: FC<{ run: IRun }> = ({ run }) 
     const [attachCommand, copyAttachCommand] = getAttachCommand(run);
     const [sshCommand, copySSHCommand] = getSSHCommand(run);
 
-    const openInIDEUrl = `${run.run_spec.configuration.ide}://vscode-remote/ssh-remote+${run.run_spec.run_name}/${run.run_spec.working_dir || 'workflow'}`;
+    const configuration = run.run_spec.configuration as TDevEnvironmentConfiguration;
+    const openInIDEUrl = `${configuration.ide}://vscode-remote/ssh-remote+${run.run_spec.run_name}/${run.run_spec.working_dir || 'workflow'}`;
+    const ideDisplayName = getIDEDisplayName(configuration.ide);
 
     const [configCliCommand, copyCliCommand] = useConfigProjectCliCommand({ projectName: run.project_name });
 
@@ -74,7 +77,7 @@ export const ConnectToRunWithDevEnvConfiguration: FC<{ run: IRun }> = ({ run }) 
                     onNavigate={({ detail }) => setActiveStepIndex(detail.requestedStepIndex)}
                     activeStepIndex={activeStepIndex}
                     onSubmit={() => window.open(openInIDEUrl, '_blank')}
-                    submitButtonText="Open in VS Code"
+                    submitButtonText={`Open in ${ideDisplayName}`}
                     allowSkipTo
                     steps={[
                         {
@@ -216,7 +219,7 @@ export const ConnectToRunWithDevEnvConfiguration: FC<{ run: IRun }> = ({ run }) 
                         },
                         {
                             title: 'Open',
-                            description: 'After the CLI is attached, you can open the dev environment in VS Code.',
+                            description: `After the CLI is attached, you can open the dev environment in ${ideDisplayName}.`,
                             content: (
                                 <SpaceBetween size="s">
                                     <Button
@@ -224,7 +227,7 @@ export const ConnectToRunWithDevEnvConfiguration: FC<{ run: IRun }> = ({ run }) 
                                         external={true}
                                         onClick={() => window.open(openInIDEUrl, '_blank')}
                                     >
-                                        Open in VS Code
+                                        Open in {ideDisplayName}
                                     </Button>
 
                                     <ExpandableSection headerText="Need plain SSH?">

--- a/frontend/src/types/run.d.ts
+++ b/frontend/src/types/run.d.ts
@@ -14,7 +14,7 @@ declare type TGPUResources = IGPUSpecRequest & {
     name?: string | string[];
 };
 
-declare type TIde = 'cursor' | 'vscode';
+declare type TIde = 'cursor' | 'vscode' | 'windsurf';
 
 declare type TVolumeMountPointRequest = {
     name: string | string[];

--- a/src/dstack/_internal/cli/services/configurators/run.py
+++ b/src/dstack/_internal/cli/services/configurators/run.py
@@ -741,7 +741,7 @@ def _detect_cursor_version(exe: str = "cursor") -> Optional[str]:
     return None
 
 
-def _detect_windsurf_version(exe: str = "surf") -> Optional[str]:
+def _detect_windsurf_version(exe: str = "windsurf") -> Optional[str]:
     """
     Detects the installed Windsurf product version and commit hash.
     Returns string in format 'version@commit' (e.g., '1.13.5@97d7a...') or None.

--- a/src/dstack/_internal/core/models/configurations.py
+++ b/src/dstack/_internal/core/models/configurations.py
@@ -619,10 +619,17 @@ class ConfigurationWithCommandsParams(CoreModel):
 
 class DevEnvironmentConfigurationParams(CoreModel):
     ide: Annotated[
-        Union[Literal["vscode"], Literal["cursor"]],
-        Field(description="The IDE to run. Supported values include `vscode` and `cursor`"),
+        Union[Literal["vscode"], Literal["cursor"], Literal["windsurf"]],
+        Field(
+            description="The IDE to run. Supported values include `vscode`, `cursor`, and `windsurf`"
+        ),
     ]
-    version: Annotated[Optional[str], Field(description="The version of the IDE")] = None
+    version: Annotated[
+        Optional[str],
+        Field(
+            description="The version of the IDE. For `windsurf`, the version is in the format `version@commit`"
+        ),
+    ] = None
     init: Annotated[CommandsList, Field(description="The shell commands to run on startup")] = []
     inactivity_duration: Annotated[
         Optional[Union[Literal["off"], int, bool, str]],
@@ -648,6 +655,19 @@ class DevEnvironmentConfigurationParams(CoreModel):
         if isinstance(v, int):
             return v
         return None
+
+    @root_validator
+    def validate_windsurf_version_format(cls, values):
+        ide = values.get("ide")
+        version = values.get("version")
+        if ide == "windsurf" and version:
+            # Validate format: version@commit
+            if not re.match(r"^.+@[a-f0-9]+$", version):
+                raise ValueError(
+                    f"Invalid Windsurf version format: `{version}`. "
+                    "Expected format: `version@commit` (e.g., `1.106.0@8951cd3ad688e789573d7f51750d67ae4a0bea7d`)"
+                )
+        return values
 
 
 class DevEnvironmentConfigurationConfig(

--- a/src/dstack/_internal/server/services/jobs/configurators/dev.py
+++ b/src/dstack/_internal/server/services/jobs/configurators/dev.py
@@ -7,6 +7,7 @@ from dstack._internal.core.models.runs import RunSpec
 from dstack._internal.server.services.jobs.configurators.base import JobConfigurator
 from dstack._internal.server.services.jobs.configurators.extensions.cursor import CursorDesktop
 from dstack._internal.server.services.jobs.configurators.extensions.vscode import VSCodeDesktop
+from dstack._internal.server.services.jobs.configurators.extensions.windsurf import WindsurfDesktop
 
 INSTALL_IPYKERNEL = (
     "(echo 'pip install ipykernel...' && pip install -q --no-cache-dir ipykernel 2> /dev/null) || "
@@ -24,6 +25,8 @@ class DevEnvironmentJobConfigurator(JobConfigurator):
             __class = VSCodeDesktop
         elif run_spec.configuration.ide == "cursor":
             __class = CursorDesktop
+        elif run_spec.configuration.ide == "windsurf":
+            __class = WindsurfDesktop
         else:
             raise ServerClientError(f"Unsupported IDE: {run_spec.configuration.ide}")
         self.ide = __class(

--- a/src/dstack/_internal/server/services/jobs/configurators/extensions/windsurf.py
+++ b/src/dstack/_internal/server/services/jobs/configurators/extensions/windsurf.py
@@ -1,0 +1,43 @@
+from typing import List, Optional
+
+
+class WindsurfDesktop:
+    def __init__(
+        self,
+        run_name: Optional[str],
+        version: Optional[str],
+        extensions: List[str],
+    ):
+        self.run_name = run_name
+        self.version = version
+        self.extensions = extensions
+
+    def get_install_commands(self) -> List[str]:
+        commands = []
+        if self.version is not None:
+            version, commit = self.version.split("@")
+            url = f"https://windsurf-stable.codeiumdata.com/linux-reh-$arch/stable/{commit}/windsurf-reh-linux-$arch-{version}.tar.gz"
+            archive = "windsurf-reh-linux-$arch.tar.gz"
+            target = f'~/.windsurf-server/bin/"{commit}"'
+            commands.extend(
+                [
+                    'if [ $(uname -m) = "aarch64" ]; then arch="arm64"; else arch="x64"; fi',
+                    "mkdir -p /tmp",
+                    f'wget -q --show-progress "{url}" -O "/tmp/{archive}"',
+                    f"mkdir -vp {target}",
+                    f'tar --no-same-owner -xz --strip-components=1 -C {target} -f "/tmp/{archive}"',
+                    f'rm "/tmp/{archive}"',
+                ]
+            )
+            if self.extensions:
+                extensions = " ".join(f'--install-extension "{name}"' for name in self.extensions)
+                commands.append(f'PATH="$PATH":{target}/bin windsurf-server {extensions}')
+        return commands
+
+    def get_print_readme_commands(self) -> List[str]:
+        return [
+            "echo To open in Windsurf, use link below:",
+            "echo",
+            f'echo "  windsurf://vscode-remote/ssh-remote+{self.run_name}$DSTACK_WORKING_DIR"',
+            "echo",
+        ]


### PR DESCRIPTION
Fixes #3443

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Windsurf as a first-class IDE option for dev environments across UI, types, CLI, and server.
> 
> - Frontend: exposes `windsurf` in `IDE_OPTIONS`, updates types and "Connect" flow to use dynamic IDE labels/URLs
> - Types: extends `TIde` and form value typings to include `windsurf`
> - Core models: add `windsurf` to `DevEnvironmentConfigurationParams`; validate Windsurf `version` as `version@commit`
> - CLI: auto-detects Windsurf version via product metadata; prints guidance if not found
> - Server: new `WindsurfDesktop` installer/README commands and wiring in dev job configurator
> - Tests: add unit tests for Windsurf version validation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e5192590917d182e3a8c4a8269b92c359b09b5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->