### PR TITLE
Add probe `until_ready` configuration option

### DIFF
--- a/src/dstack/_internal/core/models/configurations.py
+++ b/src/dstack/_internal/core/models/configurations.py
@@ -372,6 +372,16 @@ class ProbeConfig(generate_dual_core_model(ProbeConfigConfig)):
             ),
         ),
     ] = None
+    until_ready: Annotated[
+        bool,
+        Field(
+            description=(
+                "If `true`, the probe will stop being executed as soon as it reaches the"
+                " `ready_after` threshold of successful executions."
+                " Defaults to `false`"
+            ),
+        ),
+    ] = False
 
     @validator("timeout", pre=True)
     def parse_timeout(cls, v: Optional[Union[int, str]]) -> Optional[int]:

--- a/src/dstack/_internal/core/models/configurations.py
+++ b/src/dstack/_internal/core/models/configurations.py
@@ -54,6 +54,7 @@ DEFAULT_PROBE_TIMEOUT = 10
 DEFAULT_PROBE_INTERVAL = 15
 DEFAULT_PROBE_READY_AFTER = 1
 DEFAULT_PROBE_METHOD = "get"
+DEFAULT_PROBE_UNTIL_READY = False
 MAX_PROBE_URL_LEN = 2048
 DEFAULT_REPLICA_GROUP_NAME = "0"
 
@@ -373,15 +374,15 @@ class ProbeConfig(generate_dual_core_model(ProbeConfigConfig)):
         ),
     ] = None
     until_ready: Annotated[
-        bool,
+        Optional[bool],
         Field(
             description=(
                 "If `true`, the probe will stop being executed as soon as it reaches the"
                 " `ready_after` threshold of successful executions."
-                " Defaults to `false`"
+                f" Defaults to `{str(DEFAULT_PROBE_UNTIL_READY).lower()}`"
             ),
         ),
-    ] = False
+    ] = None
 
     @validator("timeout", pre=True)
     def parse_timeout(cls, v: Optional[Union[int, str]]) -> Optional[int]:

--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -247,6 +247,7 @@ class ProbeSpec(CoreModel):
     timeout: int
     interval: int
     ready_after: int
+    until_ready: bool = False
 
 
 class JobSpec(CoreModel):

--- a/src/dstack/_internal/core/models/runs.py
+++ b/src/dstack/_internal/core/models/runs.py
@@ -17,6 +17,7 @@ from dstack._internal.core.models.common import (
 )
 from dstack._internal.core.models.configurations import (
     DEFAULT_PROBE_METHOD,
+    DEFAULT_PROBE_UNTIL_READY,
     DEFAULT_REPLICA_GROUP_NAME,
     LEGACY_REPO_DIR,
     AnyRunConfiguration,
@@ -247,7 +248,7 @@ class ProbeSpec(CoreModel):
     timeout: int
     interval: int
     ready_after: int
-    until_ready: bool = False
+    until_ready: bool = DEFAULT_PROBE_UNTIL_READY
 
 
 class JobSpec(CoreModel):

--- a/src/dstack/_internal/server/services/jobs/configurators/base.py
+++ b/src/dstack/_internal/server/services/jobs/configurators/base.py
@@ -444,6 +444,7 @@ def _probe_config_to_spec(c: ProbeConfig) -> ProbeSpec:
         method=c.method if c.method is not None else DEFAULT_PROBE_METHOD,
         headers=c.headers,
         body=c.body,
+        until_ready=c.until_ready,
     )
 
 

--- a/src/dstack/_internal/server/services/jobs/configurators/base.py
+++ b/src/dstack/_internal/server/services/jobs/configurators/base.py
@@ -15,6 +15,7 @@ from dstack._internal.core.models.configurations import (
     DEFAULT_PROBE_METHOD,
     DEFAULT_PROBE_READY_AFTER,
     DEFAULT_PROBE_TIMEOUT,
+    DEFAULT_PROBE_UNTIL_READY,
     DEFAULT_PROBE_URL,
     DEFAULT_REPLICA_GROUP_NAME,
     LEGACY_REPO_DIR,
@@ -444,7 +445,7 @@ def _probe_config_to_spec(c: ProbeConfig) -> ProbeSpec:
         method=c.method if c.method is not None else DEFAULT_PROBE_METHOD,
         headers=c.headers,
         body=c.body,
-        until_ready=c.until_ready,
+        until_ready=c.until_ready if c.until_ready is not None else DEFAULT_PROBE_UNTIL_READY,
     )
 
 


### PR DESCRIPTION
This option allows to stop executing the probe
once it reaches the `ready_after` threshold of
successful executions. This is useful for heavier
probes that only need to run in the startup phase
and not during regular replica operation.