### PR TITLE
[Internal]: Fix OCI image publishing script

### DIFF
--- a/src/dstack/_internal/core/backends/oci/resources.py
+++ b/src/dstack/_internal/core/backends/oci/resources.py
@@ -728,6 +728,12 @@ def create_pre_authenticated_request(
 def delete_bucket(
     namespace: str, bucket_name: str, client: oci.object_storage.ObjectStorageClient
 ) -> None:
+    in_progress_uploads: Iterable[oci.object_storage.models.MultipartUpload] = (
+        chain_paginated_responses(client.list_multipart_uploads, namespace, bucket_name)
+    )
+    for upload in in_progress_uploads:
+        client.abort_multipart_upload(namespace, bucket_name, upload.object, upload.upload_id)
+
     par_ids = {
         par.id
         for par in chain_paginated_responses(


### PR DESCRIPTION
Fix error when deleting the storage bucket:

```
oci.exceptions.ServiceError: {'message': "Bucket named 'dstack-0.13' has pending multipart uploads. Stop all multipart uploads first.", ...}
```

For some reason, image export into a bucket leaves
a hanging multipart upload after the export
finishes. The same behavior can be reproduced in
the OCI Console. Abort such uploads before
deleting the bucket.

Fixes #3914