### PR TITLE
Support AWS G7e (`RTXPRO6000`) instances

### DIFF
--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -1177,6 +1177,7 @@ def _supported_instances(offer: InstanceOffer) -> bool:
         "p4d.",
         "p4de.",
         "p3.",
+        "g7e.",
         "g6.",
         "g6e.",
         "gr6.",

--- a/src/dstack/_internal/server/services/backends/provisioning.py
+++ b/src/dstack/_internal/server/services/backends/provisioning.py
@@ -9,6 +9,7 @@ from dstack._internal.core.models.volumes import InstanceMountPoint
 from dstack._internal.server.schemas.runner import GPUDevice
 from dstack._internal.server.services.docker import apply_server_docker_defaults, parse_image_name
 
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types
 _AWS_EFA_ENABLED_INSTANCE_TYPE_PATTERNS = [
     # TODO: p6-b200 isn't supported yet in gpuhunt
     r"^p6-b200\.(48xlarge)$",
@@ -17,6 +18,7 @@ _AWS_EFA_ENABLED_INSTANCE_TYPE_PATTERNS = [
     r"^p5en\.(48xlarge)$",
     r"^p4d\.(24xlarge)$",
     r"^p4de\.(24xlarge)$",
+    r"^g7e\.(8xlarge|12xlarge|24xlarge|48xlarge)$",
     r"^g6\.(8xlarge|12xlarge|16xlarge|24xlarge|48xlarge)$",
     r"^g6e\.(8xlarge|12xlarge|16xlarge|24xlarge|48xlarge)$",
     r"^gr6\.8xlarge$",

--- a/src/tests/_internal/server/services/backends/test_provisioning.py
+++ b/src/tests/_internal/server/services/backends/test_provisioning.py
@@ -71,6 +71,7 @@ class TestResolveProvisioningImageName:
             "p4de.24xlarge",
             "g6.8xlarge",
             "g6e.8xlarge",
+            "g7e.8xlarge",
         ],
     )
     def test_patch_all_efa_instance_types(self, instance_type: str, suffix: str) -> None:


### PR DESCRIPTION
```
$ dstack offer -b aws --gpu RTXPRO6000 --group-by gpu,backend,region                     

 #  GPU                   SPOT             $/GPU          BACKEND  REGION      
 1  RTXPRO6000:96GB:1..8  spot, on-demand  0.5245..4.143  aws      us-east-2   
 2  RTXPRO6000:96GB:1..8  spot, on-demand  0.6513..4.143  aws      us-west-2   
 3  RTXPRO6000:96GB:1..8  spot, on-demand  1.0129..4.143  aws      us-east-1
```

Tested:
- Spot and on-demand
- Single-GPU and multi-GPU
- `nvidia-smi`
- PyTorch