### PR TITLE
[runner] Decouple Server and Executor

### DIFF
--- a/runner/cmd/runner/main.go
+++ b/runner/cmd/runner/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/dstackai/dstack/runner/consts"
+	"github.com/dstackai/dstack/runner/internal/executor"
 	"github.com/dstackai/dstack/runner/internal/log"
 	"github.com/dstackai/dstack/runner/internal/runner/api"
 	"github.com/dstackai/dstack/runner/internal/ssh"
@@ -162,7 +163,12 @@ func start(ctx context.Context, tempDir string, homeDir string, httpPort int, ss
 		}
 	}()
 
-	server, err := api.NewServer(ctx, tempDir, homeDir, dstackDir, sshd, fmt.Sprintf(":%d", httpPort), version)
+	ex, err := executor.NewRunExecutor(tempDir, homeDir, dstackDir, sshd)
+	if err != nil {
+		return fmt.Errorf("create executor: %w", err)
+	}
+
+	server, err := api.NewServer(ctx, fmt.Sprintf(":%d", httpPort), version, ex)
 	if err != nil {
 		return fmt.Errorf("create server: %w", err)
 	}

--- a/runner/internal/executor/base.go
+++ b/runner/internal/executor/base.go
@@ -13,7 +13,6 @@ type Executor interface {
 	GetJobWsLogsHistory() []schemas.LogEvent
 	GetRunnerState() string
 	Run(ctx context.Context) error
-	SetCodePath(codePath string)
 	SetJob(job schemas.SubmitBody)
 	SetJobState(ctx context.Context, state types.JobState)
 	SetJobStateWithTerminationReason(
@@ -23,7 +22,8 @@ type Executor interface {
 		termination_message string,
 	)
 	SetRunnerState(state string)
-	AddFileArchive(id string, src io.Reader) error
+	WriteFileArchive(id string, src io.Reader) error
+	WriteRepoBlob(src io.Reader) error
 	Lock()
 	RLock()
 	RUnlock()

--- a/runner/internal/executor/files.go
+++ b/runner/internal/executor/files.go
@@ -18,11 +18,11 @@ import (
 
 var renameRegex = regexp.MustCompile(`^([^/]*)(/|$)`)
 
-func (ex *RunExecutor) AddFileArchive(id string, src io.Reader) error {
-	if err := os.MkdirAll(ex.archiveDir, 0o755); err != nil {
+func (ex *RunExecutor) WriteFileArchive(id string, src io.Reader) error {
+	if err := os.MkdirAll(ex.fileArchiveDir, 0o755); err != nil {
 		return fmt.Errorf("create archive directory: %w", err)
 	}
-	archivePath := path.Join(ex.archiveDir, id)
+	archivePath := path.Join(ex.fileArchiveDir, id)
 	archive, err := os.Create(archivePath)
 	if err != nil {
 		return fmt.Errorf("create archive file: %w", err)
@@ -45,13 +45,13 @@ func (ex *RunExecutor) setupFiles(ctx context.Context) error {
 		return fmt.Errorf("setup files: working dir must be absolute: %s", ex.jobWorkingDir)
 	}
 	for _, fa := range ex.jobSpec.FileArchives {
-		archivePath := path.Join(ex.archiveDir, fa.Id)
+		archivePath := path.Join(ex.fileArchiveDir, fa.Id)
 		if err := extractFileArchive(ctx, archivePath, fa.Path, ex.jobWorkingDir, ex.jobUid, ex.jobGid, ex.jobHomeDir); err != nil {
 			return fmt.Errorf("extract file archive %s: %w", fa.Id, err)
 		}
 	}
-	if err := os.RemoveAll(ex.archiveDir); err != nil {
-		log.Warning(ctx, "Failed to remove file archives dir", "path", ex.archiveDir, "err", err)
+	if err := os.RemoveAll(ex.fileArchiveDir); err != nil {
+		log.Warning(ctx, "Failed to remove file archives dir", "path", ex.fileArchiveDir, "err", err)
 	}
 	return nil
 }
@@ -90,7 +90,6 @@ func extractFileArchive(ctx context.Context, archivePath string, destPath string
 
 	if uid != -1 || gid != -1 {
 		for _, p := range paths {
-			log.Warning(ctx, "path", "path", p)
 			if err := os.Chown(path.Join(destBase, p), uid, gid); err != nil {
 				log.Warning(ctx, "Failed to chown", "path", p, "err", err)
 			}

--- a/runner/internal/runner/api/server.go
+++ b/runner/internal/runner/api/server.go
@@ -11,12 +11,10 @@ import (
 	"github.com/dstackai/dstack/runner/internal/executor"
 	"github.com/dstackai/dstack/runner/internal/log"
 	"github.com/dstackai/dstack/runner/internal/metrics"
-	"github.com/dstackai/dstack/runner/internal/ssh"
 )
 
 type Server struct {
-	srv     *http.Server
-	tempDir string
+	srv *http.Server
 
 	shutdownCh   chan interface{} // server closes this chan on shutdown
 	jobBarrierCh chan interface{} // only server listens on this chan
@@ -34,15 +32,8 @@ type Server struct {
 	version string
 }
 
-func NewServer(
-	ctx context.Context, tempDir string, homeDir string, dstackDir string, sshd ssh.SshdManager,
-	address string, version string,
-) (*Server, error) {
+func NewServer(ctx context.Context, address string, version string, ex executor.Executor) (*Server, error) {
 	r := api.NewRouter()
-	ex, err := executor.NewRunExecutor(tempDir, homeDir, dstackDir, sshd)
-	if err != nil {
-		return nil, err
-	}
 
 	metricsCollector, err := metrics.NewMetricsCollector(ctx)
 	if err != nil {
@@ -54,7 +45,6 @@ func NewServer(
 			Addr:    address,
 			Handler: r,
 		},
-		tempDir: tempDir,
 
 		shutdownCh:   make(chan interface{}),
 		jobBarrierCh: make(chan interface{}),


### PR DESCRIPTION
* Pass Executor to Server as an argument
* Move repo blob-related code from the API handler to a new Executor method
* Fix http.MaxBytesError handling