### PR TITLE
Do not show resources for SSH fleets in UI

### DIFF
--- a/frontend/src/pages/Fleets/Details/FleetDetails/index.tsx
+++ b/frontend/src/pages/Fleets/Details/FleetDetails/index.tsx
@@ -6,7 +6,13 @@ import { format } from 'date-fns';
 import { Box, ColumnLayout, Container, Header, Loader, NavigateLink, StatusIndicator } from 'components';
 
 import { DATE_TIME_FORMAT } from 'consts';
-import { formatFleetBackend, formatFleetResources, getFleetInstancesLinkText, getFleetPrice, getFleetStatusIconType } from 'libs/fleet';
+import {
+    formatFleetBackend,
+    formatFleetResources,
+    getFleetInstancesLinkText,
+    getFleetPrice,
+    getFleetStatusIconType,
+} from 'libs/fleet';
 import { ROUTES } from 'routes';
 import { useGetFleetDetailsQuery } from 'services/fleet';
 
@@ -69,7 +75,11 @@ export const FleetDetails = () => {
 
                         <div>
                             <Box variant="awsui-key-label">{t('fleets.instances.resources')}</Box>
-                            <div>{formatFleetResources(data.spec.configuration.resources)}</div>
+                            <div>
+                                {data.spec.configuration.ssh_config
+                                    ? '-'
+                                    : formatFleetResources(data.spec.configuration.resources)}
+                            </div>
                         </div>
 
                         <div>
@@ -89,7 +99,12 @@ export const FleetDetails = () => {
 
                         <div>
                             <Box variant="awsui-key-label">{t('fleets.instances.price')}</Box>
-                            <div>{(() => { const p = getFleetPrice(data); return typeof p === 'number' ? `$${p}` : '-'; })()}</div>
+                            <div>
+                                {(() => {
+                                    const p = getFleetPrice(data);
+                                    return typeof p === 'number' ? `$${p}` : '-';
+                                })()}
+                            </div>
                         </div>
                     </ColumnLayout>
                 </Container>

--- a/frontend/src/pages/Fleets/List/hooks.tsx
+++ b/frontend/src/pages/Fleets/List/hooks.tsx
@@ -89,7 +89,8 @@ export const useColumnsDefinitions = () => {
         {
             id: 'resources',
             header: t('fleets.instances.resources'),
-            cell: (item) => formatFleetResources(item.spec.configuration.resources),
+            cell: (item) =>
+                item.spec.configuration.ssh_config ? '-' : formatFleetResources(item.spec.configuration.resources),
         },
         {
             id: 'instances',


### PR DESCRIPTION
Show `-` for SSH fleet resources in fleet list and details views, matching the CLI fix.

Related: #3632