### PR TITLE
[CloudRift] Fix NTP clock skew breaking Docker; handle amd-smi 7.x output

### DIFF
--- a/runner/internal/shim/host/gpu.go
+++ b/runner/internal/shim/host/gpu.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	execute "github.com/alexellis/go-execute/v2"
 
@@ -114,6 +115,11 @@ type amdGpu struct {
 	Bus  amdBus  `json:"bus"`
 }
 
+// amd-smi >= 7.x wraps the array in {"gpu_data": [...]}
+type amdSmiOutput struct {
+	GpuData []amdGpu `json:"gpu_data"`
+}
+
 type amdAsic struct {
 	Name string `json:"market_name"`
 }
@@ -130,8 +136,26 @@ type amdBus struct {
 	BDF string `json:"bdf"` // PCIe Domain:Bus:Device.Function notation
 }
 
+// parseAmdSmiOutput handles both amd-smi output formats:
+// ROCm 6.x returns a flat array: [{"gpu": 0, ...}, ...]
+// ROCm 7.x wraps it: {"gpu_data": [{"gpu": 0, ...}, ...]}
+func parseAmdSmiOutput(data []byte) ([]amdGpu, error) {
+	var amdGpus []amdGpu
+	if err := json.Unmarshal(data, &amdGpus); err == nil {
+		return amdGpus, nil
+	}
+	var wrapped amdSmiOutput
+	if err := json.Unmarshal(data, &wrapped); err != nil {
+		return nil, err
+	}
+	return wrapped.GpuData, nil
+}
+
 func getAmdGpuInfo(ctx context.Context) []GpuInfo {
 	gpus := []GpuInfo{}
+
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
 
 	cmd := execute.ExecTask{
 		Command: "docker",
@@ -158,8 +182,8 @@ func getAmdGpuInfo(ctx context.Context) []GpuInfo {
 		return gpus
 	}
 
-	var amdGpus []amdGpu
-	if err := json.Unmarshal([]byte(res.Stdout), &amdGpus); err != nil {
+	amdGpus, err := parseAmdSmiOutput([]byte(res.Stdout))
+	if err != nil {
 		log.Error(ctx, "cannot read json", "err", err)
 		return gpus
 	}

--- a/src/dstack/_internal/core/backends/cloudrift/api_client.py
+++ b/src/dstack/_internal/core/backends/cloudrift/api_client.py
@@ -72,12 +72,16 @@ class RiftClient:
 
         return vm_recipes
 
-    def get_vm_image_url(self) -> Optional[str]:
+    def get_vm_image_url(self, gpu_vendor: Optional[str] = None) -> Optional[str]:
         recipes = self.get_vm_recipies()
+        if gpu_vendor == "amd":
+            driver_tag = "amd-driver"
+        else:
+            driver_tag = "nvidia-driver"
+
         ubuntu_images = []
         for recipe in recipes:
-            has_nvidia_driver = "nvidia-driver" in recipe.get("tags", [])
-            if not has_nvidia_driver:
+            if driver_tag not in recipe.get("tags", []):
                 continue
 
             recipe_name = recipe.get("name", "")
@@ -97,9 +101,14 @@ class RiftClient:
         return None
 
     def deploy_instance(
-        self, instance_type: str, region: str, ssh_keys: List[str], cmd: str
+        self,
+        instance_type: str,
+        region: str,
+        ssh_keys: List[str],
+        cmd: str,
+        gpu_vendor: Optional[str] = None,
     ) -> List[str]:
-        image_url = self.get_vm_image_url()
+        image_url = self.get_vm_image_url(gpu_vendor=gpu_vendor)
         if not image_url:
             raise BackendError("No suitable VM image found.")
 

--- a/src/dstack/_internal/core/backends/cloudrift/compute.py
+++ b/src/dstack/_internal/core/backends/cloudrift/compute.py
@@ -73,17 +73,31 @@ class CloudRiftCompute(
         instance_config: InstanceConfiguration,
         placement_group: Optional[PlacementGroup],
     ) -> JobProvisioningData:
-        commands = get_shim_commands()
+        # TODO: Remove once CloudRift fixes their VM RTC clock.
+        # Wrong RTC + NTP backward jump breaks Docker container lifecycle.
+        ntp_sync_commands = [
+            (
+                "timeout 60 bash -c '"
+                "while ! timedatectl show -p NTPSynchronized --value | grep -q yes;"
+                " do sleep 1; done' || true"
+            ),
+        ]
+        commands = ntp_sync_commands + get_shim_commands()
         startup_script = " ".join([" && ".join(commands)])
         logger.debug(
             f"Creating instance for offer {instance_offer.instance.name} in region {instance_offer.region} with commands: {startup_script}"
         )
+
+        gpu_vendor = None
+        if instance_offer.instance.resources.gpus:
+            gpu_vendor = instance_offer.instance.resources.gpus[0].vendor.value
 
         instance_ids = self.client.deploy_instance(
             instance_type=instance_offer.instance.name,
             region=instance_offer.region,
             ssh_keys=instance_config.get_public_keys(),
             cmd=startup_script,
+            gpu_vendor=gpu_vendor,
         )
 
         if len(instance_ids) == 0:


### PR DESCRIPTION
## Summary
- CloudRift VMs boot with incorrect RTC clock (~1h ahead). When NTP corrects it backwards, Docker discards container exit events, leaving containers stuck as ghosts. Added NTP sync wait before launching the shim.
- Handle both amd-smi output formats: flat array (ROCm 6.x) and wrapped `{"gpu_data": [...]}` (ROCm 7.x)
- Add 2-minute timeout to AMD GPU detection to prevent shim from hanging indefinitely
- Select correct VM image (AMD vs NVIDIA driver) based on GPU vendor

## Test plan
- [x] Verified NTP sync fix on CloudRift MI350X instance — no ghost containers
- [x] Verified GPU detection works with ROCm 6.4 amd-smi output format
- [x] Verified workload container starts with GPU attached (`gpus=[/dev/dri/renderD128]`)
- [x] All Python tests pass (2357 passed)
- [x] All Go tests pass
- [x] golangci-lint, ruff, pre-commit all clean

Depends on https://github.com/dstackai/gpuhunt/pull/223

🤖 Generated with [Claude Code](https://claude.com/claude-code)