### PR TITLE
Allow combining on/off idle_duration between runs and fleets

### DIFF
--- a/src/dstack/_internal/server/services/requirements/combine.py
+++ b/src/dstack/_internal/server/services/requirements/combine.py
@@ -128,8 +128,12 @@ def _combine_spot_policy_optional(
 
 
 def _combine_idle_duration(value1: int, value2: int) -> int:
-    if value1 < 0 and value2 >= 0 or value2 < 0 and value1 >= 0:
-        raise CombineError(f"idle_duration values {value1} and {value2} cannot be combined")
+    if value1 < 0:
+        if value2 < 0:
+            return min(value1, value2)
+        return value2
+    if value2 < 0:
+        return value1
     return min(value1, value2)
 
 

--- a/src/tests/_internal/server/services/requirements/test_combine.py
+++ b/src/tests/_internal/server/services/requirements/test_combine.py
@@ -43,6 +43,15 @@ class TestCombineFleetAndRunProfiles:
         )
         assert combine_fleet_and_run_profiles(profile, profile) == profile
 
+    def test_prefers_finite_idle_duration_over_off(self):
+        combined_profile = combine_fleet_and_run_profiles(
+            Profile(idle_duration=300),
+            Profile(idle_duration=-1),
+        )
+
+        assert combined_profile is not None
+        assert combined_profile.idle_duration == 300
+
     @pytest.mark.parametrize(
         argnames=["fleet_profile", "run_profile", "expected_profile"],
         argvalues=[
@@ -218,27 +227,19 @@ class TestCombineIdleDuration:
     def test_both_zero_returns_zero(self):
         assert _combine_idle_duration_optional(0, 0) == 0
 
-    def test_positive_and_negative_raises_error(self):
-        with pytest.raises(
-            CombineError, match="idle_duration values 3600 and -1 cannot be combined"
-        ):
-            _combine_idle_duration_optional(3600, -1)
+    def test_positive_and_negative_returns_positive(self):
+        assert _combine_idle_duration_optional(3600, -1) == 3600
 
-    def test_negative_and_positive_raises_error(self):
-        with pytest.raises(
-            CombineError, match="idle_duration values -1 and 3600 cannot be combined"
-        ):
-            _combine_idle_duration_optional(-1, 3600)
+    def test_negative_and_positive_returns_positive(self):
+        assert _combine_idle_duration_optional(-1, 3600) == 3600
 
     def test_zero_and_positive_returns_zero(self):
         assert _combine_idle_duration_optional(0, 3600) == 0
         assert _combine_idle_duration_optional(3600, 0) == 0
 
-    def test_zero_and_negative_raises_error(self):
-        with pytest.raises(CombineError, match="idle_duration values 0 and -1 cannot be combined"):
-            _combine_idle_duration_optional(0, -1)
-        with pytest.raises(CombineError, match="idle_duration values -1 and 0 cannot be combined"):
-            _combine_idle_duration_optional(-1, 0)
+    def test_zero_and_negative_returns_zero(self):
+        assert _combine_idle_duration_optional(0, -1) == 0
+        assert _combine_idle_duration_optional(-1, 0) == 0
 
 
 class TestCombineSpotPolicy:


### PR DESCRIPTION
Fixes #3606 

The PR makes it possible to use fleets with non-off idle_duration set for runs with `idle_duration: off` by using the min `idle_duration`.