### PR TITLE
Improve replicated gateway display in older CLIs

### DIFF
--- a/src/dstack/_internal/server/compatibility/gateways.py
+++ b/src/dstack/_internal/server/compatibility/gateways.py
@@ -8,8 +8,8 @@ from dstack._internal.core.models.gateways import Gateway
 def patch_gateway(gateway: Gateway, client_version: Optional[Version]) -> None:
     if client_version is None:
         return
-    if client_version < Version("0.20.25") and len(gateway.replicas) < 2:
+    if client_version < Version("0.20.25"):
         gateway.instance_id = ""
-        gateway.ip_address = gateway.replicas[0].hostname if gateway.replicas else ""
+        gateway.ip_address = "\n".join(r.hostname for r in gateway.replicas)
         if gateway.hostname is None:
             gateway.hostname = gateway.ip_address

--- a/src/tests/_internal/server/compatibility/test_gateways.py
+++ b/src/tests/_internal/server/compatibility/test_gateways.py
@@ -80,9 +80,10 @@ class TestPatchGateway:
         assert gw.instance_id == ""
         assert gw.hostname == ""
 
-    def test_old_version_multi_replica_is_noop(self):
+    def test_old_version_multi_replica_concatenates_hostnames(self):
         replicas = [_make_gateway_replica("1.2.3.4"), _make_gateway_replica("5.6.7.8")]
         gw = _make_gateway(replicas=replicas)
         patch_gateway(gw, Version("0.20.24"))
-        assert gw.ip_address is None
-        assert gw.instance_id is None
+        assert gw.hostname == "1.2.3.4\n5.6.7.8"
+        assert gw.ip_address == "1.2.3.4\n5.6.7.8"
+        assert gw.instance_id == ""


### PR DESCRIPTION
Adjust server-side gateway object patching for
pre-0.20.25 clients, so that such clients display
all replica hostnames (even though they are not
aware of replicated gateways).

Before:

```shell
$ dstack --version
0.20.24

$ dstack gateway list
 NAME        BACKEND         HOSTNAME  DOMAIN       DEFAULT  STATUS
 replicated  gcp (us-west4)            example.com           running
```

After:

```shell
$ dstack gateway list
 NAME        BACKEND         HOSTNAME        DOMAIN       DEFAULT  STATUS
 replicated  gcp (us-west4)  34.125.203.210  example.com           running
                             34.186.30.65
```

#3959