### PR TITLE
Show imported instances in `dstack offer`

### DIFF
--- a/src/dstack/_internal/server/services/instances.py
+++ b/src/dstack/_internal/server/services/instances.py
@@ -513,7 +513,14 @@ async def get_pool_instances(
     res = await session.execute(
         select(InstanceModel)
         .where(
-            InstanceModel.project_id == project.id,
+            or_(
+                InstanceModel.project_id == project.id,
+                exists().where(
+                    ImportModel.project_id == project.id,
+                    ImportModel.export_id == ExportedFleetModel.export_id,
+                    ExportedFleetModel.fleet_id == InstanceModel.fleet_id,
+                ),
+            ),
             InstanceModel.deleted == False,
         )
         .options(joinedload(InstanceModel.fleet))

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -1388,11 +1388,22 @@ class TestGetRunPlan:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    @pytest.mark.parametrize(
+        "configuration",
+        [
+            pytest.param({"type": "dev-environment", "ide": "vscode"}, id="regular-configuration"),
+            pytest.param(
+                {"type": "task", "commands": [":"], "image": "scratch"},
+                id="special-configuration-used-by-dstack-offer-cli-command",
+            ),
+        ],
+    )
     async def test_returns_run_plan_with_offer_from_imported_fleet(
         self,
         test_db,
         session: AsyncSession,
         client: AsyncClient,
+        configuration: dict,
     ) -> None:
         importer_user = await create_user(session, global_role=GlobalRole.USER)
         exporter_project = await create_project(session, name="exporter-project")
@@ -1424,7 +1435,7 @@ class TestGetRunPlan:
             exported_fleets=[fleet],
         )
 
-        run_spec = {"configuration": {"type": "dev-environment", "ide": "vscode"}}
+        run_spec = {"configuration": configuration}
         body = {"run_spec": run_spec}
         response = await client.post(
             "/api/project/importer-project/runs/get_plan",


### PR DESCRIPTION
Show instances from imported fleets in
`dstack offer`. Previously, they were only shown
in `dstack fleet`.

#3626