### PR TITLE
Enable pipelines by default

### DIFF
--- a/src/dstack/_internal/settings.py
+++ b/src/dstack/_internal/settings.py
@@ -44,14 +44,20 @@ class FeatureFlags:
     development. Feature flags are environment variables of the form DSTACK_FF_*
     """
 
-    # DSTACK_FF_AUTOCREATED_FLEETS_ENABLED enables legacy autocreated fleets:
-    # If there are no fleet suitable for the run, a new fleet is created automatically instead of an error.
     AUTOCREATED_FLEETS_ENABLED = os.getenv("DSTACK_FF_AUTOCREATED_FLEETS_ENABLED") is not None
-    # DSTACK_FF_PIPELINE_PROCESSING_ENABLED enables new pipeline-based processing tasks (background/pipeline_tasks/)
-    # instead of scheduler-based processing tasks (background/scheduled_tasks/) for tasks that implement pipelines.
-    PIPELINE_PROCESSING_ENABLED = os.getenv("DSTACK_FF_PIPELINE_PROCESSING_ENABLED") is not None
-    # If DSTACK_FF_CLI_PRINT_JOB_CONNECTION_INFO enabled, `dstack apply` command prints server-provided
-    # IDE URL(s) and SSH command(s) before job logs (for dev-environments only).
+    """DSTACK_FF_AUTOCREATED_FLEETS_ENABLED enables legacy autocreated fleets:
+    If there are no fleet suitable for the run, a new fleet is created automatically instead of an error.
+    """
+
+    PIPELINE_PROCESSING_DISABLED = os.getenv("DSTACK_FF_PIPELINE_PROCESSING_DISABLED") is not None
+    """DSTACK_FF_PIPELINE_PROCESSING_DISABLED disables pipeline-based processing tasks (background/pipeline_tasks/)
+    and enables legacy scheduler-based processing tasks (background/scheduled_tasks/).
+    """
+    PIPELINE_PROCESSING_ENABLED = not PIPELINE_PROCESSING_DISABLED
+
     CLI_PRINT_JOB_CONNECTION_INFO = (
         os.getenv("DSTACK_FF_CLI_PRINT_JOB_CONNECTION_INFO") is not None
     )
+    """If DSTACK_FF_CLI_PRINT_JOB_CONNECTION_INFO enabled, `dstack apply` command prints server-provided
+    IDE URL(s) and SSH command(s) before job logs (for dev-environments only).
+    """


### PR DESCRIPTION
Part of #3551

The PR enables pipelines processing by default. `DSTACK_FF_PIPELINE_PROCESSING_ENABLED` is replaced with `DSTACK_FF_PIPELINE_PROCESSING_DISABLED` as pipelines become opt-out instead of opt-in. Legacy tasks are supported temporarily until the related code is dropped.