### PR TITLE
[chore]: Fix `add_row_from_dict()` typing issues

### DIFF
--- a/src/dstack/_internal/cli/commands/export.py
+++ b/src/dstack/_internal/cli/commands/export.py
@@ -1,5 +1,4 @@
 import argparse
-from typing import Any, Union
 
 from rich.table import Table
 
@@ -148,7 +147,7 @@ def print_exports_table(exports: list[Export]):
         )
         importers = ", ".join([i.project_name for i in export.imports]) if export.imports else "-"
 
-        row: dict[Union[str, int], Any] = {
+        row = {
             "NAME": export.name,
             "FLEETS": fleets,
             "IMPORTERS": importers,

--- a/src/dstack/_internal/cli/commands/import_.py
+++ b/src/dstack/_internal/cli/commands/import_.py
@@ -1,5 +1,4 @@
 import argparse
-from typing import Any, Union
 
 from rich.table import Table
 
@@ -44,7 +43,7 @@ def print_imports_table(imports: list[Import]):
             else "-"
         )
 
-        row: dict[Union[str, int], Any] = {
+        row = {
             "NAME": name,
             "FLEETS": fleets,
         }

--- a/src/dstack/_internal/cli/commands/metrics.py
+++ b/src/dstack/_internal/cli/commands/metrics.py
@@ -1,6 +1,6 @@
 import argparse
 import time
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, List, Optional
 
 from rich.live import Live
 from rich.table import Table
@@ -79,7 +79,7 @@ def _get_metrics_table(run: Run, metrics: List[JobMetrics]) -> Table:
     table.add_column("MEMORY")
     table.add_column("GPU")
 
-    run_row: Dict[Union[str, int], Any] = {"NAME": run.name, "STATUS": run.status.value}
+    run_row = {"NAME": run.name, "STATUS": run.status.value}
     if len(run._run.jobs) != 1:
         add_row_from_dict(table, run_row)
 
@@ -117,7 +117,7 @@ def _get_metrics_table(run: Run, metrics: List[JobMetrics]) -> Table:
                         )
                     gpu_metrics += f" util={gpu_util_percent}%"
 
-        job_row: Dict[Union[str, int], Any] = {
+        job_row = {
             "NAME": f"  replica={job.job_spec.replica_num} job={job.job_spec.job_num}",
             "STATUS": job.job_submissions[-1].status.value,
             "CPU": cpu_usage or "-",

--- a/src/dstack/_internal/cli/commands/project.py
+++ b/src/dstack/_internal/cli/commands/project.py
@@ -1,6 +1,6 @@
 import argparse
 import sys
-from typing import Any, Optional, Union
+from typing import Optional
 
 import questionary
 from requests import HTTPError
@@ -191,7 +191,7 @@ class ProjectCommand(BaseCommand):
         for project_config in config_manager.list_project_configs():
             project_name = project_config.name
             is_default = project_name == default_project.name if default_project else False
-            row: dict[Union[str, int], Any] = {
+            row = {
                 "PROJECT": project_name,
                 "URL": project_config.url,
                 "DEFAULT": "✓" if is_default else "",

--- a/src/dstack/_internal/cli/utils/common.py
+++ b/src/dstack/_internal/cli/utils/common.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional
 
 import requests
 from rich.console import Console
@@ -110,17 +110,11 @@ def confirm_ask(prompt, **kwargs) -> bool:
         raise SystemExit(1)
 
 
-def add_row_from_dict(table: Table, data: Dict[Union[str, int], Any], **kwargs):
-    """Maps dict keys to a table columns. `data` key is a column name or index. Missing keys are ignored."""
+def add_row_from_dict(table: Table, data: dict[str, Any], **kwargs):
+    """Maps dict keys to table columns. `data` key is the column name. Missing keys are ignored."""
     row = []
-    for i, col in enumerate(table.columns):
-        # TODO(egor-s): clear header style
-        if col.header in data:
-            row.append(data[col.header])
-        elif i in data:
-            row.append(data[i])
-        else:
-            row.append("")
+    for col in table.columns:
+        row.append(data.get(str(col.header), ""))
     table.add_row(*row, **kwargs)
 
 

--- a/src/dstack/_internal/cli/utils/fleet.py
+++ b/src/dstack/_internal/cli/utils/fleet.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, List, Optional
 
 from rich.table import Table
 
@@ -75,7 +75,7 @@ def get_fleets_table(
         if verbose and config.placement and config.placement.value == "cluster":
             nodes = f"{nodes} (cluster)"
 
-        fleet_row: Dict[Union[str, int], Any] = {
+        fleet_row = {
             "NAME": name,
             "NODES": nodes,
             "RESOURCES": resources,
@@ -116,7 +116,7 @@ def get_fleets_table(
                     )
                 instance_price = _format_price(instance.price)
 
-            instance_row: Dict[Union[str, int], Any] = {
+            instance_row = {
                 "NAME": f"   instance={instance.instance_num}",
                 "NODES": "",
                 "RESOURCES": _format_instance_resources(instance),

--- a/src/dstack/_internal/cli/utils/run.py
+++ b/src/dstack/_internal/cli/utils/run.py
@@ -1,5 +1,5 @@
 import shutil
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from rich.markup import escape
 from rich.table import Table
@@ -398,7 +398,7 @@ def get_runs_table(
                     group_name = group.name
                     group_name_to_index[group_name] = idx
 
-        run_row: Dict[Union[str, int], Any] = {
+        run_row = {
             "NAME": _format_run_name(run, show_deployment_num),
             "SUBMITTED": format_date(run.submitted_at),
             "STATUS": _format_run_status(run),
@@ -431,7 +431,7 @@ def get_runs_table(
             if group_name_to_index:
                 group_index = group_name_to_index.get(job.job_spec.replica_group)
 
-            job_row: Dict[Union[str, int], Any] = {
+            job_row = {
                 "NAME": _format_job_name(
                     job,
                     latest_job_submission,


### PR DESCRIPTION
Drop unused index-based mapping from
`add_row_from_dict`. This simplifies its interface and fixes the
`"str" is not the same as "str | int"` typing
issue for callers that do not explicitly annotate
`data` as `dict[str | int, Any]`.