### PR TITLE
Update Docker and cloud images to 0.13

### DIFF
--- a/src/dstack/version.py
+++ b/src/dstack/version.py
@@ -5,5 +5,5 @@
 
 __version__ = "0.0.0"
 __is_release__ = False
-base_image = "0.12"
+base_image = "0.13"
 base_image_ubuntu_version = "22.04"

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -388,7 +388,7 @@ def get_dev_env_run_dict(
                 " && tail -f /dev/null"
             ),
         ]
-        image_name = "dstackai/base:0.12-base-ubuntu22.04"
+        image_name = "dstackai/base:0.13-base-ubuntu22.04"
 
     return {
         "id": run_id,


### PR DESCRIPTION
0.13 is a new minor build of our cloud (AWS, GCP,
Azure, OCI) images, which includes the updated
Linux kernel.