### PR TITLE
Fix `dstack event` compat. with older servers

### DIFF
--- a/src/dstack/_internal/core/compatibility/events.py
+++ b/src/dstack/_internal/core/compatibility/events.py
@@ -1,0 +1,13 @@
+from dstack._internal.core.models.common import IncludeExcludeDictType
+from dstack._internal.server.schemas.events import ListEventsRequest
+
+
+def get_list_events_excludes(request: ListEventsRequest) -> IncludeExcludeDictType:
+    list_gpus_excludes: IncludeExcludeDictType = {}
+    if request.target_volumes is None:
+        list_gpus_excludes["target_volumes"] = True
+    if request.target_gateways is None:
+        list_gpus_excludes["target_gateways"] = True
+    if request.target_secrets is None:
+        list_gpus_excludes["target_secrets"] = True
+    return list_gpus_excludes

--- a/src/dstack/api/server/_events.py
+++ b/src/dstack/api/server/_events.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from pydantic import parse_obj_as
 
+from dstack._internal.core.compatibility.events import get_list_events_excludes
 from dstack._internal.core.models.events import Event, EventTargetType
 from dstack._internal.server.schemas.events import LIST_EVENTS_DEFAULT_LIMIT, ListEventsRequest
 from dstack.api.server._group import APIClientGroup
@@ -57,5 +58,7 @@ class EventsAPIClient(APIClientGroup):
             limit=limit,
             ascending=ascending,
         )
-        resp = self._request("/api/events/list", body=req.json())
+        resp = self._request(
+            "/api/events/list", body=req.json(exclude=get_list_events_excludes(req))
+        )
         return parse_obj_as(list[Event.__response__], resp.json())


### PR DESCRIPTION
Fixes this error:

```
$ dstack event
Server validation error:
{'detail': [{'loc': ['body', 'target_gateways'],
             'msg': 'extra fields not permitted',
             'type': 'value_error.extra'},
            {'loc': ['body', 'target_secrets'],
             'msg': 'extra fields not permitted',
             'type': 'value_error.extra'},
            {'loc': ['body', 'target_volumes'],
             'msg': 'extra fields not permitted',
             'type': 'value_error.extra'}]}
```

#3290