### PR TITLE
Optimize fleet instances db queries

### DIFF
--- a/src/dstack/_internal/server/background/__init__.py
+++ b/src/dstack/_internal/server/background/__init__.py
@@ -42,7 +42,14 @@ def get_scheduler() -> AsyncIOScheduler:
 
 
 def start_background_tasks() -> AsyncIOScheduler:
-    # We try to process as many resources as possible without exhausting DB connections.
+    # Background processing is implemented via in-memory locks on SQLite
+    # and SELECT FOR UPDATE on Postgres. Locks may be held for a long time.
+    # This is currently the main bottleneck for scaling dstack processing
+    # as processing more resources requires more DB connections.
+    # TODO: Make background processing efficient by committing locks to DB
+    # and processing outside of DB transactions.
+    #
+    # Now we just try to process as many resources as possible without exhausting DB connections.
     #
     # Quick tasks can process multiple resources per transaction.
     # Potentially long tasks process one resource per transaction

--- a/src/dstack/_internal/server/background/tasks/process_fleets.py
+++ b/src/dstack/_internal/server/background/tasks/process_fleets.py
@@ -60,7 +60,9 @@ async def process_fleets():
                 .options(
                     load_only(FleetModel.id, FleetModel.name),
                     selectinload(FleetModel.instances).load_only(InstanceModel.id),
-                    with_loader_criteria(InstanceModel, InstanceModel.deleted == False),
+                    with_loader_criteria(
+                        InstanceModel, InstanceModel.deleted == False, include_aliases=True
+                    ),
                 )
                 .order_by(FleetModel.last_processed_at.asc())
                 .limit(BATCH_SIZE)
@@ -115,7 +117,9 @@ async def _process_fleets(session: AsyncSession, fleet_models: List[FleetModel])
         .where(FleetModel.id.in_(fleet_ids))
         .options(
             joinedload(FleetModel.instances).joinedload(InstanceModel.jobs).load_only(JobModel.id),
-            with_loader_criteria(InstanceModel, InstanceModel.deleted == False),
+            with_loader_criteria(
+                InstanceModel, InstanceModel.deleted == False, include_aliases=True
+            ),
         )
         .options(joinedload(FleetModel.project))
         .options(joinedload(FleetModel.runs).load_only(RunModel.status))

--- a/src/dstack/_internal/server/background/tasks/process_fleets.py
+++ b/src/dstack/_internal/server/background/tasks/process_fleets.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload, load_only, selectinload
+from sqlalchemy.orm import joinedload, load_only, selectinload, with_loader_criteria
 
 from dstack._internal.core.models.fleets import FleetSpec, FleetStatus
 from dstack._internal.core.models.instances import InstanceStatus, InstanceTerminationReason
@@ -60,6 +60,7 @@ async def process_fleets():
                 .options(
                     load_only(FleetModel.id, FleetModel.name),
                     selectinload(FleetModel.instances).load_only(InstanceModel.id),
+                    with_loader_criteria(InstanceModel, InstanceModel.deleted == False),
                 )
                 .order_by(FleetModel.last_processed_at.asc())
                 .limit(BATCH_SIZE)
@@ -72,6 +73,7 @@ async def process_fleets():
                 .where(
                     InstanceModel.id.not_in(instance_lockset),
                     InstanceModel.fleet_id.in_(fleet_ids),
+                    InstanceModel.deleted == False,
                 )
                 .options(load_only(InstanceModel.id, InstanceModel.fleet_id))
                 .order_by(InstanceModel.id)
@@ -113,8 +115,9 @@ async def _process_fleets(session: AsyncSession, fleet_models: List[FleetModel])
         .where(FleetModel.id.in_(fleet_ids))
         .options(
             joinedload(FleetModel.instances).joinedload(InstanceModel.jobs).load_only(JobModel.id),
-            joinedload(FleetModel.project),
+            with_loader_criteria(InstanceModel, InstanceModel.deleted == False),
         )
+        .options(joinedload(FleetModel.project))
         .options(joinedload(FleetModel.runs).load_only(RunModel.status))
         .execution_options(populate_existing=True)
     )

--- a/src/dstack/_internal/server/background/tasks/process_instances.py
+++ b/src/dstack/_internal/server/background/tasks/process_instances.py
@@ -554,7 +554,9 @@ def _deploy_instance(
 async def _create_instance(session: AsyncSession, instance: InstanceModel) -> None:
     master_instance = await _get_fleet_master_instance(session, instance)
     if _need_to_wait_fleet_provisioning(instance, master_instance):
-        logger.debug("Waiting for the first instance in the fleet to be provisioned")
+        logger.debug(
+            "%s: waiting for the first instance in the fleet to be provisioned", fmt(instance)
+        )
         return
 
     try:

--- a/src/dstack/_internal/server/background/tasks/process_runs.py
+++ b/src/dstack/_internal/server/background/tasks/process_runs.py
@@ -147,7 +147,7 @@ async def _process_next_run():
             )
             job_models = res.scalars().all()
             if len(run_model.jobs) != len(job_models):
-                # Some jobs are locked
+                # Some jobs are locked or there was a non-repeatable read
                 return
             job_ids = [j.id for j in run_model.jobs]
             run_lockset.add(run_model.id)

--- a/src/dstack/_internal/server/background/tasks/process_runs.py
+++ b/src/dstack/_internal/server/background/tasks/process_runs.py
@@ -126,6 +126,7 @@ async def _process_next_run():
                     JobModel.run_id == run_model.id,
                     JobModel.id.not_in(job_lockset),
                 )
+                .options(load_only(JobModel.id))
                 .order_by(JobModel.id)  # take locks in order
                 .with_for_update(skip_locked=True, key_share=True)
             )

--- a/src/dstack/_internal/server/services/fleets.py
+++ b/src/dstack/_internal/server/services/fleets.py
@@ -728,10 +728,6 @@ def is_cloud_cluster(fleet_model: FleetModel) -> bool:
     )
 
 
-def is_fleet_master_instance(instance: InstanceModel) -> bool:
-    return instance.fleet is not None and instance.id == instance.fleet.instances[0].id
-
-
 def get_fleet_requirements(fleet_spec: FleetSpec) -> Requirements:
     profile = fleet_spec.merged_profile
     requirements = Requirements(

--- a/src/dstack/_internal/server/services/placement.py
+++ b/src/dstack/_internal/server/services/placement.py
@@ -232,7 +232,3 @@ async def create_placement_group(
     )
     placement_group_model.provisioning_data = pgpd.json()
     return placement_group_model
-
-
-def _is_fleet_master_instance(instance: InstanceModel) -> bool:
-    return instance.fleet is not None and instance.id == instance.fleet.instances[0].id

--- a/src/dstack/_internal/server/services/placement.py
+++ b/src/dstack/_internal/server/services/placement.py
@@ -98,9 +98,10 @@ async def schedule_fleet_placement_groups_deletion(
 def get_placement_group_model_for_instance(
     placement_group_models: list[PlacementGroupModel],
     instance_model: InstanceModel,
+    master_instance_model: InstanceModel,
 ) -> Optional[PlacementGroupModel]:
     placement_group_model = None
-    if not _is_fleet_master_instance(instance_model):
+    if instance_model.id != master_instance_model.id:
         if placement_group_models:
             placement_group_model = placement_group_models[0]
         if len(placement_group_models) > 1:


### PR DESCRIPTION
The PR optimizes process_fleets to only select non-deleted instances from the db. The deleted instances are not relevant for processing and since there can be unlimited number of deleted instances for old fleet – it'll lead to heavy db queries.

Also some other query optimizations.