### PR TITLE
Speed up GCP validate_credentials

### DIFF
--- a/src/dstack/_internal/core/backends/gcp/auth.py
+++ b/src/dstack/_internal/core/backends/gcp/auth.py
@@ -49,8 +49,8 @@ def get_credentials(creds: AnyGCPCreds) -> Tuple[Credentials, Optional[str]]:
 
 def validate_credentials(credentials: Credentials, project_id: str):
     try:
-        regions_client = compute_v1.RegionsClient(credentials=credentials)
-        regions_client.list(project=project_id)
+        client = compute_v1.ProjectsClient(credentials=credentials)
+        client.get(project=project_id)
     except google.api_core.exceptions.NotFound:
         raise BackendAuthError(f"project_id {project_id} not found")
     except Exception:


### PR DESCRIPTION
#3479 

Use a faster API method to validate GCP creds (~1s faster). Reduces GCP backend configuration time and, more importantly,  GCP initialization from ~2.5s to 1.5s.
