### PR TITLE
Runpod: update `RunpodApiClient`

### DIFF
--- a/src/dstack/_internal/core/backends/runpod/api_client.py
+++ b/src/dstack/_internal/core/backends/runpod/api_client.py
@@ -22,7 +22,8 @@ class RunpodApiClientError(BackendError):
 
 class RunpodApiClient:
     def __init__(self, api_key: str):
-        self.api_key = api_key
+        self._session = requests.Session()
+        self._session.headers.update({"Authorization": f"Bearer {api_key}"})
 
     def validate_api_key(self) -> bool:
         try:
@@ -353,9 +354,9 @@ class RunpodApiClient:
 
     def _make_request(self, data: Optional[Dict[str, Any]] = None) -> Response:
         try:
-            response = requests.request(
+            response = self._session.request(
                 method="POST",
-                url=f"{API_URL}?api_key={self.api_key}",
+                url=API_URL,
                 json=data,
                 timeout=120,
             )


### PR DESCRIPTION
* Use `requests.Session`
* Pass API token as a header, not a query param. Prevents token leakage through logs:

      requests.exceptions.ConnectionError: Max retries exceeded with url:
      /graphql?api_key=rpa_xxxxx (Caused by ...)