### PR TITLE
[UX] Extend `dstack login` with interactive selection of `url` and default project

### DIFF
--- a/src/dstack/_internal/cli/commands/project.py
+++ b/src/dstack/_internal/cli/commands/project.py
@@ -2,15 +2,9 @@ import argparse
 import sys
 from typing import Any, Optional, Union
 
+import questionary
 from requests import HTTPError
 from rich.table import Table
-
-try:
-    import questionary
-
-    is_project_menu_supported = sys.stdin.isatty()
-except (ImportError, NotImplementedError, AttributeError):
-    is_project_menu_supported = False
 
 import dstack.api.server
 from dstack._internal.cli.commands import BaseCommand
@@ -21,6 +15,8 @@ from dstack._internal.core.services.configs import ConfigManager
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+is_project_menu_supported = sys.stdin.isatty()
 
 
 def select_default_project(
@@ -57,9 +53,9 @@ def select_default_project(
             default_index = i
         menu_entries.append((entry, i))
 
-    choices = [questionary.Choice(title=entry, value=index) for entry, index in menu_entries]  # pyright: ignore[reportPossiblyUnboundVariable]
+    choices = [questionary.Choice(title=entry, value=index) for entry, index in menu_entries]
     default_value = default_index
-    selected_index = questionary.select(  # pyright: ignore[reportPossiblyUnboundVariable]
+    selected_index = questionary.select(
         message="Select the default project:",
         choices=choices,
         default=default_value,  # pyright: ignore[reportArgumentType]

--- a/src/dstack/_internal/cli/utils/common.py
+++ b/src/dstack/_internal/cli/utils/common.py
@@ -99,7 +99,11 @@ def configure_logging():
 
 def confirm_ask(prompt, **kwargs) -> bool:
     kwargs["console"] = console
-    return Confirm.ask(prompt=prompt, **kwargs)
+    try:
+        return Confirm.ask(prompt=prompt, **kwargs)
+    except KeyboardInterrupt:
+        console.print("\nCancelled by user")
+        raise SystemExit(1)
 
 
 def add_row_from_dict(table: Table, data: Dict[Union[str, int], Any], **kwargs):

--- a/src/tests/_internal/cli/commands/test_login.py
+++ b/src/tests/_internal/cli/commands/test_login.py
@@ -8,34 +8,72 @@ from tests._internal.cli.common import run_dstack_cli
 
 
 class TestLogin:
+    @staticmethod
+    def _setup_auth_mocks(api_client_mock, login_server_mock, user_token="token"):
+        """Set up common authentication mocks."""
+        api_client_mock.return_value.auth.list_providers.return_value = [
+            SimpleNamespace(name="github", enabled=True)
+        ]
+        api_client_mock.return_value.auth.authorize.return_value = SimpleNamespace(
+            authorization_url="http://auth_url"
+        )
+        user = SimpleNamespace(username="me", creds=SimpleNamespace(token=user_token))
+        login_server_mock.return_value.get_logged_in_user.return_value = user
+        return user
+
+    @staticmethod
+    def _setup_config_manager_with_state_tracking(
+        config_manager_mock, tmp_path: Path, project_configs: list[SimpleNamespace]
+    ):
+        """Set up ConfigManager mock with state tracking via side effects."""
+        config_manager_mock.return_value.config_filepath = tmp_path / "config.yml"
+        config_manager_mock.return_value.list_project_configs.return_value = project_configs
+
+        def configure_project_side_effect(name, url, token, default):
+            for pc in project_configs:
+                if pc.name == name:
+                    pc.url = url
+                    pc.token = token
+                    if default:
+                        for p in project_configs:
+                            p.default = False
+                    pc.default = default or pc.default
+                    return
+
+        def get_project_config_side_effect(name=None):
+            if name is None:
+                for pc in project_configs:
+                    if pc.default:
+                        return pc
+                return None
+            for pc in project_configs:
+                if pc.name == name:
+                    return pc
+            return None
+
+        config_manager_mock.return_value.configure_project.side_effect = (
+            configure_project_side_effect
+        )
+        config_manager_mock.return_value.get_project_config.side_effect = (
+            get_project_config_side_effect
+        )
+
     def test_login_no_projects(self, capsys: CaptureFixture, tmp_path: Path):
         with (
             patch("dstack._internal.cli.commands.login.webbrowser") as webbrowser_mock,
-            patch("dstack._internal.cli.commands.login.APIClient") as APIClientMock,
-            patch("dstack._internal.cli.commands.login._LoginServer") as LoginServerMock,
+            patch("dstack._internal.cli.commands.login.APIClient") as api_client_mock,
+            patch("dstack._internal.cli.commands.login._LoginServer") as login_server_mock,
             patch(
                 "dstack._internal.cli.commands.login._normalize_url_or_error"
-            ) as _normalize_url_or_error_mock,
+            ) as normalize_url_mock,
         ):
             webbrowser_mock.open.return_value = True
-            _normalize_url_or_error_mock.return_value = "http://127.0.0.1:31313"
-            APIClientMock.return_value.auth.list_providers.return_value = [
-                SimpleNamespace(name="github", enabled=True)
-            ]
-            APIClientMock.return_value.auth.authorize.return_value = SimpleNamespace(
-                authorization_url="http://auth_url"
-            )
-            APIClientMock.return_value.projects.list.return_value = []
-            user = SimpleNamespace(username="me", creds=SimpleNamespace(token="token"))
-            LoginServerMock.return_value.get_logged_in_user.return_value = user
+            normalize_url_mock.return_value = "http://127.0.0.1:31313"
+            self._setup_auth_mocks(api_client_mock, login_server_mock)
+            api_client_mock.return_value.projects.list.return_value = []
+
             exit_code = run_dstack_cli(
-                [
-                    "login",
-                    "--url",
-                    "http://127.0.0.1:31313",
-                    "--provider",
-                    "github",
-                ],
+                ["login", "--url", "http://127.0.0.1:31313", "--provider", "github"],
                 home_dir=tmp_path,
             )
 
@@ -43,53 +81,195 @@ class TestLogin:
         assert capsys.readouterr().out.replace("\n", "") == (
             "Your browser has been opened to log in with Github:"
             "http://auth_url"
-            "Logged in as me."
+            "Logged in as me"
             "No projects configured. Create your own project via the UI or contact a project manager to add you to the project."
         )
 
     def test_login_configures_projects(self, capsys: CaptureFixture, tmp_path: Path):
         with (
             patch("dstack._internal.cli.commands.login.webbrowser") as webbrowser_mock,
-            patch("dstack._internal.cli.commands.login.APIClient") as APIClientMock,
-            patch("dstack._internal.cli.commands.login.ConfigManager") as ConfigManagerMock,
-            patch("dstack._internal.cli.commands.login._LoginServer") as LoginServerMock,
+            patch("dstack._internal.cli.commands.login.APIClient") as api_client_mock,
+            patch("dstack._internal.cli.commands.login.ConfigManager") as config_manager_mock,
+            patch("dstack._internal.cli.commands.login._LoginServer") as login_server_mock,
             patch(
                 "dstack._internal.cli.commands.login._normalize_url_or_error"
-            ) as _normalize_url_or_error_mock,
+            ) as normalize_url_mock,
         ):
-            _normalize_url_or_error_mock.return_value = "http://127.0.0.1:31313"
             webbrowser_mock.open.return_value = True
-            APIClientMock.return_value.auth.list_providers.return_value = [
-                SimpleNamespace(name="github", enabled=True)
-            ]
-            APIClientMock.return_value.auth.authorize.return_value = SimpleNamespace(
-                authorization_url="http://auth_url"
-            )
-            APIClientMock.return_value.projects.list.return_value = [
+            normalize_url_mock.return_value = "http://127.0.0.1:31313"
+            user = self._setup_auth_mocks(api_client_mock, login_server_mock)
+            api_client_mock.return_value.projects.list.return_value = [
                 SimpleNamespace(project_name="project1"),
                 SimpleNamespace(project_name="project2"),
             ]
-            APIClientMock.return_value.base_url = "http://127.0.0.1:31313"
-            ConfigManagerMock.return_value.get_project_config.return_value = None
-            user = SimpleNamespace(username="me", creds=SimpleNamespace(token="token"))
-            LoginServerMock.return_value.get_logged_in_user.return_value = user
+            api_client_mock.return_value.base_url = "http://127.0.0.1:31313"
+
+            project_configs = [
+                SimpleNamespace(
+                    name="project1", url="http://127.0.0.1:31313", token="token", default=False
+                ),
+                SimpleNamespace(
+                    name="project2", url="http://127.0.0.1:31313", token="token", default=False
+                ),
+            ]
+            config_manager_mock.return_value.get_project_config.return_value = None
+            self._setup_config_manager_with_state_tracking(
+                config_manager_mock, tmp_path, project_configs
+            )
+
             exit_code = run_dstack_cli(
-                [
-                    "login",
-                    "--url",
-                    "http://127.0.0.1:31313",
-                    "--provider",
-                    "github",
-                ],
+                ["login", "--url", "http://127.0.0.1:31313", "--provider", "github"],
                 home_dir=tmp_path,
             )
-            ConfigManagerMock.return_value.configure_project.assert_has_calls(
+
+            config_manager_mock.return_value.configure_project.assert_has_calls(
                 [
                     call(
                         name="project1",
                         url="http://127.0.0.1:31313",
                         token=user.creds.token,
-                        default=True,
+                        default=False,
+                    ),
+                    call(
+                        name="project2",
+                        url="http://127.0.0.1:31313",
+                        token=user.creds.token,
+                        default=False,
+                    ),
+                    call(
+                        name="project1", url="http://127.0.0.1:31313", token="token", default=True
+                    ),
+                ]
+            )
+            config_manager_mock.return_value.save.assert_called()
+            final_default = config_manager_mock.return_value.get_project_config()
+            assert final_default is not None
+            assert final_default.name == "project1"
+
+        assert exit_code == 0
+        assert capsys.readouterr().out.replace("\n", "") == (
+            "Your browser has been opened to log in with Github:"
+            "http://auth_url"
+            "Logged in as me"
+            f"Added project1, project2 projects at {tmp_path / 'config.yml'}"
+            f"Set project1 project as default at {tmp_path / 'config.yml'}"
+        )
+
+    def test_login_configures_projects_yes_sets_first_project_default(
+        self, capsys: CaptureFixture, tmp_path: Path
+    ):
+        with (
+            patch("dstack._internal.cli.commands.login.webbrowser") as webbrowser_mock,
+            patch("dstack._internal.cli.commands.login.APIClient") as api_client_mock,
+            patch("dstack._internal.cli.commands.login.ConfigManager") as config_manager_mock,
+            patch("dstack._internal.cli.commands.login._LoginServer") as login_server_mock,
+            patch(
+                "dstack._internal.cli.commands.login._normalize_url_or_error"
+            ) as normalize_url_mock,
+        ):
+            webbrowser_mock.open.return_value = True
+            normalize_url_mock.return_value = "http://127.0.0.1:31313"
+            user = self._setup_auth_mocks(api_client_mock, login_server_mock)
+            api_client_mock.return_value.projects.list.return_value = [
+                SimpleNamespace(project_name="project1"),
+                SimpleNamespace(project_name="project2"),
+            ]
+            api_client_mock.return_value.base_url = "http://127.0.0.1:31313"
+
+            project_configs = [
+                SimpleNamespace(
+                    name="project1", url="http://127.0.0.1:31313", token="token", default=False
+                ),
+                SimpleNamespace(
+                    name="project2", url="http://127.0.0.1:31313", token="token", default=True
+                ),
+            ]
+            self._setup_config_manager_with_state_tracking(
+                config_manager_mock, tmp_path, project_configs
+            )
+
+            exit_code = run_dstack_cli(
+                ["login", "--url", "http://127.0.0.1:31313", "--provider", "github", "--yes"],
+                home_dir=tmp_path,
+            )
+
+            config_manager_mock.return_value.configure_project.assert_has_calls(
+                [
+                    call(
+                        name="project1",
+                        url="http://127.0.0.1:31313",
+                        token=user.creds.token,
+                        default=False,
+                    ),
+                    call(
+                        name="project2",
+                        url="http://127.0.0.1:31313",
+                        token=user.creds.token,
+                        default=False,
+                    ),
+                    call(
+                        name="project1", url="http://127.0.0.1:31313", token="token", default=True
+                    ),
+                ]
+            )
+            final_default = config_manager_mock.return_value.get_project_config()
+            assert final_default is not None
+            assert final_default.name == "project1"
+
+        assert exit_code == 0
+        assert capsys.readouterr().out.replace("\n", "") == (
+            "Your browser has been opened to log in with Github:"
+            "http://auth_url"
+            "Logged in as me"
+            f"Added project1, project2 projects at {tmp_path / 'config.yml'}"
+            f"Set project1 project as default at {tmp_path / 'config.yml'}"
+        )
+
+    def test_login_configures_projects_no_does_not_change_default(
+        self, capsys: CaptureFixture, tmp_path: Path
+    ):
+        with (
+            patch("dstack._internal.cli.commands.login.webbrowser") as webbrowser_mock,
+            patch("dstack._internal.cli.commands.login.APIClient") as api_client_mock,
+            patch("dstack._internal.cli.commands.login.ConfigManager") as config_manager_mock,
+            patch("dstack._internal.cli.commands.login._LoginServer") as login_server_mock,
+            patch(
+                "dstack._internal.cli.commands.login._normalize_url_or_error"
+            ) as normalize_url_mock,
+        ):
+            webbrowser_mock.open.return_value = True
+            normalize_url_mock.return_value = "http://127.0.0.1:31313"
+            user = self._setup_auth_mocks(api_client_mock, login_server_mock)
+            api_client_mock.return_value.projects.list.return_value = [
+                SimpleNamespace(project_name="project1"),
+                SimpleNamespace(project_name="project2"),
+            ]
+            api_client_mock.return_value.base_url = "http://127.0.0.1:31313"
+
+            project_configs = [
+                SimpleNamespace(
+                    name="project1", url="http://127.0.0.1:31313", token="token", default=False
+                ),
+                SimpleNamespace(
+                    name="project2", url="http://127.0.0.1:31313", token="token", default=True
+                ),
+            ]
+            self._setup_config_manager_with_state_tracking(
+                config_manager_mock, tmp_path, project_configs
+            )
+
+            exit_code = run_dstack_cli(
+                ["login", "--url", "http://127.0.0.1:31313", "--provider", "github", "--no"],
+                home_dir=tmp_path,
+            )
+
+            config_manager_mock.return_value.configure_project.assert_has_calls(
+                [
+                    call(
+                        name="project1",
+                        url="http://127.0.0.1:31313",
+                        token=user.creds.token,
+                        default=False,
                     ),
                     call(
                         name="project2",
@@ -99,13 +279,153 @@ class TestLogin:
                     ),
                 ]
             )
-            ConfigManagerMock.return_value.save.assert_called()
+            assert (
+                call(name="project1", url="http://127.0.0.1:31313", token="token", default=True)
+                not in config_manager_mock.return_value.configure_project.mock_calls
+            )
+            final_default = config_manager_mock.return_value.get_project_config()
+            assert final_default is not None
+            assert final_default.name == "project2"
 
         assert exit_code == 0
         assert capsys.readouterr().out.replace("\n", "") == (
             "Your browser has been opened to log in with Github:"
             "http://auth_url"
-            "Logged in as me."
-            "Configured projects: project1, project2."
-            "Set project project1 as default project."
+            "Logged in as me"
+            f"Added project1, project2 projects at {tmp_path / 'config.yml'}"
+        )
+
+    def test_login_single_project_auto_default(self, capsys: CaptureFixture, tmp_path: Path):
+        with (
+            patch("dstack._internal.cli.commands.login.webbrowser") as webbrowser_mock,
+            patch("dstack._internal.cli.commands.login.APIClient") as api_client_mock,
+            patch("dstack._internal.cli.commands.login.ConfigManager") as config_manager_mock,
+            patch("dstack._internal.cli.commands.login._LoginServer") as login_server_mock,
+            patch(
+                "dstack._internal.cli.commands.login._normalize_url_or_error"
+            ) as normalize_url_mock,
+        ):
+            webbrowser_mock.open.return_value = True
+            normalize_url_mock.return_value = "http://127.0.0.1:31313"
+            user = self._setup_auth_mocks(api_client_mock, login_server_mock)
+            api_client_mock.return_value.projects.list.return_value = [
+                SimpleNamespace(project_name="project1"),
+            ]
+            api_client_mock.return_value.base_url = "http://127.0.0.1:31313"
+
+            project_configs = [
+                SimpleNamespace(
+                    name="project1", url="http://127.0.0.1:31313", token="token", default=False
+                ),
+            ]
+            config_manager_mock.return_value.get_project_config.return_value = None
+            self._setup_config_manager_with_state_tracking(
+                config_manager_mock, tmp_path, project_configs
+            )
+
+            exit_code = run_dstack_cli(
+                ["login", "--url", "http://127.0.0.1:31313", "--provider", "github"],
+                home_dir=tmp_path,
+            )
+
+            config_manager_mock.return_value.configure_project.assert_has_calls(
+                [
+                    call(
+                        name="project1",
+                        url="http://127.0.0.1:31313",
+                        token=user.creds.token,
+                        default=False,
+                    ),
+                    call(
+                        name="project1", url="http://127.0.0.1:31313", token="token", default=True
+                    ),
+                ]
+            )
+            final_default = config_manager_mock.return_value.get_project_config()
+            assert final_default is not None
+            assert final_default.name == "project1"
+
+        assert exit_code == 0
+        assert capsys.readouterr().out.replace("\n", "") == (
+            "Your browser has been opened to log in with Github:"
+            "http://auth_url"
+            "Logged in as me"
+            f"Added project1 project at {tmp_path / 'config.yml'}"
+            f"Set project1 project as default at {tmp_path / 'config.yml'}"
+        )
+
+    def test_login_interactive_prompts_for_default_project(
+        self, capsys: CaptureFixture, tmp_path: Path
+    ):
+        with (
+            patch("dstack._internal.cli.commands.login.webbrowser") as webbrowser_mock,
+            patch("dstack._internal.cli.commands.login.APIClient") as api_client_mock,
+            patch("dstack._internal.cli.commands.login.ConfigManager") as config_manager_mock,
+            patch("dstack._internal.cli.commands.login._LoginServer") as login_server_mock,
+            patch(
+                "dstack._internal.cli.commands.login._normalize_url_or_error"
+            ) as normalize_url_mock,
+            patch(
+                "dstack._internal.cli.commands.login.select_default_project"
+            ) as select_default_project_mock,
+            patch("dstack._internal.cli.commands.login.is_project_menu_supported", True),
+        ):
+            webbrowser_mock.open.return_value = True
+            normalize_url_mock.return_value = "http://127.0.0.1:31313"
+            user = self._setup_auth_mocks(api_client_mock, login_server_mock)
+            api_client_mock.return_value.projects.list.return_value = [
+                SimpleNamespace(project_name="project1"),
+                SimpleNamespace(project_name="project2"),
+            ]
+            api_client_mock.return_value.base_url = "http://127.0.0.1:31313"
+
+            project_configs = [
+                SimpleNamespace(
+                    name="project1", url="http://127.0.0.1:31313", token="token", default=False
+                ),
+                SimpleNamespace(
+                    name="project2", url="http://127.0.0.1:31313", token="token", default=False
+                ),
+            ]
+            config_manager_mock.return_value.get_project_config.return_value = None
+            self._setup_config_manager_with_state_tracking(
+                config_manager_mock, tmp_path, project_configs
+            )
+            select_default_project_mock.return_value = project_configs[1]
+
+            exit_code = run_dstack_cli(
+                ["login", "--url", "http://127.0.0.1:31313", "--provider", "github"],
+                home_dir=tmp_path,
+            )
+
+            select_default_project_mock.assert_called_once()
+            config_manager_mock.return_value.configure_project.assert_has_calls(
+                [
+                    call(
+                        name="project1",
+                        url="http://127.0.0.1:31313",
+                        token=user.creds.token,
+                        default=False,
+                    ),
+                    call(
+                        name="project2",
+                        url="http://127.0.0.1:31313",
+                        token=user.creds.token,
+                        default=False,
+                    ),
+                    call(
+                        name="project2", url="http://127.0.0.1:31313", token="token", default=True
+                    ),
+                ]
+            )
+            final_default = config_manager_mock.return_value.get_project_config()
+            assert final_default is not None
+            assert final_default.name == "project2"
+
+        assert exit_code == 0
+        assert capsys.readouterr().out.replace("\n", "") == (
+            "Your browser has been opened to log in with Github:"
+            "http://auth_url"
+            "Logged in as me"
+            f"Added project1, project2 projects at {tmp_path / 'config.yml'}"
         )


### PR DESCRIPTION
1. Similar to `gh auth login`, if the user does not pass `--url` to `dstack login`, the command prompts the user to enter it interactively. The default value in this case is `https://sky.dstack.ai`.

2. If the logged-in user has more than one project, `dstack login` prompts the user to select a default project using an interactive menu.

<img width="695" height="318" alt="Screenshot 2026-01-23 at 16 41 07" src="https://github.com/user-attachments/assets/02fb849d-6431-4fd8-84ed-58cfb6f3211a" />

3. Similar to `dstack project`, to explicitly avoid interactive prompts, `dstack login` now accepts `-n/--no` (does not change the default project) and `-y/--yes` (sets the user’s first project as the default).

<img width="626" height="154" alt="Screenshot 2026-01-23 at 16 41 16" src="https://github.com/user-attachments/assets/af61ed2b-790c-4cd1-a6ef-3fbe93930815" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves `dstack login` UX with interactive prompts and explicit non-interactive flags.
> 
> - Prompts for `--url` when running in a TTY (default `https://sky.dstack.ai`); adds rich-styled `UrlPrompt` and graceful Ctrl-C handling
> - When multiple SSO providers exist in a TTY, prompts to select provider; otherwise requires `-p/--provider`
> - Adds `-y/--yes` and `-n/--no` to control default project selection; configures all projects first, then sets default based on flags/TTY conditions (single project auto-selected; interactive menu via `select_default_project` when supported)
> - Tweaks output messages (e.g., "Logged in as", "Added ... at <config path>") and centralizes `isatty` checks
> - Wraps `confirm_ask` with KeyboardInterrupt handling; simplifies `project.py` Questionary import and cleans selection code
> - Extensive tests added/updated for new flows and messaging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc5dad75613038bb764b8ecab6e5e3058f47a51a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->