### PR TITLE
[Internal]: Handle GitHub API errors in `release_notes.py`

### DIFF
--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -32,6 +32,9 @@ def get_draft_release_by_tag(tag: str) -> dict:
         headers={"Authorization": f"token {GITHUB_TOKEN}"},
         timeout=10,
     )
+    if not r.ok:
+        msg = f"Error getting GitHub releases; status: {r.status_code}, body: {r.text}"
+        raise Exception(msg)
     for release in r.json():
         if release["tag_name"] == tag and release["draft"]:
             return release


### PR DESCRIPTION
This improves the script error message if the
GitHub API call is not successful (e.g., if the
token is expired).

Before:

```
TypeError: string indices must be integers, not 'str'
```

After:

```
Exception: Error getting GitHub releases; status: 401, body: {
  "message": "Bad credentials",
  "documentation_url": "https://docs.github.com/rest",
  "status": "401"
}
```