### PR TITLE
Support AWS p6 instances

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,7 @@ jobs:
     defaults:
       run:
         working-directory: docker
-    runs-on: ubuntu-latest
+    runs-on: dstack-ubuntu-latest-32-cores
     strategy:
       matrix:
         flavor: ["base", "devel", "devel-efa"]

--- a/docker/base/efa/Dockerfile
+++ b/docker/base/efa/Dockerfile
@@ -16,15 +16,11 @@ RUN cuda_version=$(echo ${CUDA_VERSION} | awk -F . '{ print $1"-"$2 }') \
     && apt-get install -y --no-install-recommends \
         cuda-libraries-dev-${cuda_version} \
         cuda-nvcc-${cuda_version} \
-        libhwloc-dev \
-        autoconf \
-        automake \
-        libtool \
     && rm -rf /var/lib/apt/lists/*
 
 # EFA
 
-ARG EFA_VERSION=1.38.1
+ARG EFA_VERSION=1.48.0
 
 RUN cd /tmp \
     && apt-get update \
@@ -36,33 +32,13 @@ RUN cd /tmp \
 
 # NCCL
 
-ARG NCCL_VERSION=2.26.2-1
+ARG NCCL_VERSION=2.27.7-1
 
 RUN cd /tmp \
     && git clone https://github.com/NVIDIA/nccl.git -b v${NCCL_VERSION} \
     && cd nccl \
     && make -j$(nproc) src.build BUILDDIR=${NCCL_HOME} \
     && rm -rf /tmp/nccl
-
-# AWS OFI NCCL
-
-ARG OFI_VERSION=1.14.0
-
-RUN cd /tmp \
-    && git clone https://github.com/aws/aws-ofi-nccl.git -b v${OFI_VERSION} \
-    && cd aws-ofi-nccl \
-    && ./autogen.sh \
-    && ./configure \
-        --with-cuda=${CUDA_HOME} \
-        --with-libfabric=${LIBFABRIC_PATH} \
-        --with-mpi=${OPEN_MPI_PATH} \
-        --with-cuda=${CUDA_HOME} \
-        --with-nccl=${NCCL_HOME} \
-        --disable-tests \
-        --prefix=${NCCL_HOME} \
-    && make -j$(nproc) \
-    && make install \
-    && rm -rf /tmp/aws-ofi-nccl /var/lib/apt/lists/*
 
 # NCCL Tests
 

--- a/docker/base/efa/README.md
+++ b/docker/base/efa/README.md
@@ -2,8 +2,7 @@
 
 This image has the following installed:
 
-* CUDA 12.1
-* AWS EFA Installer 1.38.1 (Libfabric + Open MPI 4 + Open MPI 5)
-* NCCL 2.26.2-1
-* AWS OFI NCCL 1.14.0
+* CUDA 12.8
+* AWS EFA Installer 1.48.0 (Libfabric + Open MPI + AWS OFI NCCL 1.19.0)
+* NCCL 2.27.7-1
 * NCCL Tests

--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -1240,6 +1240,8 @@ def _supported_instances(offer: InstanceOffer) -> bool:
         "t2.small",
         "c5.",
         "m5.",
+        "p6-b300.",
+        "p6-b200.",
         "p5.",
         "p5e.",
         "p4d.",

--- a/src/dstack/_internal/core/backends/aws/resources.py
+++ b/src/dstack/_internal/core/backends/aws/resources.py
@@ -191,40 +191,13 @@ def create_instances_struct(
     # AWS allows specifying either NetworkInterfaces for specific subnet_id
     # or instance-level SecurityGroupIds in case of no specific subnet_id, not both.
     if subnet_id is not None:
-        # AWS does not auto-assign a public IPv4 to instances launched with multiple network
-        # interfaces ("AssociatePublicIpAddress [...] You cannot specify more than one network
-        # interface in the request"). For multi-EFA instance types (e.g. p4d, p5, trn1), we
-        # therefore launch all EFA NICs without `AssociatePublicIpAddress` and, when
-        # `public_ips: true`, attach an Elastic IP after launch in `update_provisioning_data`.
-        multi_eni = max_efa_interfaces > 1
-        struct["NetworkInterfaces"] = [
-            {
-                "AssociatePublicIpAddress": allocate_public_ip and not multi_eni,
-                "DeviceIndex": 0,
-                "SubnetId": subnet_id,
-                "Groups": [security_group_id],
-                "InterfaceType": "efa" if max_efa_interfaces > 0 else "interface",
-            },
-        ]
-
-        if multi_eni:
-            for i in range(1, max_efa_interfaces):
-                # Set to efa-only to use interfaces exclusively for GPU-to-GPU communication
-                interface_type = "efa-only"
-                if instance_type == "p5.48xlarge":
-                    # EFA configuration for P5 instances:
-                    # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-acc-inst-types.html#efa-for-p5
-                    interface_type = "efa" if i % 4 == 0 else "efa-only"
-                struct["NetworkInterfaces"].append(
-                    {
-                        "AssociatePublicIpAddress": False,
-                        "NetworkCardIndex": i,
-                        "DeviceIndex": 1,
-                        "SubnetId": subnet_id,
-                        "Groups": [security_group_id],
-                        "InterfaceType": interface_type,
-                    }
-                )
+        struct["NetworkInterfaces"] = _create_network_interfaces_struct(
+            instance_type=instance_type,
+            subnet_id=subnet_id,
+            security_group_id=security_group_id,
+            allocate_public_ip=allocate_public_ip,
+            max_efa_interfaces=max_efa_interfaces,
+        )
     else:
         struct["SecurityGroupIds"] = [security_group_id]
 
@@ -630,6 +603,64 @@ def _is_private_subnet_with_internet_egress(
                     return True
 
     return False
+
+
+def _create_network_interfaces_struct(
+    instance_type: str,
+    subnet_id: str,
+    security_group_id: str,
+    allocate_public_ip: bool,
+    max_efa_interfaces: int,
+) -> List[Dict[str, Any]]:
+    # AWS does not auto-assign a public IPv4 to instances launched with multiple network
+    # interfaces ("AssociatePublicIpAddress [...] You cannot specify more than one network
+    # interface in the request"). For multi-EFA instance types (e.g. p4d, p5, p6, trn1), we
+    # therefore launch all EFA NICs without `AssociatePublicIpAddress` and, when
+    # `public_ips: true`, attach an Elastic IP after launch in `update_provisioning_data`.
+    multi_eni = max_efa_interfaces > 1
+    primary_supports_efa = _primary_nic_supports_efa(instance_type)
+    network_interfaces: List[Dict[str, Any]] = [
+        {
+            "AssociatePublicIpAddress": allocate_public_ip and not multi_eni,
+            "DeviceIndex": 0,
+            "SubnetId": subnet_id,
+            "Groups": [security_group_id],
+            "InterfaceType": "efa"
+            if max_efa_interfaces > 0 and primary_supports_efa
+            else "interface",
+        },
+    ]
+
+    if multi_eni:
+        last_card_index = max_efa_interfaces
+        if not primary_supports_efa:
+            last_card_index += 1
+        for i in range(1, last_card_index):
+            # Set to efa-only to use interfaces exclusively for GPU-to-GPU communication
+            interface_type = "efa-only"
+            if instance_type == "p5.48xlarge":
+                # EFA configuration for P5 instances:
+                # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-acc-inst-types.html#efa-for-p5
+                interface_type = "efa" if i % 4 == 0 else "efa-only"
+            network_interfaces.append(
+                {
+                    "AssociatePublicIpAddress": False,
+                    "NetworkCardIndex": i,
+                    "DeviceIndex": 1,
+                    "SubnetId": subnet_id,
+                    "Groups": [security_group_id],
+                    "InterfaceType": interface_type,
+                }
+            )
+    return network_interfaces
+
+
+def _primary_nic_supports_efa(instance_type: str) -> bool:
+    """For most EFA-supported instance types, primary network card (index 0) supports
+    attaching both ENA and EFA. But some may support only one interface (ENA),
+    and all EFA interfaces are placed on the secondary network cards (1..max_efa_interfaces).
+    """
+    return instance_type not in {"p6-b300.48xlarge"}
 
 
 def get_reservation(

--- a/src/dstack/_internal/server/services/backends/provisioning.py
+++ b/src/dstack/_internal/server/services/backends/provisioning.py
@@ -12,7 +12,7 @@ from dstack._internal.utils.docker import parse_image_name
 
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types
 _AWS_EFA_ENABLED_INSTANCE_TYPE_PATTERNS = [
-    # TODO: p6-b200 isn't supported yet in gpuhunt
+    r"^p6-b300\.(48xlarge)$",
     r"^p6-b200\.(48xlarge)$",
     r"^p5\.(4xlarge|48xlarge)$",
     r"^p5e\.(48xlarge)$",

--- a/src/tests/_internal/core/backends/aws/test_resources.py
+++ b/src/tests/_internal/core/backends/aws/test_resources.py
@@ -5,6 +5,7 @@ import pytest
 
 from dstack._internal.core.backends.aws.models import AWSOSImage, AWSOSImageConfig
 from dstack._internal.core.backends.aws.resources import (
+    _create_network_interfaces_struct,
     _is_valid_tag_key,
     _is_valid_tag_value,
     get_image_id_and_username,
@@ -235,3 +236,161 @@ class TestGetImageIdAndUsername:
                 image_config=image_config,
             )
         assert "cpu image not configured" in caplog.text
+
+
+class TestCreateNetworkInterfacesStruct:
+    def test_non_efa_instance_single_interface(self):
+        interfaces = _create_network_interfaces_struct(
+            instance_type="m5.large",
+            subnet_id="subnet-1",
+            security_group_id="sg-1",
+            allocate_public_ip=True,
+            max_efa_interfaces=0,
+        )
+        assert interfaces == [
+            {
+                "AssociatePublicIpAddress": True,
+                "DeviceIndex": 0,
+                "SubnetId": "subnet-1",
+                "Groups": ["sg-1"],
+                "InterfaceType": "interface",
+            },
+        ]
+
+    def test_non_efa_instance_no_public_ip(self):
+        interfaces = _create_network_interfaces_struct(
+            instance_type="m5.large",
+            subnet_id="subnet-1",
+            security_group_id="sg-1",
+            allocate_public_ip=False,
+            max_efa_interfaces=0,
+        )
+        assert interfaces[0]["AssociatePublicIpAddress"] is False
+        assert interfaces[0]["InterfaceType"] == "interface"
+
+    def test_single_efa_interface(self):
+        interfaces = _create_network_interfaces_struct(
+            instance_type="g5.8xlarge",
+            subnet_id="subnet-1",
+            security_group_id="sg-1",
+            allocate_public_ip=True,
+            max_efa_interfaces=1,
+        )
+        # multi_eni is False, so the single EFA NIC keeps the public IP
+        assert interfaces == [
+            {
+                "AssociatePublicIpAddress": True,
+                "DeviceIndex": 0,
+                "SubnetId": "subnet-1",
+                "Groups": ["sg-1"],
+                "InterfaceType": "efa",
+            },
+        ]
+
+    def test_multi_efa_instance(self):
+        interfaces = _create_network_interfaces_struct(
+            instance_type="p4d.24xlarge",
+            subnet_id="subnet-1",
+            security_group_id="sg-1",
+            allocate_public_ip=True,
+            max_efa_interfaces=4,
+        )
+        # Multiple NICs disable auto-assigned public IP on every interface
+        assert interfaces[0] == {
+            "AssociatePublicIpAddress": False,
+            "DeviceIndex": 0,
+            "SubnetId": "subnet-1",
+            "Groups": ["sg-1"],
+            "InterfaceType": "efa",
+        }
+        assert interfaces[1:] == [
+            {
+                "AssociatePublicIpAddress": False,
+                "NetworkCardIndex": i,
+                "DeviceIndex": 1,
+                "SubnetId": "subnet-1",
+                "Groups": ["sg-1"],
+                "InterfaceType": "efa-only",
+            }
+            for i in range(1, 4)
+        ]
+
+    def test_p5_uses_efa_every_fourth_interface(self):
+        interfaces = _create_network_interfaces_struct(
+            instance_type="p5.48xlarge",
+            subnet_id="subnet-1",
+            security_group_id="sg-1",
+            allocate_public_ip=True,
+            max_efa_interfaces=32,
+        )
+        assert len(interfaces) == 32
+        assert all(i["NetworkCardIndex"] == idx for idx, i in enumerate(interfaces) if idx > 0)
+        # The primary NIC is a combined efa interface
+        assert interfaces[0]["InterfaceType"] == "efa"
+        assert "NetworkCardIndex" not in interfaces[0]
+        # Every 4th secondary NIC is a combined efa interface, the rest are efa-only
+        for idx, interface in enumerate(interfaces[1:], start=1):
+            expected = "efa" if idx % 4 == 0 else "efa-only"
+            assert interface["InterfaceType"] == expected, idx
+
+    def test_p6_b200_efa_on_every_card(self):
+        # p6-b200 has 8 EFA-capable network cards (indexes 0-7), handled by the generic path
+        interfaces = _create_network_interfaces_struct(
+            instance_type="p6-b200.48xlarge",
+            subnet_id="subnet-1",
+            security_group_id="sg-1",
+            allocate_public_ip=True,
+            max_efa_interfaces=8,
+        )
+        assert len(interfaces) == 8
+        assert interfaces[0] == {
+            "AssociatePublicIpAddress": False,
+            "DeviceIndex": 0,
+            "SubnetId": "subnet-1",
+            "Groups": ["sg-1"],
+            "InterfaceType": "efa",
+        }
+        assert interfaces[1:] == [
+            {
+                "AssociatePublicIpAddress": False,
+                "NetworkCardIndex": i,
+                "DeviceIndex": 1,
+                "SubnetId": "subnet-1",
+                "Groups": ["sg-1"],
+                "InterfaceType": "efa-only",
+            }
+            for i in range(1, 8)
+        ]
+
+    def test_p6_b300_ena_only_primary_nic(self):
+        # p6-b300 has 17 network cards: the primary (index 0) supports only ENA, the remaining
+        # 16 cards (indexes 1-16) support EFA. max_efa_interfaces is 16.
+        interfaces = _create_network_interfaces_struct(
+            instance_type="p6-b300.48xlarge",
+            subnet_id="subnet-1",
+            security_group_id="sg-1",
+            allocate_public_ip=True,
+            max_efa_interfaces=16,
+        )
+        # 1 ENA primary + 16 EFA secondary cards
+        assert len(interfaces) == 17
+        # Primary card is a plain ENA interface, not EFA
+        assert interfaces[0] == {
+            "AssociatePublicIpAddress": False,
+            "DeviceIndex": 0,
+            "SubnetId": "subnet-1",
+            "Groups": ["sg-1"],
+            "InterfaceType": "interface",
+        }
+        # EFA-only interfaces span network card indexes 1-16
+        assert interfaces[1:] == [
+            {
+                "AssociatePublicIpAddress": False,
+                "NetworkCardIndex": i,
+                "DeviceIndex": 1,
+                "SubnetId": "subnet-1",
+                "Groups": ["sg-1"],
+                "InterfaceType": "efa-only",
+            }
+            for i in range(1, 17)
+        ]


### PR DESCRIPTION
Closes #3940 

Add support for AWS p6-b200 and p6-b300 instances. Specifically, update EFA configuration logic as every p6 type requires custom configuration (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-acc-inst-types.html)

Also update EFA Docker image to include latest EFA-related software that support Blackwell. The current image didn't work.

NCCL tests on 2x p6-200:

```
#       size         count      type   redop    root     time   algbw   busbw  #wrong     time   algbw   busbw  #wrong
#        (B)    (elements)                               (us)  (GB/s)  (GB/s)             (us)  (GB/s)  (GB/s)

           8             2     float     sum      -1    50.58    0.00    0.00       0    54.46    0.00    0.00       0
          16             4     float     sum      -1    54.55    0.00    0.00       0    54.52    0.00    0.00       0
          32             8     float     sum      -1    54.59    0.00    0.00       0    55.34    0.00    0.00       0
          64            16     float     sum      -1    55.60    0.00    0.00       0    55.51    0.00    0.00       0
         128            32     float     sum      -1    56.27    0.00    0.00       0    56.26    0.00    0.00       0
         256            64     float     sum      -1    57.14    0.00    0.01       0    56.54    0.00    0.01       0
         512           128     float     sum      -1    54.89    0.01    0.02       0    53.72    0.01    0.02       0
        1024           256     float     sum      -1    56.52    0.02    0.03       0    55.72    0.02    0.03       0
        2048           512     float     sum      -1    57.42    0.04    0.07       0    58.40    0.04    0.07       0
        4096          1024     float     sum      -1    65.08    0.06    0.12       0    62.18    0.07    0.12       0
        8192          2048     float     sum      -1    62.92    0.13    0.24       0    65.11    0.13    0.24       0
       16384          4096     float     sum      -1    63.52    0.26    0.48       0    63.80    0.26    0.48       0
       32768          8192     float     sum      -1    68.55    0.48    0.90       0    63.88    0.51    0.96       0
       65536         16384     float     sum      -1    65.94    0.99    1.86       0    68.60    0.96    1.79       0
      131072         32768     float     sum      -1    69.73    1.88    3.52       0    72.51    1.81    3.39       0
      262144         65536     float     sum      -1    88.11    2.98    5.58       0    88.38    2.97    5.56       0
      524288        131072     float     sum      -1    92.30    5.68   10.65       0    86.44    6.07   11.37       0
     1048576        262144     float     sum      -1    95.76   10.95   20.53       0    97.25   10.78   20.22       0
     2097152        524288     float     sum      -1   107.75   19.46   36.49       0   110.37   19.00   35.63       0
     4194304       1048576     float     sum      -1   138.53   30.28   56.77       0   138.33   30.32   56.85       0
     8388608       2097152     float     sum      -1   154.79   54.19  101.61       0   154.86   54.17  101.57       0
    16777216       4194304     float     sum      -1   190.75   87.95  164.91       0   188.86   88.84  166.57       0
    33554432       8388608     float     sum      -1   292.61  114.67  215.01       0   291.07  115.28  216.15       0
    67108864      16777216     float     sum      -1   481.39  139.40  261.38       0   481.32  139.43  261.43       0
   134217728      33554432     float     sum      -1   744.86  180.19  337.86       0   744.39  180.31  338.07       0
   268435456      67108864     float     sum      -1  1209.14  222.00  416.26       0  1198.05  224.06  420.11       0
   536870912     134217728     float     sum      -1  2401.34  223.57  419.20       0  2352.59  228.20  427.88       0
  1073741824     268435456     float     sum      -1  3742.18  286.93  537.99       0  3725.04  288.25  540.47       0
  2147483648     536870912     float     sum      -1  6696.75  320.68  601.27       0  6694.57  320.78  601.46       0
  4294967296    1073741824     float     sum      -1  12714.6  337.80  633.37       0  12653.1  339.44  636.45       0
  8589934592    2147483648     float     sum      -1  24589.9  349.33  654.99       0  24577.6  349.50  655.32       0
# Out of bounds values : 0 OK
# Avg bus bandwidth    : 144.893
#
# Collective test concluded: all_reduce_perf
#

```

NCCL tests on 2x p6-300:

```
           8             2     float     sum      -1    52.59    0.00    0.00       0    55.36    0.00    0.00       0
          16             4     float     sum      -1    55.83    0.00    0.00       0    55.54    0.00    0.00       0
          32             8     float     sum      -1    63.49    0.00    0.00       0    57.03    0.00    0.00       0
          64            16     float     sum      -1    56.09    0.00    0.00       0    56.66    0.00    0.00       0
         128            32     float     sum      -1    58.28    0.00    0.00       0    57.42    0.00    0.00       0
         256            64     float     sum      -1    57.46    0.00    0.01       0    59.40    0.00    0.01       0
         512           128     float     sum      -1    57.19    0.01    0.02       0    59.40    0.01    0.02       0
        1024           256     float     sum      -1    58.32    0.02    0.03       0    58.76    0.02    0.03       0
        2048           512     float     sum      -1    61.75    0.03    0.06       0    61.44    0.03    0.06       0
        4096          1024     float     sum      -1    63.86    0.06    0.12       0    63.24    0.06    0.12       0
        8192          2048     float     sum      -1    67.63    0.12    0.23       0    66.69    0.12    0.23       0
       16384          4096     float     sum      -1    66.20    0.25    0.46       0    68.05    0.24    0.45       0
       32768          8192     float     sum      -1    69.04    0.47    0.89       0    71.83    0.46    0.86       0
       65536         16384     float     sum      -1    71.60    0.92    1.72       0    70.87    0.92    1.73       0
      131072         32768     float     sum      -1    73.05    1.79    3.36       0    72.36    1.81    3.40       0
      262144         65536     float     sum      -1    87.76    2.99    5.60       0    87.54    2.99    5.62       0
      524288        131072     float     sum      -1    90.57    5.79   10.85       0    91.32    5.74   10.76       0
     1048576        262144     float     sum      -1    97.55   10.75   20.16       0    97.00   10.81   20.27       0
     2097152        524288     float     sum      -1   109.56   19.14   35.89       0   110.80   18.93   35.49       0
     4194304       1048576     float     sum      -1   139.79   30.00   56.26       0   141.73   29.59   55.49       0
     8388608       2097152     float     sum      -1   153.14   54.78  102.71       0   155.10   54.08  101.41       0
    16777216       4194304     float     sum      -1   189.00   88.77  166.44       0   193.26   86.81  162.77       0
    33554432       8388608     float     sum      -1   283.43  118.39  221.98       0   283.00  118.57  222.31       0
    67108864      16777216     float     sum      -1   394.06  170.30  319.31       0   392.35  171.04  320.71       0
   134217728      33554432     float     sum      -1   596.39  225.05  421.97       0   597.03  224.81  421.51       0
   268435456      67108864     float     sum      -1  1023.87  262.18  491.58       0  1025.24  261.83  490.93       0
   536870912     134217728     float     sum      -1  1988.76  269.95  506.16       0  1990.46  269.72  505.73       0
  1073741824     268435456     float     sum      -1  3910.37  274.59  514.85       0  3910.56  274.57  514.83       0
  2147483648     536870912     float     sum      -1  5606.43  383.04  718.20       0  5615.47  382.42  717.04       0
  4294967296    1073741824     float     sum      -1  10827.2  396.68  743.78       0  10911.1  393.63  738.06       0
  8589934592    2147483648     float     sum      -1  21327.9  402.76  755.17       0  21412.5  401.16  752.18       0

# Out of bounds values : 0 OK
# Avg bus bandwidth    : 164.191
#
```