### PR TITLE
Raise ImportError on Python 3.14 or later

### DIFF
--- a/src/dstack/__init__.py
+++ b/src/dstack/__init__.py
@@ -1,0 +1,4 @@
+import sys
+
+if sys.version_info >= (3, 14):
+    raise ImportError("dstack does not support Python 3.14 or later. Please use Python 3.10–3.13.")


### PR DESCRIPTION
Fixes #3854

Currently `dstack` is guaranteed NOT to work on Python 3.14 due to Pydantic V1 dependency (#1844). But the installation is allowed and there are no explicit errors or warnings which leads to unexpected behavior. For example, I get segfaults on macOS:

```
dstack --help
[1]    67172 segmentation fault  dstack --help
```

The solution is to error when running/importing `dstack`:

```
dstack --help
Traceback (most recent call last):
  File "/Users/r4victor/Projects/dstack/dstack/venv314/bin/dstack", line 4, in <module>
    from dstack._internal.cli.main import main
  File "/Users/r4victor/Projects/dstack/dstack/src/dstack/__init__.py", line 4, in <module>
    raise ImportError("dstack does not support Python 3.14 or later. Please use Python 3.10–3.13.")
ImportError: dstack does not support Python 3.14 or later. Please use Python 3.10–3.13
```

`ImportError` is common in the case of Python version incompatibility so that dependent packages can handle the error if they want. CLI just prints `ImportError` traceback for simplicity – we could show pretty error but it would require having a separate entry point for dstack executable so that it does not import from `dstack`.

Specifying an upper cap like `requires-python = ">=3.10, <3.14"` is not an option since it would make `pip` backtrack to find the earliest version without the cap. `uv` just ignores the upper cap.