### PR TITLE
Fix `pyright` failing in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "cryptography",
     "packaging",
     "python-dateutil",
-    "cachetools",
+    "cachetools<7.1.0",  # Pin to work around https://github.com/tkem/cachetools/issues/394
     "gitpython",
     "jsonschema",
     "paramiko>=3.2.0",


### PR DESCRIPTION
Temporarily pin `cachetools` to avoid `pyright` [errors](https://github.com/dstackai/dstack/actions/runs/25306879115/job/74186448505) in CI.

https://github.com/tkem/cachetools/issues/394