### PR TITLE
[UI] Add missing fields to `Launch` UI supported fields list

### DIFF
--- a/frontend/src/pages/Runs/Launch/hooks/useGetRunSpecFromYaml.ts
+++ b/frontend/src/pages/Runs/Launch/hooks/useGetRunSpecFromYaml.ts
@@ -41,6 +41,13 @@ const supportedFields: (keyof TDevEnvironmentConfiguration | keyof TServiceConfi
     'gateway',
     'https',
     'probes',
+    'model',
+    'strip_prefix',
+    'rate_limits',
+    'replicas',
+    'scaling',
+    'replica_groups',
+    'version',
 ];
 
 export const useGetRunSpecFromYaml = ({ projectName = '' }) => {


### PR DESCRIPTION
Fields like `model`, `strip_prefix`, `rate_limits`, `replicas`, `scaling`, `replica_groups`, and `version` were missing from the frontend allowlist, causing "Unsupported field" errors when launching templates that use them.