### PR TITLE
Show offers in dstack apply for elastic container fleets

### DIFF
--- a/src/dstack/_internal/server/background/pipeline_tasks/instances/cloud_provisioning.py
+++ b/src/dstack/_internal/server/background/pipeline_tasks/instances/cloud_provisioning.py
@@ -36,7 +36,7 @@ from dstack._internal.server.background.pipeline_tasks.instances.common import (
 )
 from dstack._internal.server.db import get_session_ctx
 from dstack._internal.server.models import FleetModel, InstanceModel, PlacementGroupModel
-from dstack._internal.server.services.fleets import get_create_instance_offers, is_cloud_cluster
+from dstack._internal.server.services.fleets import get_fleet_offers, is_cloud_cluster
 from dstack._internal.server.services.instances import (
     get_instance_configuration,
     get_instance_profile,
@@ -101,7 +101,7 @@ async def create_cloud_instance(instance_model: InstanceModel) -> ProcessResult:
         )
         master_job_provisioning_data = cluster_context.master_job_provisioning_data
 
-    offers = await get_create_instance_offers(
+    offers = await get_fleet_offers(
         project=instance_model.project,
         profile=profile,
         requirements=requirements,
@@ -111,6 +111,7 @@ async def create_cloud_instance(instance_model: InstanceModel) -> ProcessResult:
         exclude_not_available=True,
         master_job_provisioning_data=master_job_provisioning_data,
         infer_master_job_provisioning_data_from_fleet_instances=False,
+        include_only_create_instance_supported_backends=True,
     )
 
     # Limit number of offers tried to prevent long-running processing in case all offers fail.
@@ -120,7 +121,7 @@ async def create_cloud_instance(instance_model: InstanceModel) -> ProcessResult:
         compute = backend.compute()
         assert isinstance(compute, ComputeWithCreateInstanceSupport)
         if master_job_provisioning_data is not None:
-            # `get_create_instance_offers()` already restricts backend and region from the master.
+            # `get_fleet_offers()` already restricts backend and region from the master.
             # Availability zone still has to be narrowed per offer.
             instance_offer = get_instance_offer_with_restricted_az(
                 instance_offer=instance_offer,

--- a/src/dstack/_internal/server/services/fleets.py
+++ b/src/dstack/_internal/server/services/fleets.py
@@ -443,24 +443,20 @@ async def get_plan(
     offers = []
     if effective_spec.configuration.ssh_config is None:
         requirements = get_fleet_requirements(effective_spec)
-        if _is_elastic_cloud_fleet_spec(effective_spec):
-            offers_with_backends = await offers_services.get_offers_by_requirements(
-                project=project,
-                profile=effective_spec.merged_profile,
-                requirements=requirements,
-                multinode=(
-                    effective_spec.configuration.placement == InstanceGroupPlacement.CLUSTER
-                ),
-                blocks=effective_spec.configuration.blocks,
-            )
-        else:
-            offers_with_backends = await get_create_instance_offers(
-                project=project,
-                profile=effective_spec.merged_profile,
-                requirements=requirements,
-                fleet_spec=effective_spec,
-                blocks=effective_spec.configuration.blocks,
-            )
+        nodes = effective_spec.configuration.nodes
+        include_only_create_instance_supported_backends = True
+        if nodes is not None:
+            include_only_create_instance_supported_backends = nodes.target != 0
+        offers_with_backends = await get_fleet_offers(
+            project=project,
+            profile=effective_spec.merged_profile,
+            requirements=requirements,
+            fleet_spec=effective_spec,
+            blocks=effective_spec.configuration.blocks,
+            include_only_create_instance_supported_backends=(
+                include_only_create_instance_supported_backends
+            ),
+        )
         offers = [offer for _, offer in offers_with_backends]
 
     _remove_fleet_spec_sensitive_info(effective_spec)
@@ -480,16 +476,6 @@ async def get_plan(
     return plan
 
 
-def _is_elastic_cloud_fleet_spec(fleet_spec: FleetSpec) -> bool:
-    nodes = fleet_spec.configuration.nodes
-    return (
-        fleet_spec.configuration.ssh_config is None
-        and nodes is not None
-        and nodes.min == 0
-        and nodes.target == 0
-    )
-
-
 async def get_create_instance_offers(
     project: ProjectModel,
     profile: Profile,
@@ -502,6 +488,49 @@ async def get_create_instance_offers(
     master_job_provisioning_data: Optional[JobProvisioningData] = None,
     infer_master_job_provisioning_data_from_fleet_instances: bool = True,
 ) -> List[Tuple[Backend, InstanceOfferWithAvailability]]:
+    """
+    Return fleet offers restricted to backends that support `create_instance`.
+
+    This method is for create-instance provisioning semantics
+    (typically VM-based backends, not container-only backends).
+    """
+    return await get_fleet_offers(
+        project=project,
+        profile=profile,
+        requirements=requirements,
+        placement_group=placement_group,
+        fleet_spec=fleet_spec,
+        fleet_model=fleet_model,
+        blocks=blocks,
+        exclude_not_available=exclude_not_available,
+        master_job_provisioning_data=master_job_provisioning_data,
+        infer_master_job_provisioning_data_from_fleet_instances=(
+            infer_master_job_provisioning_data_from_fleet_instances
+        ),
+        include_only_create_instance_supported_backends=True,
+    )
+
+
+async def get_fleet_offers(
+    project: ProjectModel,
+    profile: Profile,
+    requirements: Requirements,
+    placement_group: Optional[PlacementGroup] = None,
+    fleet_spec: Optional[FleetSpec] = None,
+    fleet_model: Optional[FleetModel] = None,
+    blocks: Union[int, Literal["auto"]] = 1,
+    exclude_not_available: bool = False,
+    master_job_provisioning_data: Optional[JobProvisioningData] = None,
+    infer_master_job_provisioning_data_from_fleet_instances: bool = True,
+    include_only_create_instance_supported_backends: bool = True,
+) -> List[Tuple[Backend, InstanceOfferWithAvailability]]:
+    """
+    Return offers for fleet planning and provisioning.
+
+    By default, restricts to backends that support `create_instance`.
+    Set `include_only_create_instance_supported_backends=False` to include
+    all matching backends.
+    """
     multinode = False
     if fleet_spec is not None:
         multinode = fleet_spec.configuration.placement == InstanceGroupPlacement.CLUSTER
@@ -530,11 +559,12 @@ async def get_create_instance_offers(
         placement_group=placement_group,
         blocks=blocks,
     )
-    offers = [
-        (backend, offer)
-        for backend, offer in offers
-        if offer.backend in BACKENDS_WITH_CREATE_INSTANCE_SUPPORT
-    ]
+    if include_only_create_instance_supported_backends:
+        offers = [
+            (backend, offer)
+            for backend, offer in offers
+            if offer.backend in BACKENDS_WITH_CREATE_INSTANCE_SUPPORT
+        ]
     return offers
 
 

--- a/src/dstack/_internal/server/services/fleets.py
+++ b/src/dstack/_internal/server/services/fleets.py
@@ -476,41 +476,6 @@ async def get_plan(
     return plan
 
 
-async def get_create_instance_offers(
-    project: ProjectModel,
-    profile: Profile,
-    requirements: Requirements,
-    placement_group: Optional[PlacementGroup] = None,
-    fleet_spec: Optional[FleetSpec] = None,
-    fleet_model: Optional[FleetModel] = None,
-    blocks: Union[int, Literal["auto"]] = 1,
-    exclude_not_available: bool = False,
-    master_job_provisioning_data: Optional[JobProvisioningData] = None,
-    infer_master_job_provisioning_data_from_fleet_instances: bool = True,
-) -> List[Tuple[Backend, InstanceOfferWithAvailability]]:
-    """
-    Return fleet offers restricted to backends that support `create_instance`.
-
-    This method is for create-instance provisioning semantics
-    (typically VM-based backends, not container-only backends).
-    """
-    return await get_fleet_offers(
-        project=project,
-        profile=profile,
-        requirements=requirements,
-        placement_group=placement_group,
-        fleet_spec=fleet_spec,
-        fleet_model=fleet_model,
-        blocks=blocks,
-        exclude_not_available=exclude_not_available,
-        master_job_provisioning_data=master_job_provisioning_data,
-        infer_master_job_provisioning_data_from_fleet_instances=(
-            infer_master_job_provisioning_data_from_fleet_instances
-        ),
-        include_only_create_instance_supported_backends=True,
-    )
-
-
 async def get_fleet_offers(
     project: ProjectModel,
     profile: Profile,

--- a/src/dstack/_internal/server/services/fleets.py
+++ b/src/dstack/_internal/server/services/fleets.py
@@ -442,13 +442,25 @@ async def get_plan(
 
     offers = []
     if effective_spec.configuration.ssh_config is None:
-        offers_with_backends = await get_create_instance_offers(
-            project=project,
-            profile=effective_spec.merged_profile,
-            requirements=get_fleet_requirements(effective_spec),
-            fleet_spec=effective_spec,
-            blocks=effective_spec.configuration.blocks,
-        )
+        requirements = get_fleet_requirements(effective_spec)
+        if _is_elastic_cloud_fleet_spec(effective_spec):
+            offers_with_backends = await offers_services.get_offers_by_requirements(
+                project=project,
+                profile=effective_spec.merged_profile,
+                requirements=requirements,
+                multinode=(
+                    effective_spec.configuration.placement == InstanceGroupPlacement.CLUSTER
+                ),
+                blocks=effective_spec.configuration.blocks,
+            )
+        else:
+            offers_with_backends = await get_create_instance_offers(
+                project=project,
+                profile=effective_spec.merged_profile,
+                requirements=requirements,
+                fleet_spec=effective_spec,
+                blocks=effective_spec.configuration.blocks,
+            )
         offers = [offer for _, offer in offers_with_backends]
 
     _remove_fleet_spec_sensitive_info(effective_spec)
@@ -466,6 +478,16 @@ async def get_plan(
         action=action,
     )
     return plan
+
+
+def _is_elastic_cloud_fleet_spec(fleet_spec: FleetSpec) -> bool:
+    nodes = fleet_spec.configuration.nodes
+    return (
+        fleet_spec.configuration.ssh_config is None
+        and nodes is not None
+        and nodes.min == 0
+        and nodes.target == 0
+    )
 
 
 async def get_create_instance_offers(

--- a/src/tests/_internal/server/routers/test_fleets.py
+++ b/src/tests/_internal/server/routers/test_fleets.py
@@ -14,6 +14,7 @@ from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.common import EntityReference
 from dstack._internal.core.models.fleets import (
     FleetConfiguration,
+    FleetNodesSpec,
     FleetStatus,
     InstanceGroupPlacement,
     SSHHostParams,
@@ -2027,6 +2028,78 @@ class TestGetPlan:
             "max_offer_price": 1.0,
             "action": "create",
         }
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_returns_offers_for_elastic_container_backend_fleet(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        user = await create_user(session=session, global_role=GlobalRole.USER)
+        project = await create_project(session=session, owner=user)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.USER
+        )
+        offer = get_instance_offer_with_availability(
+            backend=BackendType.RUNPOD,
+            region="US-OR-1",
+            price=0.7185,
+        )
+        spec = get_fleet_spec(
+            conf=get_fleet_configuration(nodes=FleetNodesSpec(min=0, target=0, max=1))
+        )
+        with patch("dstack._internal.server.services.backends.get_project_backends") as m:
+            backend_mock = Mock()
+            m.return_value = [backend_mock]
+            backend_mock.TYPE = BackendType.RUNPOD
+            backend_mock.compute.return_value.get_offers.return_value = [offer]
+            response = await client.post(
+                f"/api/project/{project.name}/fleets/get_plan",
+                headers=get_auth_headers(user.token),
+                json={"spec": spec.dict()},
+            )
+            backend_mock.compute.return_value.get_offers.assert_called_once()
+
+        response_json = response.json()
+        assert response.status_code == 200, response_json
+        assert response_json["offers"] == [json.loads(offer.json())]
+        assert response_json["total_offers"] == 1
+        assert response_json["max_offer_price"] == offer.price
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_returns_no_offers_for_non_elastic_container_backend_fleet(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        user = await create_user(session=session, global_role=GlobalRole.USER)
+        project = await create_project(session=session, owner=user)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.USER
+        )
+        offer = get_instance_offer_with_availability(
+            backend=BackendType.RUNPOD,
+            region="US-OR-1",
+            price=0.7185,
+        )
+        spec = get_fleet_spec(
+            conf=get_fleet_configuration(nodes=FleetNodesSpec(min=0, target=1, max=1))
+        )
+        with patch("dstack._internal.server.services.backends.get_project_backends") as m:
+            backend_mock = Mock()
+            m.return_value = [backend_mock]
+            backend_mock.TYPE = BackendType.RUNPOD
+            backend_mock.compute.return_value.get_offers.return_value = [offer]
+            response = await client.post(
+                f"/api/project/{project.name}/fleets/get_plan",
+                headers=get_auth_headers(user.token),
+                json={"spec": spec.dict()},
+            )
+            backend_mock.compute.return_value.get_offers.assert_called_once()
+
+        response_json = response.json()
+        assert response.status_code == 200, response_json
+        assert response_json["offers"] == []
+        assert response_json["total_offers"] == 0
+        assert response_json["max_offer_price"] is None
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)


### PR DESCRIPTION
## Steps to reproduce
```yaml
type: fleet
name: my-fleet

# Elastic/template fleet (provision on demand)
nodes: 0..1

backends: [runpod]
spot_policy: auto
idle_duration: 10m
```

```bash
dstack apply -f fleet.dstack.yml
```

```text
Project        main
User           admin
Configuration  fleet.dstack.yml
Type           fleet
Fleet type     cloud
Nodes          min=0 target=0 max=1
Backends       runpod
Resources      cpu=2.. mem=8GB.. disk=100GB.. gpu=0..
Spot policy    auto

No matching instance offers available. Possible reasons:
https://dstack.ai/docs/guides/troubleshooting/#no-offers
```

## Expected
`dstack apply` should show matching offers for elastic container-based fleets, since runs are provisioned on demand from those offers.

This is important not only for offer visibility/convenience, but also for consistency: VM-based elastic fleets already show offers during `apply`, and container-based elastic fleets should behave the same way.

## Actual
No offers were shown for elastic container-based fleets during `apply`, even when offers existed.

## Solution
Refactored fleet offer semantics to avoid duplicating branches while preserving behavior:
- Added `get_fleet_offers(...)` as the shared offer lookup for fleet planning/provisioning.
- `get_fleet_offers(...)` defaults to filtering by `BACKENDS_WITH_CREATE_INSTANCE_SUPPORT`.
- Removed `get_create_instance_offers(...)`; create-instance paths now call `get_fleet_offers(...)` with `include_only_create_instance_supported_backends=True` explicitly.
- In `get_plan(...)`, when `nodes.target == 0`, we call `get_fleet_offers(...)` with create-instance filtering disabled, so elastic Runpod/container offers are shown.
- Removed `_is_elastic_cloud_fleet_spec(...)` helper and switched to direct `nodes.target` semantics.

This keeps non-elastic behavior unchanged while fixing elastic container fleet offer visibility in `dstack apply`.

## AI Assistance
This PR was prepared with AI assistance (Codex).
