### PR TITLE
Remove dangling services from gateway

### DIFF
--- a/src/dstack/_internal/proxy/gateway/const.py
+++ b/src/dstack/_internal/proxy/gateway/const.py
@@ -5,3 +5,4 @@ from pathlib import Path
 DSTACK_DIR_ON_GATEWAY = Path("/home/ubuntu/dstack")
 SERVER_CONNECTIONS_DIR_ON_GATEWAY = DSTACK_DIR_ON_GATEWAY / "server-connections"
 PROXY_PORT_ON_GATEWAY = 8000
+SERVICE_ALREADY_REGISTERED_ERROR_TEMPLATE = "Service {ref} is already registered"

--- a/src/dstack/_internal/proxy/gateway/services/registry.py
+++ b/src/dstack/_internal/proxy/gateway/services/registry.py
@@ -8,6 +8,7 @@ import dstack._internal.proxy.gateway.schemas.registry as schemas
 from dstack._internal.core.models.instances import SSHConnectionParams
 from dstack._internal.core.models.routers import AnyServiceRouterConfig, RouterType
 from dstack._internal.proxy.gateway import models as gateway_models
+from dstack._internal.proxy.gateway.const import SERVICE_ALREADY_REGISTERED_ERROR_TEMPLATE
 from dstack._internal.proxy.gateway.repo.repo import GatewayProxyRepo
 from dstack._internal.proxy.gateway.services.nginx import (
     LimitReqConfig,
@@ -63,7 +64,7 @@ async def register_service(
 
     async with lock:
         if await repo.get_service(project_name, run_name) is not None:
-            raise ProxyError(f"Service {service.fmt()} is already registered")
+            raise ProxyError(SERVICE_ALREADY_REGISTERED_ERROR_TEMPLATE.format(ref=service.fmt()))
 
         old_project = await repo.get_project(project_name)
         new_project = models.Project(name=project_name, ssh_private_key=ssh_private_key)


### PR DESCRIPTION
If a new service fails to be registered in the
gateway because of a dangling service with the
same name, automatically unregister the dangling
service and retry new service registration.

Fixes #3046