### PR TITLE
Add in-place update for gateway `domain`

### DIFF
--- a/src/dstack/_internal/cli/commands/gateway.py
+++ b/src/dstack/_internal/cli/commands/gateway.py
@@ -85,7 +85,7 @@ class GatewayCommand(APIBaseCommand):
         update_parser.add_argument(
             "--set-default", action="store_true", help="Set it the default gateway for the project"
         )
-        update_parser.add_argument("--domain", help="Set the domain for the gateway")
+        update_parser.add_argument("--domain", help="(deprecated) Set the domain for the gateway")
 
         get_parser = subparsers.add_parser(
             "get", help="Get a gateway", formatter_class=self._parser.formatter_class
@@ -170,6 +170,10 @@ class GatewayCommand(APIBaseCommand):
     def _update(self, args: argparse.Namespace):
         with console.status("Updating gateway..."):
             if args.domain:
+                logger.warning(
+                    "`dstack gateway update --domain` is deprecated and may be disallowed in the future."
+                    " Use `dstack apply` to update domains or other gateway configuration properties"
+                )
                 if args.name.project is not None:
                     console.print(
                         "The [code]<project>/<gateway>[/] format is not supported for gateway names"

--- a/src/dstack/_internal/cli/services/configurators/gateway.py
+++ b/src/dstack/_internal/cli/services/configurators/gateway.py
@@ -11,9 +11,14 @@ from dstack._internal.cli.utils.common import (
 )
 from dstack._internal.cli.utils.gateway import get_gateways_table
 from dstack._internal.cli.utils.rich import MultiItemStatus
-from dstack._internal.core.errors import ResourceNotExistsError
+from dstack._internal.core.errors import (
+    MethodNotAllowedError,
+    ResourceNotExistsError,
+)
+from dstack._internal.core.models.common import ApplyAction
 from dstack._internal.core.models.configurations import ApplyConfigurationType
 from dstack._internal.core.models.gateways import (
+    ApplyGatewayPlanInput,
     Gateway,
     GatewayConfiguration,
     GatewayPlan,
@@ -23,6 +28,7 @@ from dstack._internal.core.models.gateways import (
 from dstack._internal.core.services.diff import diff_models
 from dstack._internal.utils.common import local_time
 from dstack._internal.utils.logging import get_logger
+from dstack._internal.utils.nested_list import NestedList, NestedListItem
 from dstack.api._public import Client
 
 logger = get_logger(__name__)
@@ -51,26 +57,31 @@ class GatewayConfigurator(BaseApplyConfigurator[GatewayConfiguration]):
                 " https://dstack.ai/docs/concepts/services/#pd-disaggregation"
             )
         with console.status("Getting apply plan..."):
-            plan = _get_plan(api=self.api, spec=spec)
+            try:
+                plan = self.api.client.gateways.get_plan(project_name=self.api.project, spec=spec)
+                use_legacy_api = False
+            except MethodNotAllowedError:
+                # pre-0.20.27 server
+                plan = _get_plan_legacy(self.api, spec)
+                use_legacy_api = True
         _print_plan_header(plan)
 
         action_message = ""
         confirm_message = ""
+        delete_gateway_name = None
         if plan.current_resource is None:
-            if plan.spec.configuration.name is not None:
-                action_message += (
-                    f"Gateway [code]{plan.spec.configuration.name}[/] does not exist yet."
-                )
+            if plan.effective_spec.configuration.name is not None:
+                action_message += f"Gateway [code]{plan.effective_spec.configuration.name}[/] does not exist yet."
             confirm_message += "Create the gateway?"
         else:
-            action_message += f"Found gateway [code]{plan.spec.configuration.name}[/]."
+            action_message += f"Found gateway [code]{plan.effective_spec.configuration.name}[/]."
             diff = diff_models(
-                plan.spec.configuration,
                 plan.current_resource.configuration,
+                plan.effective_spec.configuration,
             )
             changed_fields = list(diff.keys())
             if (
-                plan.current_resource.configuration == plan.spec.configuration
+                plan.current_resource.configuration == plan.effective_spec.configuration
                 or changed_fields == ["default"]
             ):
                 if command_args.yes and not command_args.force:
@@ -82,38 +93,61 @@ class GatewayConfigurator(BaseApplyConfigurator[GatewayConfiguration]):
                     return
                 action_message += " No configuration changes detected."
                 confirm_message += "Re-create the gateway?"
+                delete_gateway_name = plan.current_resource.name
             else:
-                action_message += " Configuration changes detected."
-                confirm_message += "Re-create the gateway?"
+                formatted_diff = NestedList(
+                    children=[NestedListItem(field) for field in diff]
+                ).render()
+                if plan.action == ApplyAction.UPDATE:
+                    action_message += f" Detected changes that [code]can[/] be updated in-place:\n{formatted_diff}"
+                    confirm_message += "Update the gateway?"
+                else:
+                    action_message += f" Detected changes that [error]cannot[/] be updated in-place:\n{formatted_diff}"
+                    confirm_message += "Re-create the gateway?"
+                    delete_gateway_name = plan.current_resource.name
 
         console.print(action_message)
         if not command_args.yes and not confirm_ask(confirm_message):
             console.print("\nExiting...")
             return
 
-        if plan.current_resource is not None:
+        if delete_gateway_name is not None:
             with console.status("Deleting existing gateway..."):
                 self.api.client.gateways.delete(
                     project_name=self.api.project,
-                    gateways_names=[plan.current_resource.name],
+                    gateways_names=[delete_gateway_name],
                 )
                 # Gateway deletion is async. Wait for gateway to be deleted.
                 while True:
                     try:
                         self.api.client.gateways.get(
                             project_name=self.api.project,
-                            gateway_name=plan.current_resource.name,
+                            gateway_name=delete_gateway_name,
                         )
                     except ResourceNotExistsError:
                         break
                     else:
                         time.sleep(1)
 
-        with console.status("Creating gateway..."):
-            gateway = self.api.client.gateways.create(
-                project_name=self.api.project,
-                configuration=conf,
-            )
+        with console.status("Applying plan..."):
+            if use_legacy_api:
+                gateway = self.api.client.gateways.create(
+                    project_name=self.api.project,
+                    configuration=conf,
+                )
+            else:
+                gateway = self.api.client.gateways.apply_plan(
+                    project_name=self.api.project,
+                    plan=ApplyGatewayPlanInput(
+                        spec=spec,
+                        current_resource=plan.current_resource,
+                    ),
+                )
+
+        if plan.action == ApplyAction.UPDATE and delete_gateway_name is None:
+            console.print(get_gateways_table([gateway], current_project=self.api.project))
+            return
+
         if command_args.detach:
             console.print("Gateway configuration submitted. Exiting...")
             return
@@ -195,8 +229,7 @@ class GatewayConfigurator(BaseApplyConfigurator[GatewayConfiguration]):
             conf.name = args.name
 
 
-def _get_plan(api: Client, spec: GatewaySpec) -> GatewayPlan:
-    # TODO: Implement server-side /get_plan with an offer included
+def _get_plan_legacy(api: Client, spec: GatewaySpec) -> GatewayPlan:
     user = api.client.users.get_my_user()
     current_resource = None
     if spec.configuration.name is not None:
@@ -211,7 +244,9 @@ def _get_plan(api: Client, spec: GatewaySpec) -> GatewayPlan:
         project_name=api.project,
         user=user.username,
         spec=spec,
+        effective_spec=spec,
         current_resource=current_resource,
+        action=ApplyAction.CREATE,
     )
 
 
@@ -225,20 +260,22 @@ def _print_plan_header(plan: GatewayPlan):
 
     configuration_table.add_row(th("Project"), plan.project_name)
     configuration_table.add_row(th("User"), plan.user)
-    configuration_table.add_row(th("Configuration"), plan.spec.configuration_path)
-    configuration_table.add_row(th("Type"), plan.spec.configuration.type)
+    configuration_table.add_row(th("Configuration"), plan.effective_spec.configuration_path)
+    configuration_table.add_row(th("Type"), plan.effective_spec.configuration.type)
 
     domain = "-"
-    if plan.spec.configuration.domain is not None:
-        domain = plan.spec.configuration.domain
+    if plan.effective_spec.configuration.domain is not None:
+        domain = plan.effective_spec.configuration.domain
 
-    configuration_table.add_row(th("Backend"), plan.spec.configuration.backend.value)
-    configuration_table.add_row(th("Region"), plan.spec.configuration.region)
+    configuration_table.add_row(th("Backend"), plan.effective_spec.configuration.backend.value)
+    configuration_table.add_row(th("Region"), plan.effective_spec.configuration.region)
     configuration_table.add_row(th("Domain"), domain)
 
-    if plan.spec.configuration.replicas is not None:
-        assert isinstance(plan.spec.configuration.replicas, int)
-        configuration_table.add_row(th("Replicas"), str(plan.spec.configuration.replicas))
+    if plan.effective_spec.configuration.replicas is not None:
+        assert isinstance(plan.effective_spec.configuration.replicas, int)
+        configuration_table.add_row(
+            th("Replicas"), str(plan.effective_spec.configuration.replicas)
+        )
 
     console.print(configuration_table)
     console.print()

--- a/src/dstack/_internal/core/models/gateways.py
+++ b/src/dstack/_internal/core/models/gateways.py
@@ -7,7 +7,7 @@ from pydantic import Field, validator
 from typing_extensions import Annotated, Literal
 
 from dstack._internal.core.models.backends.base import BackendType
-from dstack._internal.core.models.common import CoreModel
+from dstack._internal.core.models.common import ApplyAction, CoreModel
 from dstack._internal.core.models.routers import AnyGatewayRouterConfig
 from dstack._internal.utils.tags import tags_validator
 
@@ -80,7 +80,8 @@ class GatewayConfiguration(CoreModel):
                 "The gateway wildcard domain name, e.g. `example.com`."
                 " Service domain names are constructed as `<run name>.<gateway domain`."
                 " The domain name can use the `${{ run.project_name }}` variable"
-                " to include the service’s project name"
+                " to include the service’s project name."
+                " Can be updated in-place. Updates do not affect existing services"
             )
         ),
     ] = None
@@ -165,7 +166,22 @@ class GatewayPlan(CoreModel):
     project_name: str
     user: str
     spec: GatewaySpec
+    effective_spec: GatewaySpec
     current_resource: Optional[Gateway] = None
+    action: ApplyAction
+
+
+class ApplyGatewayPlanInput(CoreModel):
+    spec: GatewaySpec
+    current_resource: Annotated[
+        Optional[Gateway],
+        Field(
+            description=(
+                "The expected current resource."
+                " If the resource has changed, the apply fails unless `force: true`."
+            )
+        ),
+    ] = None
 
 
 class GatewayComputeConfiguration(CoreModel):

--- a/src/dstack/_internal/server/compatibility/gateways.py
+++ b/src/dstack/_internal/server/compatibility/gateways.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from packaging.version import Version
 
-from dstack._internal.core.models.gateways import Gateway
+from dstack._internal.core.models.gateways import Gateway, GatewayPlan
 
 
 def patch_gateway(gateway: Gateway, client_version: Optional[Version]) -> None:
@@ -13,3 +13,10 @@ def patch_gateway(gateway: Gateway, client_version: Optional[Version]) -> None:
         gateway.ip_address = "\n".join(r.hostname for r in gateway.replicas)
         if gateway.hostname is None:
             gateway.hostname = gateway.ip_address
+
+
+def patch_gateway_plan(plan: GatewayPlan, client_version: Optional[Version]) -> None:
+    if client_version is None:
+        return
+    if plan.current_resource is not None:
+        patch_gateway(plan.current_resource, client_version)

--- a/src/dstack/_internal/server/routers/gateways.py
+++ b/src/dstack/_internal/server/routers/gateways.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple
+from typing import Annotated, List, Optional, Tuple
 
 from fastapi import APIRouter, Depends
 from packaging.version import Version
@@ -9,7 +9,7 @@ import dstack._internal.server.schemas.gateways as schemas
 import dstack._internal.server.services.gateways as gateways
 from dstack._internal.core.errors import ResourceNotExistsError
 from dstack._internal.core.models.common import EntityReference
-from dstack._internal.server.compatibility.gateways import patch_gateway
+from dstack._internal.server.compatibility.gateways import patch_gateway, patch_gateway_plan
 from dstack._internal.server.db import get_session
 from dstack._internal.server.deps import Project
 from dstack._internal.server.models import ProjectModel, UserModel
@@ -71,7 +71,53 @@ async def get_gateway(
     return CustomORJSONResponse(gateway)
 
 
-@router.post("/create", summary="Create gateway", response_model=models.Gateway)
+@router.post("/get_plan", summary="Get gateway plan", response_model=models.GatewayPlan)
+async def get_plan(
+    body: schemas.GetGatewayPlanRequest,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    user_project: Annotated[tuple[UserModel, ProjectModel], Depends(ProjectAdmin())],
+    client_version: Annotated[Optional[Version], Depends(get_client_version)],
+):
+    """
+    Returns a gateway plan for the given gateway spec.
+    This is an optional step before calling `/apply`.
+    """
+    user, project = user_project
+    plan = await gateways.get_plan(
+        session=session,
+        project=project,
+        user=user,
+        spec=body.spec,
+    )
+    patch_gateway_plan(plan, client_version)
+    return CustomORJSONResponse(plan)
+
+
+@router.post("/apply", summary="Apply gateway plan", response_model=models.Gateway)
+async def apply_plan(
+    body: schemas.ApplyGatewayPlanRequest,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    user_project: Annotated[tuple[UserModel, ProjectModel], Depends(ProjectAdmin())],
+    pipeline_hinter: Annotated[PipelineHinterProtocol, Depends(get_pipeline_hinter)],
+    client_version: Annotated[Optional[Version], Depends(get_client_version)],
+):
+    """
+    Creates a new gateway or updates an existing gateway in-place.
+    """
+    user, project = user_project
+    gateway = await gateways.apply_plan(
+        session=session,
+        user=user,
+        project=project,
+        plan=body.plan,
+        force=body.force,
+        pipeline_hinter=pipeline_hinter,
+    )
+    patch_gateway(gateway, client_version)
+    return CustomORJSONResponse(gateway)
+
+
+@router.post("/create", summary="Create gateway", response_model=models.Gateway, deprecated=True)
 async def create_gateway(
     body: schemas.CreateGatewayRequest,
     session: AsyncSession = Depends(get_session),
@@ -79,6 +125,9 @@ async def create_gateway(
     pipeline_hinter: PipelineHinterProtocol = Depends(get_pipeline_hinter),
     client_version: Optional[Version] = Depends(get_client_version),
 ):
+    """
+    Deprecated in favor of `/apply`.
+    """
     user, project = user_project
     gateway = await gateways.create_gateway(
         session=session,
@@ -121,13 +170,21 @@ async def set_default_gateway(
     )
 
 
-@router.post("/set_wildcard_domain", summary="Set wildcard domain", response_model=models.Gateway)
+@router.post(
+    "/set_wildcard_domain",
+    summary="Set wildcard domain",
+    response_model=models.Gateway,
+    deprecated=True,
+)
 async def set_gateway_wildcard_domain(
     body: schemas.SetWildcardDomainRequest,
     session: AsyncSession = Depends(get_session),
     user_project: Tuple[UserModel, ProjectModel] = Depends(ProjectAdmin()),
     client_version: Optional[Version] = Depends(get_client_version),
 ):
+    """
+    Deprecated in favor of `/apply` (in-place update).
+    """
     user, project = user_project
     gateway = await gateways.set_gateway_wildcard_domain(
         session=session,

--- a/src/dstack/_internal/server/schemas/gateways.py
+++ b/src/dstack/_internal/server/schemas/gateways.py
@@ -1,7 +1,13 @@
-from typing import Any, Dict, List, Optional
+from typing import Annotated, Any, Dict, List, Optional
+
+from pydantic import Field
 
 from dstack._internal.core.models.common import CoreConfig, CoreModel, generate_dual_core_model
-from dstack._internal.core.models.gateways import GatewayConfiguration
+from dstack._internal.core.models.gateways import (
+    ApplyGatewayPlanInput,
+    GatewayConfiguration,
+    GatewaySpec,
+)
 
 
 class CreateGatewayRequestConfig(CoreConfig):
@@ -20,6 +26,20 @@ class ListGatewaysRequest(CoreModel):
 
 class GetGatewayRequest(CoreModel):
     name: str
+
+
+class GetGatewayPlanRequest(CoreModel):
+    spec: GatewaySpec
+
+
+class ApplyGatewayPlanRequest(CoreModel):
+    plan: ApplyGatewayPlanInput
+    force: Annotated[
+        bool,
+        Field(
+            description="Use `force: true` to apply even if the expected resource does not match."
+        ),
+    ]
 
 
 class DeleteGatewaysRequest(CoreModel):

--- a/src/dstack/_internal/server/services/gateways/__init__.py
+++ b/src/dstack/_internal/server/services/gateways/__init__.py
@@ -30,19 +30,26 @@ from dstack._internal.core.errors import (
     SSHError,
 )
 from dstack._internal.core.models.backends.base import BackendType
-from dstack._internal.core.models.common import EntityReference
+from dstack._internal.core.models.common import ApplyAction, EntityReference
 from dstack._internal.core.models.gateways import (
     GATEWAY_REPLICAS_DEFAULT,
     AnyGatewayRouterConfig,
+    ApplyGatewayPlanInput,
     Gateway,
     GatewayComputeConfiguration,
     GatewayConfiguration,
+    GatewayPlan,
     GatewayReplica,
     GatewaySpec,
     GatewayStatus,
     LetsEncryptGatewayCertificate,
 )
 from dstack._internal.core.services import validate_dstack_resource_name
+from dstack._internal.core.services.diff import (
+    ModelDiff,
+    diff_models,
+    format_diff_fields_for_event,
+)
 from dstack._internal.proxy.gateway.const import SERVICE_SCALING_WINDOWS
 from dstack._internal.proxy.gateway.schemas.stats import PerWindowStats, Stat
 from dstack._internal.server import settings
@@ -80,6 +87,7 @@ from dstack._internal.utils.crypto import generate_rsa_key_pair_bytes
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
+_CONF_UPDATABLE_FIELDS = frozenset({"domain"})
 
 
 def switch_gateway_status(
@@ -227,15 +235,18 @@ async def create_gateway(
     project: ProjectModel,
     configuration: GatewayConfiguration,
     pipeline_hinter: PipelineHinterProtocol,
+    *,
+    effective_configuration: Optional[GatewayConfiguration] = None,
 ) -> Gateway:
-    spec = await apply_plugin_policies(
-        user=user.name,
-        project=project.name,
-        # Create pseudo spec until the gateway API is updated to accept spec
-        spec=GatewaySpec(configuration=configuration),
-    )
-    configuration = spec.configuration
-    _validate_gateway_configuration(configuration)
+    if effective_configuration is None:
+        spec = await apply_plugin_policies(
+            user=user.name,
+            project=project.name,
+            spec=GatewaySpec(configuration=configuration),
+        )
+        effective_configuration = spec.configuration
+        _validate_gateway_configuration(effective_configuration)
+    configuration = effective_configuration
 
     backend_model, _ = await get_project_backend_with_model_by_type_or_error(
         project=project, backend_type=configuration.backend
@@ -871,6 +882,134 @@ def gateway_model_to_gateway(
         configuration=configuration,
         replicas=replicas,
     )
+
+
+async def get_plan(
+    session: AsyncSession,
+    project: ProjectModel,
+    user: UserModel,
+    spec: GatewaySpec,
+) -> GatewayPlan:
+    effective_spec = await apply_plugin_policies(
+        user=user.name,
+        project=project.name,
+        spec=spec,
+    )
+    _validate_gateway_configuration(effective_spec.configuration)
+
+    action = ApplyAction.CREATE
+    current_gateway: Optional[Gateway] = None
+
+    if effective_spec.configuration.name is not None:
+        current_gateway_model = await get_project_gateway_model_by_reference(
+            session=session,
+            project=project,
+            ref=EntityReference(name=effective_spec.configuration.name, project=None),
+            load_gateway_compute=True,
+            load_backend_type=True,
+        )
+        if current_gateway_model is not None:
+            if current_gateway_model.to_be_deleted:
+                raise ServerClientError(
+                    f"Gateway {effective_spec.configuration.name!r} is being deleted. Try again later."
+                )
+            current_gateway = gateway_model_to_gateway(
+                current_gateway_model, default_gateway_id=project.default_gateway_id
+            )
+            if _can_update_gateway_in_place(
+                diff_models(current_gateway.configuration, effective_spec.configuration)
+            ):
+                action = ApplyAction.UPDATE
+
+    return GatewayPlan(
+        project_name=project.name,
+        user=user.name,
+        spec=spec,
+        effective_spec=effective_spec,
+        current_resource=current_gateway,
+        action=action,
+    )
+
+
+async def apply_plan(
+    session: AsyncSession,
+    user: UserModel,
+    project: ProjectModel,
+    plan: ApplyGatewayPlanInput,
+    force: bool,
+    pipeline_hinter: PipelineHinterProtocol,
+) -> Gateway:
+    spec = await apply_plugin_policies(
+        user=user.name,
+        project=project.name,
+        spec=plan.spec,
+    )
+    new_configuration = spec.configuration
+    _validate_gateway_configuration(new_configuration)
+
+    if new_configuration.name is None:
+        return await create_gateway(
+            session=session,
+            user=user,
+            project=project,
+            configuration=plan.spec.configuration,
+            pipeline_hinter=pipeline_hinter,
+            effective_configuration=new_configuration,
+        )
+
+    async with get_project_gateway_model_by_name_for_update(
+        session, project, new_configuration.name
+    ) as gateway_model:
+        if gateway_model is None:
+            return await create_gateway(
+                session=session,
+                user=user,
+                project=project,
+                configuration=plan.spec.configuration,
+                pipeline_hinter=pipeline_hinter,
+                effective_configuration=new_configuration,
+            )
+        if gateway_model.to_be_deleted:
+            raise ServerClientError(
+                f"Gateway {new_configuration.name!r} is being deleted. Try again later."
+            )
+        current_configuration = gateway_model_to_gateway(
+            gateway_model,
+            default_gateway_id=project.default_gateway_id,
+        ).configuration
+
+        if not force:
+            if (
+                plan.current_resource is None
+                or plan.current_resource.id != gateway_model.id
+                or plan.current_resource.configuration != current_configuration
+            ):
+                raise ServerClientError(
+                    "Failed to apply plan. Resource has been changed. Try again or use force apply."
+                )
+
+        diff = diff_models(current_configuration, new_configuration)
+        if not _can_update_gateway_in_place(diff):
+            raise ServerClientError(
+                f"Gateway {new_configuration.name!r} cannot be updated in-place."
+                " Delete it and re-apply."
+            )
+
+        gateway_model.wildcard_domain = new_configuration.domain
+        gateway_model.configuration = new_configuration.json()
+        events.emit(
+            session,
+            f"Gateway updated. Changed fields: {format_diff_fields_for_event(diff)}",
+            actor=events.UserActor.from_user(user),
+            targets=[events.Target.from_model(gateway_model)],
+        )
+        await session.commit()
+
+    return gateway_model_to_gateway(gateway_model, default_gateway_id=project.default_gateway_id)
+
+
+def _can_update_gateway_in_place(conf_diff: ModelDiff) -> bool:
+    return all(field in _CONF_UPDATABLE_FIELDS for field in conf_diff)
 
 
 def _validate_gateway_configuration(configuration: GatewayConfiguration):

--- a/src/dstack/api/server/_gateways.py
+++ b/src/dstack/api/server/_gateways.py
@@ -6,10 +6,18 @@ from dstack._internal.core.compatibility.gateways import (
     get_create_gateway_excludes,
     get_set_default_gateway_excludes,
 )
-from dstack._internal.core.models.gateways import Gateway, GatewayConfiguration
+from dstack._internal.core.models.gateways import (
+    ApplyGatewayPlanInput,
+    Gateway,
+    GatewayConfiguration,
+    GatewayPlan,
+    GatewaySpec,
+)
 from dstack._internal.server.schemas.gateways import (
+    ApplyGatewayPlanRequest,
     CreateGatewayRequest,
     DeleteGatewaysRequest,
+    GetGatewayPlanRequest,
     GetGatewayRequest,
     ListGatewaysRequest,
     SetDefaultGatewayRequest,
@@ -29,6 +37,18 @@ class GatewaysAPIClient(APIClientGroup):
     def get(self, project_name: str, gateway_name: str) -> Gateway:
         body = GetGatewayRequest(name=gateway_name)
         resp = self._request(f"/api/project/{project_name}/gateways/get", body=body.json())
+        return parse_obj_as(Gateway.__response__, resp.json())
+
+    def get_plan(self, project_name: str, spec: GatewaySpec) -> GatewayPlan:
+        body = GetGatewayPlanRequest(spec=spec)
+        resp = self._request(f"/api/project/{project_name}/gateways/get_plan", body=body.json())
+        return parse_obj_as(GatewayPlan.__response__, resp.json())
+
+    def apply_plan(
+        self, project_name: str, plan: ApplyGatewayPlanInput, *, force: bool = False
+    ) -> Gateway:
+        body = ApplyGatewayPlanRequest(plan=plan, force=force)
+        resp = self._request(f"/api/project/{project_name}/gateways/apply", body=body.json())
         return parse_obj_as(Gateway.__response__, resp.json())
 
     def create(

--- a/src/tests/_internal/server/routers/test_gateways.py
+++ b/src/tests/_internal/server/routers/test_gateways.py
@@ -6,6 +6,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dstack._internal.core.models.backends.base import BackendType
+from dstack._internal.core.models.common import ApplyAction
 from dstack._internal.core.models.users import GlobalRole, ProjectRole
 from dstack._internal.server.services.projects import add_project_member
 from dstack._internal.server.testing.common import (
@@ -1355,3 +1356,875 @@ class TestUpdateGateway:
             json={"name": gateway.name, "wildcard_domain": "new.example"},
         )
         assert response.status_code == 403
+
+
+class TestGetGatewayPlan:
+    @pytest.mark.asyncio
+    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+        response = await client.post("/api/project/main/gateways/get_plan")
+        assert response.status_code in [401, 403]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_regular_user_cannot_get_plan(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        user = await create_user(session, global_role=GlobalRole.USER)
+        project = await create_project(session)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.USER
+        )
+        response = await client.post(
+            f"/api/project/{project.name}/gateways/get_plan",
+            headers=get_auth_headers(user.token),
+            json={
+                "spec": {
+                    "configuration": {
+                        "type": "gateway",
+                        "name": "my-gateway",
+                        "backend": "aws",
+                        "region": "us-east-1",
+                    }
+                }
+            },
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_importer_member_cannot_get_plan_on_exporter_project(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        importer_user = await create_user(
+            session, name="importer-user", global_role=GlobalRole.USER
+        )
+        exporter_project = await create_project(session, name="exporter-project")
+        importer_project = await create_project(
+            session, name="importer-project", owner=importer_user
+        )
+        await add_project_member(
+            session=session,
+            project=importer_project,
+            user=importer_user,
+            project_role=ProjectRole.ADMIN,
+        )
+        backend = await create_backend(session=session, project_id=exporter_project.id)
+        gateway = await create_gateway(
+            session=session,
+            project_id=exporter_project.id,
+            backend_id=backend.id,
+            name="exported-gateway",
+        )
+        await create_export(
+            session=session,
+            exporter_project=exporter_project,
+            importer_projects=[importer_project],
+            exported_fleets=[],
+            exported_gateways=[gateway],
+        )
+        response = await client.post(
+            f"/api/project/{exporter_project.name}/gateways/get_plan",
+            headers=get_auth_headers(importer_user.token),
+            json={
+                "spec": {
+                    "configuration": {
+                        "type": "gateway",
+                        "name": "exported-gateway",
+                        "backend": "aws",
+                        "region": "us-east-1",
+                    }
+                }
+            },
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_get_plan_no_existing_gateway(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        user = await create_user(session, global_role=GlobalRole.USER)
+        project = await create_project(session)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.ADMIN
+        )
+        await create_backend(session, project.id, backend_type=BackendType.AWS)
+        response = await client.post(
+            f"/api/project/{project.name}/gateways/get_plan",
+            json={
+                "spec": {
+                    "configuration": {
+                        "type": "gateway",
+                        "name": "my-gateway",
+                        "backend": "aws",
+                        "region": "us-east-1",
+                    }
+                }
+            },
+            headers=get_auth_headers(user.token),
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["action"] == ApplyAction.CREATE
+        assert data["current_resource"] is None
+        assert data["spec"]["configuration"]["name"] == "my-gateway"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    @pytest.mark.parametrize("populate_configuration", [True, False])
+    async def test_get_plan_with_existing_gateway_no_changes(
+        self, test_db, session: AsyncSession, client: AsyncClient, populate_configuration: bool
+    ):
+        user = await create_user(session, global_role=GlobalRole.USER)
+        project = await create_project(session)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.ADMIN
+        )
+        backend = await create_backend(session, project.id, backend_type=BackendType.AWS)
+        gateway = await create_gateway(
+            session=session,
+            project_id=project.id,
+            backend_id=backend.id,
+            name="my-gateway",
+            region="us-east-1",
+            populate_configuration=populate_configuration,
+        )
+        await create_gateway_compute(
+            session=session,
+            backend_id=backend.id,
+            gateway_id=gateway.id,
+            populate_configuration=populate_configuration,
+        )
+        response = await client.post(
+            f"/api/project/{project.name}/gateways/get_plan",
+            json={
+                "spec": {
+                    "configuration": {
+                        "type": "gateway",
+                        "name": "my-gateway",
+                        "backend": "aws",
+                        "region": "us-east-1",
+                    }
+                }
+            },
+            headers=get_auth_headers(user.token),
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["action"] == ApplyAction.UPDATE
+        assert data["current_resource"]["name"] == "my-gateway"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    @pytest.mark.parametrize("populate_configuration", [True, False])
+    async def test_get_plan_with_domain_change_is_update(
+        self, test_db, session: AsyncSession, client: AsyncClient, populate_configuration: bool
+    ):
+        user = await create_user(session, global_role=GlobalRole.USER)
+        project = await create_project(session)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.ADMIN
+        )
+        backend = await create_backend(session, project.id, backend_type=BackendType.AWS)
+        gateway = await create_gateway(
+            session=session,
+            project_id=project.id,
+            backend_id=backend.id,
+            name="my-gateway",
+            region="us-east-1",
+            wildcard_domain="old.example.com",
+            populate_configuration=populate_configuration,
+        )
+        await create_gateway_compute(
+            session=session,
+            backend_id=backend.id,
+            gateway_id=gateway.id,
+            populate_configuration=populate_configuration,
+        )
+        response = await client.post(
+            f"/api/project/{project.name}/gateways/get_plan",
+            json={
+                "spec": {
+                    "configuration": {
+                        "type": "gateway",
+                        "name": "my-gateway",
+                        "backend": "aws",
+                        "region": "us-east-1",
+                        "domain": "new.example.com",
+                    }
+                }
+            },
+            headers=get_auth_headers(user.token),
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["action"] == ApplyAction.UPDATE
+        assert data["current_resource"]["wildcard_domain"] == "old.example.com"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    @pytest.mark.parametrize("populate_configuration", [True, False])
+    async def test_get_plan_with_region_change_is_create(
+        self, test_db, session: AsyncSession, client: AsyncClient, populate_configuration: bool
+    ):
+        user = await create_user(session, global_role=GlobalRole.USER)
+        project = await create_project(session)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.ADMIN
+        )
+        backend = await create_backend(session, project.id, backend_type=BackendType.AWS)
+        gateway = await create_gateway(
+            session=session,
+            project_id=project.id,
+            backend_id=backend.id,
+            name="my-gateway",
+            region="us-east-1",
+            populate_configuration=populate_configuration,
+        )
+        await create_gateway_compute(
+            session=session,
+            backend_id=backend.id,
+            gateway_id=gateway.id,
+            populate_configuration=populate_configuration,
+        )
+        response = await client.post(
+            f"/api/project/{project.name}/gateways/get_plan",
+            json={
+                "spec": {
+                    "configuration": {
+                        "type": "gateway",
+                        "name": "my-gateway",
+                        "backend": "aws",
+                        "region": "eu-west-1",
+                    }
+                }
+            },
+            headers=get_auth_headers(user.token),
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["action"] == ApplyAction.CREATE
+        assert data["current_resource"]["name"] == "my-gateway"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_get_plan_validates_configuration(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        user = await create_user(session, global_role=GlobalRole.USER)
+        project = await create_project(session)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.ADMIN
+        )
+        await create_backend(session, project.id, backend_type=BackendType.AWS)
+        # Invalid domain interpolation → validation failure
+        response = await client.post(
+            f"/api/project/{project.name}/gateways/get_plan",
+            json={
+                "spec": {
+                    "configuration": {
+                        "type": "gateway",
+                        "name": "my-gateway",
+                        "backend": "aws",
+                        "region": "us-east-1",
+                        "domain": "${{ run.unknown_variable }}.example.com",
+                    }
+                }
+            },
+            headers=get_auth_headers(user.token),
+        )
+        assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    @pytest.mark.parametrize("populate_configuration", [True, False])
+    async def test_get_plan_rejects_to_be_deleted_gateway(
+        self, test_db, session: AsyncSession, client: AsyncClient, populate_configuration: bool
+    ):
+        user = await create_user(session, global_role=GlobalRole.USER)
+        project = await create_project(session)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.ADMIN
+        )
+        backend = await create_backend(session, project.id, backend_type=BackendType.AWS)
+        gateway = await create_gateway(
+            session=session,
+            project_id=project.id,
+            backend_id=backend.id,
+            name="my-gateway",
+            region="us-east-1",
+            wildcard_domain="old.example.com",
+            populate_configuration=populate_configuration,
+        )
+        await create_gateway_compute(
+            session=session,
+            backend_id=backend.id,
+            gateway_id=gateway.id,
+            populate_configuration=populate_configuration,
+        )
+        gateway.to_be_deleted = True
+        await session.commit()
+        response = await client.post(
+            f"/api/project/{project.name}/gateways/get_plan",
+            json={
+                "spec": {
+                    "configuration": {
+                        "type": "gateway",
+                        "name": "my-gateway",
+                        "backend": "aws",
+                        "region": "us-east-1",
+                        "domain": "new.example.com",
+                    }
+                }
+            },
+            headers=get_auth_headers(user.token),
+        )
+        assert response.status_code == 400
+        assert "being deleted" in response.json()["detail"][0]["msg"]
+
+
+class TestApplyGatewayPlan:
+    @pytest.mark.asyncio
+    async def test_returns_40x_if_not_authenticated(self, client: AsyncClient):
+        response = await client.post("/api/project/main/gateways/apply")
+        assert response.status_code in [401, 403]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_regular_user_cannot_apply(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        user = await create_user(session, global_role=GlobalRole.USER)
+        project = await create_project(session)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.USER
+        )
+        response = await client.post(
+            f"/api/project/{project.name}/gateways/apply",
+            headers=get_auth_headers(user.token),
+            json={
+                "plan": {
+                    "spec": {
+                        "configuration": {
+                            "type": "gateway",
+                            "name": "my-gateway",
+                            "backend": "aws",
+                            "region": "us-east-1",
+                        }
+                    }
+                },
+                "force": False,
+            },
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_importer_member_cannot_apply_on_exporter_project(
+        self, test_db, session: AsyncSession, client: AsyncClient
+    ):
+        importer_user = await create_user(
+            session, name="importer-user", global_role=GlobalRole.USER
+        )
+        exporter_project = await create_project(session, name="exporter-project")
+        importer_project = await create_project(
+            session, name="importer-project", owner=importer_user
+        )
+        await add_project_member(
+            session=session,
+            project=importer_project,
+            user=importer_user,
+            project_role=ProjectRole.ADMIN,
+        )
+        backend = await create_backend(session=session, project_id=exporter_project.id)
+        gateway = await create_gateway(
+            session=session,
+            project_id=exporter_project.id,
+            backend_id=backend.id,
+            name="exported-gateway",
+        )
+        await create_export(
+            session=session,
+            exporter_project=exporter_project,
+            importer_projects=[importer_project],
+            exported_fleets=[],
+            exported_gateways=[gateway],
+        )
+        response = await client.post(
+            f"/api/project/{exporter_project.name}/gateways/apply",
+            headers=get_auth_headers(importer_user.token),
+            json={
+                "plan": {
+                    "spec": {
+                        "configuration": {
+                            "type": "gateway",
+                            "name": "exported-gateway",
+                            "backend": "aws",
+                            "region": "us-east-1",
+                        }
+                    },
+                    "current_resource": None,
+                },
+                "force": False,
+            },
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    async def test_creates_new_gateway(self, test_db, session: AsyncSession, client: AsyncClient):
+        user = await create_user(session, global_role=GlobalRole.USER)
+        project = await create_project(session)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.ADMIN
+        )
+        await create_backend(session, project.id, backend_type=BackendType.AWS)
+        response = await client.post(
+            f"/api/project/{project.name}/gateways/apply",
+            json={
+                "plan": {
+                    "spec": {
+                        "configuration": {
+                            "type": "gateway",
+                            "name": "my-gateway",
+                            "backend": "aws",
+                            "region": "us-east-1",
+                        }
+                    },
+                    "current_resource": None,
+                },
+                "force": False,
+            },
+            headers=get_auth_headers(user.token),
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "my-gateway"
+        assert data["status"] == "submitted"
+        events = await list_events(session)
+        assert events[0].message == "Gateway created. Status: SUBMITTED"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    @pytest.mark.parametrize("populate_configuration", [True, False])
+    async def test_updates_in_place(
+        self, test_db, session: AsyncSession, client: AsyncClient, populate_configuration: bool
+    ):
+        user = await create_user(session, global_role=GlobalRole.USER)
+        project = await create_project(session)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.ADMIN
+        )
+        backend = await create_backend(session, project.id, backend_type=BackendType.AWS)
+        gateway = await create_gateway(
+            session=session,
+            project_id=project.id,
+            backend_id=backend.id,
+            name="my-gateway",
+            region="us-east-1",
+            wildcard_domain="old.example.com",
+            populate_configuration=populate_configuration,
+        )
+        await create_gateway_compute(
+            session=session,
+            backend_id=backend.id,
+            gateway_id=gateway.id,
+            populate_configuration=populate_configuration,
+        )
+        get_response = await client.post(
+            f"/api/project/{project.name}/gateways/get",
+            json={"name": "my-gateway"},
+            headers=get_auth_headers(user.token),
+        )
+        assert get_response.status_code == 200
+        current_resource = get_response.json()
+        response = await client.post(
+            f"/api/project/{project.name}/gateways/apply",
+            json={
+                "plan": {
+                    "spec": {
+                        "configuration": {
+                            "type": "gateway",
+                            "name": "my-gateway",
+                            "backend": "aws",
+                            "region": "us-east-1",
+                            "domain": "new.example.com",
+                        }
+                    },
+                    "current_resource": current_resource,
+                },
+                "force": False,
+            },
+            headers=get_auth_headers(user.token),
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["wildcard_domain"] == "new.example.com"
+        assert data["configuration"]["domain"] == "new.example.com"
+        events = await list_events(session)
+        assert any("Gateway updated." in e.message and "domain" in e.message for e in events)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    @pytest.mark.parametrize("populate_configuration", [True, False])
+    async def test_updates_in_place_with_force_apply(
+        self, test_db, session: AsyncSession, client: AsyncClient, populate_configuration: bool
+    ):
+        user = await create_user(session, global_role=GlobalRole.USER)
+        project = await create_project(session)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.ADMIN
+        )
+        backend = await create_backend(session, project.id, backend_type=BackendType.AWS)
+        gateway = await create_gateway(
+            session=session,
+            project_id=project.id,
+            backend_id=backend.id,
+            name="my-gateway",
+            region="us-east-1",
+            wildcard_domain="old.example.com",
+            populate_configuration=populate_configuration,
+        )
+        await create_gateway_compute(
+            session=session,
+            backend_id=backend.id,
+            gateway_id=gateway.id,
+            populate_configuration=populate_configuration,
+        )
+        response = await client.post(
+            f"/api/project/{project.name}/gateways/apply",
+            json={
+                "plan": {
+                    "spec": {
+                        "configuration": {
+                            "type": "gateway",
+                            "name": "my-gateway",
+                            "backend": "aws",
+                            "region": "us-east-1",
+                            "domain": "new.example.com",
+                        }
+                    },
+                    "current_resource": None,
+                },
+                "force": True,
+            },
+            headers=get_auth_headers(user.token),
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "my-gateway"
+        assert data["wildcard_domain"] == "new.example.com"
+        assert data["configuration"]["domain"] == "new.example.com"
+        events = await list_events(session)
+        assert any("Gateway updated." in e.message and "domain" in e.message for e in events)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    @pytest.mark.parametrize("populate_configuration", [True, False])
+    async def test_force_apply_no_changes_succeeds(
+        self, test_db, session: AsyncSession, client: AsyncClient, populate_configuration: bool
+    ):
+        user = await create_user(session, global_role=GlobalRole.USER)
+        project = await create_project(session)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.ADMIN
+        )
+        backend = await create_backend(session, project.id, backend_type=BackendType.AWS)
+        gateway = await create_gateway(
+            session=session,
+            project_id=project.id,
+            backend_id=backend.id,
+            name="my-gateway",
+            region="us-east-1",
+            populate_configuration=populate_configuration,
+        )
+        await create_gateway_compute(
+            session=session,
+            backend_id=backend.id,
+            gateway_id=gateway.id,
+            populate_configuration=populate_configuration,
+        )
+        response = await client.post(
+            f"/api/project/{project.name}/gateways/apply",
+            json={
+                "plan": {
+                    "spec": {
+                        "configuration": {
+                            "type": "gateway",
+                            "name": "my-gateway",
+                            "backend": "aws",
+                            "region": "us-east-1",
+                        }
+                    },
+                    "current_resource": None,
+                },
+                "force": True,
+            },
+            headers=get_auth_headers(user.token),
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "my-gateway"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    @pytest.mark.parametrize("populate_configuration", [True, False])
+    async def test_rejects_update(
+        self, test_db, session: AsyncSession, client: AsyncClient, populate_configuration: bool
+    ):
+        user = await create_user(session, global_role=GlobalRole.USER)
+        project = await create_project(session)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.ADMIN
+        )
+        backend = await create_backend(session, project.id, backend_type=BackendType.AWS)
+        gateway = await create_gateway(
+            session=session,
+            project_id=project.id,
+            backend_id=backend.id,
+            name="my-gateway",
+            region="us-east-1",
+            populate_configuration=populate_configuration,
+        )
+        await create_gateway_compute(
+            session=session,
+            backend_id=backend.id,
+            gateway_id=gateway.id,
+            populate_configuration=populate_configuration,
+        )
+        get_response = await client.post(
+            f"/api/project/{project.name}/gateways/get",
+            json={"name": "my-gateway"},
+            headers=get_auth_headers(user.token),
+        )
+        assert get_response.status_code == 200
+        current_resource = get_response.json()
+        response = await client.post(
+            f"/api/project/{project.name}/gateways/apply",
+            json={
+                "plan": {
+                    "spec": {
+                        "configuration": {
+                            "type": "gateway",
+                            "name": "my-gateway",
+                            "backend": "aws",
+                            "region": "eu-west-1",  # changed region
+                        }
+                    },
+                    "current_resource": current_resource,
+                },
+                "force": False,
+            },
+            headers=get_auth_headers(user.token),
+        )
+        assert response.status_code == 400
+        assert "cannot be updated in-place" in response.json()["detail"][0]["msg"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    @pytest.mark.parametrize("populate_configuration", [True, False])
+    async def test_rejects_update_with_force_apply(
+        self, test_db, session: AsyncSession, client: AsyncClient, populate_configuration: bool
+    ):
+        user = await create_user(session, global_role=GlobalRole.USER)
+        project = await create_project(session)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.ADMIN
+        )
+        backend = await create_backend(session, project.id, backend_type=BackendType.AWS)
+        gateway = await create_gateway(
+            session=session,
+            project_id=project.id,
+            backend_id=backend.id,
+            name="my-gateway",
+            region="us-east-1",
+            populate_configuration=populate_configuration,
+        )
+        await create_gateway_compute(
+            session=session,
+            backend_id=backend.id,
+            gateway_id=gateway.id,
+            populate_configuration=populate_configuration,
+        )
+        response = await client.post(
+            f"/api/project/{project.name}/gateways/apply",
+            json={
+                "plan": {
+                    "spec": {
+                        "configuration": {
+                            "type": "gateway",
+                            "name": "my-gateway",
+                            "backend": "aws",
+                            "region": "eu-west-1",  # changed region
+                        }
+                    },
+                    "current_resource": None,
+                },
+                "force": True,
+            },
+            headers=get_auth_headers(user.token),
+        )
+        assert response.status_code == 400
+        assert "cannot be updated in-place" in response.json()["detail"][0]["msg"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    @pytest.mark.parametrize("populate_configuration", [True, False])
+    async def test_returns_error_on_missing_current_resource(
+        self, test_db, session: AsyncSession, client: AsyncClient, populate_configuration: bool
+    ):
+        user = await create_user(session, global_role=GlobalRole.USER)
+        project = await create_project(session)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.ADMIN
+        )
+        backend = await create_backend(session, project.id, backend_type=BackendType.AWS)
+        gateway = await create_gateway(
+            session=session,
+            project_id=project.id,
+            backend_id=backend.id,
+            name="my-gateway",
+            region="us-east-1",
+            populate_configuration=populate_configuration,
+        )
+        await create_gateway_compute(
+            session=session,
+            backend_id=backend.id,
+            gateway_id=gateway.id,
+            populate_configuration=populate_configuration,
+        )
+        response = await client.post(
+            f"/api/project/{project.name}/gateways/apply",
+            json={
+                "plan": {
+                    "spec": {
+                        "configuration": {
+                            "type": "gateway",
+                            "name": "my-gateway",
+                            "backend": "aws",
+                            "region": "us-east-1",
+                            "domain": "new.example.com",
+                        }
+                    },
+                    "current_resource": None,
+                },
+                "force": False,
+            },
+            headers=get_auth_headers(user.token),
+        )
+        assert response.status_code == 400
+        assert "Resource has been changed" in response.json()["detail"][0]["msg"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    @pytest.mark.parametrize("populate_configuration", [True, False])
+    async def test_returns_error_on_current_resource_mismatch(
+        self, test_db, session: AsyncSession, client: AsyncClient, populate_configuration: bool
+    ):
+        user = await create_user(session, global_role=GlobalRole.USER)
+        project = await create_project(session)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.ADMIN
+        )
+        backend = await create_backend(session, project.id, backend_type=BackendType.AWS)
+        gateway = await create_gateway(
+            session=session,
+            project_id=project.id,
+            backend_id=backend.id,
+            name="my-gateway",
+            region="us-east-1",
+            populate_configuration=populate_configuration,
+        )
+        await create_gateway_compute(
+            session=session,
+            backend_id=backend.id,
+            gateway_id=gateway.id,
+            populate_configuration=populate_configuration,
+        )
+        get_response = await client.post(
+            f"/api/project/{project.name}/gateways/get",
+            json={"name": "my-gateway"},
+            headers=get_auth_headers(user.token),
+        )
+        assert get_response.status_code == 200
+        stale_resource = get_response.json()
+        stale_resource["configuration"]["domain"] = "stale.example.com"
+        response = await client.post(
+            f"/api/project/{project.name}/gateways/apply",
+            json={
+                "plan": {
+                    "spec": {
+                        "configuration": {
+                            "type": "gateway",
+                            "name": "my-gateway",
+                            "backend": "aws",
+                            "region": "us-east-1",
+                            "domain": "new.example.com",
+                        }
+                    },
+                    "current_resource": stale_resource,
+                },
+                "force": False,
+            },
+            headers=get_auth_headers(user.token),
+        )
+        assert response.status_code == 400
+        assert "Resource has been changed" in response.json()["detail"][0]["msg"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True)
+    @pytest.mark.parametrize("populate_configuration", [True, False])
+    async def test_rejects_apply_on_to_be_deleted_gateway(
+        self, test_db, session: AsyncSession, client: AsyncClient, populate_configuration: bool
+    ):
+        user = await create_user(session, global_role=GlobalRole.USER)
+        project = await create_project(session)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.ADMIN
+        )
+        backend = await create_backend(session, project.id, backend_type=BackendType.AWS)
+        gateway = await create_gateway(
+            session=session,
+            project_id=project.id,
+            backend_id=backend.id,
+            name="my-gateway",
+            region="us-east-1",
+            wildcard_domain="old.example.com",
+            populate_configuration=populate_configuration,
+        )
+        await create_gateway_compute(
+            session=session,
+            backend_id=backend.id,
+            gateway_id=gateway.id,
+            populate_configuration=populate_configuration,
+        )
+        get_response = await client.post(
+            f"/api/project/{project.name}/gateways/get",
+            json={"name": "my-gateway"},
+            headers=get_auth_headers(user.token),
+        )
+        assert get_response.status_code == 200
+        current_resource = get_response.json()
+        gateway.to_be_deleted = True
+        await session.commit()
+        response = await client.post(
+            f"/api/project/{project.name}/gateways/apply",
+            json={
+                "plan": {
+                    "spec": {
+                        "configuration": {
+                            "type": "gateway",
+                            "name": "my-gateway",
+                            "backend": "aws",
+                            "region": "us-east-1",
+                            "domain": "new.example.com",
+                        }
+                    },
+                    "current_resource": current_resource,
+                },
+                "force": False,
+            },
+            headers=get_auth_headers(user.token),
+        )
+        assert response.status_code == 400
+        assert "being deleted" in response.json()["detail"][0]["msg"]


### PR DESCRIPTION
Introduce gateway in-place update mechanism. For
now, only `domain` can be updated.

```yaml
$ dstack apply -f test.dstack.yml

Found gateway test-gateway. Detected changes that can be updated in-place:
- domain

Update the gateway? [y/n]: y
 NAME          BACKEND         HOSTNAME       DOMAIN           DEFAULT  STATUS
 test-gateway  gcp (us-west4)  34.125.56.225  new.example.com           running
```

Add new API methods:
- `/api/project/{project_name}/gateways/get_plan`
- `/api/project/{project_name}/gateways/apply`

Deprecate API methods:
- `/api/project/{project_name}/gateways/create`
- `/api/project/{project_name}/gateways/set_wildcard_domain`

Deprecate CLI arguments:
- `dstack gateway update --domain`

#3959