### PR TITLE
Fix Azure backend with azure-mgmt-resource 26

### DIFF
--- a/src/dstack/_internal/core/backends/azure/configurator.py
+++ b/src/dstack/_internal/core/backends/azure/configurator.py
@@ -6,7 +6,6 @@ import azure.core.exceptions
 from azure.core.credentials import TokenCredential
 from azure.mgmt import msi as msi_mgmt
 from azure.mgmt import network as network_mgmt
-from azure.mgmt import resource as resource_mgmt
 from azure.mgmt import subscription as subscription_mgmt
 from azure.mgmt.network.models import (
     AddressSpace,
@@ -18,6 +17,7 @@ from azure.mgmt.network.models import (
     Subnet,
     VirtualNetwork,
 )
+from azure.mgmt.resource import resources as resource_mgmt
 from azure.mgmt.resource.resources.models import ResourceGroup
 
 from dstack._internal.core.backends.azure import auth, compute, resources

--- a/src/tests/_internal/server/routers/test_backends.py
+++ b/src/tests/_internal/server/routers/test_backends.py
@@ -492,9 +492,15 @@ class TestCreateBackend:
         }
         with (
             patch("dstack._internal.core.backends.azure.auth.authenticate") as authenticate_mock,
-            patch("azure.mgmt.subscription.SubscriptionClient") as SubscriptionClientMock,
-            patch("azure.mgmt.resource.ResourceManagementClient") as ResourceManagementClientMock,
-            patch("azure.mgmt.network.NetworkManagementClient") as NetworkManagementClientMock,
+            patch(
+                "dstack._internal.core.backends.azure.configurator.subscription_mgmt.SubscriptionClient"
+            ) as SubscriptionClientMock,
+            patch(
+                "dstack._internal.core.backends.azure.configurator.resource_mgmt.ResourceManagementClient"
+            ) as ResourceManagementClientMock,
+            patch(
+                "dstack._internal.core.backends.azure.configurator.network_mgmt.NetworkManagementClient"
+            ) as NetworkManagementClientMock,
         ):
             authenticate_mock.return_value = None, "test_tenant"
             subscription_client_mock = SubscriptionClientMock.return_value


### PR DESCRIPTION
Azure SDK 26 stopped re-exporting `ResourceManagementClient` from `azure.mgmt.resource`; the client is available from `azure.mgmt.resource.resources` instead.

References:
- Azure issue: https://github.com/Azure/azure-sdk-for-python/issues/47651
- Azure release: https://pypi.org/project/azure-mgmt-resource/26.0.0/

Fresh installs can now resolve `azure-mgmt-resource==26.0.0`, causing Azure backend creation to fail before creating the resource group.

This PR:
- imports the resource client from the stable `azure.mgmt.resource.resources` path
- updates the Azure backend test to patch the configurator import path