### PR TITLE
Fix 500 server error when re-applying replica groups service

### DIFF
--- a/src/dstack/_internal/core/models/configurations.py
+++ b/src/dstack/_internal/core/models/configurations.py
@@ -987,7 +987,7 @@ class ServiceConfigurationParams(CoreModel):
     @root_validator()
     def validate_top_level_properties_with_replica_groups(cls, values):
         """
-        When replicas is a list of ReplicaGroup, forbid top-level scaling, commands, and resources
+        When replicas is a list of ReplicaGroup, forbid top-level scaling and commands.
         """
         replicas = values.get("replicas")
 
@@ -1006,15 +1006,6 @@ class ServiceConfigurationParams(CoreModel):
             raise ValueError(
                 "Top-level `commands` is not allowed when `replicas` is a list. "
                 "Specify `commands` in each replica group instead."
-            )
-
-        resources = values.get("resources")
-
-        default_resources = ResourcesSpec()
-        if resources and resources.dict() != default_resources.dict():
-            raise ValueError(
-                "Top-level `resources` is not allowed when `replicas` is a list. "
-                "Specify `resources` in each replica group instead."
             )
 
         return values

--- a/src/dstack/_internal/server/services/runs/spec.py
+++ b/src/dstack/_internal/server/services/runs/spec.py
@@ -5,6 +5,7 @@ from dstack._internal.core.models.configurations import (
     ServiceConfiguration,
 )
 from dstack._internal.core.models.repos.virtual import DEFAULT_VIRTUAL_REPO_ID, VirtualRunRepoData
+from dstack._internal.core.models.resources import ResourcesSpec
 from dstack._internal.core.models.runs import LEGACY_REPO_DIR, AnyRunConfiguration, RunSpec
 from dstack._internal.core.models.volumes import InstanceMountPoint
 from dstack._internal.core.services import validate_dstack_resource_name
@@ -112,6 +113,16 @@ def validate_run_spec_and_set_defaults(
             raise ServerClientError(
                 f"Probe timeout cannot be longer than {settings.MAX_PROBE_TIMEOUT}s"
             )
+        if isinstance(run_spec.configuration.replicas, list):
+            default_resources = ResourcesSpec()
+            if (
+                run_spec.configuration.resources
+                and run_spec.configuration.resources.dict() != default_resources.dict()
+            ):
+                raise ServerClientError(
+                    "Top-level `resources` is not allowed when `replicas` is a list. "
+                    "Specify `resources` in each replica group instead."
+                )
     if run_spec.configuration.priority is None:
         run_spec.configuration.priority = RUN_PRIORITY_DEFAULT
     set_resources_defaults(run_spec.configuration.resources)


### PR DESCRIPTION
Fixes [#3676]( https://github.com/dstackai/dstack/issues/3676)
Move the top-level resources check out of the model validator and perform it on the server, inside `validate_run_spec_and_set_defaults`, before `set_resources_defaults` and `set_gpu_vendor_default` run. This keeps the same validation rule but evaluates it before any mutations, so valid configs no longer fail.