### PR TITLE
[UI] Unify Connect UX across run configuration types (plus fix)

### DIFF
--- a/frontend/src/pages/Project/Details/Settings/index.tsx
+++ b/frontend/src/pages/Project/Details/Settings/index.tsx
@@ -230,7 +230,7 @@ export const ProjectSettings: React.FC = () => {
                                 onNavigate={({ detail }) => setActiveStepIndex(detail.requestedStepIndex)}
                                 activeStepIndex={activeStepIndex}
                                 onSubmit={() => setIsExpandedCliSection(false)}
-                                submitButtonText="Dismiss"
+                                submitButtonText="Done"
                                 allowSkipTo={true}
                                 steps={[
                                     {

--- a/frontend/src/pages/Runs/Details/RunDetails/ConnectToRunWithDevEnvConfiguration/index.tsx
+++ b/frontend/src/pages/Runs/Details/RunDetails/ConnectToRunWithDevEnvConfiguration/index.tsx
@@ -1,20 +1,7 @@
 import React, { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import {
-    Alert,
-    Box,
-    Button,
-    Code,
-    Container,
-    ExpandableSection,
-    Header,
-    Popover,
-    SpaceBetween,
-    StatusIndicator,
-    Tabs,
-    Wizard,
-} from 'components';
+import { Alert, Box, Button, Code, ExpandableSection, Popover, SpaceBetween, StatusIndicator, Tabs, Wizard } from 'components';
 
 import { copyToClipboard } from 'libs';
 
@@ -28,6 +15,7 @@ const PipInstallCommand = 'pip install dstack -U';
 
 export const ConnectToRunWithDevEnvConfiguration: FC<{ run: IRun }> = ({ run }) => {
     const { t } = useTranslation();
+    const [isExpandedConnectSection, setIsExpandedConnectSection] = React.useState(true);
 
     const getAttachCommand = (runData: IRun) => {
         const attachCommand = `dstack attach ${runData.run_spec.run_name} --logs`;
@@ -62,9 +50,19 @@ export const ConnectToRunWithDevEnvConfiguration: FC<{ run: IRun }> = ({ run }) 
     const [configCliCommand, copyCliCommand] = useConfigProjectCliCommand({ projectName: run.project_name });
 
     return (
-        <Container>
-            <Header variant="h2">Connect</Header>
-
+        <ExpandableSection
+            variant="container"
+            headerText="Connect"
+            expanded={isExpandedConnectSection}
+            onChange={({ detail }) => setIsExpandedConnectSection(detail.expanded)}
+            headerActions={
+                <Button
+                    iconName="script"
+                    variant={isExpandedConnectSection ? 'normal' : 'primary'}
+                    onClick={() => setIsExpandedConnectSection((prev) => !prev)}
+                />
+            }
+        >
             {run.status === 'running' && (
                 <Wizard
                     i18nStrings={{
@@ -78,15 +76,15 @@ export const ConnectToRunWithDevEnvConfiguration: FC<{ run: IRun }> = ({ run }) 
                     }}
                     onNavigate={({ detail }) => setActiveStepIndex(detail.requestedStepIndex)}
                     activeStepIndex={activeStepIndex}
-                    onSubmit={() => window.open(openInIDEUrl, '_blank')}
-                    submitButtonText={`Open in ${ideDisplayName}`}
+                    onSubmit={() => setIsExpandedConnectSection(false)}
+                    submitButtonText="Done"
                     allowSkipTo
                     steps={[
                         {
                             title: 'Attach',
+                            description: 'To access this run, first you need to attach to it.',
                             content: (
                                 <SpaceBetween size="s">
-                                    <Box>To access this run, first you need to attach to it.</Box>
                                     <div className={styles.codeWrapper}>
                                         <Code className={styles.code}>{attachCommand}</Code>
 
@@ -275,6 +273,6 @@ export const ConnectToRunWithDevEnvConfiguration: FC<{ run: IRun }> = ({ run }) 
                     <Alert type="info">Waiting for the run to start.</Alert>
                 </SpaceBetween>
             )}
-        </Container>
+        </ExpandableSection>
     );
 };

--- a/frontend/src/pages/Runs/Details/RunDetails/ConnectToServiceRun/index.tsx
+++ b/frontend/src/pages/Runs/Details/RunDetails/ConnectToServiceRun/index.tsx
@@ -1,12 +1,17 @@
 import React, { FC } from 'react';
+import { useTranslation } from 'react-i18next';
 
-import { Alert, Box, Container, Header, Link, SpaceBetween } from 'components';
+import { Alert, Box, Button, ExpandableSection, Link, Popover, SpaceBetween, StatusIndicator, Wizard } from 'components';
 
+import { copyToClipboard } from 'libs';
 import { getRunProbeStatuses } from 'libs/run';
 
 import { getRunListItemServiceUrl } from '../../../List/helpers';
 
 export const ConnectToServiceRun: FC<{ run: IRun }> = ({ run }) => {
+    const { t } = useTranslation();
+    const [isExpandedEndpointSection, setIsExpandedEndpointSection] = React.useState(true);
+    const [activeStepIndex, setActiveStepIndex] = React.useState(0);
     const serviceUrl = getRunListItemServiceUrl(run);
     const probeStatuses = getRunProbeStatuses(run);
     const hasProbes = probeStatuses.length > 0;
@@ -14,9 +19,19 @@ export const ConnectToServiceRun: FC<{ run: IRun }> = ({ run }) => {
     const serviceReady = run.status === 'running' && (!hasProbes || allProbesReady) && serviceUrl;
 
     return (
-        <Container>
-            <Header variant="h2">Endpoint</Header>
-
+        <ExpandableSection
+            variant="container"
+            headerText="Connect"
+            expanded={isExpandedEndpointSection}
+            onChange={({ detail }) => setIsExpandedEndpointSection(detail.expanded)}
+            headerActions={
+                <Button
+                    iconName="script"
+                    variant={isExpandedEndpointSection ? 'normal' : 'primary'}
+                    onClick={() => setIsExpandedEndpointSection((prev) => !prev)}
+                />
+            }
+        >
             {run.status !== 'running' && (
                 <SpaceBetween size="s">
                     <Box />
@@ -32,16 +47,58 @@ export const ConnectToServiceRun: FC<{ run: IRun }> = ({ run }) => {
             )}
 
             {serviceReady && (
-                <SpaceBetween size="s">
-                    <Box />
-                    <Alert type="success">
-                        The service is ready at{' '}
-                        <Link href={serviceUrl} external>
-                            {serviceUrl}
-                        </Link>
-                    </Alert>
-                </SpaceBetween>
+                <Wizard
+                    i18nStrings={{
+                        stepNumberLabel: (stepNumber) => `Step ${stepNumber}`,
+                        collapsedStepsLabel: (stepNumber, stepsCount) => `Step ${stepNumber} of ${stepsCount}`,
+                        skipToButtonLabel: (step) => `Skip to ${step.title}`,
+                        navigationAriaLabel: 'Steps',
+                        previousButton: 'Previous',
+                        nextButton: 'Next',
+                        optional: 'required',
+                    }}
+                    onNavigate={({ detail }) => setActiveStepIndex(detail.requestedStepIndex)}
+                    activeStepIndex={activeStepIndex}
+                    onSubmit={() => setIsExpandedEndpointSection(false)}
+                    submitButtonText="Done"
+                    allowSkipTo
+                    steps={[
+                        {
+                            title: 'Open',
+                            description: 'Open the service endpoint.',
+                            content: (
+                                <SpaceBetween size="s">
+                                    <Alert
+                                        type="info"
+                                        action={
+                                            <Popover
+                                                dismissButton={false}
+                                                position="top"
+                                                size="small"
+                                                triggerType="custom"
+                                                content={<StatusIndicator type="success">{t('common.copied')}</StatusIndicator>}
+                                            >
+                                                <Button
+                                                    formAction="none"
+                                                    iconName="copy"
+                                                    variant="normal"
+                                                    onClick={() => copyToClipboard(serviceUrl)}
+                                                />
+                                            </Popover>
+                                        }
+                                    >
+                                        The service is ready at{' '}
+                                        <Link href={serviceUrl} external>
+                                            {serviceUrl}
+                                        </Link>
+                                    </Alert>
+                                </SpaceBetween>
+                            ),
+                            isOptional: true,
+                        },
+                    ]}
+                />
             )}
-        </Container>
+        </ExpandableSection>
     );
 };

--- a/frontend/src/pages/Runs/Details/RunDetails/ConnectToTaskRun/index.tsx
+++ b/frontend/src/pages/Runs/Details/RunDetails/ConnectToTaskRun/index.tsx
@@ -1,0 +1,254 @@
+import React, { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import {
+    Alert,
+    Box,
+    Button,
+    ButtonDropdown,
+    Code,
+    Container,
+    ExpandableSection,
+    Header,
+    Popover,
+    SpaceBetween,
+    StatusIndicator,
+    Tabs,
+    Wizard,
+} from 'components';
+
+import { copyToClipboard } from 'libs';
+
+import { useConfigProjectCliCommand } from 'pages/Project/hooks/useConfigProjectCliComand';
+
+import styles from '../ConnectToRunWithDevEnvConfiguration/styles.module.scss';
+
+const UvInstallCommand = 'uv tool install dstack -U';
+const PipInstallCommand = 'pip install dstack -U';
+
+const getPort = (spec: IAppSpec): number => spec.map_to_port ?? spec.port;
+
+export const ConnectToTaskRun: FC<{ run: IRun }> = ({ run }) => {
+    const { t } = useTranslation();
+
+    const attachCommand = `dstack attach ${run.run_spec.run_name} --logs`;
+    const appSpecs = run.jobs[0]?.job_spec?.app_specs ?? [];
+
+    const [activeStepIndex, setActiveStepIndex] = React.useState(0);
+    const [selectedPort, setSelectedPort] = React.useState(() => getPort(appSpecs[0]));
+    const [configCliCommand, copyCliCommand] = useConfigProjectCliCommand({ projectName: run.project_name });
+
+    const openPort = (port: number) => window.open(`http://127.0.0.1:${port}`, '_blank');
+
+    return (
+        <Container>
+            <Header variant="h2">Connect</Header>
+
+            {run.status === 'running' && (
+                <Wizard
+                    i18nStrings={{
+                        stepNumberLabel: (stepNumber) => `Step ${stepNumber}`,
+                        collapsedStepsLabel: (stepNumber, stepsCount) => `Step ${stepNumber} of ${stepsCount}`,
+                        skipToButtonLabel: (step) => `Skip to ${step.title}`,
+                        navigationAriaLabel: 'Steps',
+                        previousButton: 'Previous',
+                        nextButton: 'Next',
+                        optional: 'required',
+                    }}
+                    onNavigate={({ detail }) => setActiveStepIndex(detail.requestedStepIndex)}
+                    activeStepIndex={activeStepIndex}
+                    onSubmit={() => openPort(selectedPort)}
+                    submitButtonText={appSpecs.length === 1 ? 'Open port' : `Open port ${selectedPort}`}
+                    allowSkipTo
+                    steps={[
+                        {
+                            title: 'Attach',
+                            content: (
+                                <SpaceBetween size="s">
+                                    <Box>To access this run, first you need to attach to it.</Box>
+                                    <div className={styles.codeWrapper}>
+                                        <Code className={styles.code}>{attachCommand}</Code>
+
+                                        <div className={styles.copy}>
+                                            <Popover
+                                                dismissButton={false}
+                                                position="top"
+                                                size="small"
+                                                triggerType="custom"
+                                                content={<StatusIndicator type="success">{t('common.copied')}</StatusIndicator>}
+                                            >
+                                                <Button
+                                                    formAction="none"
+                                                    iconName="copy"
+                                                    variant="normal"
+                                                    onClick={() => copyToClipboard(attachCommand)}
+                                                />
+                                            </Popover>
+                                        </div>
+                                    </div>
+
+                                    <ExpandableSection headerText="No CLI installed?">
+                                        <SpaceBetween size="s">
+                                            <Box />
+                                            <Box>To use dstack, install the CLI on your local machine.</Box>
+
+                                            <Tabs
+                                                variant="container"
+                                                tabs={[
+                                                    {
+                                                        label: 'uv',
+                                                        id: 'uv',
+                                                        content: (
+                                                            <>
+                                                                <div className={styles.codeWrapper}>
+                                                                    <Code className={styles.code}>{UvInstallCommand}</Code>
+
+                                                                    <div className={styles.copy}>
+                                                                        <Popover
+                                                                            dismissButton={false}
+                                                                            position="top"
+                                                                            size="small"
+                                                                            triggerType="custom"
+                                                                            content={
+                                                                                <StatusIndicator type="success">
+                                                                                    {t('common.copied')}
+                                                                                </StatusIndicator>
+                                                                            }
+                                                                        >
+                                                                            <Button
+                                                                                formAction="none"
+                                                                                iconName="copy"
+                                                                                variant="normal"
+                                                                                onClick={() =>
+                                                                                    copyToClipboard(UvInstallCommand)
+                                                                                }
+                                                                            />
+                                                                        </Popover>
+                                                                    </div>
+                                                                </div>
+                                                            </>
+                                                        ),
+                                                    },
+                                                    {
+                                                        label: 'pip',
+                                                        id: 'pip',
+                                                        content: (
+                                                            <>
+                                                                <div className={styles.codeWrapper}>
+                                                                    <Code className={styles.code}>{PipInstallCommand}</Code>
+
+                                                                    <div className={styles.copy}>
+                                                                        <Popover
+                                                                            dismissButton={false}
+                                                                            position="top"
+                                                                            size="small"
+                                                                            triggerType="custom"
+                                                                            content={
+                                                                                <StatusIndicator type="success">
+                                                                                    {t('common.copied')}
+                                                                                </StatusIndicator>
+                                                                            }
+                                                                        >
+                                                                            <Button
+                                                                                formAction="none"
+                                                                                iconName="copy"
+                                                                                variant="normal"
+                                                                                onClick={() =>
+                                                                                    copyToClipboard(PipInstallCommand)
+                                                                                }
+                                                                            />
+                                                                        </Popover>
+                                                                    </div>
+                                                                </div>
+                                                            </>
+                                                        ),
+                                                    },
+                                                ]}
+                                            />
+
+                                            <Box>And then configure the project.</Box>
+
+                                            <div className={styles.codeWrapper}>
+                                                <Code className={styles.code}>{configCliCommand}</Code>
+
+                                                <div className={styles.copy}>
+                                                    <Popover
+                                                        dismissButton={false}
+                                                        position="top"
+                                                        size="small"
+                                                        triggerType="custom"
+                                                        content={
+                                                            <StatusIndicator type="success">
+                                                                {t('common.copied')}
+                                                            </StatusIndicator>
+                                                        }
+                                                    >
+                                                        <Button
+                                                            formAction="none"
+                                                            iconName="copy"
+                                                            variant="normal"
+                                                            onClick={copyCliCommand}
+                                                        />
+                                                    </Popover>
+                                                </div>
+                                            </div>
+                                        </SpaceBetween>
+                                    </ExpandableSection>
+                                </SpaceBetween>
+                            ),
+                            isOptional: true,
+                        },
+                        {
+                            title: 'Open',
+                            description: 'After the CLI is attached, you can open the forwarded ports.',
+                            content: (
+                                <SpaceBetween size="s">
+                                    {appSpecs.length === 1 ? (
+                                        <Button
+                                            variant="primary"
+                                            external={true}
+                                            onClick={() => openPort(getPort(appSpecs[0]))}
+                                        >
+                                            Open port
+                                        </Button>
+                                    ) : (
+                                        <ButtonDropdown
+                                            variant="primary"
+                                            mainAction={{
+                                                text: `Open port ${selectedPort}`,
+                                                external: true,
+                                                onClick: () => openPort(selectedPort),
+                                            }}
+                                            items={appSpecs.map((spec) => {
+                                                const port = getPort(spec);
+
+                                                return {
+                                                    id: String(port),
+                                                    text: `Port ${port}`,
+                                                    external: true,
+                                                };
+                                            })}
+                                            onItemClick={({ detail }) => {
+                                                const port = Number(detail.id);
+                                                setSelectedPort(port);
+                                                openPort(port);
+                                            }}
+                                        />
+                                    )}
+                                </SpaceBetween>
+                            ),
+                            isOptional: true,
+                        },
+                    ]}
+                />
+            )}
+
+            {run.status !== 'running' && (
+                <SpaceBetween size="s">
+                    <Box />
+                    <Alert type="info">Waiting for the run to start.</Alert>
+                </SpaceBetween>
+            )}
+        </Container>
+    );
+};

--- a/frontend/src/pages/Runs/Details/RunDetails/ConnectToTaskRun/index.tsx
+++ b/frontend/src/pages/Runs/Details/RunDetails/ConnectToTaskRun/index.tsx
@@ -5,11 +5,9 @@ import {
     Alert,
     Box,
     Button,
-    ButtonDropdown,
     Code,
-    Container,
     ExpandableSection,
-    Header,
+    Link,
     Popover,
     SpaceBetween,
     StatusIndicator,
@@ -26,24 +24,33 @@ import styles from '../ConnectToRunWithDevEnvConfiguration/styles.module.scss';
 const UvInstallCommand = 'uv tool install dstack -U';
 const PipInstallCommand = 'pip install dstack -U';
 
-const getPort = (spec: IAppSpec): number => spec.map_to_port ?? spec.port;
+const getMappedPort = (spec: IAppSpec): number | undefined => spec.map_to_port;
 
 export const ConnectToTaskRun: FC<{ run: IRun }> = ({ run }) => {
     const { t } = useTranslation();
+    const [isExpandedConnectSection, setIsExpandedConnectSection] = React.useState(true);
 
     const attachCommand = `dstack attach ${run.run_spec.run_name} --logs`;
     const appSpecs = run.jobs[0]?.job_spec?.app_specs ?? [];
+    const mappedAppSpecs = appSpecs.filter((spec) => getMappedPort(spec) != null);
 
     const [activeStepIndex, setActiveStepIndex] = React.useState(0);
-    const [selectedPort, setSelectedPort] = React.useState(() => getPort(appSpecs[0]));
     const [configCliCommand, copyCliCommand] = useConfigProjectCliCommand({ projectName: run.project_name });
 
-    const openPort = (port: number) => window.open(`http://127.0.0.1:${port}`, '_blank');
-
     return (
-        <Container>
-            <Header variant="h2">Connect</Header>
-
+        <ExpandableSection
+            variant="container"
+            headerText="Connect"
+            expanded={isExpandedConnectSection}
+            onChange={({ detail }) => setIsExpandedConnectSection(detail.expanded)}
+            headerActions={
+                <Button
+                    iconName="script"
+                    variant={isExpandedConnectSection ? 'normal' : 'primary'}
+                    onClick={() => setIsExpandedConnectSection((prev) => !prev)}
+                />
+            }
+        >
             {run.status === 'running' && (
                 <Wizard
                     i18nStrings={{
@@ -57,15 +64,15 @@ export const ConnectToTaskRun: FC<{ run: IRun }> = ({ run }) => {
                     }}
                     onNavigate={({ detail }) => setActiveStepIndex(detail.requestedStepIndex)}
                     activeStepIndex={activeStepIndex}
-                    onSubmit={() => openPort(selectedPort)}
-                    submitButtonText={appSpecs.length === 1 ? 'Open port' : `Open port ${selectedPort}`}
+                    onSubmit={() => setIsExpandedConnectSection(false)}
+                    submitButtonText="Done"
                     allowSkipTo
                     steps={[
                         {
                             title: 'Attach',
+                            description: 'To access this run, first you need to attach to it.',
                             content: (
                                 <SpaceBetween size="s">
-                                    <Box>To access this run, first you need to attach to it.</Box>
                                     <div className={styles.codeWrapper}>
                                         <Code className={styles.code}>{attachCommand}</Code>
 
@@ -198,47 +205,55 @@ export const ConnectToTaskRun: FC<{ run: IRun }> = ({ run }) => {
                             ),
                             isOptional: true,
                         },
-                        {
-                            title: 'Open',
-                            description: 'After the CLI is attached, you can open the forwarded ports.',
-                            content: (
-                                <SpaceBetween size="s">
-                                    {appSpecs.length === 1 ? (
-                                        <Button
-                                            variant="primary"
-                                            external={true}
-                                            onClick={() => openPort(getPort(appSpecs[0]))}
-                                        >
-                                            Open port
-                                        </Button>
-                                    ) : (
-                                        <ButtonDropdown
-                                            variant="primary"
-                                            mainAction={{
-                                                text: `Open port ${selectedPort}`,
-                                                external: true,
-                                                onClick: () => openPort(selectedPort),
-                                            }}
-                                            items={appSpecs.map((spec) => {
-                                                const port = getPort(spec);
+                        ...(mappedAppSpecs.length > 0
+                            ? [
+                                  {
+                                      title: 'Open',
+                                      description: 'After the CLI is attached, use the forwarded localhost URLs.',
+                                      content: (
+                                          <SpaceBetween size="s">
+                                              {mappedAppSpecs.map((spec) => {
+                                                  const mappedPort = getMappedPort(spec)!;
+                                                  const localUrl = `http://127.0.0.1:${mappedPort}`;
 
-                                                return {
-                                                    id: String(port),
-                                                    text: `Port ${port}`,
-                                                    external: true,
-                                                };
-                                            })}
-                                            onItemClick={({ detail }) => {
-                                                const port = Number(detail.id);
-                                                setSelectedPort(port);
-                                                openPort(port);
-                                            }}
-                                        />
-                                    )}
-                                </SpaceBetween>
-                            ),
-                            isOptional: true,
-                        },
+                                                  return (
+                                                      <Alert
+                                                          key={`${spec.port}-${mappedPort}`}
+                                                          type="info"
+                                                          action={
+                                                              <Popover
+                                                                  dismissButton={false}
+                                                                  position="top"
+                                                                  size="small"
+                                                                  triggerType="custom"
+                                                                  content={
+                                                                      <StatusIndicator type="success">
+                                                                          {t('common.copied')}
+                                                                      </StatusIndicator>
+                                                                  }
+                                                              >
+                                                                  <Button
+                                                                      formAction="none"
+                                                                      iconName="copy"
+                                                                      variant="normal"
+                                                                      onClick={() => copyToClipboard(localUrl)}
+                                                                  />
+                                                              </Popover>
+                                                          }
+                                                      >
+                                                          Port {spec.port} is forwarded to{' '}
+                                                          <Link href={localUrl} external>
+                                                              {localUrl}
+                                                          </Link>
+                                                      </Alert>
+                                                  );
+                                              })}
+                                          </SpaceBetween>
+                                      ),
+                                      isOptional: true,
+                                  },
+                              ]
+                            : []),
                     ]}
                 />
             )}
@@ -249,6 +264,6 @@ export const ConnectToTaskRun: FC<{ run: IRun }> = ({ run }) => {
                     <Alert type="info">Waiting for the run to start.</Alert>
                 </SpaceBetween>
             )}
-        </Container>
+        </ExpandableSection>
     );
 };

--- a/frontend/src/pages/Runs/Details/RunDetails/index.tsx
+++ b/frontend/src/pages/Runs/Details/RunDetails/index.tsx
@@ -36,6 +36,7 @@ import { EventsList } from '../Events/List';
 import { JobList } from '../Jobs/List';
 import { ConnectToRunWithDevEnvConfiguration } from './ConnectToRunWithDevEnvConfiguration';
 import { ConnectToServiceRun } from './ConnectToServiceRun';
+import { ConnectToTaskRun } from './ConnectToTaskRun';
 
 export const RunDetails = () => {
     const { t } = useTranslation();
@@ -102,7 +103,7 @@ export const RunDetails = () => {
 
                     <div>
                         <Box variant="awsui-key-label">{t('projects.run.configuration')}</Box>
-                        <div>{runData.run_spec.configuration_path}</div>
+                        <div>{runData.run_spec.configuration_path || '-'}</div>
                     </div>
 
                     <div>
@@ -209,6 +210,11 @@ export const RunDetails = () => {
 
             {runData.run_spec.configuration.type === 'service' && !runIsStopped(runData.status) && (
                 <ConnectToServiceRun run={runData} />
+            )}
+
+            {runData.run_spec.configuration.type === 'task' && !runIsStopped(runData.status) &&
+                (runData.jobs[0]?.job_spec?.app_specs?.length ?? 0) > 0 && (
+                <ConnectToTaskRun run={runData} />
             )}
 
             {runData.jobs.length > 1 && (

--- a/frontend/src/pages/Runs/Launch/components/ParamsWizardStep/index.tsx
+++ b/frontend/src/pages/Runs/Launch/components/ParamsWizardStep/index.tsx
@@ -54,8 +54,6 @@ export const ParamsWizardStep: React.FC<ParamsWizardStepProps> = ({ formMethods,
         if (detail.activeTabId === DockerPythonTabs.PYTHON) {
             setValue(FORM_FIELD_NAMES.image, '');
         }
-
-        setValue(FORM_FIELD_NAMES.docker, detail.activeTabId === DockerPythonTabs.DOCKER);
     };
 
     const defaultPassword = generateSecurePassword(20);

--- a/frontend/src/pages/Runs/Launch/constants.tsx
+++ b/frontend/src/pages/Runs/Launch/constants.tsx
@@ -7,8 +7,8 @@ export const CONFIGURATION_INFO = {
     body: (
         <>
             <p>
-                This is the <code>dstack</code> run configuration generated from the template and your settings. You
-                can review and adjust it before launching.
+                This is the <code>dstack</code> run configuration generated from the template and your settings. You can review
+                and adjust it before launching.
             </p>
 
             <p>To learn more, see:</p>
@@ -38,10 +38,7 @@ export const PASSWORD_INFO = {
     header: <h2>Password</h2>,
     body: (
         <>
-            <p>
-                A random password has been generated for this run. You will need it to access the run once it is
-                launched.
-            </p>
+            <p>A random password has been generated for this run. You will need it to access the run once it is launched.</p>
 
             <p>Make sure to copy the password before proceeding. Only share it with those you want to give access to.</p>
         </>
@@ -56,7 +53,6 @@ export const FORM_FIELD_NAMES = {
     name: 'name',
     ide: 'ide',
     config_yaml: 'config_yaml',
-    docker: 'docker',
     image: 'image',
     python: 'python',
     repo_enabled: 'repo_enabled',

--- a/frontend/src/pages/Runs/Launch/hooks/useGenerateYaml.ts
+++ b/frontend/src/pages/Runs/Launch/hooks/useGenerateYaml.ts
@@ -32,7 +32,6 @@ export const useGenerateYaml = ({ formValues, configuration, envParam, backends 
 
                 ...(name ? { name } : {}),
                 ...(ide ? { ide } : {}),
-                ...(docker ? { docker } : {}),
                 ...(image ? { image } : {}),
                 ...(python ? { python } : {}),
                 ...(envEntries.length > 0 ? { env: envEntries } : {}),

--- a/frontend/src/pages/Runs/Launch/hooks/useGenerateYaml.ts
+++ b/frontend/src/pages/Runs/Launch/hooks/useGenerateYaml.ts
@@ -14,8 +14,7 @@ export type UseGenerateYamlArgs = {
 
 export const useGenerateYaml = ({ formValues, configuration, envParam, backends }: UseGenerateYamlArgs) => {
     return useMemo(() => {
-        const { name, ide, image, python, offer, docker, repo_url, repo_path, working_dir, password, gpu_enabled } =
-            formValues;
+        const { name, ide, image, python, offer, repo_url, repo_path, working_dir, password, gpu_enabled } = formValues;
         const gpuEnabled = gpu_enabled === true;
 
         const envEntries: string[] = [];

--- a/frontend/src/pages/Runs/Launch/hooks/useGetRunSpecFromYaml.ts
+++ b/frontend/src/pages/Runs/Launch/hooks/useGetRunSpecFromYaml.ts
@@ -36,6 +36,7 @@ const supportedFields: (keyof TDevEnvironmentConfiguration | keyof TServiceConfi
     'repos',
     'auth',
     'commands',
+    'ports',
     'port',
     'gateway',
     'https',

--- a/frontend/src/pages/Runs/Launch/types.ts
+++ b/frontend/src/pages/Runs/Launch/types.ts
@@ -6,7 +6,6 @@ export interface IRunEnvironmentFormValues {
     name: string;
     ide: 'cursor' | 'vscode' | 'windsurf' | 'coder';
     config_yaml: string;
-    docker: boolean;
     image?: string;
     python?: string;
     repo_enabled?: boolean;

--- a/frontend/src/types/run.d.ts
+++ b/frontend/src/types/run.d.ts
@@ -241,7 +241,7 @@ declare interface IJobProbe {
 }
 
 declare interface IJobSpec {
-    app_specs?: IAppSpec;
+    app_specs?: IAppSpec[];
     commands: string[];
     env?: { [key: string]: string };
     home_dir?: string;


### PR DESCRIPTION
This PR delivers two major updates and minor UI polish.

- Major: all run configuration types (dev environments, tasks, services) now have a consistent Connect UI to access the run.
- Major: fixed incorrect handling of the `docker` property in launch-form wiring.
- Minor: styling and interaction polish in Connect/Open flows (button labels, collapsible behavior, link/copy presentation).
