### PR TITLE
Implement pagination for `/api/project/list` and `/api/users/list`

### DIFF
--- a/src/dstack/_internal/core/models/projects.py
+++ b/src/dstack/_internal/core/models/projects.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from pydantic import UUID4
 
@@ -26,6 +26,16 @@ class Project(CoreModel):
     backends: List[BackendInfo]
     members: List[Member]
     is_public: bool = False
+
+
+class ProjectsInfoList(CoreModel):
+    total_count: Optional[int] = None
+    projects: List[Project]
+
+
+# For backward compatibility with 0.20 clients, endpoints return `List[Project]` if `total_count` is None.
+# TODO: Replace with ProjectsInfoList in 0.21.
+ProjectsInfoListOrProjectsList = Union[List[Project], ProjectsInfoList]
 
 
 class ProjectHookConfig(CoreModel):

--- a/src/dstack/_internal/core/models/users.py
+++ b/src/dstack/_internal/core/models/users.py
@@ -1,6 +1,6 @@
 import enum
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional, Union
 
 from pydantic import UUID4
 
@@ -40,6 +40,16 @@ class UserTokenCreds(CoreModel):
 class UserWithCreds(User):
     creds: UserTokenCreds
     ssh_private_key: Optional[str] = None
+
+
+class UsersInfoList(CoreModel):
+    total_count: Optional[int] = None
+    users: List[User]
+
+
+# For backward compatibility with 0.20 clients, endpoints return `List[User]` if `total_count` is None.
+# TODO: Replace with UsersInfoList in 0.21.
+UsersInfoListOrUsersList = Union[List[User], UsersInfoList]
 
 
 class UserHookConfig(CoreModel):

--- a/src/dstack/_internal/server/routers/projects.py
+++ b/src/dstack/_internal/server/routers/projects.py
@@ -52,7 +52,7 @@ async def list_projects(
     """
     if body is None:
         # For backward compatibility
-        body = ListProjectsRequest(limit=2000)
+        body = ListProjectsRequest()
     return CustomORJSONResponse(
         await projects.list_user_accessible_projects(
             session=session,

--- a/src/dstack/_internal/server/routers/projects.py
+++ b/src/dstack/_internal/server/routers/projects.py
@@ -59,6 +59,7 @@ async def list_projects(
             user=user,
             include_not_joined=body.include_not_joined,
             return_total_count=body.return_total_count,
+            name_pattern=body.name_pattern,
             prev_created_at=body.prev_created_at,
             prev_id=body.prev_id,
             limit=body.limit,

--- a/src/dstack/_internal/server/routers/projects.py
+++ b/src/dstack/_internal/server/routers/projects.py
@@ -52,10 +52,16 @@ async def list_projects(
     """
     if body is None:
         # For backward compatibility
-        body = ListProjectsRequest()
+        body = ListProjectsRequest(limit=2000)
     return CustomORJSONResponse(
         await projects.list_user_accessible_projects(
-            session=session, user=user, include_not_joined=body.include_not_joined
+            session=session,
+            user=user,
+            include_not_joined=body.include_not_joined,
+            prev_created_at=body.prev_created_at,
+            prev_id=body.prev_id,
+            limit=body.limit,
+            ascending=body.ascending,
         )
     )
 

--- a/src/dstack/_internal/server/routers/projects.py
+++ b/src/dstack/_internal/server/routers/projects.py
@@ -43,7 +43,7 @@ async def list_projects(
     user: UserModel = Depends(Authenticated()),
 ):
     """
-    Returns projects visible to the user, sorted by ascending `created_at`.
+    Returns projects visible to the user.
 
     Returns all accessible projects (member projects for regular users, all non-deleted
     projects for global admins, plus public projects if `include_not_joined` is `True`).

--- a/src/dstack/_internal/server/routers/projects.py
+++ b/src/dstack/_internal/server/routers/projects.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Tuple
 from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from dstack._internal.core.models.projects import Project
+from dstack._internal.core.models.projects import Project, ProjectsInfoListOrProjectsList
 from dstack._internal.server.db import get_session
 from dstack._internal.server.models import ProjectModel, UserModel
 from dstack._internal.server.schemas.projects import (
@@ -36,7 +36,7 @@ router = APIRouter(
 )
 
 
-@router.post("/list", response_model=List[Project])
+@router.post("/list", response_model=ProjectsInfoListOrProjectsList)
 async def list_projects(
     body: Optional[ListProjectsRequest] = None,
     session: AsyncSession = Depends(get_session),
@@ -58,6 +58,7 @@ async def list_projects(
             session=session,
             user=user,
             include_not_joined=body.include_not_joined,
+            return_total_count=body.return_total_count,
             prev_created_at=body.prev_created_at,
             prev_id=body.prev_id,
             limit=body.limit,

--- a/src/dstack/_internal/server/routers/users.py
+++ b/src/dstack/_internal/server/routers/users.py
@@ -51,6 +51,7 @@ async def list_users(
             session=session,
             user=user,
             return_total_count=body.return_total_count,
+            name_pattern=body.name_pattern,
             prev_created_at=body.prev_created_at,
             prev_id=body.prev_id,
             limit=body.limit,

--- a/src/dstack/_internal/server/schemas/fleets.py
+++ b/src/dstack/_internal/server/schemas/fleets.py
@@ -9,10 +9,10 @@ from dstack._internal.core.models.fleets import ApplyFleetPlanInput, FleetSpec
 
 
 class ListFleetsRequest(CoreModel):
-    project_name: Optional[str]
+    project_name: Optional[str] = None
     only_active: bool = False
-    prev_created_at: Optional[datetime]
-    prev_id: Optional[UUID]
+    prev_created_at: Optional[datetime] = None
+    prev_id: Optional[UUID] = None
     limit: int = Field(100, ge=0, le=100)
     ascending: bool = False
 

--- a/src/dstack/_internal/server/schemas/projects.py
+++ b/src/dstack/_internal/server/schemas/projects.py
@@ -1,4 +1,6 @@
-from typing import Annotated, List
+from datetime import datetime
+from typing import Annotated, List, Optional
+from uuid import UUID
 
 from pydantic import Field
 
@@ -10,6 +12,10 @@ class ListProjectsRequest(CoreModel):
     include_not_joined: Annotated[
         bool, Field(description="Include public projects where user is not a member")
     ] = True
+    prev_created_at: Optional[datetime] = None
+    prev_id: Optional[UUID] = None
+    limit: int = Field(2000, ge=0, le=2000)
+    ascending: bool = False
 
 
 class CreateProjectRequest(CoreModel):

--- a/src/dstack/_internal/server/schemas/projects.py
+++ b/src/dstack/_internal/server/schemas/projects.py
@@ -14,7 +14,7 @@ class ListProjectsRequest(CoreModel):
     ] = True
     prev_created_at: Optional[datetime] = None
     prev_id: Optional[UUID] = None
-    limit: int = Field(2000, ge=0, le=2000)
+    limit: int = Field(default=2000, ge=0, le=2000)
     ascending: bool = False
 
 

--- a/src/dstack/_internal/server/schemas/projects.py
+++ b/src/dstack/_internal/server/schemas/projects.py
@@ -19,7 +19,7 @@ class ListProjectsRequest(CoreModel):
         Optional[str],
         Field(
             description="Include only projects with the name containing `name_pattern`.",
-            regex="^[a-zA-Z0-9-]*$",
+            regex="^[a-zA-Z0-9-_]*$",
         ),
     ] = None
     prev_created_at: Annotated[

--- a/src/dstack/_internal/server/schemas/projects.py
+++ b/src/dstack/_internal/server/schemas/projects.py
@@ -10,12 +10,35 @@ from dstack._internal.core.models.users import ProjectRole
 
 class ListProjectsRequest(CoreModel):
     include_not_joined: Annotated[
-        bool, Field(description="Include public projects where user is not a member")
+        bool, Field(description="Include public projects where user is not a member.")
     ] = True
-    prev_created_at: Optional[datetime] = None
-    prev_id: Optional[UUID] = None
-    limit: int = Field(default=2000, ge=0, le=2000)
-    ascending: bool = False
+    return_total_count: Annotated[
+        bool, Field(description="Return `total_count` with the total number of projects.")
+    ] = False
+    prev_created_at: Annotated[
+        Optional[datetime],
+        Field(
+            description="Paginate projects by specifying `created_at` of the last (first) project in previous batch for descending (ascending)."
+        ),
+    ] = None
+    prev_id: Annotated[
+        Optional[UUID],
+        Field(
+            description=(
+                "Paginate projects by specifying `id` of the last (first) project in previous batch for descending (ascending)."
+                " Must be used together with `prev_created_at`."
+            )
+        ),
+    ] = None
+    limit: Annotated[
+        int, Field(ge=0, le=2000, description="Limit number of projects returned.")
+    ] = 2000
+    ascending: Annotated[
+        bool,
+        Field(
+            description="Return projects sorted by `created_at` in ascending order. Defaults to descending."
+        ),
+    ] = False
 
 
 class CreateProjectRequest(CoreModel):

--- a/src/dstack/_internal/server/schemas/projects.py
+++ b/src/dstack/_internal/server/schemas/projects.py
@@ -15,6 +15,13 @@ class ListProjectsRequest(CoreModel):
     return_total_count: Annotated[
         bool, Field(description="Return `total_count` with the total number of projects.")
     ] = False
+    name_pattern: Annotated[
+        Optional[str],
+        Field(
+            description="Include only projects with the name containing `name_pattern`.",
+            regex="^[a-zA-Z0-9-]*$",
+        ),
+    ] = None
     prev_created_at: Annotated[
         Optional[datetime],
         Field(

--- a/src/dstack/_internal/server/schemas/users.py
+++ b/src/dstack/_internal/server/schemas/users.py
@@ -12,6 +12,13 @@ class ListUsersRequest(CoreModel):
     return_total_count: Annotated[
         bool, Field(description="Return `total_count` with the total number of users.")
     ] = False
+    name_pattern: Annotated[
+        Optional[str],
+        Field(
+            description="Include only users with the name containing `name_pattern`.",
+            regex="^[a-zA-Z0-9-_]*$",
+        ),
+    ] = None
     prev_created_at: Annotated[
         Optional[datetime],
         Field(

--- a/src/dstack/_internal/server/schemas/users.py
+++ b/src/dstack/_internal/server/schemas/users.py
@@ -1,7 +1,46 @@
-from typing import List, Optional
+from datetime import datetime
+from typing import Annotated, List, Optional
+from uuid import UUID
+
+from pydantic import Field
 
 from dstack._internal.core.models.common import CoreModel
 from dstack._internal.core.models.users import GlobalRole
+
+
+class ListUsersRequest(CoreModel):
+    return_total_count: Annotated[
+        bool, Field(description="Return `total_count` with the total number of users.")
+    ] = False
+    prev_created_at: Annotated[
+        Optional[datetime],
+        Field(
+            description=(
+                "Paginate users by specifying `created_at` of the last (first) user in previous "
+                "batch for descending (ascending)."
+            )
+        ),
+    ] = None
+    prev_id: Annotated[
+        Optional[UUID],
+        Field(
+            description=(
+                "Paginate users by specifying `id` of the last (first) user in previous batch "
+                "for descending (ascending). Must be used together with `prev_created_at`."
+            )
+        ),
+    ] = None
+    limit: Annotated[int, Field(ge=0, le=2000, description="Limit number of users returned.")] = (
+        2000
+    )
+    ascending: Annotated[
+        bool,
+        Field(
+            description=(
+                "Return users sorted by `created_at` in ascending order. Defaults to descending."
+            )
+        ),
+    ] = False
 
 
 class GetUserRequest(CoreModel):

--- a/src/dstack/_internal/server/services/projects.py
+++ b/src/dstack/_internal/server/services/projects.py
@@ -1,3 +1,4 @@
+import re
 import secrets
 import uuid
 from datetime import datetime
@@ -167,6 +168,7 @@ async def create_project(
     user_permissions = users.get_user_permissions(user)
     if not user_permissions.can_create_projects:
         raise ForbiddenError("User cannot create projects")
+    validate_project_name(project_name)
     project = await get_project_model_by_name(
         session=session, project_name=project_name, ignore_case=True
     )
@@ -679,6 +681,15 @@ def get_member_permissions(member_model: MemberModel) -> MemberPermissions:
     return MemberPermissions(
         can_manage_ssh_fleets=can_manage_ssh_fleets,
     )
+
+
+def validate_project_name(project_name: str):
+    if not is_valid_project_name(project_name):
+        raise ServerClientError("Project name should match regex '^[a-zA-Z0-9-_]{1,50}$'")
+
+
+def is_valid_project_name(project_name: str) -> bool:
+    return re.match("^[a-zA-Z0-9-_]{1,50}$", project_name) is not None
 
 
 _CREATE_PROJECT_HOOKS = []

--- a/src/dstack/_internal/server/services/projects.py
+++ b/src/dstack/_internal/server/services/projects.py
@@ -126,7 +126,7 @@ async def list_user_accessible_projects(
     if ascending:
         order_by = (ProjectModel.created_at.asc(), ProjectModel.id.desc())
     res = await session.execute(stmt.where(*pagination_filters).order_by(*order_by).limit(limit))
-    project_models = res.scalars().all()
+    project_models = res.unique().scalars().all()
     return [
         project_model_to_project(p, include_backends=False, include_members=False)
         for p in project_models

--- a/src/dstack/_internal/server/services/users.py
+++ b/src/dstack/_internal/server/services/users.py
@@ -5,9 +5,10 @@ import secrets
 import uuid
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from datetime import datetime
 from typing import Awaitable, Callable, List, Optional, Tuple
 
-from sqlalchemy import delete, select
+from sqlalchemy import and_, delete, literal_column, or_, select
 from sqlalchemy import func as safunc
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import load_only
@@ -21,6 +22,8 @@ from dstack._internal.core.models.users import (
     User,
     UserHookConfig,
     UserPermissions,
+    UsersInfoList,
+    UsersInfoListOrUsersList,
     UserTokenCreds,
     UserWithCreds,
 )
@@ -55,23 +58,82 @@ async def get_or_create_admin_user(session: AsyncSession) -> Tuple[UserModel, bo
 async def list_users_for_user(
     session: AsyncSession,
     user: UserModel,
-) -> List[User]:
+    return_total_count: bool,
+    prev_created_at: Optional[datetime],
+    prev_id: Optional[uuid.UUID],
+    limit: int,
+    ascending: bool,
+) -> UsersInfoListOrUsersList:
     if user.global_role == GlobalRole.ADMIN:
-        return await list_all_users(session=session)
-    return [user_model_to_user(user)]
+        return await list_all_users(
+            session=session,
+            include_deleted=False,
+            return_total_count=return_total_count,
+            prev_created_at=prev_created_at,
+            prev_id=prev_id,
+            limit=limit,
+            ascending=ascending,
+        )
+    users = [user_model_to_user(user)]
+    if return_total_count:
+        return UsersInfoList(total_count=len(users), users=users)
+    return users
 
 
 async def list_all_users(
     session: AsyncSession,
     include_deleted: bool = False,
-) -> List[User]:
+    return_total_count: bool = False,
+    prev_created_at: Optional[datetime] = None,
+    prev_id: Optional[uuid.UUID] = None,
+    limit: int = 2000,
+    ascending: bool = False,
+) -> UsersInfoListOrUsersList:
     filters = []
     if not include_deleted:
         filters.append(UserModel.deleted == False)
-    res = await session.execute(select(UserModel).where(*filters))
+    stmt = select(UserModel).where(*filters)
+    pagination_filters = []
+    if prev_created_at is not None:
+        if ascending:
+            if prev_id is None:
+                pagination_filters.append(UserModel.created_at > prev_created_at)
+            else:
+                pagination_filters.append(
+                    or_(
+                        UserModel.created_at > prev_created_at,
+                        and_(
+                            UserModel.created_at == prev_created_at,
+                            UserModel.id < prev_id,
+                        ),
+                    )
+                )
+        else:
+            if prev_id is None:
+                pagination_filters.append(UserModel.created_at < prev_created_at)
+            else:
+                pagination_filters.append(
+                    or_(
+                        UserModel.created_at < prev_created_at,
+                        and_(
+                            UserModel.created_at == prev_created_at,
+                            UserModel.id > prev_id,
+                        ),
+                    )
+                )
+    order_by = (UserModel.created_at.desc(), UserModel.id)
+    if ascending:
+        order_by = (UserModel.created_at.asc(), UserModel.id.desc())
+    total_count = None
+    if return_total_count:
+        res = await session.execute(stmt.with_only_columns(safunc.count(literal_column("1"))))
+        total_count = res.scalar_one()
+    res = await session.execute(stmt.where(*pagination_filters).order_by(*order_by).limit(limit))
     user_models = res.scalars().all()
-    user_models = sorted(user_models, key=lambda u: u.created_at)
-    return [user_model_to_user(u) for u in user_models]
+    users = [user_model_to_user(u) for u in user_models]
+    if total_count is None:
+        return users
+    return UsersInfoList(total_count=total_count, users=users)
 
 
 async def get_user_with_creds_by_name(

--- a/src/dstack/api/server/_projects.py
+++ b/src/dstack/api/server/_projects.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from typing import Any, List, Optional
+from typing import Any, List, Literal, Optional, Union, overload
 from uuid import UUID
 
 from pydantic import parse_obj_as
@@ -23,9 +23,38 @@ from dstack.api.server._group import APIClientGroup
 
 
 class ProjectsAPIClient(APIClientGroup):
+    @overload
     def list(
         self,
         include_not_joined: bool = True,
+        *,
+        return_total_count: Literal[True],
+        name_pattern: Optional[str] = None,
+        prev_created_at: Optional[datetime] = None,
+        prev_id: Optional[UUID] = None,
+        limit: Optional[int] = None,
+        ascending: Optional[bool] = None,
+    ) -> ProjectsInfoList:
+        pass
+
+    @overload
+    def list(
+        self,
+        include_not_joined: bool = True,
+        *,
+        return_total_count: Union[Literal[False], None] = None,
+        name_pattern: Optional[str] = None,
+        prev_created_at: Optional[datetime] = None,
+        prev_id: Optional[UUID] = None,
+        limit: Optional[int] = None,
+        ascending: Optional[bool] = None,
+    ) -> List[Project]:
+        pass
+
+    def list(
+        self,
+        include_not_joined: bool = True,
+        *,
         return_total_count: Optional[bool] = None,
         name_pattern: Optional[str] = None,
         prev_created_at: Optional[datetime] = None,

--- a/src/dstack/api/server/_projects.py
+++ b/src/dstack/api/server/_projects.py
@@ -5,7 +5,11 @@ from uuid import UUID
 
 from pydantic import parse_obj_as
 
-from dstack._internal.core.models.projects import Project
+from dstack._internal.core.models.projects import (
+    Project,
+    ProjectsInfoList,
+    ProjectsInfoListOrProjectsList,
+)
 from dstack._internal.core.models.users import ProjectRole
 from dstack._internal.server.schemas.projects import (
     AddProjectMemberRequest,
@@ -22,15 +26,18 @@ class ProjectsAPIClient(APIClientGroup):
     def list(
         self,
         include_not_joined: bool = True,
+        return_total_count: Optional[bool] = None,
         prev_created_at: Optional[datetime] = None,
         prev_id: Optional[UUID] = None,
         limit: Optional[int] = None,
         ascending: Optional[bool] = None,
-    ) -> List[Project]:
-        # Excluding None fields for backward compatibility with 0.20 servers.
+    ) -> ProjectsInfoListOrProjectsList:
+        # Passing only non-None fields for backward compatibility with 0.20 servers.
         body: dict[str, Any] = {
             "include_not_joined": include_not_joined,
         }
+        if return_total_count is not None:
+            body["return_total_count"] = return_total_count
         if prev_created_at is not None:
             body["prev_created_at"] = prev_created_at
         if prev_id is not None:
@@ -40,7 +47,9 @@ class ProjectsAPIClient(APIClientGroup):
         if ascending is not None:
             body["ascending"] = ascending
         resp = self._request("/api/projects/list", body=json.dumps(body))
-        return parse_obj_as(List[Project.__response__], resp.json())
+        if return_total_count is None:
+            return parse_obj_as(List[Project.__response__], resp.json())
+        return parse_obj_as(ProjectsInfoList, resp.json())
 
     def create(self, project_name: str, is_public: bool = False) -> Project:
         body = CreateProjectRequest(project_name=project_name, is_public=is_public)

--- a/src/dstack/api/server/_projects.py
+++ b/src/dstack/api/server/_projects.py
@@ -39,17 +39,18 @@ class ProjectsAPIClient(APIClientGroup):
         if return_total_count is not None:
             body["return_total_count"] = return_total_count
         if prev_created_at is not None:
-            body["prev_created_at"] = prev_created_at
+            body["prev_created_at"] = prev_created_at.isoformat()
         if prev_id is not None:
-            body["prev_id"] = prev_id
+            body["prev_id"] = str(prev_id)
         if limit is not None:
             body["limit"] = limit
         if ascending is not None:
             body["ascending"] = ascending
         resp = self._request("/api/projects/list", body=json.dumps(body))
-        if return_total_count is None:
-            return parse_obj_as(List[Project.__response__], resp.json())
-        return parse_obj_as(ProjectsInfoList, resp.json())
+        resp_json = resp.json()
+        if isinstance(resp_json, list):
+            return parse_obj_as(List[Project.__response__], resp_json)
+        return parse_obj_as(ProjectsInfoList, resp_json)
 
     def create(self, project_name: str, is_public: bool = False) -> Project:
         body = CreateProjectRequest(project_name=project_name, is_public=is_public)

--- a/src/dstack/api/server/_projects.py
+++ b/src/dstack/api/server/_projects.py
@@ -27,6 +27,7 @@ class ProjectsAPIClient(APIClientGroup):
         self,
         include_not_joined: bool = True,
         return_total_count: Optional[bool] = None,
+        name_pattern: Optional[str] = None,
         prev_created_at: Optional[datetime] = None,
         prev_id: Optional[UUID] = None,
         limit: Optional[int] = None,
@@ -38,6 +39,8 @@ class ProjectsAPIClient(APIClientGroup):
         }
         if return_total_count is not None:
             body["return_total_count"] = return_total_count
+        if name_pattern is not None:
+            body["name_pattern"] = name_pattern
         if prev_created_at is not None:
             body["prev_created_at"] = prev_created_at.isoformat()
         if prev_id is not None:

--- a/src/dstack/api/server/_users.py
+++ b/src/dstack/api/server/_users.py
@@ -26,6 +26,7 @@ class UsersAPIClient(APIClientGroup):
     def list(
         self,
         return_total_count: Optional[bool] = None,
+        name_pattern: Optional[str] = None,
         prev_created_at: Optional[datetime] = None,
         prev_id: Optional[UUID] = None,
         limit: Optional[int] = None,
@@ -35,6 +36,8 @@ class UsersAPIClient(APIClientGroup):
         body: dict[str, Any] = {}
         if return_total_count is not None:
             body["return_total_count"] = return_total_count
+        if name_pattern is not None:
+            body["name_pattern"] = name_pattern
         if prev_created_at is not None:
             body["prev_created_at"] = prev_created_at
         if prev_id is not None:

--- a/src/dstack/api/server/_users.py
+++ b/src/dstack/api/server/_users.py
@@ -1,8 +1,18 @@
-from typing import List
+import json
+from datetime import datetime
+from typing import Any, List, Optional
+from uuid import UUID
 
 from pydantic import parse_obj_as
+from pydantic.json import pydantic_encoder
 
-from dstack._internal.core.models.users import GlobalRole, User, UserWithCreds
+from dstack._internal.core.models.users import (
+    GlobalRole,
+    User,
+    UsersInfoList,
+    UsersInfoListOrUsersList,
+    UserWithCreds,
+)
 from dstack._internal.server.schemas.users import (
     CreateUserRequest,
     GetUserRequest,
@@ -13,9 +23,36 @@ from dstack.api.server._group import APIClientGroup
 
 
 class UsersAPIClient(APIClientGroup):
-    def list(self) -> List[User]:
-        resp = self._request("/api/users/list")
-        return parse_obj_as(List[User.__response__], resp.json())
+    def list(
+        self,
+        return_total_count: Optional[bool] = None,
+        prev_created_at: Optional[datetime] = None,
+        prev_id: Optional[UUID] = None,
+        limit: Optional[int] = None,
+        ascending: Optional[bool] = None,
+    ) -> UsersInfoListOrUsersList:
+        # Passing only non-None fields for backward compatibility with 0.20 servers.
+        body: dict[str, Any] = {}
+        if return_total_count is not None:
+            body["return_total_count"] = return_total_count
+        if prev_created_at is not None:
+            body["prev_created_at"] = prev_created_at
+        if prev_id is not None:
+            body["prev_id"] = prev_id
+        if limit is not None:
+            body["limit"] = limit
+        if ascending is not None:
+            body["ascending"] = ascending
+        if body:
+            resp = self._request(
+                "/api/users/list", body=json.dumps(body, default=pydantic_encoder)
+            )
+        else:
+            resp = self._request("/api/users/list")
+        resp_json = resp.json()
+        if isinstance(resp_json, list):
+            return parse_obj_as(List[User.__response__], resp_json)
+        return parse_obj_as(UsersInfoList, resp_json)
 
     def get_my_user(self) -> UserWithCreds:
         resp = self._request("/api/users/get_my_user")

--- a/src/tests/api/common.py
+++ b/src/tests/api/common.py
@@ -1,0 +1,29 @@
+import json
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import requests
+
+
+@dataclass
+class RequestRecorder:
+    payload: Any
+    last_path: Optional[str] = None
+    last_body: Optional[str] = None
+    last_kwargs: dict[str, Any] = field(default_factory=dict)
+
+    def __call__(
+        self,
+        path: str,
+        body: Optional[str] = None,
+        raise_for_status: bool = True,
+        method: str = "POST",
+        **kwargs,
+    ) -> requests.Response:
+        self.last_path = path
+        self.last_body = body
+        self.last_kwargs = kwargs
+        resp = requests.Response()
+        resp.status_code = 200
+        resp._content = json.dumps(self.payload).encode("utf-8")
+        return resp

--- a/src/tests/api/test_projects.py
+++ b/src/tests/api/test_projects.py
@@ -1,0 +1,60 @@
+import json
+import logging
+from datetime import datetime, timezone
+from uuid import UUID
+
+from dstack.api.server._projects import ProjectsAPIClient
+from tests.api.common import RequestRecorder
+
+PROJECT_PAYLOAD = {
+    "project_id": "1b0e1b45-2f8c-4ab6-8010-a0d1a3e44e0e",
+    "project_name": "p",
+    "owner": {
+        "id": "2b0e1b45-2f8c-4ab6-8010-a0d1a3e44e0e",
+        "username": "u",
+        "created_at": "2023-01-02T03:04:00+00:00",
+        "global_role": "user",
+        "email": None,
+        "active": True,
+        "permissions": {"can_create_projects": True},
+        "ssh_public_key": None,
+    },
+    "created_at": "2023-01-02T03:04:00+00:00",
+    "backends": [],
+    "members": [],
+    "is_public": False,
+}
+
+
+class TestProjectsList:
+    def test_projects_list_serializes_pagination_and_parses_total_count(self):
+        request = RequestRecorder(payload={"total_count": 1, "projects": [PROJECT_PAYLOAD]})
+        client = ProjectsAPIClient(_request=request, _logger=logging.getLogger("test"))
+        dt = datetime(2023, 1, 2, 3, 4, tzinfo=timezone.utc)
+        pid = UUID("3b0e1b45-2f8c-4ab6-8010-a0d1a3e44e0e")
+
+        result = client.list(
+            return_total_count=True,
+            prev_created_at=dt,
+            prev_id=pid,
+            limit=1,
+            ascending=True,
+        )
+
+        payload = json.loads(request.last_body)
+        assert request.last_path == "/api/projects/list"
+        assert payload["include_not_joined"] is True
+        assert payload["return_total_count"] is True
+        assert payload["prev_created_at"] == dt.isoformat()
+        assert payload["prev_id"] == str(pid)
+        assert payload["limit"] == 1
+        assert payload["ascending"] is True
+        assert result.total_count == 1
+        assert result.projects[0].project_name == "p"
+
+    def test_projects_list_parses_list_response(self):
+        request = RequestRecorder(payload=[PROJECT_PAYLOAD])
+        client = ProjectsAPIClient(_request=request, _logger=logging.getLogger("test"))
+        result = client.list()
+        assert isinstance(result, list)
+        assert result[0].project_name == PROJECT_PAYLOAD["project_name"]

--- a/src/tests/api/test_projects.py
+++ b/src/tests/api/test_projects.py
@@ -26,8 +26,8 @@ PROJECT_PAYLOAD = {
 }
 
 
-class TestProjectsList:
-    def test_projects_list_serializes_pagination_and_parses_total_count(self):
+class TestProjectsAPIClientList:
+    def test_projects_list_serializes_pagination_and_parses_info_list(self):
         request = RequestRecorder(payload={"total_count": 1, "projects": [PROJECT_PAYLOAD]})
         client = ProjectsAPIClient(_request=request, _logger=logging.getLogger("test"))
         dt = datetime(2023, 1, 2, 3, 4, tzinfo=timezone.utc)

--- a/src/tests/api/test_projects.py
+++ b/src/tests/api/test_projects.py
@@ -36,6 +36,7 @@ class TestProjectsList:
         result = client.list(
             return_total_count=True,
             prev_created_at=dt,
+            name_pattern="p",
             prev_id=pid,
             limit=1,
             ascending=True,
@@ -45,6 +46,7 @@ class TestProjectsList:
         assert request.last_path == "/api/projects/list"
         assert payload["include_not_joined"] is True
         assert payload["return_total_count"] is True
+        assert payload["name_pattern"] == "p"
         assert payload["prev_created_at"] == dt.isoformat()
         assert payload["prev_id"] == str(pid)
         assert payload["limit"] == 1

--- a/src/tests/api/test_users.py
+++ b/src/tests/api/test_users.py
@@ -19,7 +19,7 @@ USER_PAYLOAD = {
 
 
 class TestUsersAPIClientList:
-    def test_serializes_pagination_and_parses_total_count(self):
+    def test_serializes_pagination_and_parses_info_list(self):
         recorder = RequestRecorder({"total_count": 1, "users": [USER_PAYLOAD]})
         client = UsersAPIClient(_request=recorder, _logger=logging.getLogger("test"))
         dt = datetime(2023, 1, 2, 3, 4, tzinfo=timezone.utc)

--- a/src/tests/api/test_users.py
+++ b/src/tests/api/test_users.py
@@ -1,0 +1,52 @@
+import json
+import logging
+from datetime import datetime, timezone
+from uuid import UUID
+
+from dstack.api.server._users import UsersAPIClient
+from tests.api.common import RequestRecorder
+
+USER_PAYLOAD = {
+    "id": "11111111-1111-4111-8111-111111111111",
+    "username": "user",
+    "created_at": "2023-01-02T03:04:00+00:00",
+    "global_role": "user",
+    "email": None,
+    "active": True,
+    "permissions": {"can_create_projects": True},
+    "ssh_public_key": None,
+}
+
+
+class TestUsersAPIClientList:
+    def test_serializes_pagination_and_parses_total_count(self):
+        recorder = RequestRecorder({"total_count": 1, "users": [USER_PAYLOAD]})
+        client = UsersAPIClient(_request=recorder, _logger=logging.getLogger("test"))
+        dt = datetime(2023, 1, 2, 3, 4, tzinfo=timezone.utc)
+        uid = UUID("22222222-2222-4222-8222-222222222222")
+
+        result = client.list(
+            return_total_count=True,
+            prev_created_at=dt,
+            prev_id=uid,
+            limit=1,
+            ascending=True,
+        )
+
+        payload = json.loads(recorder.last_body)
+        assert recorder.last_path == "/api/users/list"
+        assert payload["return_total_count"] is True
+        assert payload["prev_created_at"] == dt.isoformat()
+        assert payload["prev_id"] == str(uid)
+        assert payload["limit"] == 1
+        assert payload["ascending"] is True
+        assert result.total_count == 1
+        assert result.users[0].username == "user"
+
+    def test_parses_list_response(self):
+        recorder = RequestRecorder([USER_PAYLOAD])
+        client = UsersAPIClient(_request=recorder, _logger=logging.getLogger("test"))
+        result = client.list()
+
+        assert isinstance(result, list)
+        assert result[0].username == "user"

--- a/src/tests/api/test_users.py
+++ b/src/tests/api/test_users.py
@@ -27,6 +27,7 @@ class TestUsersAPIClientList:
 
         result = client.list(
             return_total_count=True,
+            name_pattern="user",
             prev_created_at=dt,
             prev_id=uid,
             limit=1,
@@ -36,6 +37,7 @@ class TestUsersAPIClientList:
         payload = json.loads(recorder.last_body)
         assert recorder.last_path == "/api/users/list"
         assert payload["return_total_count"] is True
+        assert payload["name_pattern"] == "user"
         assert payload["prev_created_at"] == dt.isoformat()
         assert payload["prev_id"] == str(uid)
         assert payload["limit"] == 1


### PR DESCRIPTION
Closes #3487

This PR implements cursor-based pagination for endpoints `/api/project/list` and `/api/users/list` similar to other paginated endpoints.

Max and default `limit` is currently set to 2000 to avoid breaking the UI. The UI should switch to the new API for performance.

Notes:
* Added `return_total_count` param to include `total_count` in response so that the UI can still show the number of projects/users without getting all of them.
* Added `name_pattern` to be able to filter projects/users by name substring on the server side. The UI can also use this to get project and user names for filters, e.g. by requesting one page.
