### PR TITLE
Optimize /api/runs/list job loading

### DIFF
--- a/frontend/src/layouts/AppLayout/TutorialPanel/hooks.ts
+++ b/frontend/src/layouts/AppLayout/TutorialPanel/hooks.ts
@@ -47,6 +47,7 @@ export const useTutorials = () => {
     const { data: projectData } = useGetProjectsQuery({});
     const { data: runsData } = useGetRunsQuery({
         limit: 1,
+        job_submissions_limit: 1,
     });
 
     const completeIsChecked = useRef<boolean>(false);

--- a/frontend/src/pages/Project/Details/Settings/index.tsx
+++ b/frontend/src/pages/Project/Details/Settings/index.tsx
@@ -86,6 +86,7 @@ export const ProjectSettings: React.FC = () => {
     const { data: runsData } = useGetRunsQuery({
         project_name: paramProjectName,
         limit: 1,
+        job_submissions_limit: 1,
     });
 
     useEffect(() => {

--- a/src/dstack/_internal/cli/commands/ps.py
+++ b/src/dstack/_internal/cli/commands/ps.py
@@ -67,6 +67,7 @@ class PsCommand(APIBaseCommand):
         if args.watch and args.format == "json":
             raise CLIError("JSON output is not supported together with --watch")
 
+        # TODO: Add a `ps --json` option to control how many job submissions are returned.
         runs = self.api.runs.list(all=args.all, limit=args.last)
         deprecated_router_runs = [
             run._run.run_spec.run_name

--- a/src/dstack/_internal/server/services/projects.py
+++ b/src/dstack/_internal/server/services/projects.py
@@ -469,19 +469,24 @@ async def list_user_project_models(
     user: UserModel,
     only_names: bool = False,
     include_members: bool = False,
+    project_names: Optional[List[str]] = None,
 ) -> List[ProjectModel]:
     load_only_attrs = []
     if only_names:
         load_only_attrs += [ProjectModel.id, ProjectModel.name]
     if user.global_role == GlobalRole.ADMIN:
         return await list_project_models(
-            session=session, load_only_attrs=load_only_attrs, include_members=include_members
+            session=session,
+            load_only_attrs=load_only_attrs,
+            include_members=include_members,
+            project_names=project_names,
         )
     return await list_member_project_models(
         session=session,
         user=user,
         load_only_attrs=load_only_attrs,
         include_members=include_members,
+        project_names=project_names,
     )
 
 
@@ -490,6 +495,7 @@ async def list_member_project_models(
     user: UserModel,
     include_members: bool = False,
     load_only_attrs: Optional[List[QueryableAttribute]] = None,
+    project_names: Optional[List[str]] = None,
 ) -> List[ProjectModel]:
     """
     List project models for a user where they are a member.
@@ -499,15 +505,14 @@ async def list_member_project_models(
         options.append(joinedload(ProjectModel.members))
     if load_only_attrs:
         options.append(load_only(*load_only_attrs))
-    res = await session.execute(
-        select(ProjectModel)
-        .where(
-            MemberModel.project_id == ProjectModel.id,
-            MemberModel.user_id == user.id,
-            ProjectModel.deleted == False,
-        )
-        .options(*options)
-    )
+    filters = [
+        MemberModel.project_id == ProjectModel.id,
+        MemberModel.user_id == user.id,
+        ProjectModel.deleted == False,
+    ]
+    if project_names is not None:
+        filters.append(ProjectModel.name.in_(project_names))
+    res = await session.execute(select(ProjectModel).where(*filters).options(*options))
     return list(res.scalars().unique().all())
 
 
@@ -547,15 +552,17 @@ async def list_project_models(
     session: AsyncSession,
     load_only_attrs: Optional[List[QueryableAttribute]] = None,
     include_members: bool = False,
+    project_names: Optional[List[str]] = None,
 ) -> List[ProjectModel]:
     options = []
     if include_members:
         options.append(joinedload(ProjectModel.members))
     if load_only_attrs:
         options.append(load_only(*load_only_attrs))
-    res = await session.execute(
-        select(ProjectModel).where(ProjectModel.deleted == False).options(*options)
-    )
+    filters = [ProjectModel.deleted == False]
+    if project_names is not None:
+        filters.append(ProjectModel.name.in_(project_names))
+    res = await session.execute(select(ProjectModel).where(*filters).options(*options))
     return list(res.scalars().unique().all())
 
 

--- a/src/dstack/_internal/server/services/runs/__init__.py
+++ b/src/dstack/_internal/server/services/runs/__init__.py
@@ -52,6 +52,7 @@ from dstack._internal.server.models import (
     UserModel,
 )
 from dstack._internal.server.services import events, services
+from dstack._internal.server.services import projects as projects_services
 from dstack._internal.server.services import repos as repos_services
 from dstack._internal.server.services.jobs import (
     check_can_attach_job_volumes,
@@ -178,11 +179,13 @@ async def list_user_runs(
     repo = None
     project = None
     if project_name is not None:
-        project = await _get_project_model(
+        projects = await projects_services.list_user_project_models(
             session=session,
             user=user,
-            project_name=project_name,
+            only_names=True,
+            project_names=[project_name],
         )
+        project = next(iter(projects), None)
         if project is None:
             return []
         if repo_id is not None:
@@ -229,31 +232,6 @@ async def list_user_runs(
     if len(run_models) > len(runs):
         logger.debug("Can't load %s runs", len(run_models) - len(runs))
     return runs
-
-
-async def _get_project_model(
-    session: AsyncSession,
-    user: UserModel,
-    project_name: str,
-) -> Optional[ProjectModel]:
-    """
-    Resolve project_name and check user access for the runs list.
-
-    This avoids loading project relations that are not used by runs list responses.
-    """
-    filters = [
-        ProjectModel.name == project_name,
-        ProjectModel.deleted == False,
-    ]
-    if user.global_role != GlobalRole.ADMIN:
-        filters.extend(
-            [
-                MemberModel.project_id == ProjectModel.id,
-                MemberModel.user_id == user.id,
-            ]
-        )
-    res = await session.execute(select(ProjectModel).where(*filters))
-    return res.scalar()
 
 
 async def list_projects_run_models(
@@ -399,16 +377,19 @@ async def _list_job_models(
         )
         return list(res.unique().scalars().all())
 
-    requested_jobs = await _list_requested_job_submissions(
+    requested_jobs = await _list_latest_job_models_per_job(
         session=session,
         run_ids=run_ids,
-        job_submissions_limit=max(job_submissions_limit, 1),
+        limit_per_job=max(job_submissions_limit, 1),
         include_probes=include_probes,
     )
-    # Extra rows used only to preserve run.status_message, e.g. `retrying`.
-    status_message_jobs = await _list_status_message_jobs(
+    # Also load rows needed to preserve run.status_message, e.g. `retrying`.
+    status_message_jobs = await _list_latest_job_models_per_job(
         session=session,
         run_ids=run_ids,
+        limit_per_job=1,
+        include_probes=False,
+        only_with_termination_reason=True,
     )
 
     # Merge the two job lists by ID because the same row may appear in both.
@@ -418,35 +399,6 @@ async def _list_job_models(
     return sorted(
         jobs_by_id.values(),
         key=lambda j: (j.run_id, j.replica_num, j.job_num, j.submission_num),
-    )
-
-
-async def _list_requested_job_submissions(
-    session: AsyncSession,
-    run_ids: List[uuid.UUID],
-    job_submissions_limit: int,
-    include_probes: bool,
-) -> List[JobModel]:
-    """List submissions requested by job_submissions_limit."""
-    return await _list_latest_job_models_per_job(
-        session=session,
-        run_ids=run_ids,
-        limit_per_job=job_submissions_limit,
-        include_probes=include_probes,
-    )
-
-
-async def _list_status_message_jobs(
-    session: AsyncSession,
-    run_ids: List[uuid.UUID],
-) -> List[JobModel]:
-    """List jobs with termination reasons used to compute run.status_message."""
-    return await _list_latest_job_models_per_job(
-        session=session,
-        run_ids=run_ids,
-        limit_per_job=1,
-        include_probes=False,
-        only_with_termination_reason=True,
     )
 
 

--- a/src/dstack/_internal/server/services/runs/__init__.py
+++ b/src/dstack/_internal/server/services/runs/__init__.py
@@ -11,7 +11,6 @@ from apscheduler.triggers.cron import CronTrigger
 from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, joinedload, noload, selectinload
-from sqlalchemy.orm.attributes import set_committed_value
 
 import dstack._internal.utils.common as common_utils
 from dstack._internal.core.errors import (
@@ -179,7 +178,7 @@ async def list_user_runs(
     repo = None
     project = None
     if project_name is not None:
-        project = await _get_project_model_for_runs_list(
+        project = await _get_project_model(
             session=session,
             user=user,
             project_name=project_name,
@@ -206,7 +205,7 @@ async def list_user_runs(
         limit=limit,
         ascending=ascending,
     )
-    await _load_run_jobs_for_list(
+    jobs_by_run = await _list_job_models_by_run_id(
         session=session,
         run_models=run_models,
         include_jobs=include_jobs,
@@ -222,6 +221,7 @@ async def list_user_runs(
                     return_in_api=True,
                     include_jobs=include_jobs,
                     job_submissions_limit=job_submissions_limit,
+                    loaded_jobs=jobs_by_run.get(r.id, []),
                 )
             )
         except pydantic.ValidationError:
@@ -231,11 +231,16 @@ async def list_user_runs(
     return runs
 
 
-async def _get_project_model_for_runs_list(
+async def _get_project_model(
     session: AsyncSession,
     user: UserModel,
     project_name: str,
 ) -> Optional[ProjectModel]:
+    """
+    Resolve project_name and check user access for the runs list.
+
+    This avoids loading project relations that are not used by runs list responses.
+    """
     filters = [
         ProjectModel.name == project_name,
         ProjectModel.deleted == False,
@@ -265,12 +270,15 @@ async def list_projects_run_models(
 ) -> List[RunModel]:
     filters = []
     if project is not None:
+        # Project-scoped list.
         filters.append(RunModel.project_id == project.id)
     elif user.global_role == GlobalRole.ADMIN:
+        # Global admins can list runs from all non-deleted projects.
         filters.append(
             RunModel.project_id.in_(select(ProjectModel.id).where(ProjectModel.deleted == False))
         )
     else:
+        # Regular users can list runs only from projects they belong to.
         filters.append(
             RunModel.project_id.in_(
                 select(MemberModel.project_id)
@@ -331,40 +339,53 @@ async def list_projects_run_models(
     return run_models
 
 
-async def _load_run_jobs_for_list(
+async def _list_job_models_by_run_id(
     session: AsyncSession,
     run_models: List[RunModel],
     include_jobs: bool,
     job_submissions_limit: Optional[int],
     return_in_api: bool,
-) -> None:
+) -> dict[uuid.UUID, List[JobModel]]:
+    """
+    List only the job rows needed for runs list responses, grouped by run ID.
+
+    This avoids loading every historical submission through RunModel.jobs.
+    """
     if len(run_models) == 0:
-        return
+        return {}
 
     effective_job_submissions_limit = job_submissions_limit if include_jobs else 0
-    jobs = await _list_jobs_for_runs_list(
+    jobs = await _list_job_models(
         session=session,
         run_ids=[r.id for r in run_models],
         job_submissions_limit=effective_job_submissions_limit,
         include_probes=include_jobs and return_in_api,
     )
-    jobs_by_run = defaultdict(list)
+    jobs_by_run: defaultdict[uuid.UUID, List[JobModel]] = defaultdict(list)
     for job in jobs:
         jobs_by_run[job.run_id].append(job)
-    for run_model in run_models:
-        set_committed_value(run_model, "jobs", jobs_by_run.get(run_model.id, []))
+    return dict(jobs_by_run)
 
 
-async def _list_jobs_for_runs_list(
+async def _list_job_models(
     session: AsyncSession,
     run_ids: List[uuid.UUID],
     job_submissions_limit: Optional[int],
     include_probes: bool,
 ) -> List[JobModel]:
+    """
+    List job models for runs list responses.
+
+    When job_submissions_limit is set, include up to job_submissions_limit latest
+    submissions per job plus the latest terminated submission per job. This gives
+    run_model_to_run enough data without loading every historical submission.
+    """
     options = []
     if include_probes:
         options.append(joinedload(JobModel.probes))
     if job_submissions_limit is None:
+        # With no job_submissions_limit, return full submission history. This
+        # can be slow. UI/CLI list views pass a limit, but API callers may omit it.
         res = await session.execute(
             select(JobModel)
             .where(JobModel.run_id.in_(run_ids))
@@ -378,18 +399,21 @@ async def _list_jobs_for_runs_list(
         )
         return list(res.unique().scalars().all())
 
-    jobs = await _list_latest_jobs_for_runs_list(
+    requested_jobs = await _list_requested_job_submissions(
         session=session,
         run_ids=run_ids,
         job_submissions_limit=max(job_submissions_limit, 1),
         include_probes=include_probes,
     )
-    latest_termination_jobs = await _list_latest_termination_jobs_for_runs_list(
+    # Extra rows used only to preserve run.status_message, e.g. `retrying`.
+    status_message_jobs = await _list_status_message_jobs(
         session=session,
         run_ids=run_ids,
     )
-    jobs_by_id = {job.id: job for job in jobs}
-    for job in latest_termination_jobs:
+
+    # Merge the two job lists by ID because the same row may appear in both.
+    jobs_by_id = {job.id: job for job in requested_jobs}
+    for job in status_message_jobs:
         jobs_by_id.setdefault(job.id, job)
     return sorted(
         jobs_by_id.values(),
@@ -397,12 +421,49 @@ async def _list_jobs_for_runs_list(
     )
 
 
-async def _list_latest_jobs_for_runs_list(
+async def _list_requested_job_submissions(
     session: AsyncSession,
     run_ids: List[uuid.UUID],
     job_submissions_limit: int,
     include_probes: bool,
 ) -> List[JobModel]:
+    """List submissions requested by job_submissions_limit."""
+    return await _list_latest_job_models_per_job(
+        session=session,
+        run_ids=run_ids,
+        limit_per_job=job_submissions_limit,
+        include_probes=include_probes,
+    )
+
+
+async def _list_status_message_jobs(
+    session: AsyncSession,
+    run_ids: List[uuid.UUID],
+) -> List[JobModel]:
+    """List jobs with termination reasons used to compute run.status_message."""
+    return await _list_latest_job_models_per_job(
+        session=session,
+        run_ids=run_ids,
+        limit_per_job=1,
+        include_probes=False,
+        only_with_termination_reason=True,
+    )
+
+
+async def _list_latest_job_models_per_job(
+    session: AsyncSession,
+    run_ids: List[uuid.UUID],
+    limit_per_job: int,
+    include_probes: bool,
+    only_with_termination_reason: bool = False,
+) -> List[JobModel]:
+    """
+    List up to N newest submissions for each job.
+
+    A newer submission has a higher submission_num. The SQL window applies the
+    per-job limit in the database instead of loading all retries and slicing them
+    in Python.
+    """
     row_number = (
         func.row_number()
         .over(
@@ -411,12 +472,15 @@ async def _list_latest_jobs_for_runs_list(
         )
         .label("row_number")
     )
+    filters = [JobModel.run_id.in_(run_ids)]
+    if only_with_termination_reason:
+        filters.append(JobModel.termination_reason.isnot(None))
     jobs_sq = (
         select(
             JobModel,
             row_number,
         )
-        .where(JobModel.run_id.in_(run_ids))
+        .where(*filters)
         .subquery()
     )
     job_alias = aliased(JobModel, jobs_sq)
@@ -425,7 +489,7 @@ async def _list_latest_jobs_for_runs_list(
         options.append(joinedload(job_alias.probes))
     res = await session.execute(
         select(job_alias)
-        .where(jobs_sq.c.row_number <= job_submissions_limit)
+        .where(jobs_sq.c.row_number <= limit_per_job)
         .options(*options)
         .order_by(
             job_alias.run_id,
@@ -435,43 +499,6 @@ async def _list_latest_jobs_for_runs_list(
         )
     )
     return list(res.unique().scalars().all())
-
-
-async def _list_latest_termination_jobs_for_runs_list(
-    session: AsyncSession,
-    run_ids: List[uuid.UUID],
-) -> List[JobModel]:
-    row_number = (
-        func.row_number()
-        .over(
-            partition_by=(JobModel.run_id, JobModel.replica_num, JobModel.job_num),
-            order_by=JobModel.submission_num.desc(),
-        )
-        .label("row_number")
-    )
-    jobs_sq = (
-        select(
-            JobModel,
-            row_number,
-        )
-        .where(
-            JobModel.run_id.in_(run_ids),
-            JobModel.termination_reason.isnot(None),
-        )
-        .subquery()
-    )
-    job_alias = aliased(JobModel, jobs_sq)
-    res = await session.execute(
-        select(job_alias)
-        .where(jobs_sq.c.row_number == 1)
-        .order_by(
-            job_alias.run_id,
-            job_alias.replica_num,
-            job_alias.job_num,
-            job_alias.submission_num,
-        )
-    )
-    return list(res.scalars().all())
 
 
 async def get_run(
@@ -974,14 +1001,18 @@ def run_model_to_run(
     return_in_api: bool = False,
     include_sensitive: bool = False,
     include_job_connection_info: bool = False,
+    loaded_jobs: Optional[List[JobModel]] = None,
 ) -> Run:
     run_spec = get_run_spec(run_model)
+    # Runs-list passes an explicitly bounded job set. Detail/update paths use
+    # the ORM relationship loaded by their queries.
+    job_models = loaded_jobs if loaded_jobs is not None else run_model.jobs
 
     jobs: List[Job] = []
     if include_jobs:
         jobs = _get_run_jobs_with_submissions(
-            run_model=run_model,
             run_spec=run_spec,
+            job_models=job_models,
             job_submissions_limit=job_submissions_limit,
             return_in_api=return_in_api,
             include_sensitive=include_sensitive,
@@ -997,7 +1028,7 @@ def run_model_to_run(
     if run_model.service_spec is not None:
         service_spec = ServiceSpec.__response__.parse_raw(run_model.service_spec)
 
-    status_message = _get_run_status_message(run_model)
+    status_message = _get_run_status_message(run_model, job_models=job_models)
     error = _get_run_error(run_model)
     fleet = _get_run_fleet(run_model)
     next_triggered_at = None
@@ -1039,28 +1070,29 @@ def _set_run_resources_defaults(run_spec: RunSpec) -> None:
 
 
 def _get_run_jobs_with_submissions(
-    run_model: RunModel,
     run_spec: RunSpec,
+    job_models: List[JobModel],
     job_submissions_limit: Optional[int],
     return_in_api: bool = False,
     include_sensitive: bool = False,
     include_job_connection_info: bool = False,
 ) -> List[Job]:
     jobs: List[Job] = []
-    run_jobs = sorted(run_model.jobs, key=lambda j: (j.replica_num, j.job_num, j.submission_num))
+    run_jobs = sorted(job_models, key=lambda j: (j.replica_num, j.job_num, j.submission_num))
     for replica_num, replica_submissions in itertools.groupby(
         run_jobs, key=lambda j: j.replica_num
     ):
-        for job_num, job_models in itertools.groupby(replica_submissions, key=lambda j: j.job_num):
+        for job_num, job_group in itertools.groupby(replica_submissions, key=lambda j: j.job_num):
+            job_submissions = list(job_group)
             submissions = []
             job_model = None
             if job_submissions_limit is not None:
                 if job_submissions_limit == 0:
                     # Take latest job submission to return its job_spec
-                    job_models = list(job_models)[-1:]
+                    job_submissions = job_submissions[-1:]
                 else:
-                    job_models = list(job_models)[-job_submissions_limit:]
-            for job_model in job_models:
+                    job_submissions = job_submissions[-job_submissions_limit:]
+            for job_model in job_submissions:
                 if job_submissions_limit != 0:
                     job_submission = job_model_to_job_submission(
                         job_model, include_probes=return_in_api
@@ -1092,12 +1124,12 @@ def _get_run_jobs_with_submissions(
     return jobs
 
 
-def _get_run_status_message(run_model: RunModel) -> str:
-    if len(run_model.jobs) == 0:
+def _get_run_status_message(run_model: RunModel, job_models: List[JobModel]) -> str:
+    if len(job_models) == 0:
         return run_model.status.value
 
     sorted_job_models = sorted(
-        run_model.jobs, key=lambda j: (j.replica_num, j.job_num, j.submission_num)
+        job_models, key=lambda j: (j.replica_num, j.job_num, j.submission_num)
     )
     job_models_grouped_by_job = list(
         list(jm)

--- a/src/dstack/_internal/server/services/runs/__init__.py
+++ b/src/dstack/_internal/server/services/runs/__init__.py
@@ -1,6 +1,7 @@
 import itertools
 import math
 import uuid
+from collections import defaultdict
 from collections.abc import Iterable
 from datetime import datetime, timezone
 from typing import List, Optional
@@ -9,7 +10,8 @@ import pydantic
 from apscheduler.triggers.cron import CronTrigger
 from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload, selectinload
+from sqlalchemy.orm import aliased, joinedload, noload, selectinload
+from sqlalchemy.orm.attributes import set_committed_value
 
 import dstack._internal.utils.common as common_utils
 from dstack._internal.core.errors import (
@@ -37,11 +39,13 @@ from dstack._internal.core.models.runs import (
     RunTerminationReason,
     ServiceSpec,
 )
+from dstack._internal.core.models.users import GlobalRole
 from dstack._internal.core.services.diff import format_diff_fields_for_event
 from dstack._internal.server.db import get_db, is_db_postgres, is_db_sqlite
 from dstack._internal.server.models import (
     FleetModel,
     JobModel,
+    MemberModel,
     ProbeModel,
     ProjectModel,
     RepoModel,
@@ -63,7 +67,6 @@ from dstack._internal.server.services.locking import get_locker, string_to_lock_
 from dstack._internal.server.services.pipelines import PipelineHinterProtocol
 from dstack._internal.server.services.plugins import apply_plugin_policies
 from dstack._internal.server.services.probes import is_probe_ready
-from dstack._internal.server.services.projects import list_user_project_models
 from dstack._internal.server.services.resources import (
     set_gpu_vendor_default,
     set_resources_defaults,
@@ -168,32 +171,33 @@ async def list_user_runs(
 ) -> List[Run]:
     if project_name is None and repo_id is not None:
         return []
-    projects = await list_user_project_models(
-        session=session,
-        user=user,
-        only_names=True,
-    )
     runs_user = None
     if username is not None:
         runs_user = await get_user_model_by_name(session=session, username=username)
         if runs_user is None:
             raise ResourceNotExistsError("User not found")
     repo = None
+    project = None
     if project_name is not None:
-        projects = [p for p in projects if p.name == project_name]
-        if len(projects) == 0:
+        project = await _get_project_model_for_runs_list(
+            session=session,
+            user=user,
+            project_name=project_name,
+        )
+        if project is None:
             return []
         if repo_id is not None:
             repo = await repos_services.get_repo_model(
                 session=session,
-                project=projects[0],
+                project=project,
                 repo_id=repo_id,
             )
             if repo is None:
                 raise RepoDoesNotExistError.with_id(repo_id)
     run_models = await list_projects_run_models(
         session=session,
-        projects=projects,
+        user=user,
+        project=project,
         repo=repo,
         runs_user=runs_user,
         only_active=only_active,
@@ -201,6 +205,13 @@ async def list_user_runs(
         prev_run_id=prev_run_id,
         limit=limit,
         ascending=ascending,
+    )
+    await _load_run_jobs_for_list(
+        session=session,
+        run_models=run_models,
+        include_jobs=include_jobs,
+        job_submissions_limit=job_submissions_limit,
+        return_in_api=True,
     )
     runs = []
     for r in run_models:
@@ -220,9 +231,30 @@ async def list_user_runs(
     return runs
 
 
+async def _get_project_model_for_runs_list(
+    session: AsyncSession,
+    user: UserModel,
+    project_name: str,
+) -> Optional[ProjectModel]:
+    filters = [
+        ProjectModel.name == project_name,
+        ProjectModel.deleted == False,
+    ]
+    if user.global_role != GlobalRole.ADMIN:
+        filters.extend(
+            [
+                MemberModel.project_id == ProjectModel.id,
+                MemberModel.user_id == user.id,
+            ]
+        )
+    res = await session.execute(select(ProjectModel).where(*filters))
+    return res.scalar()
+
+
 async def list_projects_run_models(
     session: AsyncSession,
-    projects: List[ProjectModel],
+    user: UserModel,
+    project: Optional[ProjectModel],
     repo: Optional[RepoModel],
     runs_user: Optional[UserModel],
     only_active: bool,
@@ -232,7 +264,24 @@ async def list_projects_run_models(
     ascending: bool,
 ) -> List[RunModel]:
     filters = []
-    filters.append(RunModel.project_id.in_(p.id for p in projects))
+    if project is not None:
+        filters.append(RunModel.project_id == project.id)
+    elif user.global_role == GlobalRole.ADMIN:
+        filters.append(
+            RunModel.project_id.in_(select(ProjectModel.id).where(ProjectModel.deleted == False))
+        )
+    else:
+        filters.append(
+            RunModel.project_id.in_(
+                select(MemberModel.project_id)
+                .where(MemberModel.user_id == user.id)
+                .where(
+                    MemberModel.project_id.in_(
+                        select(ProjectModel.id).where(ProjectModel.deleted == False)
+                    )
+                )
+            )
+        )
     if repo is not None:
         filters.append(RunModel.repo_id == repo.id)
     if runs_user is not None:
@@ -271,14 +320,158 @@ async def list_projects_run_models(
     res = await session.execute(
         select(RunModel)
         .where(*filters)
+        .options(joinedload(RunModel.project).load_only(ProjectModel.id, ProjectModel.name))
         .options(joinedload(RunModel.user).load_only(UserModel.name))
         .options(joinedload(RunModel.fleet).load_only(FleetModel.id, FleetModel.name))
-        .options(selectinload(RunModel.jobs).joinedload(JobModel.probes))
+        .options(noload(RunModel.jobs))
         .order_by(*order_by)
         .limit(limit)
     )
     run_models = list(res.scalars().all())
     return run_models
+
+
+async def _load_run_jobs_for_list(
+    session: AsyncSession,
+    run_models: List[RunModel],
+    include_jobs: bool,
+    job_submissions_limit: Optional[int],
+    return_in_api: bool,
+) -> None:
+    if len(run_models) == 0:
+        return
+
+    effective_job_submissions_limit = job_submissions_limit if include_jobs else 0
+    jobs = await _list_jobs_for_runs_list(
+        session=session,
+        run_ids=[r.id for r in run_models],
+        job_submissions_limit=effective_job_submissions_limit,
+        include_probes=include_jobs and return_in_api,
+    )
+    jobs_by_run = defaultdict(list)
+    for job in jobs:
+        jobs_by_run[job.run_id].append(job)
+    for run_model in run_models:
+        set_committed_value(run_model, "jobs", jobs_by_run.get(run_model.id, []))
+
+
+async def _list_jobs_for_runs_list(
+    session: AsyncSession,
+    run_ids: List[uuid.UUID],
+    job_submissions_limit: Optional[int],
+    include_probes: bool,
+) -> List[JobModel]:
+    options = []
+    if include_probes:
+        options.append(joinedload(JobModel.probes))
+    if job_submissions_limit is None:
+        res = await session.execute(
+            select(JobModel)
+            .where(JobModel.run_id.in_(run_ids))
+            .options(*options)
+            .order_by(
+                JobModel.run_id,
+                JobModel.replica_num,
+                JobModel.job_num,
+                JobModel.submission_num,
+            )
+        )
+        return list(res.unique().scalars().all())
+
+    jobs = await _list_latest_jobs_for_runs_list(
+        session=session,
+        run_ids=run_ids,
+        job_submissions_limit=max(job_submissions_limit, 1),
+        include_probes=include_probes,
+    )
+    latest_termination_jobs = await _list_latest_termination_jobs_for_runs_list(
+        session=session,
+        run_ids=run_ids,
+    )
+    jobs_by_id = {job.id: job for job in jobs}
+    for job in latest_termination_jobs:
+        jobs_by_id.setdefault(job.id, job)
+    return sorted(
+        jobs_by_id.values(),
+        key=lambda j: (j.run_id, j.replica_num, j.job_num, j.submission_num),
+    )
+
+
+async def _list_latest_jobs_for_runs_list(
+    session: AsyncSession,
+    run_ids: List[uuid.UUID],
+    job_submissions_limit: int,
+    include_probes: bool,
+) -> List[JobModel]:
+    row_number = (
+        func.row_number()
+        .over(
+            partition_by=(JobModel.run_id, JobModel.replica_num, JobModel.job_num),
+            order_by=JobModel.submission_num.desc(),
+        )
+        .label("row_number")
+    )
+    jobs_sq = (
+        select(
+            JobModel,
+            row_number,
+        )
+        .where(JobModel.run_id.in_(run_ids))
+        .subquery()
+    )
+    job_alias = aliased(JobModel, jobs_sq)
+    options = []
+    if include_probes:
+        options.append(joinedload(job_alias.probes))
+    res = await session.execute(
+        select(job_alias)
+        .where(jobs_sq.c.row_number <= job_submissions_limit)
+        .options(*options)
+        .order_by(
+            job_alias.run_id,
+            job_alias.replica_num,
+            job_alias.job_num,
+            job_alias.submission_num,
+        )
+    )
+    return list(res.unique().scalars().all())
+
+
+async def _list_latest_termination_jobs_for_runs_list(
+    session: AsyncSession,
+    run_ids: List[uuid.UUID],
+) -> List[JobModel]:
+    row_number = (
+        func.row_number()
+        .over(
+            partition_by=(JobModel.run_id, JobModel.replica_num, JobModel.job_num),
+            order_by=JobModel.submission_num.desc(),
+        )
+        .label("row_number")
+    )
+    jobs_sq = (
+        select(
+            JobModel,
+            row_number,
+        )
+        .where(
+            JobModel.run_id.in_(run_ids),
+            JobModel.termination_reason.isnot(None),
+        )
+        .subquery()
+    )
+    job_alias = aliased(JobModel, jobs_sq)
+    res = await session.execute(
+        select(job_alias)
+        .where(jobs_sq.c.row_number == 1)
+        .order_by(
+            job_alias.run_id,
+            job_alias.replica_num,
+            job_alias.job_num,
+            job_alias.submission_num,
+        )
+    )
+    return list(res.scalars().all())
 
 
 async def get_run(

--- a/src/dstack/api/_public/runs.py
+++ b/src/dstack/api/_public/runs.py
@@ -650,6 +650,7 @@ class RunCollection:
                 project_name=self._project,
                 repo_id=None,
                 limit=1,
+                job_submissions_limit=1,
             )
         return [self._model_to_run(run) for run in runs]
 

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -903,6 +903,7 @@ class TestListRuns:
         job2 = await create_job(
             session=session,
             run=run,
+            submission_num=1,
             submitted_at=run_submitted_at,
             last_processed_at=run_submitted_at,
         )
@@ -930,7 +931,7 @@ class TestListRuns:
                         "job_submissions": [
                             {
                                 "id": str(job2.id),
-                                "submission_num": 0,
+                                "submission_num": 1,
                                 "deployment_num": 0,
                                 "submitted_at": run_submitted_at.isoformat(),
                                 "last_processed_at": run_submitted_at.isoformat(),
@@ -953,7 +954,7 @@ class TestListRuns:
                 ],
                 "latest_job_submission": {
                     "id": str(job2.id),
-                    "submission_num": 0,
+                    "submission_num": 1,
                     "deployment_num": 0,
                     "submitted_at": run_submitted_at.isoformat(),
                     "last_processed_at": run_submitted_at.isoformat(),

--- a/src/tests/_internal/server/services/runs/test_runs.py
+++ b/src/tests/_internal/server/services/runs/test_runs.py
@@ -1,11 +1,327 @@
 import pytest
+from sqlalchemy import event, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from dstack._internal.core.errors import ServerClientError
 from dstack._internal.core.models.backends.base import BackendType
+from dstack._internal.core.models.profiles import Profile, ProfileRetry, RetryEvent
+from dstack._internal.core.models.runs import JobStatus, JobTerminationReason, RunStatus
+from dstack._internal.core.models.users import GlobalRole, ProjectRole
+from dstack._internal.server.models import UserModel
+from dstack._internal.server.services import runs as runs_services
 from dstack._internal.server.services.jobs import check_can_attach_job_volumes
+from dstack._internal.server.services.projects import add_project_member
 from dstack._internal.server.testing.common import (
+    create_job,
+    create_project,
+    create_repo,
+    create_run,
+    create_user,
+    get_run_spec,
     get_volume,
 )
+
+
+class TestListUserRuns:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    @pytest.mark.parametrize("include_jobs", [True, False])
+    async def test_limited_list_materializes_only_latest_and_status_jobs(
+        self,
+        test_db,
+        session: AsyncSession,
+        include_jobs: bool,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        user = await create_user(session=session, global_role=GlobalRole.USER)
+        project = await create_project(session=session, owner=user)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.USER
+        )
+        repo = await create_repo(session=session, project_id=project.id)
+        run_spec = get_run_spec(
+            repo_id=repo.name,
+            profile=Profile(
+                name="default",
+                retry=ProfileRetry(duration=3600, on_events=[RetryEvent.NO_CAPACITY]),
+            ),
+        )
+        run = await create_run(
+            session=session,
+            project=project,
+            repo=repo,
+            user=user,
+            status=RunStatus.PENDING,
+            run_spec=run_spec,
+        )
+        await create_job(
+            session=session,
+            run=run,
+            submission_num=0,
+            status=JobStatus.TERMINATED,
+            termination_reason=JobTerminationReason.FAILED_TO_START_DUE_TO_NO_CAPACITY,
+        )
+        for submission_num in range(1, 12):
+            await create_job(
+                session=session,
+                run=run,
+                submission_num=submission_num,
+                status=JobStatus.SUBMITTED,
+            )
+
+        user_id = user.id
+        project_name = project.name
+        session.expunge_all()
+        user = (
+            await session.execute(select(UserModel).where(UserModel.id == user_id))
+        ).scalar_one()
+        loaded_job_submission_nums = []
+        unbounded_job_selects = []
+        original_list_jobs = runs_services._list_jobs_for_runs_list
+
+        async def list_jobs_wrapper(*args, **kwargs):
+            jobs = await original_list_jobs(*args, **kwargs)
+            loaded_job_submission_nums.append(sorted(job.submission_num for job in jobs))
+            return jobs
+
+        monkeypatch.setattr(runs_services, "_list_jobs_for_runs_list", list_jobs_wrapper)
+
+        @event.listens_for(test_db.engine.sync_engine, "before_cursor_execute")
+        def before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+            normalized_statement = statement.lower()
+            if "from jobs" in normalized_statement and "row_number" not in normalized_statement:
+                unbounded_job_selects.append(statement)
+
+        try:
+            runs = await runs_services.list_user_runs(
+                session=session,
+                user=user,
+                project_name=project_name,
+                repo_id=None,
+                username=None,
+                only_active=False,
+                include_jobs=include_jobs,
+                job_submissions_limit=1,
+                prev_submitted_at=None,
+                prev_run_id=None,
+                limit=100,
+                ascending=False,
+            )
+        finally:
+            event.remove(
+                test_db.engine.sync_engine, "before_cursor_execute", before_cursor_execute
+            )
+
+        assert len(runs) == 1
+        assert runs[0].status_message == "retrying"
+        if include_jobs:
+            assert len(runs[0].jobs) == 1
+            assert [s.submission_num for s in runs[0].jobs[0].job_submissions] == [11]
+            assert runs[0].latest_job_submission is not None
+            assert runs[0].latest_job_submission.submission_num == 11
+        else:
+            assert runs[0].jobs == []
+            assert runs[0].latest_job_submission is None
+
+        assert loaded_job_submission_nums == [[0, 11]]
+        assert unbounded_job_selects == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    @pytest.mark.parametrize(
+        ("include_jobs", "job_submissions_limit"),
+        [
+            (True, 1),
+            (True, 0),
+            (True, None),
+            (False, 1),
+        ],
+    )
+    async def test_limited_list_preserves_status_message_matrix(
+        self,
+        test_db,
+        session: AsyncSession,
+        include_jobs: bool,
+        job_submissions_limit: int | None,
+    ) -> None:
+        user = await create_user(session=session, global_role=GlobalRole.USER)
+        project = await create_project(session=session, owner=user)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.USER
+        )
+        repo = await create_repo(session=session, project_id=project.id)
+        retry_profile = Profile(
+            name="default",
+            retry=ProfileRetry(duration=3600, on_events=[RetryEvent.NO_CAPACITY]),
+        )
+        no_retry_profile = Profile(name="default")
+
+        async def create_listed_run(
+            name: str,
+            status: RunStatus,
+            profile: Profile = no_retry_profile,
+        ):
+            run_spec = get_run_spec(repo_id=repo.name, run_name=name, profile=profile)
+            return await create_run(
+                session=session,
+                project=project,
+                repo=repo,
+                user=user,
+                run_name=name,
+                status=status,
+                run_spec=run_spec,
+            )
+
+        await create_listed_run("no-jobs", RunStatus.SUBMITTED)
+
+        all_pulling = await create_listed_run("all-pulling", RunStatus.PROVISIONING)
+        await create_job(
+            session=session,
+            run=all_pulling,
+            job_num=0,
+            submission_num=0,
+            status=JobStatus.DONE,
+        )
+        await create_job(
+            session=session,
+            run=all_pulling,
+            job_num=0,
+            submission_num=1,
+            status=JobStatus.PULLING,
+        )
+        await create_job(
+            session=session,
+            run=all_pulling,
+            job_num=1,
+            submission_num=0,
+            status=JobStatus.PULLING,
+        )
+
+        some_pulling = await create_listed_run("some-pulling", RunStatus.PROVISIONING)
+        await create_job(
+            session=session,
+            run=some_pulling,
+            job_num=0,
+            submission_num=0,
+            status=JobStatus.PULLING,
+        )
+        await create_job(
+            session=session,
+            run=some_pulling,
+            job_num=1,
+            submission_num=0,
+            status=JobStatus.RUNNING,
+        )
+
+        retrying = await create_listed_run(
+            "retrying",
+            RunStatus.PENDING,
+            profile=retry_profile,
+        )
+        await create_job(
+            session=session,
+            run=retrying,
+            submission_num=0,
+            status=JobStatus.TERMINATED,
+            termination_reason=JobTerminationReason.FAILED_TO_START_DUE_TO_NO_CAPACITY,
+        )
+        await create_job(
+            session=session,
+            run=retrying,
+            submission_num=1,
+            status=JobStatus.SUBMITTED,
+        )
+
+        no_retry = await create_listed_run("no-retry", RunStatus.PENDING)
+        await create_job(
+            session=session,
+            run=no_retry,
+            submission_num=0,
+            status=JobStatus.TERMINATED,
+            termination_reason=JobTerminationReason.FAILED_TO_START_DUE_TO_NO_CAPACITY,
+        )
+        await create_job(
+            session=session,
+            run=no_retry,
+            submission_num=1,
+            status=JobStatus.SUBMITTED,
+        )
+
+        newer_termination = await create_listed_run(
+            "newer-termination",
+            RunStatus.PENDING,
+            profile=retry_profile,
+        )
+        await create_job(
+            session=session,
+            run=newer_termination,
+            submission_num=0,
+            status=JobStatus.TERMINATED,
+            termination_reason=JobTerminationReason.FAILED_TO_START_DUE_TO_NO_CAPACITY,
+        )
+        await create_job(
+            session=session,
+            run=newer_termination,
+            submission_num=1,
+            status=JobStatus.FAILED,
+            termination_reason=JobTerminationReason.CONTAINER_EXITED_WITH_ERROR,
+        )
+        await create_job(
+            session=session,
+            run=newer_termination,
+            submission_num=2,
+            status=JobStatus.SUBMITTED,
+        )
+
+        finished_failed = await create_listed_run(
+            "finished-failed",
+            RunStatus.FAILED,
+            profile=retry_profile,
+        )
+        await create_job(
+            session=session,
+            run=finished_failed,
+            submission_num=0,
+            status=JobStatus.TERMINATED,
+            termination_reason=JobTerminationReason.FAILED_TO_START_DUE_TO_NO_CAPACITY,
+        )
+
+        user_id = user.id
+        project_name = project.name
+        session.expunge_all()
+        user = (
+            await session.execute(select(UserModel).where(UserModel.id == user_id))
+        ).scalar_one()
+
+        runs = await runs_services.list_user_runs(
+            session=session,
+            user=user,
+            project_name=project_name,
+            repo_id=None,
+            username=None,
+            only_active=False,
+            include_jobs=include_jobs,
+            job_submissions_limit=job_submissions_limit,
+            prev_submitted_at=None,
+            prev_run_id=None,
+            limit=100,
+            ascending=False,
+        )
+        status_messages = {run.run_spec.run_name: run.status_message for run in runs}
+
+        assert status_messages == {
+            "no-jobs": "submitted",
+            "all-pulling": "pulling",
+            "some-pulling": "provisioning",
+            "retrying": "retrying",
+            "no-retry": "pending",
+            "newer-termination": "pending",
+            "finished-failed": "failed",
+        }
+        if include_jobs and job_submissions_limit == 0:
+            assert all(len(job.job_submissions) == 0 for run in runs for job in run.jobs)
+        if not include_jobs:
+            assert all(run.jobs == [] for run in runs)
 
 
 class TestCanAttachRunVolumes:

--- a/src/tests/_internal/server/services/runs/test_runs.py
+++ b/src/tests/_internal/server/services/runs/test_runs.py
@@ -77,14 +77,14 @@ class TestListUserRuns:
         ).scalar_one()
         loaded_job_submission_nums = []
         unbounded_job_selects = []
-        original_list_jobs = runs_services._list_jobs_for_runs_list
+        original_list_jobs = runs_services._list_job_models
 
         async def list_jobs_wrapper(*args, **kwargs):
             jobs = await original_list_jobs(*args, **kwargs)
             loaded_job_submission_nums.append(sorted(job.submission_num for job in jobs))
             return jobs
 
-        monkeypatch.setattr(runs_services, "_list_jobs_for_runs_list", list_jobs_wrapper)
+        monkeypatch.setattr(runs_services, "_list_job_models", list_jobs_wrapper)
 
         @event.listens_for(test_db.engine.sync_engine, "before_cursor_execute")
         def before_cursor_execute(conn, cursor, statement, parameters, context, executemany):

--- a/src/tests/api/test_runs.py
+++ b/src/tests/api/test_runs.py
@@ -1,0 +1,29 @@
+from dstack.api._public.runs import RunCollection
+
+
+class _RunsAPI:
+    def __init__(self):
+        self.calls = []
+
+    def list(self, **kwargs):
+        self.calls.append(kwargs)
+        if len(self.calls) == 1:
+            return []
+        return ["finished-run"]
+
+
+class _APIClient:
+    def __init__(self):
+        self.runs = _RunsAPI()
+
+
+class TestRunCollectionList:
+    def test_default_list_fallback_limits_job_submissions(self):
+        api_client = _APIClient()
+        runs = RunCollection(api_client=api_client, project="main", client=None)
+        runs._model_to_run = lambda run: run
+
+        assert runs.list() == ["finished-run"]
+
+        assert api_client.runs.calls[0]["job_submissions_limit"] == 1
+        assert api_client.runs.calls[1]["job_submissions_limit"] == 1


### PR DESCRIPTION
Fixes #3983

## Problem

`/api/runs/list` powers both the Runs UI and `dstack ps`. UI/CLI list views normally need only the latest job submission, but the server still eager-loaded the full `RunModel.jobs` history and trimmed it later during response serialization.

On runs with many retries/submissions, one page could materialize tens of thousands of `JobModel` rows. Admin/all-project requests also had extra overhead because the service loaded accessible projects into Python and filtered runs with a large `project_id IN (...)` list.

## Fix

- Stop eager-loading `RunModel.jobs` in the runs-list path.
- After selecting the requested page of runs, load only the job rows needed for the response.
- When `job_submissions_limit` is set, load the latest N submissions per `(run_id, replica_num, job_num)` with a SQL window query.
- Also load the latest terminated submission with a termination reason per logical job, so status messages such as `retrying` stay correct without loading full history.
- Replace Python-built project ID lists with direct project lookup/subqueries for single-project, admin all-project, and member all-project paths.
- Ensure lightweight UI/CLI list callers pass `job_submissions_limit=1`.
