### PR TITLE
Support secrets management by Manager role

### DIFF
--- a/frontend/src/pages/Project/Secrets/index.tsx
+++ b/frontend/src/pages/Project/Secrets/index.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import { Button, ButtonWithConfirmation, Header, ListEmptyMessage, Modal, Pagination, SpaceBetween, Table } from 'components';
 
-import { useAppSelector, useCollection, useNotifications, usePermissionGuard } from 'hooks';
+import { useAppSelector, useCollection, useNotifications } from 'hooks';
 import { getServerError } from 'libs';
 import {
     useDeleteSecretsMutation,
@@ -11,11 +11,11 @@ import {
     useLazyGetSecretQuery,
     useUpdateSecretMutation,
 } from 'services/secrets';
-import { GlobalUserRole, ProjectUserRole } from 'types';
+import { GlobalUserRole } from 'types';
 
 import { selectUserData } from 'App/slice';
 
-import { getProjectRoleByUserName } from '../utils';
+import { getMemberCanManageSecrets } from '../utils';
 import { SecretForm } from './Form';
 
 import { IProps, TFormValues } from './types';
@@ -30,11 +30,8 @@ export const ProjectSecrets: React.FC<IProps> = ({ project, loading }) => {
     const projectName = project?.project_name ?? '';
     const [pushNotification] = useNotifications();
 
-    const [hasPermissionForSecretsManaging] = usePermissionGuard({
-        allowedProjectRoles: [ProjectUserRole.ADMIN],
-        allowedGlobalRoles: [GlobalUserRole.ADMIN],
-        projectRole: project ? (getProjectRoleByUserName(project, userName) ?? undefined) : undefined,
-    });
+    const hasPermissionForSecretsManaging =
+        userData?.global_role === GlobalUserRole.ADMIN || (project ? getMemberCanManageSecrets(project, userName) : false);
 
     const { data, isLoading, isFetching } = useGetAllSecretsQuery(
         { project_name: projectName },

--- a/frontend/src/pages/Project/utils.ts
+++ b/frontend/src/pages/Project/utils.ts
@@ -4,3 +4,8 @@ export const getProjectRoleByUserName = (
 ): TProjectRole | null => {
     return project.members.find((m) => m.user.username === userName)?.project_role ?? null;
 };
+
+export const getMemberCanManageSecrets = (project: IProject, userName: IProjectMember['user']['username']): boolean => {
+    const member = project.members.find((m) => m.user.username === userName);
+    return member?.permissions?.can_manage_secrets ?? false;
+};

--- a/frontend/src/types/project.d.ts
+++ b/frontend/src/types/project.d.ts
@@ -33,9 +33,15 @@ declare interface IProject {
     templates_repo?: string | null;
 }
 
+declare interface IProjectMemberPermissions {
+    can_manage_ssh_fleets: boolean;
+    can_manage_secrets: boolean;
+}
+
 declare interface IProjectMember {
     project_role: TProjectRole;
     user: IUser | { username: string };
+    permissions?: IProjectMemberPermissions;
 }
 
 declare type TSetProjectMembersParams = {

--- a/src/dstack/_internal/core/models/projects.py
+++ b/src/dstack/_internal/core/models/projects.py
@@ -10,7 +10,9 @@ from dstack._internal.core.models.users import ProjectRole, User
 
 class MemberPermissions(CoreModel):
     can_manage_ssh_fleets: bool
-    can_manage_secrets: bool
+    can_manage_secrets: bool = False
+    """Default is for client-side compatibility with older servers.
+    Always explicitly set on the server."""
 
 
 class Member(CoreModel):

--- a/src/dstack/_internal/core/models/projects.py
+++ b/src/dstack/_internal/core/models/projects.py
@@ -10,6 +10,7 @@ from dstack._internal.core.models.users import ProjectRole, User
 
 class MemberPermissions(CoreModel):
     can_manage_ssh_fleets: bool
+    can_manage_secrets: bool
 
 
 class Member(CoreModel):

--- a/src/dstack/_internal/server/routers/secrets.py
+++ b/src/dstack/_internal/server/routers/secrets.py
@@ -12,7 +12,7 @@ from dstack._internal.server.schemas.secrets import (
     DeleteSecretsRequest,
     GetSecretRequest,
 )
-from dstack._internal.server.security.permissions import ProjectAdmin
+from dstack._internal.server.security.permissions import ProjectManager
 from dstack._internal.server.services import secrets as secrets_services
 from dstack._internal.server.utils.routers import CustomORJSONResponse
 
@@ -25,13 +25,14 @@ router = APIRouter(
 @router.post("/list", response_model=List[Secret])
 async def list_secrets(
     session: AsyncSession = Depends(get_session),
-    user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectAdmin()),
+    user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectManager()),
 ):
-    _, project = user_project
+    user, project = user_project
     return CustomORJSONResponse(
         await secrets_services.list_secrets(
             session=session,
             project=project,
+            user=user,
         )
     )
 
@@ -40,13 +41,14 @@ async def list_secrets(
 async def get_secret(
     body: GetSecretRequest,
     session: AsyncSession = Depends(get_session),
-    user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectAdmin()),
+    user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectManager()),
 ):
-    _, project = user_project
+    user, project = user_project
     secret = await secrets_services.get_secret(
         session=session,
         project=project,
         name=body.name,
+        user=user,
     )
     if secret is None:
         raise ResourceNotExistsError()
@@ -57,7 +59,7 @@ async def get_secret(
 async def create_or_update_secret(
     body: CreateOrUpdateSecretRequest,
     session: AsyncSession = Depends(get_session),
-    user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectAdmin()),
+    user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectManager()),
 ):
     user, project = user_project
     return CustomORJSONResponse(
@@ -75,7 +77,7 @@ async def create_or_update_secret(
 async def delete_secrets(
     body: DeleteSecretsRequest,
     session: AsyncSession = Depends(get_session),
-    user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectAdmin()),
+    user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectManager()),
 ):
     user, project = user_project
     await secrets_services.delete_secrets(

--- a/src/dstack/_internal/server/services/permissions.py
+++ b/src/dstack/_internal/server/services/permissions.py
@@ -23,6 +23,12 @@ class DefaultPermissions(CoreModel):
             )
         ),
     ] = True
+    allow_managers_manage_secrets: Annotated[
+        bool,
+        Field(
+            description=("This flag controls whether project managers can manage project secrets")
+        ),
+    ] = False
 
 
 _default_permissions = DefaultPermissions()

--- a/src/dstack/_internal/server/services/projects.py
+++ b/src/dstack/_internal/server/services/projects.py
@@ -716,8 +716,17 @@ def get_member_permissions(member_model: MemberModel) -> MemberPermissions:
             and member_model.project_role != ProjectRole.ADMIN
         ):
             can_manage_ssh_fleets = False
+    can_manage_secrets = (
+        user_model.global_role == GlobalRole.ADMIN
+        or member_model.project_role == ProjectRole.ADMIN
+        or (
+            member_model.project_role == ProjectRole.MANAGER
+            and default_permissions.allow_managers_manage_secrets
+        )
+    )
     return MemberPermissions(
         can_manage_ssh_fleets=can_manage_ssh_fleets,
+        can_manage_secrets=can_manage_secrets,
     )
 
 

--- a/src/dstack/_internal/server/services/secrets.py
+++ b/src/dstack/_internal/server/services/secrets.py
@@ -9,15 +9,18 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dstack._internal.core.errors import (
+    ForbiddenError,
     ResourceExistsError,
     ResourceNotExistsError,
     ServerClientError,
 )
 from dstack._internal.core.models.secrets import Secret
+from dstack._internal.core.models.users import GlobalRole
 from dstack._internal.server.db import get_db
 from dstack._internal.server.models import DecryptedString, ProjectModel, SecretModel, UserModel
 from dstack._internal.server.services import events
 from dstack._internal.server.services.locking import get_locker
+from dstack._internal.server.services.projects import get_member, get_member_permissions
 
 _SECRET_NAME_REGEX = "^[A-Za-z0-9-_]{1,200}$"
 _SECRET_VALUE_MAX_LENGTH = 5000
@@ -26,7 +29,9 @@ _SECRET_VALUE_MAX_LENGTH = 5000
 async def list_secrets(
     session: AsyncSession,
     project: ProjectModel,
+    user: UserModel,
 ) -> List[Secret]:
+    _check_can_manage_secrets(user=user, project=project)
     secret_models = await list_project_secret_models(session=session, project=project)
     return [secret_model_to_secret(s, include_value=False) for s in secret_models]
 
@@ -43,7 +48,9 @@ async def get_secret(
     session: AsyncSession,
     project: ProjectModel,
     name: str,
+    user: UserModel,
 ) -> Optional[Secret]:
+    _check_can_manage_secrets(user=user, project=project)
     secret_model = await get_project_secret_model_by_name(
         session=session,
         project=project,
@@ -61,6 +68,7 @@ async def create_or_update_secret(
     value: str,
     user: UserModel,
 ) -> Secret:
+    _check_can_manage_secrets(user=user, project=project)
     _validate_secret(name=name, value=value)
     try:
         secret_model = await create_secret(
@@ -87,6 +95,7 @@ async def delete_secrets(
     names: List[str],
     user: UserModel,
 ):
+    _check_can_manage_secrets(user=user, project=project)
     async with get_project_secret_models_by_name_for_update(
         session=session, project=project, names=names
     ) as secret_models:
@@ -243,3 +252,15 @@ def _validate_secret_name(name: str):
 def _validate_secret_value(value: str):
     if len(value) > _SECRET_VALUE_MAX_LENGTH:
         raise ServerClientError(f"Secret value length must not exceed {_SECRET_VALUE_MAX_LENGTH}")
+
+
+def _check_can_manage_secrets(user: UserModel, project: ProjectModel):
+    if user.global_role == GlobalRole.ADMIN:
+        return
+    member = get_member(user=user, project=project)
+    if member is None:
+        raise ForbiddenError()
+    permissions = get_member_permissions(member)
+    if permissions.can_manage_secrets:
+        return
+    raise ForbiddenError()

--- a/src/tests/_internal/server/routers/test_projects.py
+++ b/src/tests/_internal/server/routers/test_projects.py
@@ -976,6 +976,7 @@ class TestCreateProject:
                     "project_role": ProjectRole.ADMIN,
                     "permissions": {
                         "can_manage_ssh_fleets": True,
+                        "can_manage_secrets": True,
                     },
                 }
             ],
@@ -1439,6 +1440,7 @@ class TestGetProject:
                     "project_role": ProjectRole.ADMIN,
                     "permissions": {
                         "can_manage_ssh_fleets": True,
+                        "can_manage_secrets": True,
                     },
                 }
             ],
@@ -1669,6 +1671,7 @@ class TestSetProjectMembers:
                 "project_role": ProjectRole.ADMIN,
                 "permissions": {
                     "can_manage_ssh_fleets": True,
+                    "can_manage_secrets": True,
                 },
             },
             {
@@ -1687,6 +1690,7 @@ class TestSetProjectMembers:
                 "project_role": ProjectRole.ADMIN,
                 "permissions": {
                     "can_manage_ssh_fleets": True,
+                    "can_manage_secrets": True,
                 },
             },
             {
@@ -1705,6 +1709,7 @@ class TestSetProjectMembers:
                 "project_role": ProjectRole.USER,
                 "permissions": {
                     "can_manage_ssh_fleets": True,
+                    "can_manage_secrets": False,
                 },
             },
         ]
@@ -1762,6 +1767,7 @@ class TestSetProjectMembers:
                 "project_role": ProjectRole.ADMIN,
                 "permissions": {
                     "can_manage_ssh_fleets": True,
+                    "can_manage_secrets": True,
                 },
             },
         ]

--- a/src/tests/_internal/server/routers/test_projects.py
+++ b/src/tests/_internal/server/routers/test_projects.py
@@ -1709,7 +1709,7 @@ class TestSetProjectMembers:
                 "project_role": ProjectRole.USER,
                 "permissions": {
                     "can_manage_ssh_fleets": True,
-                    "can_manage_secrets": False,
+                    "can_manage_secrets": True,
                 },
             },
         ]

--- a/src/tests/_internal/server/routers/test_secrets.py
+++ b/src/tests/_internal/server/routers/test_secrets.py
@@ -5,11 +5,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from dstack._internal.core.models.users import GlobalRole, ProjectRole
 from dstack._internal.server.models import SecretModel
+from dstack._internal.server.services.permissions import DefaultPermissions
 from dstack._internal.server.services.projects import add_project_member
 from dstack._internal.server.testing.common import (
     create_project,
     create_secret,
     create_user,
+    default_permissions_context,
     get_auth_headers,
     list_events,
 )
@@ -18,7 +20,7 @@ from dstack._internal.server.testing.common import (
 class TestListSecrets:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
-    async def test_returns_403_if_not_admin(
+    async def test_returns_403_if_not_authorized(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
@@ -32,6 +34,43 @@ class TestListSecrets:
             json={},
         )
         assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_returns_403_for_manager_by_default(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        user = await create_user(session=session, global_role=GlobalRole.USER)
+        project = await create_project(session=session, owner=user)
+        manager = await create_user(session=session, name="manager", global_role=GlobalRole.USER)
+        await add_project_member(
+            session=session, project=project, user=manager, project_role=ProjectRole.MANAGER
+        )
+        response = await client.post(
+            f"/api/project/{project.name}/secrets/list",
+            headers=get_auth_headers(manager.token),
+            json={},
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_manager_can_list_when_allowed(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        user = await create_user(session=session, global_role=GlobalRole.USER)
+        project = await create_project(session=session, owner=user)
+        manager = await create_user(session=session, name="manager", global_role=GlobalRole.USER)
+        await add_project_member(
+            session=session, project=project, user=manager, project_role=ProjectRole.MANAGER
+        )
+        with default_permissions_context(DefaultPermissions(allow_managers_manage_secrets=True)):
+            response = await client.post(
+                f"/api/project/{project.name}/secrets/list",
+                headers=get_auth_headers(manager.token),
+                json={},
+            )
+        assert response.status_code == 200
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
@@ -70,7 +109,7 @@ class TestListSecrets:
 class TestGetSecret:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
-    async def test_returns_403_if_not_admin(
+    async def test_returns_403_if_not_authorized(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
@@ -84,6 +123,44 @@ class TestGetSecret:
             json={"name": "my_secret"},
         )
         assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_returns_403_for_manager_by_default(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        user = await create_user(session=session, global_role=GlobalRole.USER)
+        project = await create_project(session=session, owner=user)
+        manager = await create_user(session=session, name="manager", global_role=GlobalRole.USER)
+        await add_project_member(
+            session=session, project=project, user=manager, project_role=ProjectRole.MANAGER
+        )
+        response = await client.post(
+            f"/api/project/{project.name}/secrets/get",
+            headers=get_auth_headers(manager.token),
+            json={"name": "my_secret"},
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_manager_can_get_when_allowed(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        user = await create_user(session=session, global_role=GlobalRole.USER)
+        project = await create_project(session=session, owner=user)
+        manager = await create_user(session=session, name="manager", global_role=GlobalRole.USER)
+        await add_project_member(
+            session=session, project=project, user=manager, project_role=ProjectRole.MANAGER
+        )
+        await create_secret(session=session, project=project, name="secret1", value="123456")
+        with default_permissions_context(DefaultPermissions(allow_managers_manage_secrets=True)):
+            response = await client.post(
+                f"/api/project/{project.name}/secrets/get",
+                headers=get_auth_headers(manager.token),
+                json={"name": "secret1"},
+            )
+        assert response.status_code == 200
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
@@ -114,7 +191,7 @@ class TestGetSecret:
 class TestCreateOrUpdateSecret:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
-    async def test_returns_403_if_not_admin(
+    async def test_returns_403_if_not_authorized(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
@@ -128,6 +205,43 @@ class TestCreateOrUpdateSecret:
             json={"name": "my_secret"},
         )
         assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_returns_403_for_manager_by_default(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        user = await create_user(session=session, global_role=GlobalRole.USER)
+        project = await create_project(session=session, owner=user)
+        manager = await create_user(session=session, name="manager", global_role=GlobalRole.USER)
+        await add_project_member(
+            session=session, project=project, user=manager, project_role=ProjectRole.MANAGER
+        )
+        response = await client.post(
+            f"/api/project/{project.name}/secrets/create_or_update",
+            headers=get_auth_headers(manager.token),
+            json={"name": "my_secret", "value": "123456"},
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_manager_can_create_when_allowed(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        user = await create_user(session=session, global_role=GlobalRole.USER)
+        project = await create_project(session=session, owner=user)
+        manager = await create_user(session=session, name="manager", global_role=GlobalRole.USER)
+        await add_project_member(
+            session=session, project=project, user=manager, project_role=ProjectRole.MANAGER
+        )
+        with default_permissions_context(DefaultPermissions(allow_managers_manage_secrets=True)):
+            response = await client.post(
+                f"/api/project/{project.name}/secrets/create_or_update",
+                headers=get_auth_headers(manager.token),
+                json={"name": "secret1", "value": "123456"},
+            )
+        assert response.status_code == 200
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
@@ -230,7 +344,7 @@ class TestCreateOrUpdateSecret:
 class TestDeleteSecrets:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
-    async def test_returns_403_if_not_admin(
+    async def test_returns_403_if_not_authorized(
         self, test_db, session: AsyncSession, client: AsyncClient
     ):
         user = await create_user(session=session, global_role=GlobalRole.USER)
@@ -244,6 +358,44 @@ class TestDeleteSecrets:
             json={"secrets_names": ["my_secret"]},
         )
         assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_returns_403_for_manager_by_default(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        user = await create_user(session=session, global_role=GlobalRole.USER)
+        project = await create_project(session=session, owner=user)
+        manager = await create_user(session=session, name="manager", global_role=GlobalRole.USER)
+        await add_project_member(
+            session=session, project=project, user=manager, project_role=ProjectRole.MANAGER
+        )
+        response = await client.post(
+            f"/api/project/{project.name}/secrets/delete",
+            headers=get_auth_headers(manager.token),
+            json={"secrets_names": ["my_secret"]},
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_manager_can_delete_when_allowed(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        user = await create_user(session=session, global_role=GlobalRole.USER)
+        project = await create_project(session=session, owner=user)
+        manager = await create_user(session=session, name="manager", global_role=GlobalRole.USER)
+        await add_project_member(
+            session=session, project=project, user=manager, project_role=ProjectRole.MANAGER
+        )
+        await create_secret(session=session, project=project, name="secret1", value="123456")
+        with default_permissions_context(DefaultPermissions(allow_managers_manage_secrets=True)):
+            response = await client.post(
+                f"/api/project/{project.name}/secrets/delete",
+                headers=get_auth_headers(manager.token),
+                json={"secrets_names": ["secret1"]},
+            )
+        assert response.status_code == 200
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)


### PR DESCRIPTION
Closes #3799 

- Allow project managers to manage secrets when allow_managers_manage_secrets is enabled in default_permissions server config (defaults to False)
- Add can_manage_secrets to MemberPermissions so the frontend can gate the secrets UI based on the server-computed permission and update the UI