### PR TITLE
Optimize create instance on AWS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ include = [
     "src/dstack/plugins",
     "src/dstack/_internal/server",
     "src/dstack/_internal/core/services",
+    "src/dstack/_internal/core/backends/aws",
     "src/dstack/_internal/core/backends/kubernetes",
     "src/dstack/_internal/core/backends/runpod",
     "src/dstack/_internal/cli/services/configurators",

--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -320,7 +320,7 @@ class AWSCompute(
                 vpc_id=vpc_id,
             )
             try:
-                response = ec2_resource.create_instances(
+                response = ec2_resource.create_instances(  # pyright: ignore[reportAttributeAccessIssue]
                     **aws_resources.create_instances_struct(
                         disk_size=disk_size,
                         image_id=image_id,
@@ -525,7 +525,7 @@ class AWSCompute(
             allocate_public_ip=configuration.public_ip,
         )
         try:
-            response = ec2_resource.create_instances(**instance_struct)
+            response = ec2_resource.create_instances(**instance_struct)  # pyright: ignore[reportAttributeAccessIssue]
         except botocore.exceptions.ClientError as e:
             msg = f"AWS Error: {e.response['Error']['Code']}"
             if e.response["Error"].get("Message"):

--- a/src/dstack/_internal/core/backends/base/configurator.py
+++ b/src/dstack/_internal/core/backends/base/configurator.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Generic, List, Optional, TypeVar
+from typing import Any, ClassVar, Generic, List, NoReturn, Optional, TypeVar
 from uuid import UUID
 
 from dstack._internal.core.backends.base.backend import Backend
@@ -110,7 +110,7 @@ class Configurator(ABC, Generic[BackendConfigWithoutCredsT, BackendConfigWithCre
 
 def raise_invalid_credentials_error(
     fields: Optional[List[List[str]]] = None, details: Optional[Any] = None
-):
+) -> NoReturn:
     msg = BackendInvalidCredentialsError.msg
     if details:
         msg += f": {details}"

--- a/src/dstack/_internal/server/services/backends/__init__.py
+++ b/src/dstack/_internal/server/services/backends/__init__.py
@@ -361,7 +361,7 @@ async def get_backend_offers(
             if not exclude_not_available or offer.availability.is_available():
                 yield (backend, offer)
 
-    logger.info("Requesting instance offers from backends: %s", [b.TYPE.value for b in backends])
+    logger.debug("Requesting instance offers from backends: %s", [b.TYPE.value for b in backends])
     tasks = [run_async(get_offers_tracked, backend, requirements) for backend in backends]
     offers_by_backend = []
     for backend, result in zip(backends, await asyncio.gather(*tasks, return_exceptions=True)):


### PR DESCRIPTION
Related to #3551

This PR optimizes `AWSCompute.create_instance()` from **15-30s to 5s** by removing `instance.wait_until_running()`, which checked instance state with a 15s delay, and implementing `update_provisioning_data()` instead.

Also fixes a bug that could lead to orphaned AWS instances – a try/except block around `ec2_resource.create_instances()` were also applied to subsequent `instance.reload()` and `ec2_client.cancel_spot_instance_requests()` calls without distinction.