### PR TITLE
fix: use fleet blocks config for string SSH hosts in create_fleet_ssh_instance_model

### DIFF
--- a/src/dstack/_internal/server/services/fleets.py
+++ b/src/dstack/_internal/server/services/fleets.py
@@ -684,7 +684,7 @@ async def create_fleet_ssh_instance_model(
         port = ssh_params.port
         proxy_jump = ssh_params.proxy_jump
         internal_ip = None
-        blocks = 1
+        blocks = spec.configuration.blocks
     else:
         hostname = host.hostname
         ssh_user = host.user or ssh_params.user


### PR DESCRIPTION
## Summary

Fixes #3475

When SSH fleet hosts are specified as plain strings (e.g., `hosts: ["192.168.0.1"]`), the fleet-level `blocks` configuration is ignored and hardcoded to `1`. This prevents instances from being divided into multiple GPU blocks, even when `blocks: auto` or a specific number is set in the fleet YAML.

## Root Cause

In `create_fleet_ssh_instance_model()`, the `if isinstance(host, str)` branch hardcodes `blocks = 1`, while the `else` branch (for `SSHHostParams` objects) correctly reads `blocks` from `host.blocks`. The fleet-level `spec.configuration.blocks` is never used for string hosts.

## Fix

Replace `blocks = 1` with `blocks = spec.configuration.blocks` in the string host branch, consistent with how fleet-level configuration is propagated for other SSH parameters (`ssh_user`, `ssh_key`, `port`) in the same branch.

## Steps to reproduce

1. Create an SSH fleet with `blocks: 3` (or `blocks: auto`):
```yaml
type: fleet
name: my-fleet
blocks: 3
ssh_config:
  user: myuser
  identity_file: ~/.ssh/id_rsa
  hosts:
    - 192.168.0.1
```
2. Apply: `dstack apply -f fleet.dstack.yml`
3. Check blocks: `dstack fleet get my-fleet --json | jq ".instances[0].total_blocks"`
4. Observe `total_blocks: 1` instead of `3`

After this fix, the instance correctly reports `total_blocks: 3`.

## AI Assistance Disclosure

This PR was written with AI assistance (code agent).