### PR TITLE
Fix pipeline fetcher deadlock

### DIFF
--- a/src/dstack/_internal/server/background/pipeline_tasks/instances/__init__.py
+++ b/src/dstack/_internal/server/background/pipeline_tasks/instances/__init__.py
@@ -167,16 +167,20 @@ class InstanceFetcher(Fetcher[InstancePipelineItem]):
                         ),
                         InstanceModel.deleted == False,
                         or_(
-                            # Do not try to lock instances if the fleet is waiting for the lock.
-                            InstanceModel.fleet_id.is_(None),
-                            FleetModel.lock_owner.is_(None),
-                        ),
-                        or_(
                             InstanceModel.last_processed_at <= now - self._min_processing_interval,
                             InstanceModel.last_processed_at == InstanceModel.created_at,
                         ),
                         or_(
-                            InstanceModel.lock_expires_at.is_(None),
+                            and_(
+                                # Do not try to lock instances if the fleet is waiting for the
+                                # lock, but allow retrying instances whose own lock is stale
+                                # because the fleet pipeline cannot reclaim stale instance locks.
+                                or_(
+                                    InstanceModel.fleet_id.is_(None),
+                                    FleetModel.lock_owner.is_(None),
+                                ),
+                                InstanceModel.lock_expires_at.is_(None),
+                            ),
                             InstanceModel.lock_expires_at < now,
                         ),
                         or_(

--- a/src/dstack/_internal/server/background/pipeline_tasks/jobs_running.py
+++ b/src/dstack/_internal/server/background/pipeline_tasks/jobs_running.py
@@ -197,10 +197,14 @@ class JobRunningFetcher(Fetcher[JobRunningPipelineItem]):
                         ),
                         RunModel.status.not_in([RunStatus.TERMINATING]),
                         JobModel.last_processed_at <= now - self._min_processing_interval,
-                        # Do not try to lock jobs if the run is waiting for the lock.
-                        RunModel.lock_owner.is_(None),
                         or_(
-                            JobModel.lock_expires_at.is_(None),
+                            and_(
+                                # Do not try to lock jobs if the run is waiting for the lock,
+                                # but allow retrying jobs whose own lock is stale because
+                                # the run pipeline cannot reclaim stale job locks.
+                                RunModel.lock_owner.is_(None),
+                                JobModel.lock_expires_at.is_(None),
+                            ),
                             JobModel.lock_expires_at < now,
                         ),
                         or_(

--- a/src/dstack/_internal/server/background/pipeline_tasks/jobs_submitted.py
+++ b/src/dstack/_internal/server/background/pipeline_tasks/jobs_submitted.py
@@ -243,10 +243,14 @@ class JobSubmittedFetcher(Fetcher[JobSubmittedPipelineItem]):
                             JobModel.last_processed_at <= now - self._min_processing_interval,
                             JobModel.last_processed_at == JobModel.submitted_at,
                         ),
-                        # Do not try to lock jobs if the run is waiting for the lock.
-                        RunModel.lock_owner.is_(None),
                         or_(
-                            JobModel.lock_expires_at.is_(None),
+                            and_(
+                                # Do not try to lock jobs if the run is waiting for the lock,
+                                # but allow retrying jobs whose own lock is stale because
+                                # the run pipeline cannot reclaim stale job locks.
+                                RunModel.lock_owner.is_(None),
+                                JobModel.lock_expires_at.is_(None),
+                            ),
                             JobModel.lock_expires_at < now,
                         ),
                         or_(

--- a/src/dstack/_internal/server/background/pipeline_tasks/jobs_submitted.py
+++ b/src/dstack/_internal/server/background/pipeline_tasks/jobs_submitted.py
@@ -244,13 +244,9 @@ class JobSubmittedFetcher(Fetcher[JobSubmittedPipelineItem]):
                             JobModel.last_processed_at == JobModel.submitted_at,
                         ),
                         or_(
-                            and_(
-                                # Do not try to lock jobs if the run is waiting for the lock,
-                                # but allow retrying jobs whose own lock is stale because
-                                # the run pipeline cannot reclaim stale job locks.
-                                RunModel.lock_owner.is_(None),
-                                JobModel.lock_expires_at.is_(None),
-                            ),
+                            # This pipeline does not check RunModel.lock_owner
+                            # because we want to provision jobs ASAP and RunPipeline can wait.
+                            JobModel.lock_expires_at.is_(None),
                             JobModel.lock_expires_at < now,
                         ),
                         or_(

--- a/src/tests/_internal/server/background/pipeline_tasks/test_instances/test_pipeline.py
+++ b/src/tests/_internal/server/background/pipeline_tasks/test_instances/test_pipeline.py
@@ -6,6 +6,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dstack._internal.core.models.instances import InstanceStatus
+from dstack._internal.server.background.pipeline_tasks.fleets import FleetPipeline
 from dstack._internal.server.background.pipeline_tasks.instances import (
     InstanceFetcher,
     InstancePipeline,
@@ -191,6 +192,64 @@ class TestInstanceFetcher:
         assert oldest.lock_owner == InstancePipeline.__name__
         assert middle.lock_owner == InstancePipeline.__name__
         assert newest.lock_owner is None
+
+    async def test_fetch_allows_stale_instance_locks_if_fleet_is_waiting_for_instance_locks(
+        self, test_db, session: AsyncSession, fetcher: InstanceFetcher
+    ):
+        project = await create_project(session=session)
+        fleet = await create_fleet(session=session, project=project)
+        stale = get_current_datetime() - dt.timedelta(minutes=1)
+
+        fleet.lock_owner = FleetPipeline.__name__
+        fleet.lock_token = None
+        fleet.lock_expires_at = None
+
+        instance = await create_instance(
+            session=session,
+            project=project,
+            fleet=fleet,
+            status=InstanceStatus.IDLE,
+            name="stale-locked",
+            last_processed_at=stale - dt.timedelta(seconds=1),
+        )
+        lock_instance(instance)
+        instance.lock_expires_at = stale
+        await session.commit()
+
+        items = await fetcher.fetch(limit=10)
+
+        assert [item.id for item in items] == [instance.id]
+
+        await session.refresh(instance)
+        assert instance.lock_owner == InstancePipeline.__name__
+
+    async def test_fetch_excludes_fresh_instances_when_fleet_is_waiting_for_instance_locks(
+        self, test_db, session: AsyncSession, fetcher: InstanceFetcher
+    ):
+        project = await create_project(session=session)
+        fleet = await create_fleet(session=session, project=project)
+        stale = get_current_datetime() - dt.timedelta(minutes=1)
+
+        fleet.lock_owner = FleetPipeline.__name__
+        fleet.lock_token = None
+        fleet.lock_expires_at = None
+
+        instance = await create_instance(
+            session=session,
+            project=project,
+            fleet=fleet,
+            status=InstanceStatus.IDLE,
+            name="fresh-unlocked",
+            last_processed_at=stale - dt.timedelta(seconds=1),
+        )
+        await session.commit()
+
+        items = await fetcher.fetch(limit=10)
+
+        assert items == []
+
+        await session.refresh(instance)
+        assert instance.lock_owner is None
 
 
 @pytest.mark.asyncio

--- a/src/tests/_internal/server/background/pipeline_tasks/test_running_jobs.py
+++ b/src/tests/_internal/server/background/pipeline_tasks/test_running_jobs.py
@@ -40,6 +40,7 @@ from dstack._internal.server.background.pipeline_tasks.jobs_running import (
     _RunnerAvailability,
     _SubmitJobToRunnerResult,
 )
+from dstack._internal.server.background.pipeline_tasks.runs import RunPipeline
 from dstack._internal.server.models import JobModel, ProbeModel
 from dstack._internal.server.schemas.runner import (
     HealthcheckResponse,
@@ -306,6 +307,63 @@ class TestJobRunningFetcher:
 
         assert active_job.lock_owner == JobRunningPipeline.__name__
         assert terminating_run_job.lock_owner is None
+
+    async def test_fetch_allows_stale_job_locks_even_if_run_is_waiting_for_job_locks(
+        self, test_db, session: AsyncSession, fetcher: JobRunningFetcher
+    ):
+        project = await create_project(session=session)
+        user = await create_user(session=session)
+        repo = await create_repo(session=session, project_id=project.id)
+        run = await create_run(session=session, project=project, repo=repo, user=user)
+        stale = get_current_datetime() - timedelta(minutes=1)
+
+        run.lock_owner = RunPipeline.__name__
+        run.lock_token = None
+        run.lock_expires_at = None
+
+        job = await create_job(
+            session=session,
+            run=run,
+            status=JobStatus.RUNNING,
+            last_processed_at=stale - timedelta(seconds=1),
+        )
+        _lock_job_expired_same_owner(job)
+        await session.commit()
+
+        items = await fetcher.fetch(limit=10)
+
+        assert [item.id for item in items] == [job.id]
+
+        await session.refresh(job)
+        assert job.lock_owner == JobRunningPipeline.__name__
+
+    async def test_fetch_excludes_jobs_when_run_is_waiting_for_related_job_locks(
+        self, test_db, session: AsyncSession, fetcher: JobRunningFetcher
+    ):
+        project = await create_project(session=session)
+        user = await create_user(session=session)
+        repo = await create_repo(session=session, project_id=project.id)
+        run = await create_run(session=session, project=project, repo=repo, user=user)
+        stale = get_current_datetime() - timedelta(minutes=1)
+
+        run.lock_owner = RunPipeline.__name__
+        run.lock_token = None
+        run.lock_expires_at = None
+
+        job = await create_job(
+            session=session,
+            run=run,
+            status=JobStatus.RUNNING,
+            last_processed_at=stale - timedelta(seconds=1),
+        )
+        await session.commit()
+
+        items = await fetcher.fetch(limit=10)
+
+        assert items == []
+
+        await session.refresh(job)
+        assert job.lock_owner is None
 
     async def test_fetch_returns_oldest_jobs_first_up_to_limit(
         self, test_db, session: AsyncSession, fetcher: JobRunningFetcher

--- a/src/tests/_internal/server/background/pipeline_tasks/test_submitted_jobs.py
+++ b/src/tests/_internal/server/background/pipeline_tasks/test_submitted_jobs.py
@@ -28,6 +28,7 @@ from dstack._internal.server.background.pipeline_tasks.jobs_submitted import (
     JobSubmittedPipelineItem,
     JobSubmittedWorker,
 )
+from dstack._internal.server.background.pipeline_tasks.runs import RunPipeline
 from dstack._internal.server.models import (
     ComputeGroupModel,
     InstanceModel,
@@ -250,6 +251,67 @@ class TestJobSubmittedFetcher:
         assert waiting_run_fleet.lock_owner is None
         assert recent_retry.lock_owner is None
         assert foreign_locked.lock_owner == "OtherPipeline"
+
+    async def test_fetch_allows_stale_job_locks_even_if_run_is_waiting_for_job_locks(
+        self, test_db, session: AsyncSession, fetcher: JobSubmittedFetcher
+    ):
+        project = await create_project(session=session)
+        user = await create_user(session=session)
+        repo = await create_repo(session=session, project_id=project.id)
+        fleet = await create_fleet(session=session, project=project)
+        run = await create_run(session=session, project=project, repo=repo, user=user, fleet=fleet)
+        stale = get_current_datetime() - timedelta(minutes=1)
+
+        run.lock_owner = RunPipeline.__name__
+        run.lock_token = None
+        run.lock_expires_at = None
+
+        job = await create_job(
+            session=session,
+            run=run,
+            status=JobStatus.SUBMITTED,
+            submitted_at=stale - timedelta(minutes=1),
+            last_processed_at=stale - timedelta(seconds=1),
+        )
+        _lock_job_expired_same_owner(job)
+        await session.commit()
+
+        items = await fetcher.fetch(limit=10)
+
+        assert [item.id for item in items] == [job.id]
+
+        await session.refresh(job)
+        assert job.lock_owner == JobSubmittedPipeline.__name__
+
+    async def test_fetch_excludes_fresh_jobs_when_run_is_waiting_for_job_locks(
+        self, test_db, session: AsyncSession, fetcher: JobSubmittedFetcher
+    ):
+        project = await create_project(session=session)
+        user = await create_user(session=session)
+        repo = await create_repo(session=session, project_id=project.id)
+        fleet = await create_fleet(session=session, project=project)
+        run = await create_run(session=session, project=project, repo=repo, user=user, fleet=fleet)
+        stale = get_current_datetime() - timedelta(minutes=1)
+
+        run.lock_owner = RunPipeline.__name__
+        run.lock_token = None
+        run.lock_expires_at = None
+
+        job = await create_job(
+            session=session,
+            run=run,
+            status=JobStatus.SUBMITTED,
+            submitted_at=stale - timedelta(minutes=1),
+            last_processed_at=stale - timedelta(seconds=1),
+        )
+        await session.commit()
+
+        items = await fetcher.fetch(limit=10)
+
+        assert items == []
+
+        await session.refresh(job)
+        assert job.lock_owner is None
 
     async def test_fetch_orders_by_priority_then_last_processed_at(
         self, test_db, session: AsyncSession, fetcher: JobSubmittedFetcher

--- a/src/tests/_internal/server/background/pipeline_tasks/test_submitted_jobs.py
+++ b/src/tests/_internal/server/background/pipeline_tasks/test_submitted_jobs.py
@@ -28,7 +28,6 @@ from dstack._internal.server.background.pipeline_tasks.jobs_submitted import (
     JobSubmittedPipelineItem,
     JobSubmittedWorker,
 )
-from dstack._internal.server.background.pipeline_tasks.runs import RunPipeline
 from dstack._internal.server.models import (
     ComputeGroupModel,
     InstanceModel,
@@ -251,67 +250,6 @@ class TestJobSubmittedFetcher:
         assert waiting_run_fleet.lock_owner is None
         assert recent_retry.lock_owner is None
         assert foreign_locked.lock_owner == "OtherPipeline"
-
-    async def test_fetch_allows_stale_job_locks_even_if_run_is_waiting_for_job_locks(
-        self, test_db, session: AsyncSession, fetcher: JobSubmittedFetcher
-    ):
-        project = await create_project(session=session)
-        user = await create_user(session=session)
-        repo = await create_repo(session=session, project_id=project.id)
-        fleet = await create_fleet(session=session, project=project)
-        run = await create_run(session=session, project=project, repo=repo, user=user, fleet=fleet)
-        stale = get_current_datetime() - timedelta(minutes=1)
-
-        run.lock_owner = RunPipeline.__name__
-        run.lock_token = None
-        run.lock_expires_at = None
-
-        job = await create_job(
-            session=session,
-            run=run,
-            status=JobStatus.SUBMITTED,
-            submitted_at=stale - timedelta(minutes=1),
-            last_processed_at=stale - timedelta(seconds=1),
-        )
-        _lock_job_expired_same_owner(job)
-        await session.commit()
-
-        items = await fetcher.fetch(limit=10)
-
-        assert [item.id for item in items] == [job.id]
-
-        await session.refresh(job)
-        assert job.lock_owner == JobSubmittedPipeline.__name__
-
-    async def test_fetch_excludes_fresh_jobs_when_run_is_waiting_for_job_locks(
-        self, test_db, session: AsyncSession, fetcher: JobSubmittedFetcher
-    ):
-        project = await create_project(session=session)
-        user = await create_user(session=session)
-        repo = await create_repo(session=session, project_id=project.id)
-        fleet = await create_fleet(session=session, project=project)
-        run = await create_run(session=session, project=project, repo=repo, user=user, fleet=fleet)
-        stale = get_current_datetime() - timedelta(minutes=1)
-
-        run.lock_owner = RunPipeline.__name__
-        run.lock_token = None
-        run.lock_expires_at = None
-
-        job = await create_job(
-            session=session,
-            run=run,
-            status=JobStatus.SUBMITTED,
-            submitted_at=stale - timedelta(minutes=1),
-            last_processed_at=stale - timedelta(seconds=1),
-        )
-        await session.commit()
-
-        items = await fetcher.fetch(limit=10)
-
-        assert items == []
-
-        await session.refresh(job)
-        assert job.lock_owner is None
 
     async def test_fetch_orders_by_priority_then_last_processed_at(
         self, test_db, session: AsyncSession, fetcher: JobSubmittedFetcher


### PR DESCRIPTION
This PR fixes a deadlock with child-parent pipelines. E.g. `JobRunningPipeline` skipped jobs if `RunModel.lock_owner` was set to prioritize `RunPipeline` but if the jobs was stale this cause deadlock because `RunPipeline` cannot recover stale job locks. The fix is to skip locking only new jobs and still process stale jobs irrespective of parent's `lock_owner`.

Also prioritizes `JobSubmittedPipeline` over `RunPipeline` to speedup provisioning (especially large multi-node tasks).