### PR TITLE
Set INSTANCE_UNREACHABLE for unreachable on-demand instances

### DIFF
--- a/src/tests/_internal/server/background/tasks/test_process_running_jobs.py
+++ b/src/tests/_internal/server/background/tasks/test_process_running_jobs.py
@@ -532,7 +532,7 @@ class TestProcessRunningJobs:
             assert SSHTunnelMock.call_count == 3
         await session.refresh(job)
         assert job.status == JobStatus.TERMINATING
-        assert job.termination_reason == JobTerminationReason.INTERRUPTED_BY_NO_CAPACITY
+        assert job.termination_reason == JobTerminationReason.INSTANCE_UNREACHABLE
         assert job.remove_at is None
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Previously, if an instance is killed (e.g. a memory issue) while the job was running, the run got the `interrupted` status message.

This PR changes this for on-demand instances from `interrupted` to `error` along with a proper error message `instance unreachable`. Example:

```
Submit a new run? [y/n]: y
 NAME           BACKEND        RESOURCES             INSTA…  PRICE  STAT…  PROB…  SUBM…  ERROR
 stale-dingo-1  gcp            cpu=2 mem=8GB         e2-st…  $0.0…  error         14:10  instance un…
                (us-east5)     disk=100GB

stale-dingo-1 provisioning completed (failed)
Error (Instance unreachable)
```