### PR TITLE
Fix `probes=None` server incompatibility

### DIFF
--- a/src/dstack/_internal/server/compatibility/runs.py
+++ b/src/dstack/_internal/server/compatibility/runs.py
@@ -11,6 +11,8 @@ def patch_run_plan(run_plan: RunPlan, client_version: Optional[Version]) -> None
     if client_version is None:
         return
     patch_run_spec(run_plan.run_spec, client_version)
+    if run_plan.effective_run_spec is not None:
+        patch_run_spec(run_plan.effective_run_spec, client_version)
     if run_plan.current_resource is not None:
         patch_run(run_plan.current_resource, client_version)
     for job_plan in run_plan.job_plans:

--- a/src/dstack/_internal/server/compatibility/runs.py
+++ b/src/dstack/_internal/server/compatibility/runs.py
@@ -1,0 +1,34 @@
+from typing import Optional
+
+from packaging.version import Version
+
+from dstack._internal.core.models.configurations import ServiceConfiguration
+from dstack._internal.core.models.runs import Run, RunPlan, RunSpec
+from dstack._internal.server.compatibility.common import patch_offers_list
+
+
+def patch_run_plan(run_plan: RunPlan, client_version: Optional[Version]) -> None:
+    if client_version is None:
+        return
+    patch_run_spec(run_plan.run_spec, client_version)
+    if run_plan.current_resource is not None:
+        patch_run(run_plan.current_resource, client_version)
+    for job_plan in run_plan.job_plans:
+        patch_offers_list(job_plan.offers, client_version)
+
+
+def patch_run(run: Run, client_version: Optional[Version]) -> None:
+    if client_version is None:
+        return
+    patch_run_spec(run.run_spec, client_version)
+
+
+def patch_run_spec(run_spec: RunSpec, client_version: Optional[Version]) -> None:
+    if client_version is None:
+        return
+    # Clients prior to 0.20.8 do not support probes = None
+    if client_version < Version("0.20.8") and isinstance(
+        run_spec.configuration, ServiceConfiguration
+    ):
+        if run_spec.configuration.probes is None:
+            run_spec.configuration.probes = []

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -1625,6 +1625,7 @@ class TestGetRunPlan:
         assert response.status_code == 200
         run_plan = response.json()
         assert run_plan["run_spec"]["configuration"]["probes"] == expected_probes
+        assert run_plan["effective_run_spec"]["configuration"]["probes"] == expected_probes
         assert (
             run_plan["current_resource"]["run_spec"]["configuration"]["probes"] == expected_probes
         )


### PR DESCRIPTION
This fixes server compatibility with clients prior
to 0.20.8 that don't support `probes=None`, by
replacing `None` with `[]` in responses for older
clients. This incompatibility could be observed
when there are both new and old clients in the
same project, so old clients would fail when
viewing runs submitted by new clients.