### PR TITLE
Upgrade litestream 0.5.0 → 0.5.9 and simplify entrypoint restore

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -13,15 +13,9 @@ if [[ -z "${LITESTREAM_REPLICA_URL}" ]]; then
   exec dstack server --host 0.0.0.0
 else
   if [[ ! -f "$DB_PATH" ]]; then
-    echo "Attempting Litestream restore..."
-    if ! output=$(litestream restore -o "$DB_PATH" "$LITESTREAM_REPLICA_URL" 2>&1); then
-      if echo "$output" | grep -qiE "cannot calc restore plan"; then
-        echo "No replica snapshots found; starting with empty database."
-      else
-        echo "$output" >&2
-        exit 1
-      fi
-    fi
+    echo "Starting db restore"
+    litestream restore -if-replica-exists -o "$DB_PATH" "$LITESTREAM_REPLICA_URL"
+    echo "Finished db restore"
   fi
   exec litestream replicate -exec "dstack server --host 0.0.0.0" "$DB_PATH" "$LITESTREAM_REPLICA_URL"
 fi

--- a/docker/server/release/Dockerfile
+++ b/docker/server/release/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN if [ $(uname -m) = "aarch64" ]; then ARCH="arm64"; else ARCH="x86_64"; fi && \
-    curl https://github.com/benbjohnson/litestream/releases/download/v0.5.0/litestream-0.5.0-linux-$ARCH.deb -O -L && \
-    dpkg -i litestream-0.5.0-linux-$ARCH.deb
+    curl https://github.com/benbjohnson/litestream/releases/download/v0.5.9/litestream-0.5.9-linux-$ARCH.deb -O -L && \
+    dpkg -i litestream-0.5.9-linux-$ARCH.deb
 
 ADD https://astral.sh/uv/install.sh /uv-installer.sh
 RUN sh /uv-installer.sh && rm /uv-installer.sh

--- a/docker/server/stgn/Dockerfile
+++ b/docker/server/stgn/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN if [ $(uname -m) = "aarch64" ]; then ARCH="arm64"; else ARCH="x86_64"; fi && \
-    curl https://github.com/benbjohnson/litestream/releases/download/v0.5.0/litestream-0.5.0-linux-$ARCH.deb -O -L && \
-    dpkg -i litestream-0.5.0-linux-$ARCH.deb
+    curl https://github.com/benbjohnson/litestream/releases/download/v0.5.9/litestream-0.5.9-linux-$ARCH.deb -O -L && \
+    dpkg -i litestream-0.5.9-linux-$ARCH.deb
 
 ADD https://astral.sh/uv/install.sh /uv-installer.sh
 RUN sh /uv-installer.sh && rm /uv-installer.sh


### PR DESCRIPTION
## Summary

- Upgrades litestream from 0.5.0 to 0.5.9 in release and staging Dockerfiles
- Simplifies `entrypoint.sh` restore logic: uses `restore -if-replica-exists` instead of parsing error messages (consistent with enterprise entrypoint)
- Fixes CVE-2023-44487 (HTTP/2 Rapid Reset) in litestream's bundled Go dependencies

## Test plan

- [x] Built and tested locally (linux/amd64)
- [x] Fresh start with empty S3 bucket — server starts correctly
- [x] Stop and restart — DB restored from S3, admin token persisted
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)