### PR TITLE
Restore instance.wait_until_running() in AWS create_instance

### DIFF
--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -351,6 +351,9 @@ class AWSCompute(
                     raise ComputeError(f"Invalid AWS request: {msg}")
                 continue
             instance = response[0]
+            # wait_until_running() is only needed so that instance is immediately ready for volume attach.
+            # TODO: Drop wait_until_running() once attach readiness is checked outside.
+            instance.wait_until_running()
             if instance_offer.instance.resources.spot:
                 # it will not terminate the instance
                 try:


### PR DESCRIPTION
Workaround for #3603 

The fix restore the previous logic waiting for instance running state in create_instance. This slows down provisioning (reduces throughput) so it should eventually be replaced with outside check.