### PR TITLE
[UX] Wait for run provisioning in `dstack attach`; pretty-print "port in use" error during `dstack apply` and `dstack attach`

### DIFF
--- a/src/dstack/_internal/core/services/ssh/ports.py
+++ b/src/dstack/_internal/core/services/ssh/ports.py
@@ -11,7 +11,9 @@ RESERVED_PORTS_END = 10999
 
 
 class PortUsedError(DstackError):
-    pass
+    def __init__(self, port: int):
+        self.port = port
+        super().__init__(f"Port {port} is already in use")
 
 
 class PortsLock:
@@ -28,10 +30,10 @@ class PortsLock:
             if not local_port:  # None or 0
                 continue
             if local_port in assigned_ports:
-                raise PortUsedError(f"Port {local_port} is already in use")
+                raise PortUsedError(local_port)
             sock = self._listen(local_port)
             if sock is None:
-                raise PortUsedError(f"Port {local_port} is already in use")
+                raise PortUsedError(local_port)
             self.sockets[remote_port] = sock
             assigned_ports.add(local_port)
 


### PR DESCRIPTION
- `dstack attach` now shows a live spinner with the run status table while the run is provisioning (same UX as `dstack apply`), instead of silently polling or exiting with an error.
- When a port is already in use, both `dstack attach` and `dstack apply` now show a clear error message with a `-p` suggestion instead of a raw traceback:

  ```
  Failed to attach: port 8000 is already in use. Use -p in dstack attach to override the local port mapping, e.g. -p 8001:8000.
  ```