### PR TITLE
Discover and use the latest AWS Ubuntu 22.04 DLAMI

### DIFF
--- a/src/dstack/_internal/core/backends/aws/resources.py
+++ b/src/dstack/_internal/core/backends/aws/resources.py
@@ -32,8 +32,7 @@ def get_image_id_and_username(
         image_owner = image.owner
         username = image.user
     elif _supported_by_dlami(instance_type):
-        # TODO: Update DLAMI image version from time to time
-        image_name = "Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 22.04) 20250516"
+        image_name = "Deep Learning Base OSS Nvidia Driver GPU AMI (Ubuntu 22.04) *"
         image_owner = DLAMI_OWNER_ACCOUNT_ID
         username = "ubuntu"
     else:


### PR DESCRIPTION
Automatically use the latest build, so that
customers can benefit from the latest security
patches without setting `os_images` or waiting for
the dstack team to update the default AMI. Still,
only use Ubuntu 22.04 to avoid breaking changes.

Implementation: fetch the details of all Ubuntu
22.04 DLAMI builds (119 as of today), find the
most recent in runtime.