### PR TITLE
[Docs] Fix `gen_schema_reference.py` on Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,18 +153,20 @@ dev = [
     "pytest-xdist>=3.6.1",
     "pyinstrument>=5.0.0",
     "kubernetes-stubs-elephant-fork",
-    # docs
-    "dstack[server]; python_version >= '3.11'",
-    "dstack-plugin-server; python_version >= '3.11'",
-    "pillow; python_version >= '3.11'",
-    "cairosvg; python_version >= '3.11'",
-    "mkdocs-material>=9.7.0; python_version >= '3.11'",
-    "mkdocs-material[imaging]; python_version >= '3.11'",
-    "mkdocs-material-extensions; python_version >= '3.11'",
-    "mkdocs-redirects; python_version >= '3.11'",
-    "mkdocs-gen-files; python_version >= '3.11'",
-    "mkdocstrings[python]; python_version >= '3.11'",
-    "mkdocs-render-swagger-plugin; python_version >= '3.11'",
+    {include-group = "docs"},
+]
+docs = [
+    "dstack[server]",
+    "dstack-plugin-server",
+    "pillow",
+    "cairosvg",
+    "mkdocs-material>=9.7.0",
+    "mkdocs-material[imaging]",
+    "mkdocs-material-extensions",
+    "mkdocs-redirects",
+    "mkdocs-gen-files",
+    "mkdocstrings[python]",
+    "mkdocs-render-swagger-plugin",
 ]
 
 [project.optional-dependencies]

--- a/scripts/docs/gen_schema_reference.py
+++ b/scripts/docs/gen_schema_reference.py
@@ -27,9 +27,10 @@ logger.info("Generating schema reference...")
 
 def _is_linkable_type(annotation: Any) -> bool:
     """Check if a type annotation contains a BaseModel subclass (excluding Range)."""
-    if inspect.isclass(annotation):
-        return issubclass(annotation, BaseModel) and not issubclass(annotation, Range)
     origin = get_origin(annotation)
+    type_ = origin if origin is not None else annotation
+    if inspect.isclass(type_):
+        return issubclass(type_, BaseModel) and not issubclass(type_, Range)
     if origin is Annotated:
         return _is_linkable_type(get_args(annotation)[0])
     if origin is Union:
@@ -239,12 +240,12 @@ def generate_schema_reference(
             default_repr = None
         elif isinstance(default, (list, tuple, dict)) and len(default) == 0:
             default_repr = None
-        elif isinstance(default, str):
-            default_repr = default
-        elif isinstance(default, BaseModel):
-            default_repr = str(default)
         elif isinstance(default, Enum):
             default_repr = str(default.value)
+        elif isinstance(default, BaseModel):
+            default_repr = str(default)
+        elif isinstance(default, str):
+            default_repr = default
         else:
             default_repr = json.dumps(default)
         friendly_type = get_friendly_type(field.annotation)


### PR DESCRIPTION
Allows to generate docs on Python 3.10, which is still supported by dstack.

In addition, str Enum representation on Python 3.11+ was fixed.