### PR TITLE
Do not wait in `VerdaCompute.create_instance`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,11 +226,11 @@ gcp = [
     "dstack[server]",
 ]
 datacrunch = [
-    "verda; python_version >= '3.10'",
+    "verda>=1.23.0; python_version >= '3.10'",
     "dstack[server]",
 ]
 verda = [
-    "verda; python_version >= '3.10'",
+    "verda>=1.23.0; python_version >= '3.10'",
     "dstack[server]",
 ]
 kubernetes = [

--- a/src/dstack/_internal/core/backends/verda/compute.py
+++ b/src/dstack/_internal/core/backends/verda/compute.py
@@ -258,6 +258,7 @@ def _deploy_instance(
             is_spot=is_spot,
             location=location,
             os_volume={"name": "OS volume", "size": disk_size},
+            wait_for_status=None,  # return asap
         )
     except APIException as e:
         # FIXME: Catch only no capacity errors


### PR DESCRIPTION
Previously, `VerdaCompute.create_instance` would
block for up to 3 minutes while the SDK was
waiting for the instance to leave the `ORDERED`
status. This could hurt performance (the database
connection is blocked while waiting) and
reliability (server restarts or exceptions during
the wait cause the instance to be orphaned).

Use the newly introduced Verda SDK option to avoid
the wait in `create_instance()`, so that it is
performed by subsequent
`update_provisioning_data()` calls instead.