### PR TITLE
Support Zed as dev-environment IDE

### DIFF
--- a/mkdocs/docs/concepts/dev-environments.md
+++ b/mkdocs/docs/concepts/dev-environments.md
@@ -65,6 +65,8 @@ To connect via SSH, use: `ssh vscode`
 
 `dstack apply` automatically provisions an instance and sets up an IDE on it.
 
+The `ide` property supports `vscode`, `cursor`, `windsurf`, and `zed`.
+
 ??? info "SSH-only"
     The `ide` property is optional. If omitted, no IDE is pre-installed, but the dev environment
     is still accessible via SSH:

--- a/src/dstack/_internal/core/models/configurations.py
+++ b/src/dstack/_internal/core/models/configurations.py
@@ -685,9 +685,9 @@ class ConfigurationWithCommandsParams(CoreModel):
 
 class DevEnvironmentConfigurationParams(CoreModel):
     ide: Annotated[
-        Optional[Union[Literal["vscode"], Literal["cursor"], Literal["windsurf"]]],
+        Optional[Union[Literal["vscode"], Literal["cursor"], Literal["windsurf"], Literal["zed"]]],
         Field(
-            description="The IDE to pre-install. Supported values include `vscode`, `cursor`, and `windsurf`. Defaults to no IDE (SSH only)"
+            description="The IDE to pre-install. Supported values include `vscode`, `cursor`, `windsurf`, and `zed`. Defaults to no IDE (SSH only)"
         ),
     ] = None
     version: Annotated[

--- a/src/dstack/_internal/server/services/ides/__init__.py
+++ b/src/dstack/_internal/server/services/ides/__init__.py
@@ -4,13 +4,15 @@ from dstack._internal.server.services.ides.base import IDE
 from dstack._internal.server.services.ides.cursor import CursorDesktop
 from dstack._internal.server.services.ides.vscode import VSCodeDesktop
 from dstack._internal.server.services.ides.windsurf import WindsurfDesktop
+from dstack._internal.server.services.ides.zed import ZedDesktop
 
-_IDELiteral = Literal["vscode", "cursor", "windsurf"]
+_IDELiteral = Literal["vscode", "cursor", "windsurf", "zed"]
 
 _ide_literal_to_ide_class_map: dict[_IDELiteral, type[IDE]] = {
     "vscode": VSCodeDesktop,
     "cursor": CursorDesktop,
     "windsurf": WindsurfDesktop,
+    "zed": ZedDesktop,
 }
 
 

--- a/src/dstack/_internal/server/services/ides/zed.py
+++ b/src/dstack/_internal/server/services/ides/zed.py
@@ -1,0 +1,19 @@
+from typing import Optional
+
+from dstack._internal.server.services.ides.base import IDE
+
+
+class ZedDesktop(IDE):
+    name = "Zed"
+    url_scheme = "zed"
+
+    def get_install_commands(
+        self, version: Optional[str] = None, extensions: Optional[list[str]] = None
+    ) -> list[str]:
+        # We don't need to pre-install any extensions for Zed so we let it
+        # auto-install the remote server into ~/.zed_server on the first SSH connect,
+        # downloading the binary that matches the connecting Zed client version.
+        return []
+
+    def get_url(self, authority: str, working_dir: str) -> str:
+        return f"zed://ssh/{authority}{working_dir}"

--- a/src/tests/_internal/core/models/test_configurations.py
+++ b/src/tests/_internal/core/models/test_configurations.py
@@ -817,6 +817,16 @@ class TestDevEnvironmentConfigurationParams:
         assert params.ide == "cursor"
         assert params.version == "0.40.0"
 
+    def test_zed_ide_allowed(self):
+        params = DevEnvironmentConfigurationParams(ide="zed")
+        assert params.ide == "zed"
+        assert params.version is None
+
+    def test_zed_version_not_validated(self):
+        params = DevEnvironmentConfigurationParams(ide="zed", version="0.100.0")
+        assert params.ide == "zed"
+        assert params.version == "0.100.0"
+
     def test_ide_optional(self):
         params = DevEnvironmentConfigurationParams()
         assert params.ide is None


### PR DESCRIPTION
Closes #3945 

You can run `ide: zed` dev environments:

```yaml
type: dev-environment
ide: zed
```

and get a zed:// remote project:

```shell
✗ dstack apply
...
tiny-pig-2 provisioning completed (running)
pip install ipykernel...

To open in Zed, use link below:

  zed://ssh/tiny-pig-2/dstack/run

To connect via SSH, use: `ssh tiny-pig-2`

To exit, press Ctrl+C.
```

As Zed does not require any plugins, we don't need to pre-install the Zed server – it's installed on first connect. The implementation is just the printing of a proper URL scheme.