### PR TITLE
Do not filter by fleet in `filter_instances()`

### DIFF
--- a/src/dstack/_internal/cli/commands/offer.py
+++ b/src/dstack/_internal/cli/commands/offer.py
@@ -15,7 +15,10 @@ from dstack._internal.core.errors import CLIError
 from dstack._internal.core.models.configurations import ApplyConfigurationType, TaskConfiguration
 from dstack._internal.core.models.gpus import GpuGroup
 from dstack._internal.core.models.runs import RunSpec
+from dstack._internal.utils.logging import get_logger
 from dstack.api.utils import load_profile
+
+logger = get_logger(__name__)
 
 
 class OfferConfigurator(BaseRunConfigurator):
@@ -74,6 +77,11 @@ class OfferCommand(APIBaseCommand):
 
     def _command(self, args: argparse.Namespace):
         super()._command(args)
+        if args.fleets:
+            logger.warning(
+                "Specifying `--fleet` in `dstack offer` has no defined effect"
+                " and may be disallowed in a future release"
+            )
         # Set image and user so that the server (a) does not default gpu.vendor
         # to nvidia — `dstack offer` should show all vendors, and (b) does not
         # attempt to pull image config from the Docker registry.

--- a/src/dstack/_internal/server/services/instances.py
+++ b/src/dstack/_internal/server/services/instances.py
@@ -363,7 +363,6 @@ def filter_instances(
     *,
     requirements: Optional[Requirements] = None,
     status: Optional[InstanceStatus] = None,
-    fleet_model: Optional[FleetModel] = None,
     multinode: bool = False,
     master_job_provisioning_data: Optional[JobProvisioningData] = None,
     volumes: Optional[List[List[Volume]]] = None,
@@ -417,12 +416,6 @@ def filter_instances(
             continue
         if instance.health.is_failure():
             continue
-        if profile.fleets is not None:
-            fleet_name = fleet_model.name if fleet_model is not None else None
-            if fleet_name is None and instance.fleet is not None:
-                fleet_name = instance.fleet.name
-            if fleet_name is None or fleet_name not in profile.fleets:
-                continue
         if status is not None and instance.status != status:
             continue
         jpd = get_instance_provisioning_data(instance)
@@ -467,7 +460,6 @@ def get_shared_instances_with_offers(
     requirements: Requirements,
     *,
     idle_only: bool = False,
-    fleet_model: Optional[FleetModel] = None,
     multinode: bool = False,
     volumes: Optional[List[List[Volume]]] = None,
 ) -> list[tuple[InstanceModel, InstanceOfferWithAvailability]]:
@@ -476,7 +468,6 @@ def get_shared_instances_with_offers(
     filtered_instances = filter_instances(
         instances=instances,
         profile=profile,
-        fleet_model=fleet_model,
         multinode=multinode,
         volumes=volumes,
         shared=True,

--- a/src/dstack/_internal/server/services/runs/plan.py
+++ b/src/dstack/_internal/server/services/runs/plan.py
@@ -484,7 +484,6 @@ def get_instance_offers_in_fleet(
         instances=fleet_model.instances,
         profile=profile,
         requirements=job.job_spec.requirements,
-        fleet_model=fleet_model,
         multinode=multinode,
         master_job_provisioning_data=master_job_provisioning_data,
         volumes=volumes,
@@ -495,7 +494,6 @@ def get_instance_offers_in_fleet(
         instances=fleet_model.instances,
         profile=profile,
         requirements=job.job_spec.requirements,
-        fleet_model=fleet_model,
         multinode=multinode,
         volumes=volumes,
     )


### PR DESCRIPTION
Motivation:
- Simplify the implementation and improve the
  performance of the upcoming `<project>/<fleet>`
  syntax in the `fleets` property. Filtering by
  fleet in `filter_instances()` would require
  loading the project from the database for each
  fleet in order to support filtering by
  `<project>/<fleet>` (part of #3626).
- Make the behavior of `dstack offer --fleet`
  consistent for idle instances and backend
  offers, by ignoring `--fleet` for both. At least
  as a temporary solution, until we support
  filtering backend offers by `--fleet` (fixes #3672).

Apart from `dstack offer`, there is no other
impact of this change for end users. In all other
cases when `filter_instances()` is called,
filtering by fleet is actually redundant — either
because the instances are already pre-filtered by
`select_run_candidate_fleet_models_with_filters`,
or because `profile.fleets` is guaranteed to be
`None` (the case for autocreated fleets).