### PR TITLE
Add `--verbose` to `dstack apply` and enhance run plan output

### DIFF
--- a/src/dstack/_internal/cli/commands/apply.py
+++ b/src/dstack/_internal/cli/commands/apply.py
@@ -62,6 +62,12 @@ class ApplyCommand(APIBaseCommand):
             help="Exit immediately after submitting configuration",
             action="store_true",
         )
+        self._parser.add_argument(
+            "-v",
+            "--verbose",
+            help="Show all plan properties including those with default values",
+            action="store_true",
+        )
 
     def _command(self, args: argparse.Namespace):
         try:

--- a/src/dstack/_internal/cli/services/configurators/run.py
+++ b/src/dstack/_internal/cli/services/configurators/run.py
@@ -115,7 +115,12 @@ class BaseRunConfigurator(
             if len(self.api.client.fleets.list(self.api.project)) == 0:
                 no_fleets = True
 
-        print_run_plan(run_plan, max_offers=configurator_args.max_offers, no_fleets=no_fleets)
+        print_run_plan(
+            run_plan,
+            max_offers=configurator_args.max_offers,
+            no_fleets=no_fleets,
+            verbose=command_args.verbose,
+        )
 
         confirm_message = "Submit a new run?"
         if conf.name:


### PR DESCRIPTION
- [x] Add `--verbose` to `dstack apply`
- [x] Show creation policy and reservation only if non-default or verbose); 
- [x] Replaced `-` with actual defaults (`off`)