### PR TITLE
fix(backends/vastai): route /instances/ to /api/v1/ (v0 deprecated, returns HTTP 410)

### DIFF
--- a/src/dstack/_internal/core/backends/vastai/api_client.py
+++ b/src/dstack/_internal/core/backends/vastai/api_client.py
@@ -135,7 +135,13 @@ class VastAIAPIClient:
             return False
 
     def _url(self, path):
-        return f"{self.api_url}/{path.lstrip('/')}?api_key={self.api_key}"
+        base = self.api_url
+        # Vast.ai deprecated /api/v0/instances/ (HTTP 410). /api/v1/instances/
+        # returns a schema-compatible response (success flag + instances list).
+        # /bundles/ and /asks/ remain on v0; v1 is not yet published for them.
+        if path.lstrip("/").startswith("instances/"):
+            base = base.replace("/api/v0", "/api/v1")
+        return f"{base}/{path.lstrip('/')}?api_key={self.api_key}"
 
     def _invalidate_cache(self):
         with self.lock:


### PR DESCRIPTION
## Problem

`VastAIAPIClient._url()` in `src/dstack/_internal/core/backends/vastai/api_client.py` hardcodes `https://console.vast.ai/api/v0` for all Vast API calls. Vast.ai has deprecated **only the `/api/v0/instances/` path family** — the endpoint now responds with **HTTP 410 `deprecated_endpoint`**.

Reproduction (any current dstack release, including `master` and PyPI 0.20.24):

```bash
curl -sS -o /dev/null -w '%{http_code}\n' "https://console.vast.ai/api/v0/instances/?api_key=$VASTAI_API_KEY"
# -> 410
curl -sS -o /dev/null -w '%{http_code}\n' "https://console.vast.ai/api/v1/instances/?api_key=$VASTAI_API_KEY"
# -> 200
```

This breaks `vastai` backend registration: `auth_test()` calls `get_instances()`, the 410 is raised as an HTTPError, dstack reports it back to the operator as **"Invalid credentials"**. The API key is fine — the URL is dead.

`/bundles/` and `/asks/` still work on v0 (v1 is not yet published for them), so offer queries and instance creation are unaffected — only the `/instances/` family needs the v1 prefix.

## Fix

Route paths under `/instances/` (covers `get_instances`, `destroy_instance`, `request_logs`) to `/api/v1/`. Leave `/bundles/` and `/asks/` on v0. The v1 instances response preserves the existing schema (`success` flag, `instances` list); it adds pagination fields the existing code ignores.

## Verification

Applied to a self-hosted dstack 0.20.23 broker. Before: backend registration fails with "Invalid credentials". After patch + restart:

- `POST /api/project/<p>/backends/create_yaml` → 200
- Project backends list includes `vastai`
- `dstack offer --backend vastai --gpu A6000` returns 7+ live offers
- `dstack apply` of a task config successfully provisions a Vast.ai instance through the patched code path (instance transitions provisioning → running cleanly)

## Notes

- Targeted patch — only the `_url()` helper changes. No new dependencies, no behavioral change for `bundles`/`asks` callers.
- Bug exists on `master` and on every tagged release I checked (0.20.20 through 0.20.24).
- If Vast publishes `/api/v1/bundles/` and `/api/v1/asks/` later, the same conditional shape will accept additional path prefixes cleanly.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
