### PR TITLE
Fix Crusoe CPU instances and add H200/B200 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ dependencies = [
     "python-multipart>=0.0.16",
     "filelock",
     "psutil",
-    "gpuhunt==0.1.17",
+    # TODO: Pin to gpuhunt release once crusoe-add-new-gpu-types branch is merged.
+    "gpuhunt @ git+https://github.com/dstackai/gpuhunt.git@crusoe-add-new-gpu-types",
     "argcomplete>=3.5.0",
     "ignore-python>=0.2.0",
     "orjson",
@@ -53,6 +54,9 @@ build-backend = "hatchling.build"
 
 [project.scripts]
 dstack = "dstack._internal.cli.main:main"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 path = "src/dstack/version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,7 @@ dependencies = [
     "python-multipart>=0.0.16",
     "filelock",
     "psutil",
-    # TODO: Pin to gpuhunt release once crusoe-add-new-gpu-types branch is merged.
-    "gpuhunt @ git+https://github.com/dstackai/gpuhunt.git@crusoe-add-new-gpu-types",
+    "gpuhunt==0.1.18",
     "argcomplete>=3.5.0",
     "ignore-python>=0.2.0",
     "orjson",
@@ -54,9 +53,6 @@ build-backend = "hatchling.build"
 
 [project.scripts]
 dstack = "dstack._internal.cli.main:main"
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.hatch.version]
 path = "src/dstack/version.py"

--- a/src/dstack/_internal/core/backends/crusoe/compute.py
+++ b/src/dstack/_internal/core/backends/crusoe/compute.py
@@ -91,18 +91,17 @@ STORAGE_SETUP_COMMANDS = [
 IMAGE_SXM_DOCKER = "ubuntu22.04-nvidia-sxm-docker:latest"
 IMAGE_PCIE_DOCKER = "ubuntu22.04-nvidia-pcie-docker:latest"
 IMAGE_ROCM = "ubuntu-rocm:latest"
-IMAGE_BASE = "ubuntu22.04:latest"
 
 
 def _get_image(instance_name: str, gpu_type: str) -> str:
-    if not gpu_type:
-        return IMAGE_BASE
     # Check instance name for SXM -- gpu_type from gpuhunt is normalized (e.g. "A100")
     # and doesn't contain "SXM", but instance names like "a100-80gb-sxm-ib.8x" do.
     if "-sxm" in instance_name.lower():
         return IMAGE_SXM_DOCKER
     if "MI3" in gpu_type:
         return IMAGE_ROCM
+    # Use PCIe docker image for both PCIe GPUs and CPU-only types.
+    # Crusoe has no CPU-specific Docker image; the base ubuntu image lacks Docker.
     return IMAGE_PCIE_DOCKER
 
 


### PR DESCRIPTION
## Summary

- Fix CPU-only instances (c1a/s1a): use `ubuntu22.04-nvidia-pcie-docker` VM image since the base `ubuntu22.04` image lacks Docker/containerd, causing shim startup to fail
- Update gpuhunt with H200, B200, and CPU instance support