### PR TITLE
Fix runtime error with grpcio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,7 @@ server = [
     "asyncpg",
     "python-json-logger>=3.1.0",
     "prometheus-client",
-    "grpcio>=1.50",
+    "grpcio>=1.81.0",
     "protobuf>=6.33.5",
     "smg-grpc-proto>=0.4.7",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,7 +202,7 @@ server = [
     "prometheus-client",
     "grpcio>=1.81.0",
     "protobuf>=6.33.5",
-    "smg-grpc-proto>=0.4.7",
+    "smg-grpc-proto==0.4.9", # Pin to avoid grpcio version mismatch when smg-grpc-proto bumps grpcio dependency https://github.com/dstackai/dstack/pull/3971
 ]
 aws = [
     "boto3>=1.38.13",


### PR DESCRIPTION
Fixes issue #3957 
Supporting `grpcio<1.81` would require pinning `smg-grpc-proto<=0.4.8`, since 0.4.9+ stubs enforce grpcio>=1.81 at import time. Pinning smg-grpc-proto<=0.4.8 keeps us on older pre-built stubs and blocks newer fixes, which is risky long-term. Therefore this PR prefers pinning `grpcio>=1.81.0` instead.