### PR TITLE
Support imported fleets in `dstack event`

### DIFF
--- a/src/dstack/_internal/cli/commands/event.py
+++ b/src/dstack/_internal/cli/commands/event.py
@@ -12,6 +12,7 @@ from dstack._internal.cli.utils.common import (
     get_start_time,
 )
 from dstack._internal.core.errors import CLIError
+from dstack._internal.core.models.common import EntityReference
 from dstack._internal.core.models.events import EventTargetType
 from dstack._internal.server.schemas.events import LIST_EVENTS_DEFAULT_LIMIT
 from dstack.api import Client
@@ -55,6 +56,7 @@ class EventCommand(APIBaseCommand):
                 action="append",
                 metavar="NAME",
                 dest="target_fleets",
+                type=EntityReference.parse,
                 help="Only show events that target the specified fleets",
             )
             target_filters_group.add_argument(
@@ -91,6 +93,7 @@ class EventCommand(APIBaseCommand):
                 action="append",
                 metavar="NAME",
                 dest="within_fleets",
+                type=EntityReference.parse,
                 help="Only show events that target the specified fleets or instances within those fleets",
             )
             within_filters_group.add_argument(
@@ -137,9 +140,11 @@ class EventCommand(APIBaseCommand):
 def _build_filters(args: argparse.Namespace, api: Client) -> EventListFilters:
     filters = EventListFilters()
 
+    has_target_filters = True
     if args.target_fleets:
         filters.target_fleets = [
-            api.client.fleets.get(api.project, name).id for name in args.target_fleets
+            api.client.fleets.get(ref.project or api.project, ref.name).id
+            for ref in args.target_fleets
         ]
     elif args.target_runs:
         filters.target_runs = [
@@ -165,16 +170,21 @@ def _build_filters(args: argparse.Namespace, api: Client) -> EventListFilters:
         filters.target_secrets = [
             api.client.secrets.get(api.project, name=name).id for name in args.target_secrets
         ]
+    else:
+        has_target_filters = False
 
     if args.within_fleets:
         filters.within_fleets = [
-            api.client.fleets.get(api.project, name).id for name in args.within_fleets
+            api.client.fleets.get(ref.project or api.project, ref.name).id
+            for ref in args.within_fleets
         ]
     elif args.within_runs:
         filters.within_runs = [
             api.client.runs.get(api.project, name).id for name in args.within_runs
         ]
-    else:
+    elif not has_target_filters:
+        # default - limit to current project,
+        # unless there are more specific filters (e.g., for imported entities)
         filters.within_projects = [api.client.projects.get(api.project).project_id]
 
     if args.include_target_types:


### PR DESCRIPTION
Allow filtering events by imported fleets.
Examples:

```
$ dstack event --within-fleet my-project/my-fleet
$ dstack event --target-fleet my-project/my-fleet
```

#3626