### PR TITLE
[Docs] Update SKILL.md

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -109,30 +109,6 @@ Once the server is up, you can access it via the `dstack` CLI.
     (or `Use Git and optional Unix tools from the Command Prompt`), and 
     `Use bundled OpenSSH`.
 
-### Configure the default project
-
-To point the CLI to the `dstack` server, configure it
-with the server address, user token, and project name:
-
-<div class="termy">
-
-```shell
-$ dstack project add \
-    --name main \
-    --url http://127.0.0.1:3000 \
-    --token bbae0f28-d3dd-4820-bf61-8f4bb40815da
-    
-Configuration is updated at ~/.dstack/config.yml
-```
-
-</div>
-
-This configuration is stored in `~/.dstack/config.yml`.
-
-<!-- ### Check offers -->
-
-<!-- To verify that both the server and CLI are properly configured, use the [`dstack offer`](reference/cli/dstack/offer.md#list-gpu-offers) command to list available GPU offers. If you don't see valid offers, ensure you've set up [backends](concepts/backends.md). -->
-
 ??? info "Shell autocompletion"
 
     `dstack` supports shell autocompletion for `bash` and `zsh`.
@@ -199,9 +175,41 @@ This configuration is stored in `~/.dstack/config.yml`.
         > If you get an error similar to `2: command not found: compdef`, then add the following line to the beginning of your `~/.zshrc` file:
         > `autoload -Uz compinit && compinit`.
 
+### Configure the default project
+
+To point the CLI to the `dstack` server, configure it
+with the server address, user token, and project name:
+
+<div class="termy">
+
+```shell
+$ dstack project add \
+    --name main \
+    --url http://127.0.0.1:3000 \
+    --token bbae0f28-d3dd-4820-bf61-8f4bb40815da
+    
+Configuration is updated at ~/.dstack/config.yml
+```
+
+</div>
+
+This configuration is stored in `~/.dstack/config.yml`.
+
+### Install agent skills
+
+Install [skills](https://skills.sh/dstackai/dstack/dstack) to help AI agents use the `dstack` CLI and edit configuration files.
+
+<div class="termy">
+
+```shell
+$ npx skills add dstackai/dstack
+```
+
+</div>
+
+Agent skills are experimental. Share your feedback via [GitHub issues](https://github.com/dstackai/dstack/issues).
+
 !!! info "What's next?"
     1. See [Backends](concepts/backends.md)
     2. Follow [Quickstart](quickstart.md)
     3. Check the [server deployment](guides/server-deployment.md) guide
-    4. Browse [examples](../examples.md)
-    5. Join the community via [Discord](https://discord.gg/u8SmfwPpMd)

--- a/skills/dstack/SKILL.md
+++ b/skills/dstack/SKILL.md
@@ -89,6 +89,12 @@ Instead, use `dstack ps -v` to check status, or `dstack apply -d` for detached m
 - When user confirms deletion/stop operations, use `-y` flag to skip confirmation prompts
 - Avoid waiting indefinitely; display essential output once command is finished (even if by timeout)
 
+### Interpreting user requests
+
+**"Run something":** When the user asks to "run" a workload (dev environment, task, or service), use `dstack apply` with the appropriate configuration. Note: `dstack run` only supports `dstack run get --json` for retrieving run details—it cannot start workloads.
+
+**"Connect to" or "open" a dev environment:** If a dev environment is already running, retrieve its IDE connection URL (`cursor://`, `vscode://`, etc.) from `dstack logs <run-name>` and provide it to the user.
+
 ## Configuration types
 
 `dstack` supports five main configuration types, each with specific use cases. Configuration files can be named `<name>.dstack.yml` or simply `.dstack.yml`.
@@ -102,6 +108,7 @@ Instead, use `dstack ps -v` to check status, or `dstack apply -d` for detached m
 
 **Best practices:**
  - Prefer giving configurations a `name` property for easier management
+ - When configurations need credentials (API keys, tokens), list only env var *names* in the `env` section (e.g., `- HF_TOKEN`), not values. Recommend storing actual values in a `.envrc` file alongside the configuration, applied via `source .envrc && dstack apply`.
 
 See configuration reference pages for complete parameter lists.
 


### PR DESCRIPTION
The prior guidance led to vague prompts, blocking attach sessions, and missing key operational details. This update makes agent behavior predictable and reduces user friction.

## What changed
- **Detached runs:** After `dstack apply -d`, the skill now instructs agents to check status, attach for dev environments and tasks with ports, and use service endpoints for services.
- **Attach behavior:** Agents must run `dstack attach` in the background by default (non‑blocking), store a PID, and stop it safely; user-facing language stays “attach.”
- **Sandbox fallback:** If attach fails in the sandbox (permissions/timeouts), agents should request escalation or ask the user to run attach locally.
- **Stop confirmation:** `dstack stop` must always use `-y` once the user approves to avoid interactive prompts.
- **Restored concepts:** Reintroduced distributed tasks, fleet provisioning behavior (node ranges), SSH fleets, instance volumes, and correct `dstack offer` semantics; clarified service endpoint access.
