### PR TITLE
Fix CloudRift SSH port mapping

### DIFF
--- a/src/dstack/_internal/core/backends/cloudrift/compute.py
+++ b/src/dstack/_internal/core/backends/cloudrift/compute.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from dstack._internal.core.backends.base.compute import (
     Compute,
@@ -24,6 +24,8 @@ from dstack._internal.core.models.runs import JobProvisioningData
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+CLOUDRIFT_VM_SSH_PORT = 22
 
 
 class CloudRiftCompute(
@@ -114,7 +116,7 @@ class CloudRiftCompute(
             region=instance_offer.region,
             price=instance_offer.price,
             username="riftuser",
-            ssh_port=22,
+            ssh_port=None,
             dockerized=True,
             ssh_proxy=None,
             backend_data=None,
@@ -142,7 +144,12 @@ class CloudRiftCompute(
 
         vm_ready = vms[0].get("ready", False)
         if vm_ready:
-            provisioning_data.hostname = instance_info.get("host_address", None)
+            hostname = instance_info.get("host_address", None)
+            ssh_port = _get_vm_ssh_port(instance_info)
+            if hostname is None or ssh_port is None:
+                return
+            provisioning_data.hostname = hostname
+            provisioning_data.ssh_port = ssh_port
 
     def terminate_instance(
         self, instance_id: str, region: str, backend_data: Optional[str] = None
@@ -150,3 +157,102 @@ class CloudRiftCompute(
         terminated = self.client.terminate_instance(instance_id=instance_id)
         if not terminated:
             raise ComputeError(f"Failed to terminate instance {instance_id} in region {region}.")
+
+
+def _get_vm_ssh_port(instance_info: Dict) -> Optional[int]:
+    if ssh_port := _get_vm_ssh_port_from_port_mappings(instance_info):
+        return ssh_port
+    if ssh_port := _get_vm_ssh_port_from_instructions(instance_info):
+        return ssh_port
+    if _has_unusable_vm_ssh_port_data(instance_info):
+        return None
+    return CLOUDRIFT_VM_SSH_PORT
+
+
+def _get_vm_ssh_port_from_port_mappings(instance_info: Dict) -> Optional[int]:
+    port_mappings = instance_info.get("port_mappings")
+    if not isinstance(port_mappings, list):
+        return None
+    for port_mapping in port_mappings:
+        parsed_mapping = _parse_port_mapping(port_mapping)
+        if parsed_mapping is None:
+            continue
+        vm_port, host_port = parsed_mapping
+        if vm_port == CLOUDRIFT_VM_SSH_PORT:
+            return host_port
+    return None
+
+
+def _get_vm_ssh_port_from_instructions(instance_info: Dict) -> Optional[int]:
+    instructions = instance_info.get("instructions")
+    if not isinstance(instructions, dict):
+        return None
+    placeholder_values = instructions.get("placeholder_values")
+    if not isinstance(placeholder_values, list):
+        return None
+    for placeholder_value in placeholder_values:
+        ssh_port = _parse_ssh_port_placeholder_value(placeholder_value)
+        if ssh_port is not None:
+            return ssh_port
+    return None
+
+
+def _has_unusable_vm_ssh_port_data(instance_info: Dict) -> bool:
+    return isinstance(instance_info.get("port_mappings"), list) or _has_ssh_port_placeholder(
+        instance_info
+    )
+
+
+def _has_ssh_port_placeholder(instance_info: Dict) -> bool:
+    instructions = instance_info.get("instructions")
+    if not isinstance(instructions, dict):
+        return False
+    placeholder_values = instructions.get("placeholder_values")
+    if not isinstance(placeholder_values, list):
+        return False
+    return any(_is_ssh_port_placeholder_value(value) for value in placeholder_values)
+
+
+def _parse_ssh_port_placeholder_value(placeholder_value: Any) -> Optional[int]:
+    if not _is_ssh_port_placeholder_value(placeholder_value):
+        return None
+    return _parse_ssh_port_option(placeholder_value[1])
+
+
+def _is_ssh_port_placeholder_value(placeholder_value: Any) -> bool:
+    return (
+        isinstance(placeholder_value, (list, tuple))
+        and len(placeholder_value) >= 2
+        and placeholder_value[0] == "SSH_PORT"
+    )
+
+
+def _parse_ssh_port_option(ssh_port_option: Any) -> Optional[int]:
+    if not isinstance(ssh_port_option, str):
+        return None
+    if ssh_port_option.strip() == "":
+        return CLOUDRIFT_VM_SSH_PORT
+    parts = ssh_port_option.split()
+    if len(parts) != 2 or parts[0] != "-p":
+        return None
+    return _parse_port(parts[1])
+
+
+def _parse_port_mapping(port_mapping: Any) -> Optional[tuple[int, int]]:
+    if not isinstance(port_mapping, (list, tuple)) or len(port_mapping) < 2:
+        return None
+    vm_port = _parse_port(port_mapping[0])
+    host_port = _parse_port(port_mapping[1])
+    if vm_port is None or host_port is None:
+        return None
+    return vm_port, host_port
+
+
+def _parse_port(port: Any) -> Optional[int]:
+    try:
+        parsed_port = int(port)
+    except (TypeError, ValueError):
+        return None
+    if parsed_port <= 0 or parsed_port > 65535:
+        return None
+    return parsed_port

--- a/src/tests/_internal/core/backends/cloudrift/test_compute.py
+++ b/src/tests/_internal/core/backends/cloudrift/test_compute.py
@@ -1,0 +1,282 @@
+from unittest.mock import MagicMock
+
+from dstack._internal.core.backends.cloudrift.compute import CloudRiftCompute
+from dstack._internal.core.backends.cloudrift.models import CloudRiftConfig, CloudRiftCreds
+from dstack._internal.core.models.backends.base import BackendType
+from dstack._internal.core.models.instances import (
+    Gpu,
+    InstanceAvailability,
+    InstanceConfiguration,
+    InstanceOfferWithAvailability,
+    InstanceType,
+    Resources,
+    SSHKey,
+)
+from dstack._internal.core.models.runs import JobProvisioningData
+
+
+def _compute() -> CloudRiftCompute:
+    compute = CloudRiftCompute(CloudRiftConfig(creds=CloudRiftCreds(api_key="test")))
+    compute.client = MagicMock()
+    return compute
+
+
+def _provisioning_data(ssh_port: int | None = None) -> JobProvisioningData:
+    return JobProvisioningData(
+        backend=BackendType.CLOUDRIFT,
+        instance_type=InstanceType(
+            name="rtx49-10c-kn.1",
+            resources=Resources(
+                cpus=7,
+                memory_mib=48 * 1024,
+                gpus=[Gpu(name="RTX4090", memory_mib=24 * 1024)],
+                spot=False,
+            ),
+        ),
+        instance_id="instance-id",
+        hostname=None,
+        internal_ip=None,
+        region="ap-east-tw-kn-1",
+        price=0.39,
+        username="riftuser",
+        ssh_port=ssh_port,
+        dockerized=True,
+    )
+
+
+def _vm_instance_info(**overrides) -> dict:
+    instance_info = {
+        "node_mode": "VirtualMachine",
+        "host_address": "211.21.50.85",
+        "virtual_machines": [{"ready": True}],
+        "port_mappings": [[22, 57001], [80, 57002]],
+    }
+    instance_info.update(overrides)
+    return instance_info
+
+
+def _offer() -> InstanceOfferWithAvailability:
+    return InstanceOfferWithAvailability(
+        backend=BackendType.CLOUDRIFT,
+        instance=InstanceType(
+            name="rtx49-10c-kn.1",
+            resources=Resources(
+                cpus=7,
+                memory_mib=48 * 1024,
+                gpus=[Gpu(name="RTX4090", memory_mib=24 * 1024)],
+                spot=False,
+            ),
+        ),
+        region="ap-east-tw-kn-1",
+        price=0.39,
+        availability=InstanceAvailability.AVAILABLE,
+    )
+
+
+class TestCloudRiftComputeCreateInstance:
+    def test_waits_for_ssh_endpoint_from_cloudrift(self):
+        compute = _compute()
+        compute.client.deploy_instance.return_value = ["instance-id"]
+        instance_config = InstanceConfiguration(
+            project_name="main",
+            instance_name="test-instance",
+            user="test-user",
+            ssh_keys=[SSHKey(public="ssh-rsa test")],
+        )
+
+        provisioning_data = compute.create_instance(
+            instance_offer=_offer(),
+            instance_config=instance_config,
+            placement_group=None,
+        )
+
+        assert provisioning_data.instance_id == "instance-id"
+        assert provisioning_data.hostname is None
+        assert provisioning_data.ssh_port is None
+
+
+class TestCloudRiftComputeUpdateProvisioningData:
+    def test_sets_hostname_and_mapped_ssh_port(self):
+        compute = _compute()
+        provisioning_data = _provisioning_data()
+        compute.client.get_instance_by_id.return_value = _vm_instance_info()
+
+        compute.update_provisioning_data(
+            provisioning_data=provisioning_data,
+            project_ssh_public_key="ssh-rsa test",
+            project_ssh_private_key="private",
+        )
+
+        assert provisioning_data.hostname == "211.21.50.85"
+        assert provisioning_data.ssh_port == 57001
+
+    def test_accepts_string_port_mapping_values(self):
+        compute = _compute()
+        provisioning_data = _provisioning_data()
+        compute.client.get_instance_by_id.return_value = _vm_instance_info(
+            port_mappings=[["22", "57001"]]
+        )
+
+        compute.update_provisioning_data(
+            provisioning_data=provisioning_data,
+            project_ssh_public_key="ssh-rsa test",
+            project_ssh_private_key="private",
+        )
+
+        assert provisioning_data.hostname == "211.21.50.85"
+        assert provisioning_data.ssh_port == 57001
+
+    def test_uses_ssh_port_from_instructions_when_port_mappings_are_missing(self):
+        compute = _compute()
+        provisioning_data = _provisioning_data()
+        compute.client.get_instance_by_id.return_value = _vm_instance_info(
+            port_mappings=None,
+            instructions={"placeholder_values": [["SSH_PORT", "-p 57001"]]},
+        )
+
+        compute.update_provisioning_data(
+            provisioning_data=provisioning_data,
+            project_ssh_public_key="ssh-rsa test",
+            project_ssh_private_key="private",
+        )
+
+        assert provisioning_data.hostname == "211.21.50.85"
+        assert provisioning_data.ssh_port == 57001
+
+    def test_uses_ssh_port_from_instructions_when_port_mappings_are_empty(self):
+        compute = _compute()
+        provisioning_data = _provisioning_data()
+        compute.client.get_instance_by_id.return_value = _vm_instance_info(
+            port_mappings=[],
+            instructions={"placeholder_values": [["SSH_PORT", "-p 57001"]]},
+        )
+
+        compute.update_provisioning_data(
+            provisioning_data=provisioning_data,
+            project_ssh_public_key="ssh-rsa test",
+            project_ssh_private_key="private",
+        )
+
+        assert provisioning_data.hostname == "211.21.50.85"
+        assert provisioning_data.ssh_port == 57001
+
+    def test_uses_default_ssh_port_from_empty_ssh_port_instruction(self):
+        compute = _compute()
+        provisioning_data = _provisioning_data()
+        compute.client.get_instance_by_id.return_value = _vm_instance_info(
+            port_mappings=None,
+            instructions={"placeholder_values": [["SSH_PORT", ""]]},
+        )
+
+        compute.update_provisioning_data(
+            provisioning_data=provisioning_data,
+            project_ssh_public_key="ssh-rsa test",
+            project_ssh_private_key="private",
+        )
+
+        assert provisioning_data.hostname == "211.21.50.85"
+        assert provisioning_data.ssh_port == 22
+
+    def test_uses_default_ssh_port_when_cloudrift_does_not_return_port_mapping_data(self):
+        compute = _compute()
+        provisioning_data = _provisioning_data()
+        instance_info = _vm_instance_info()
+        instance_info.pop("port_mappings")
+        compute.client.get_instance_by_id.return_value = instance_info
+
+        compute.update_provisioning_data(
+            provisioning_data=provisioning_data,
+            project_ssh_public_key="ssh-rsa test",
+            project_ssh_private_key="private",
+        )
+
+        assert provisioning_data.hostname == "211.21.50.85"
+        assert provisioning_data.ssh_port == 22
+
+    def test_uses_default_ssh_port_when_instructions_do_not_include_ssh_port(self):
+        compute = _compute()
+        provisioning_data = _provisioning_data()
+        instance_info = _vm_instance_info(
+            instructions={"placeholder_values": [["USERNAME", "riftuser"]]}
+        )
+        instance_info.pop("port_mappings")
+        compute.client.get_instance_by_id.return_value = instance_info
+
+        compute.update_provisioning_data(
+            provisioning_data=provisioning_data,
+            project_ssh_public_key="ssh-rsa test",
+            project_ssh_private_key="private",
+        )
+
+        assert provisioning_data.hostname == "211.21.50.85"
+        assert provisioning_data.ssh_port == 22
+
+    def test_waits_for_ssh_port_when_port_mappings_are_temporarily_missing(self):
+        compute = _compute()
+        provisioning_data = _provisioning_data()
+        compute.client.get_instance_by_id.return_value = _vm_instance_info(port_mappings=[])
+
+        compute.update_provisioning_data(
+            provisioning_data=provisioning_data,
+            project_ssh_public_key="ssh-rsa test",
+            project_ssh_private_key="private",
+        )
+
+        assert provisioning_data.hostname is None
+        assert provisioning_data.ssh_port is None
+
+    def test_waits_for_ssh_port_when_port_mappings_are_invalid(self):
+        compute = _compute()
+        provisioning_data = _provisioning_data()
+        compute.client.get_instance_by_id.return_value = _vm_instance_info(
+            port_mappings=[
+                [22],
+                [22, "not-a-port"],
+                [22, 0],
+                [22, 65536],
+                [80, 57002],
+            ]
+        )
+
+        compute.update_provisioning_data(
+            provisioning_data=provisioning_data,
+            project_ssh_public_key="ssh-rsa test",
+            project_ssh_private_key="private",
+        )
+
+        assert provisioning_data.hostname is None
+        assert provisioning_data.ssh_port is None
+
+    def test_waits_for_ssh_port_when_ssh_port_instruction_is_invalid(self):
+        compute = _compute()
+        provisioning_data = _provisioning_data()
+        instance_info = _vm_instance_info(
+            instructions={"placeholder_values": [["SSH_PORT", "-p not-a-port"]]}
+        )
+        instance_info.pop("port_mappings")
+        compute.client.get_instance_by_id.return_value = instance_info
+
+        compute.update_provisioning_data(
+            provisioning_data=provisioning_data,
+            project_ssh_public_key="ssh-rsa test",
+            project_ssh_private_key="private",
+        )
+
+        assert provisioning_data.hostname is None
+        assert provisioning_data.ssh_port is None
+
+    def test_does_not_update_before_vm_is_ready(self):
+        compute = _compute()
+        provisioning_data = _provisioning_data()
+        compute.client.get_instance_by_id.return_value = _vm_instance_info(
+            virtual_machines=[{"ready": False}]
+        )
+
+        compute.update_provisioning_data(
+            provisioning_data=provisioning_data,
+            project_ssh_public_key="ssh-rsa test",
+            project_ssh_private_key="private",
+        )
+
+        assert provisioning_data.hostname is None
+        assert provisioning_data.ssh_port is None


### PR DESCRIPTION
Fixes #4003.

CloudRift instances have a public host address and, in some cases, public port mappings. `POST /api/v1/instances/list` returns that data in `ListInstancesResponseProto.data.instances[]`.

Currently, `create_instance()` always returns `ssh_port=22` for CloudRift instances. This is only correct when SSH is reachable at `host_address:22`.

In the reproduced case, CloudRift returned:

```text
host_address: <public-host>
port_mappings: [[22, 57001]]
```

Here `[22, 57001]` means port `22` on the instance is exposed as public port `57001` on `host_address`. So the SSH endpoint is `<public-host>:57001`, not `<public-host>:22`.

dstack ignored `port_mappings`, returned `ssh_port=22`, and tried `<public-host>:22`. That timed out. `<public-host>:57001` worked.

The fix is to resolve SSH from CloudRift's instance connection fields before returning the compute:

1. If `port_mappings` contains an entry whose first value is `22`, use the second value as the SSH port.
2. Otherwise, use `instructions.placeholder_values.SSH_PORT` if CloudRift returns it.
3. Otherwise, fall back to `22`.

The fallback preserves instances where CloudRift exposes SSH directly on public port `22`, or where CloudRift does not return SSH-port metadata.

CloudRift API docs: https://docs.cloudrift.ai/extras/rest-api

AI Assistance: This PR was prepared with AI assistance.
