### PR TITLE
Set runner/shim default compiled versions to `latest`

### DIFF
--- a/runner/cmd/runner/main.go
+++ b/runner/cmd/runner/main.go
@@ -23,7 +23,8 @@ import (
 )
 
 // Version is a build-time variable. The value is overridden by ldflags.
-var Version string
+// The "latest" default marks a dev build; the server treats it as the newest version.
+var Version = "latest"
 
 func main() {
 	os.Exit(mainInner())

--- a/runner/cmd/shim/main.go
+++ b/runner/cmd/shim/main.go
@@ -25,7 +25,8 @@ import (
 )
 
 // Version is a build-time variable. The value is overridden by ldflags.
-var Version string
+// The "latest" default marks a dev build; the server treats it as the newest version.
+var Version = "latest"
 
 // https://everything.curl.dev/usingcurl/proxies/env.html
 // https://cs.opensource.google/go/x/net/+/657eb1317b5dd33038d683297c6be9cae05fa97d:http/httpproxy/proxy.go


### PR DESCRIPTION
Both runner and shim require Version to be set as `shim` calls `shim --version` and `runner --version` and if Version is not specified via ldflags, then shim fails (--version flag is missing).

The PR adds default Version so that shim and runner can be built with simple `go build` for dev purposes.

Does not affect release and dev CI builds as they set Version via ldflags.