### PR TITLE
Fix Pyright errors with `requests==2.34.0`

### DIFF
--- a/src/dstack/_internal/cli/commands/project.py
+++ b/src/dstack/_internal/cli/commands/project.py
@@ -140,9 +140,9 @@ class ProjectCommand(BaseCommand):
         try:
             api_client.projects.get(args.name)
         except HTTPError as e:
-            if e.response.status_code == 403:
+            if e.response is not None and e.response.status_code == 403:
                 raise CLIError("Forbidden. Ensure the token is valid.")
-            elif e.response.status_code == 404:
+            elif e.response is not None and e.response.status_code == 404:
                 raise CLIError(f"Project '{args.name}' not found.")
             else:
                 raise e

--- a/src/dstack/_internal/core/backends/cudo/compute.py
+++ b/src/dstack/_internal/core/backends/cudo/compute.py
@@ -133,10 +133,10 @@ class CudoCompute(
         try:
             self.api_client.terminate_virtual_machine(instance_id, self.config.project_id)
         except requests.HTTPError as e:
-            if e.response.status_code == requests.codes.not_found:
+            if e.response is not None and e.response.status_code == requests.codes.not_found:
                 logger.debug("The instance with name %s not found", instance_id)
                 return
-            raise BackendError(e.response.text)
+            raise BackendError(e.response.text if e.response is not None else str(e))
 
     def update_provisioning_data(
         self,

--- a/src/dstack/_internal/core/backends/digitalocean_base/api_client.py
+++ b/src/dstack/_internal/core/backends/digitalocean_base/api_client.py
@@ -20,8 +20,7 @@ class DigitalOceanAPIClient:
             response.raise_for_status()
             return True
         except requests.HTTPError as e:
-            status = e.response.status_code
-            if status == 401:
+            if e.response is not None and e.response.status_code == 401:
                 raise_invalid_credentials_error(
                     fields=[["creds", "api_key"]], details="Invaild API key"
                 )

--- a/src/dstack/_internal/core/backends/lambdalabs/api_client.py
+++ b/src/dstack/_internal/core/backends/lambdalabs/api_client.py
@@ -13,7 +13,7 @@ class LambdaAPIClient:
         try:
             self.list_instance_types()
         except requests.HTTPError as e:
-            if e.response.status_code in [401, 403]:
+            if e.response is not None and e.response.status_code in [401, 403]:
                 return False
             raise e
         return True

--- a/src/dstack/_internal/core/backends/vultr/compute.py
+++ b/src/dstack/_internal/core/backends/vultr/compute.py
@@ -117,7 +117,7 @@ class VultrCompute(
         try:
             self.api_client.terminate_instance(instance_id=instance_id, plan_type=plan_type)
         except requests.HTTPError as e:
-            raise BackendError(e.response.text)
+            raise BackendError(e.response.text if e.response is not None else str(e))
 
     def update_provisioning_data(
         self,


### PR DESCRIPTION
The latest `requests` version annotates `HTTPError.response` as optional, which [breaks](https://github.com/dstackai/dstack/actions/runs/25719152300/job/75516007123) our Pyright checks.