### PR TITLE
Add misssing `compute.projects.get` GCP permission

### DIFF
--- a/docs/docs/concepts/backends.md
+++ b/docs/docs/concepts/backends.md
@@ -521,6 +521,7 @@ gcloud projects list --format="json(projectId)"
     compute.instances.setTags
     compute.networks.get
     compute.networks.updatePolicy
+    compute.projects.get
     compute.regions.get
     compute.regions.list
     compute.reservations.list

--- a/src/dstack/_internal/core/backends/gcp/auth.py
+++ b/src/dstack/_internal/core/backends/gcp/auth.py
@@ -53,5 +53,5 @@ def validate_credentials(credentials: Credentials, project_id: str):
         client.get(project=project_id)
     except google.api_core.exceptions.NotFound:
         raise BackendAuthError(f"project_id {project_id} not found")
-    except Exception:
-        raise BackendAuthError("Insufficient permissions")
+    except Exception as e:
+        raise BackendAuthError(f"Insufficient permissions: {e}")


### PR DESCRIPTION
Required since https://github.com/dstackai/dstack/pull/3795

In addition, `BackendAuthError` now shows the underlying exception message