### PR TITLE
[runner] Drop buildLDLibraryPathEnv()

### DIFF
--- a/runner/internal/executor/executor.go
+++ b/runner/internal/executor/executor.go
@@ -444,15 +444,6 @@ func (ex *RunExecutor) execJob(ctx context.Context, jobLogFile io.Writer) error 
 		"DSTACK_MPI_HOSTFILE":   mpiHostfilePath,
 	}
 
-	// Call buildLDLibraryPathEnv and update jobEnvs if no error occurs
-	newLDPath, err := buildLDLibraryPathEnv(ctx)
-	if err != nil {
-		log.Info(ctx, "Continuing without updating LD_LIBRARY_PATH")
-	} else {
-		jobEnvs["LD_LIBRARY_PATH"] = newLDPath
-		log.Info(ctx, "New LD_LIBRARY_PATH set", "LD_LIBRARY_PATH", newLDPath)
-	}
-
 	cmd := exec.CommandContext(ctx, ex.jobSpec.Commands[0], ex.jobSpec.Commands[1:]...)
 	cmd.Cancel = func() error {
 		// returns error on Windows
@@ -504,8 +495,7 @@ func (ex *RunExecutor) execJob(ctx context.Context, jobLogFile io.Writer) error 
 		log.Warning(ctx, "failed to include dstack_profile", "path", profilePath, "err", err)
 	}
 
-	err = writeMpiHostfile(ctx, ex.clusterInfo.JobIPs, gpusPerNodeNum, mpiHostfilePath)
-	if err != nil {
+	if err := writeMpiHostfile(ctx, ex.clusterInfo.JobIPs, gpusPerNodeNum, mpiHostfilePath); err != nil {
 		return fmt.Errorf("write MPI hostfile: %w", err)
 	}
 
@@ -619,40 +609,6 @@ func isPtyError(err error) bool {
 	/* read /dev/ptmx: input/output error */
 	var e *os.PathError
 	return errors.As(err, &e) && errors.Is(e.Err, syscall.EIO)
-}
-
-func buildLDLibraryPathEnv(ctx context.Context) (string, error) {
-	// Execute shell command to get Python prefix
-	cmd := exec.CommandContext(ctx, "bash", "-i", "-c", "python3-config --prefix")
-	output, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("error executing command: %w", err)
-	}
-
-	// Extract and trim the prefix path
-	prefixPath := strings.TrimSpace(string(output))
-
-	// Check if the prefix path exists
-	if _, err := os.Stat(prefixPath); os.IsNotExist(err) {
-		return "", fmt.Errorf("python prefix path does not exist: %s", prefixPath)
-	}
-
-	// Construct the path to Python's shared libraries
-	sharedLibPath := fmt.Sprintf("%s/lib", prefixPath)
-
-	// Get current LD_LIBRARY_PATH
-	currentLDPath := os.Getenv("LD_LIBRARY_PATH")
-
-	// Append Python's shared library path if not already present
-	if !strings.Contains(currentLDPath, sharedLibPath) {
-		if currentLDPath == "" {
-			currentLDPath = sharedLibPath
-		} else {
-			currentLDPath = fmt.Sprintf("%s:%s", currentLDPath, sharedLibPath)
-		}
-	}
-
-	return currentLDPath, nil
 }
 
 // A simplified copypasta of creack/pty Start->StartWithSize->StartWithAttrs


### PR DESCRIPTION
This code is:

- conda-specific
- dead

Basically, the function (ab)uses python3-config [1] utility (which, BTW, is not present in dstack base images since conda -> uv migration) to calculate the path to conda-installed shared objects and export it via LD_LIBRARY_PATH (the proper way to add conda-installed libs would be to use ld.so's configuration files, that is, ld.so.conf.d/*).

Although this code was added in
https://github.com/dstackai/dstack/pull/1354, it is not related to TPU support at all.

[1]: https://manpages.debian.org/testing/python3-dev/python3-config.1.en.html