### PR TITLE
Emit events for instance status changes

### DIFF
--- a/src/dstack/_internal/core/models/instances.py
+++ b/src/dstack/_internal/core/models/instances.py
@@ -256,6 +256,7 @@ class InstanceStatus(str, Enum):
 
 
 class InstanceTerminationReason(str, Enum):
+    TERMINATED_BY_USER = "terminated_by_user"
     IDLE_TIMEOUT = "idle_timeout"
     PROVISIONING_TIMEOUT = "provisioning_timeout"
     ERROR = "error"

--- a/src/dstack/_internal/server/models.py
+++ b/src/dstack/_internal/server/models.py
@@ -632,6 +632,7 @@ class InstanceModel(BaseModel):
     compute_group_id: Mapped[Optional[uuid.UUID]] = mapped_column(ForeignKey("compute_groups.id"))
     compute_group: Mapped[Optional["ComputeGroupModel"]] = relationship(back_populates="instances")
 
+    # NOTE: `status` must be changed only via `switch_instance_status()`
     status: Mapped[InstanceStatus] = mapped_column(EnumAsString(InstanceStatus, 100), index=True)
     unreachable: Mapped[bool] = mapped_column(Boolean)
 


### PR DESCRIPTION
- Emit an event on every instance status change
- To make events more informative, set termination reasons whenever terminating instances
- Add `terminated_by_user` termination reason
- Remove redundant logging now covered by events
- Refactor runtime-only status changes that were not persisted and did not affect logic
- For event readability, only include the busy blocks count in job assigned/unassigned events, which is the only place where the count can change

#3290