### PR TITLE
Fix SELinux denials and "Text file busy" on SSH fleet provisioning

### DIFF
--- a/src/dstack/_internal/core/backends/base/compute.py
+++ b/src/dstack/_internal/core/backends/base/compute.py
@@ -906,8 +906,9 @@ def get_shim_pre_start_commands(
         f"dlpath=$(sudo mktemp -t {DSTACK_SHIM_BINARY_NAME}.XXXXXXXXXX)",
         # -sS -- disable progress meter and warnings, but still show errors (unlike bare -s)
         f'sudo curl -sS --compressed --connect-timeout 60 --max-time 240 --retry 1 --output "$dlpath" "{url}"',
-        f'sudo cp "$dlpath" {dstack_shim_binary_path} && sudo rm "$dlpath"',
+        f'sudo mv "$dlpath" {dstack_shim_binary_path}',
         f"sudo chmod +x {dstack_shim_binary_path}",
+        f"{{ sudo chcon system_u:object_r:bin_t:s0 {dstack_shim_binary_path} 2>/dev/null || true; }}",
         f"sudo mkdir {dstack_working_dir} -p",
     ]
 


### PR DESCRIPTION
## Summary
- Revert shim binary download from `cp` back to `mv` to fix "Text file busy" (ETXTBSY) errors when re-provisioning an SSH fleet without host cleanup — `cp` fails on a running executable, while `mv` atomically replaces the directory entry
- Add `chcon` after `mv` to set correct SELinux context (`bin_t`) for the shim binary — on SELinux-enforcing hosts (RHEL, Rocky, CentOS), files moved from `/tmp` retain `user_tmp_t` context which blocks execution; no-op on non-SELinux systems

Companion to #3702 which fixed the same SELinux issue for the service file and env file.

## Test plan
- [x] RHEL 9.4 (SELinux Enforcing) clean provision — fleet active
- [x] RHEL 9.4 (SELinux Enforcing) re-provision without cleanup — fleet active
- [x] Ubuntu 24.04 (no SELinux) clean provision — fleet active
- [x] Ubuntu 24.04 (no SELinux) re-provision without cleanup — fleet active (no "Text file busy")
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)