### PR TITLE
Fix SELinux denials on SSH fleet provisioning

### DIFF
--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -906,7 +906,7 @@ def get_shim_pre_start_commands(
         f"dlpath=$(sudo mktemp -t {DSTACK_SHIM_BINARY_NAME}.XXXXXXXXXX)",
         # -sS -- disable progress meter and warnings, but still show errors (unlike bare -s)
         f'sudo curl -sS --compressed --connect-timeout 60 --max-time 240 --retry 1 --output "$dlpath" "{url}"',
-        f'sudo mv "$dlpath" {dstack_shim_binary_path}',
+        f'sudo cp "$dlpath" {dstack_shim_binary_path} && sudo rm "$dlpath"',
         f"sudo chmod +x {dstack_shim_binary_path}",
         f"sudo mkdir {dstack_working_dir} -p",
     ]

--- a/src/dstack/_internal/server/services/ssh_fleets/provisioning.py
+++ b/src/dstack/_internal/server/services/ssh_fleets/provisioning.py
@@ -73,7 +73,11 @@ def upload_envs(client: paramiko.SSHClient, working_dir: str, envs: Dict[str, st
     tmp_file_path = f"/tmp/{DSTACK_SHIM_ENV_FILE}"
     sftp_upload(client, tmp_file_path, dot_env)
     try:
-        cmd = f"sudo mkdir -p {working_dir} && sudo mv {tmp_file_path} {working_dir}/"
+        dest = f"{working_dir}/{DSTACK_SHIM_ENV_FILE}"
+        cmd = (
+            f"sudo mkdir -p {working_dir} && sudo mv {tmp_file_path} {dest}"
+            f" && {{ sudo chcon system_u:object_r:etc_t:s0 {dest} 2>/dev/null || true; }}"
+        )
         _, stdout, stderr = client.exec_command(cmd, timeout=20)
         out = stdout.read().strip().decode()
         err = stderr.read().strip().decode()
@@ -148,6 +152,7 @@ def run_shim_as_systemd_service(
     try:
         cmd = """\
             sudo mv /tmp/dstack-shim.service /etc/systemd/system/dstack-shim.service && \
+            { sudo chcon system_u:object_r:systemd_unit_file_t:s0 /etc/systemd/system/dstack-shim.service 2>/dev/null || true; } && \
             sudo systemctl daemon-reload && \
             sudo systemctl --quiet enable dstack-shim && \
             sudo systemctl restart dstack-shim


### PR DESCRIPTION
## Summary
- On SELinux-enforcing hosts (RHEL, Rocky, CentOS), files moved from `/tmp` retain their original SELinux context (`user_tmp_t`/`unconfined_u`). systemd cannot read these files, causing the shim service to fail with "Permission denied".
- Add `chcon` after `mv` to set correct SELinux contexts: `systemd_unit_file_t` for the service file, `etc_t` for the env file. No-op on non-SELinux systems.
- Replace `mv` with `cp`+`rm` for the shim binary to ensure correct context in `/usr/local/bin/`.

## Test plan
- [x] Tested on RHEL 9.4 with SELinux Enforcing — fleet goes active
- [x] Tested on Ubuntu 24.04 (no SELinux) — fleet goes active
- [x] All Python tests pass (2357 passed)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)