### PR TITLE
Support shared AWS compute caches

### DIFF
--- a/src/dstack/_internal/core/backends/aws/backend.py
+++ b/src/dstack/_internal/core/backends/aws/backend.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import botocore.exceptions
 
 from dstack._internal.core.backends.aws.compute import AWSCompute
@@ -11,9 +13,12 @@ class AWSBackend(Backend):
     TYPE = BackendType.AWS
     COMPUTE_CLASS = AWSCompute
 
-    def __init__(self, config: AWSConfig):
+    def __init__(self, config: AWSConfig, compute: Optional[AWSCompute] = None):
         self.config = config
-        self._compute = AWSCompute(self.config)
+        if compute is not None:
+            self._compute = compute
+        else:
+            self._compute = AWSCompute(self.config)
         self._check_credentials()
 
     def compute(self) -> AWSCompute:

--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -1,6 +1,6 @@
 import threading
 from collections.abc import Iterable
-from concurrent.futures import ThreadPoolExecutor, as_completed, wait
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import boto3
@@ -147,15 +147,7 @@ class AWSCompute(
         with self._get_regions_to_quotas_execution_lock:
             # Cache lock does not prevent concurrent execution.
             # We use a separate lock to avoid requesting quotas in parallel and hitting rate limits.
-            with ThreadPoolExecutor() as executor:
-                fs = [
-                    executor.submit(self._get_regions_to_quotas, self.session, regions),
-                    executor.submit(self._get_regions_to_zones, self.session, regions),
-                ]
-                wait(fs)
-
-        # Read from cache
-        regions_to_quotas = self._get_regions_to_quotas(self.session, regions)
+            regions_to_quotas = self._get_regions_to_quotas(self.session, regions)
         regions_to_zones = self._get_regions_to_zones(self.session, regions)
 
         availability_offers = []

--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -1,6 +1,6 @@
 import threading
 from collections.abc import Iterable
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, as_completed, wait
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import boto3
@@ -147,7 +147,15 @@ class AWSCompute(
         with self._get_regions_to_quotas_execution_lock:
             # Cache lock does not prevent concurrent execution.
             # We use a separate lock to avoid requesting quotas in parallel and hitting rate limits.
-            regions_to_quotas = self._get_regions_to_quotas(self.session, regions)
+            with ThreadPoolExecutor() as executor:
+                fs = [
+                    executor.submit(self._get_regions_to_quotas, self.session, regions),
+                    executor.submit(self._get_regions_to_zones, self.session, regions),
+                ]
+                wait(fs)
+
+        # Read from cache
+        regions_to_quotas = self._get_regions_to_quotas(self.session, regions)
         regions_to_zones = self._get_regions_to_zones(self.session, regions)
 
         availability_offers = []

--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -6,6 +6,7 @@ import string
 import threading
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator
+from dataclasses import dataclass, field
 from enum import Enum
 from functools import lru_cache
 from pathlib import Path
@@ -14,7 +15,7 @@ from typing import Callable, Dict, List, Optional
 import git
 import requests
 import yaml
-from cachetools import TTLCache, cachedmethod
+from cachetools import Cache, TTLCache, cachedmethod
 from gpuhunt import CPUArchitecture
 
 from dstack._internal import settings
@@ -87,6 +88,18 @@ class GoArchType(str, Enum):
         if self == self.ARM64:
             return CPUArchitecture.ARM
         assert False, self
+
+
+@dataclass
+class ComputeCache:
+    cache: Cache
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+@dataclass
+class ComputeTTLCache:
+    cache: TTLCache
+    lock: threading.Lock = field(default_factory=threading.Lock)
 
 
 class Compute(ABC):

--- a/src/dstack/_internal/server/services/backends/__init__.py
+++ b/src/dstack/_internal/server/services/backends/__init__.py
@@ -362,7 +362,7 @@ async def get_backend_offers(
                 yield (backend, offer)
 
     logger.info("Requesting instance offers from backends: %s", [b.TYPE.value for b in backends])
-    tasks = [run_async(_get_offers, backend, requirements) for backend in backends]
+    tasks = [run_async(get_offers_tracked, backend, requirements) for backend in backends]
     offers_by_backend = []
     for backend, result in zip(backends, await asyncio.gather(*tasks, return_exceptions=True)):
         if isinstance(result, BackendError):
@@ -394,7 +394,7 @@ def check_backend_type_available(backend_type: BackendType):
         )
 
 
-def _get_offers(
+def get_offers_tracked(
     backend: Backend, requirements: Requirements
 ) -> Iterator[InstanceOfferWithAvailability]:
     start = time.time()


### PR DESCRIPTION
#3479

This PR:
* Allows reusing quotas and zones cache across AWSCompute instances, which can be used in dstack Sky to improve AWS offers cold cache.
* Refactors compute caches.
* Adds logging of get offers execution times.