### PR TITLE
Fix Verda spot offers marked unavailable due to on-demand-only availability check

### DIFF
--- a/src/dstack/_internal/core/backends/verda/compute.py
+++ b/src/dstack/_internal/core/backends/verda/compute.py
@@ -78,9 +78,6 @@ class VerdaCompute(
     def _get_offers_with_availability(
         self, offers: List[InstanceOffer]
     ) -> List[InstanceOfferWithAvailability]:
-        # Verda reports spot and on-demand availability separately. Query both so that
-        # spot offers (e.g. B200 spot) are matched against spot inventory rather than
-        # being marked NOT_AVAILABLE based on on-demand inventory only.
         region_availabilities = {}
         for is_spot in (False, True):
             raw_availabilities: List[Dict] = self.client.instances.get_availabilities(

--- a/src/dstack/_internal/core/backends/verda/compute.py
+++ b/src/dstack/_internal/core/backends/verda/compute.py
@@ -78,19 +78,24 @@ class VerdaCompute(
     def _get_offers_with_availability(
         self, offers: List[InstanceOffer]
     ) -> List[InstanceOfferWithAvailability]:
-        raw_availabilities: List[Dict] = self.client.instances.get_availabilities()
-
+        # Verda reports spot and on-demand availability separately. Query both so that
+        # spot offers (e.g. B200 spot) are matched against spot inventory rather than
+        # being marked NOT_AVAILABLE based on on-demand inventory only.
         region_availabilities = {}
-        for location in raw_availabilities:
-            location_code = location["location_code"]
-            availabilities = location["availabilities"]
-            for name in availabilities:
-                key = (name, location_code)
-                region_availabilities[key] = InstanceAvailability.AVAILABLE
+        for is_spot in (False, True):
+            raw_availabilities: List[Dict] = self.client.instances.get_availabilities(
+                is_spot=is_spot
+            )
+            for location in raw_availabilities:
+                location_code = location["location_code"]
+                availabilities = location["availabilities"]
+                for name in availabilities:
+                    key = (name, location_code, is_spot)
+                    region_availabilities[key] = InstanceAvailability.AVAILABLE
 
         availability_offers = []
         for offer in offers:
-            key = (offer.instance.name, offer.region)
+            key = (offer.instance.name, offer.region, offer.instance.resources.spot)
             availability = region_availabilities.get(key, InstanceAvailability.NOT_AVAILABLE)
             availability_offers.append(offer.with_availability(availability=availability))
 

--- a/src/tests/_internal/core/backends/verda/test_compute.py
+++ b/src/tests/_internal/core/backends/verda/test_compute.py
@@ -11,6 +11,26 @@ from dstack._internal.core.backends.verda.compute import (
     _create_startup_script,
 )
 from dstack._internal.core.errors import BackendError, NoCapacityError
+from dstack._internal.core.models.backends.base import BackendType
+from dstack._internal.core.models.instances import (
+    InstanceAvailability,
+    InstanceOffer,
+    InstanceType,
+    Resources,
+)
+
+
+def _offer(spot: bool, name: str = "SOME.INSTANCE", region: str = "FIN-01") -> InstanceOffer:
+    # Availability is keyed by (name, region, spot) only; other resources are irrelevant.
+    return InstanceOffer(
+        backend=BackendType.VERDA,
+        instance=InstanceType(
+            name=name,
+            resources=Resources(cpus=8, memory_mib=16384, gpus=[], spot=spot),
+        ),
+        region=region,
+        price=1.0,
+    )
 
 
 def _assert_terminate_call(action_mock: MagicMock):
@@ -284,6 +304,42 @@ class TestCreateInstance:
         backend_data = VerdaInstanceBackendData.load(jpd.backend_data)
         assert backend_data.startup_script_id == "startup-script-id"
         assert backend_data.ssh_key_ids == ["ssh-key-id-1", "ssh-key-id-2"]
+
+
+class TestGetOffersWithAvailability:
+    @pytest.mark.parametrize("available_as_spot", [True, False])
+    def test_availability_resolved_against_matching_inventory(self, available_as_spot):
+        # Verda reports spot and on-demand availability separately. The same instance type
+        # in the same region may be available as one but not the other. Each offer's
+        # availability must come from the inventory matching its own spot flag, not the
+        # other one. Parametrized to cover both directions; not specific to any GPU/instance.
+        compute = VerdaCompute.__new__(VerdaCompute)
+        compute.client = MagicMock()
+
+        def get_availabilities(is_spot):
+            names = ["SOME.INSTANCE"] if is_spot == available_as_spot else []
+            return [{"location_code": "FIN-01", "availabilities": names}]
+
+        compute.client.instances.get_availabilities.side_effect = get_availabilities
+
+        offers = compute._get_offers_with_availability([_offer(spot=False), _offer(spot=True)])
+        availability_by_spot = {o.instance.resources.spot: o.availability for o in offers}
+
+        assert availability_by_spot[available_as_spot] == InstanceAvailability.AVAILABLE
+        assert availability_by_spot[not available_as_spot] == InstanceAvailability.NOT_AVAILABLE
+
+    def test_queries_both_spot_and_on_demand_availability(self):
+        compute = VerdaCompute.__new__(VerdaCompute)
+        compute.client = MagicMock()
+        compute.client.instances.get_availabilities.return_value = []
+
+        compute._get_offers_with_availability([_offer(spot=True)])
+
+        requested_is_spot = {
+            call.kwargs.get("is_spot")
+            for call in compute.client.instances.get_availabilities.call_args_list
+        }
+        assert requested_is_spot == {True, False}
 
 
 class TestTerminateInstance:

--- a/src/tests/_internal/core/backends/verda/test_compute.py
+++ b/src/tests/_internal/core/backends/verda/test_compute.py
@@ -21,7 +21,6 @@ from dstack._internal.core.models.instances import (
 
 
 def _offer(spot: bool, name: str = "SOME.INSTANCE", region: str = "FIN-01") -> InstanceOffer:
-    # Availability is keyed by (name, region, spot) only; other resources are irrelevant.
     return InstanceOffer(
         backend=BackendType.VERDA,
         instance=InstanceType(
@@ -309,10 +308,6 @@ class TestCreateInstance:
 class TestGetOffersWithAvailability:
     @pytest.mark.parametrize("available_as_spot", [True, False])
     def test_availability_resolved_against_matching_inventory(self, available_as_spot):
-        # Verda reports spot and on-demand availability separately. The same instance type
-        # in the same region may be available as one but not the other. Each offer's
-        # availability must come from the inventory matching its own spot flag, not the
-        # other one. Parametrized to cover both directions; not specific to any GPU/instance.
         compute = VerdaCompute.__new__(VerdaCompute)
         compute.client = MagicMock()
 


### PR DESCRIPTION
## What this does

Fixes spot offers on the `verda` backend being marked `NOT_AVAILABLE` and never provisioned.

`VerdaCompute._get_offers_with_availability` queried instance availability without the `is_spot` parameter (so the Verda API returned **on-demand inventory only**) and keyed the availability map by `(instance_name, region)`, ignoring the spot dimension. As a result, spot offers (e.g. B200 spot) inherited on-demand availability and were marked `NOT_AVAILABLE` whenever the on-demand variant was unavailable. Provisioning requests offers with `exclude_not_available=True`, so these offers were dropped and never provisioned.

The fix queries both spot and on-demand availability and keys the map by `(instance_name, region, is_spot)`, so each offer is matched against the correct inventory.

## Reproduction

See linked issue. With B200 available as spot but not on-demand, `dstack offer --backend verda --gpu B200 --spot` showed B200 spot as "not available", and provisioning found no offers.

## Tests

Added `TestGetOffersWithAvailability` in `tests/.../verda/test_compute.py` covering:
- spot and on-demand availability are resolved independently;
- both `is_spot=True` and `is_spot=False` availability are queried.

These tests fail against the previous code and pass with the fix. `ruff check` / `ruff format` clean.

Closes #3927

---

This PR was written primarily by Claude Code (with maintainer review of the diagnosis and fix).
