### PR TITLE
Use the same metrics endpoint label for 404 requests

### DIFF
--- a/src/dstack/_internal/server/routers/prometheus.py
+++ b/src/dstack/_internal/server/routers/prometheus.py
@@ -25,6 +25,9 @@ router = APIRouter(
 async def get_prometheus_metrics(
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> str:
+    # Note: Prometheus warns against storing high cardinality values in labels,
+    # yet both client and custom metrics have labels like project, run, fleet, etc.
+    # This may require a very big Prometheus server with lots of storage.
     if not settings.ENABLE_PROMETHEUS_METRICS:
         raise error_not_found()
     custom_metrics_ = await custom_metrics.get_metrics(session=session)


### PR DESCRIPTION
The PR fixes an issue with prometheus metrics collected for every requested endpoint, even for paths that result in 404. This resulted in ever-growing memory usage and may quickly take all of the prometheus storage space. Now non-existent paths record metrics under the same `"__not_found__"` and non-api paths under `"__non_api__"`.