### PR TITLE
Update Cuda runtime from 12.8 to 13.0 in dstack base Docker images

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -5,7 +5,7 @@ ARG UBUNTU_VERSION
 # (base / devel / devel-efa).
 # ============================================================================
 
-FROM nvidia/cuda:12.8.2-base-ubuntu${UBUNTU_VERSION}.04 AS common
+FROM nvidia/cuda:13.0.3-base-ubuntu${UBUNTU_VERSION}.04 AS common
 
 # ARGs before FROM must be redeclared to be used after FROM
 ARG UBUNTU_VERSION
@@ -60,7 +60,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | INSTALLER_NO_MODIFY_PATH=1 sh \
 # builder: builds NCCL and nccl-tests from source for the base/devel flavors.
 # ============================================================================
 
-FROM nvidia/cuda:12.8.2-base-ubuntu${UBUNTU_VERSION}.04 AS builder
+FROM nvidia/cuda:13.0.3-base-ubuntu${UBUNTU_VERSION}.04 AS builder
 
 ENV NCCL_HOME=/opt/nccl
 ENV CUDA_HOME=/usr/local/cuda
@@ -86,7 +86,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         python3 \
         build-essential
 
-ARG NCCL_VERSION=2.26.2-1
+ARG NCCL_VERSION=2.30.7-1
 
 RUN cd /tmp \
     && git clone https://github.com/NVIDIA/nccl.git -b v${NCCL_VERSION} \
@@ -167,7 +167,7 @@ RUN cd /tmp \
     && ./efa_installer.sh -y --skip-kmod -g \
     && rm -rf /tmp/aws-efa-installer /var/lib/apt/lists/*
 
-ARG NCCL_VERSION=2.27.7-1
+ARG NCCL_VERSION=2.30.7-1
 
 RUN cd /tmp \
     && git clone https://github.com/NVIDIA/nccl.git -b v${NCCL_VERSION} \

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -86,7 +86,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         python3 \
         build-essential
 
-ARG NCCL_VERSION=2.30.7-1
+ARG NCCL_VERSION=2.28.3-1
 
 RUN cd /tmp \
     && git clone https://github.com/NVIDIA/nccl.git -b v${NCCL_VERSION} \
@@ -167,7 +167,7 @@ RUN cd /tmp \
     && ./efa_installer.sh -y --skip-kmod -g \
     && rm -rf /tmp/aws-efa-installer /var/lib/apt/lists/*
 
-ARG NCCL_VERSION=2.30.7-1
+ARG NCCL_VERSION=2.28.3-1
 
 RUN cd /tmp \
     && git clone https://github.com/NVIDIA/nccl.git -b v${NCCL_VERSION} \

--- a/runner/README.md
+++ b/runner/README.md
@@ -68,7 +68,7 @@ Build the runner and shim and upload them to S3 using `just` (see [`justfile`](j
 > These variables are required and must be set before running any upload commands.
 
 ```shell
-just upload
+just upload-runner
 ```
 
 To use the built shim and runner with the `dstack` server, pass the URLs via `DSTACK_SHIM_DOWNLOAD_URL` and `DSTACK_RUNNER_DOWNLOAD_URL`:

--- a/src/dstack/_internal/core/backends/gcp/compute.py
+++ b/src/dstack/_internal/core/backends/gcp/compute.py
@@ -1014,7 +1014,7 @@ def _is_supported_gcp_instance(instance_name: str, gpu_name: Optional[str]) -> b
     ]:
         if instance_name.startswith(family):
             return True
-    if gpu_name is not None and gpu_name not in {"K80", "P4"}:
+    if gpu_name is not None and gpu_name not in {"K80", "P4", "P100"}:
         return True
     return False
 

--- a/src/dstack/_internal/core/backends/oci/compute.py
+++ b/src/dstack/_internal/core/backends/oci/compute.py
@@ -43,8 +43,6 @@ SUPPORTED_SHAPE_FAMILIES = [
     "BM.Standard.E4.",
     "BM.Standard.E5.",
     "BM.Optimized3.",
-    "VM.GPU2.",
-    "BM.GPU2.",
     "VM.GPU3.",
     "BM.GPU3.",
     "BM.GPU4.",

--- a/src/dstack/_internal/core/backends/verda/compute.py
+++ b/src/dstack/_internal/core/backends/verda/compute.py
@@ -234,14 +234,15 @@ class VerdaCompute(
 
 
 def _get_vm_image_id(instance_offer: InstanceOfferWithAvailability) -> str:
-    # https://api.verda.com/v1/images
+    # https://api.datacrunch.io/v1/docs#tag/images/GET/v1/images
     if len(instance_offer.instance.resources.gpus) > 0 and instance_offer.instance.resources.gpus[
         0
     ].name in ["V100", "A6000"]:
+        # * A6000: Verda returns "Operating system is not valid for this instance type" for newer images
         # Ubuntu 22.04 + CUDA 12.0 + Docker
         return "2088da25-bb0d-41cc-a191-dccae45d96fd"
-    # Ubuntu 24.04 + CUDA 12.8 Open + Docker
-    return "77777777-4f48-4249-82b3-f199fb9b701b"
+    # Ubuntu 24.04 + CUDA 13.0 Open + Docker
+    return "2404f580-1300-1111-82b3-f199fb9b701b"
 
 
 def _create_ssh_key(client: VerdaClient, name: str, public_key: str) -> str:

--- a/src/dstack/_internal/core/models/configurations.py
+++ b/src/dstack/_internal/core/models/configurations.py
@@ -487,9 +487,18 @@ class BaseRunConfiguration(CoreModel):
         Optional[str],
         Field(description="The run name. If not specified, a random name is generated"),
     ] = None
-    image: Annotated[Optional[str], Field(description="The name of the Docker image to run")] = (
-        None
-    )
+    image: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "The name of the Docker image to run."
+                " If no `image` is specified, `dstack` uses an Ubuntu 24.04-based Docker image that comes pre-configured"
+                " with `uv`, `python`, `pip`, the CUDA 13.0 runtime, InfiniBand, NCCL, and NCCL tests."
+                " It may also include provider-specific components such as EFA support on AWS."
+                " For non-Nvidia accelerators or NVidia GPUs unsupported by CUDA 13.0 (e.g. V100, P100), specify a custom Docker image."
+            )
+        ),
+    ] = None
     user: Annotated[
         Optional[str],
         Field(

--- a/src/dstack/version.py
+++ b/src/dstack/version.py
@@ -5,6 +5,6 @@
 
 __version__ = "0.0.0"
 __is_release__ = False
-docker_base_image = "0.14"
+docker_base_image = "0.15"
 docker_base_image_ubuntu_version = "24.04"
 vm_base_image = "0.14"

--- a/src/tests/_internal/server/routers/test_runs.py
+++ b/src/tests/_internal/server/routers/test_runs.py
@@ -155,7 +155,7 @@ def get_dev_env_run_plan_dict(
                 " && tail -f /dev/null"
             ),
         ]
-        image_name = "dstackai/base:0.14-base-ubuntu24.04"
+        image_name = "dstackai/base:0.15-base-ubuntu24.04"
 
     run_spec = {
         "configuration": {
@@ -397,7 +397,7 @@ def get_dev_env_run_dict(
                 " && tail -f /dev/null"
             ),
         ]
-        image_name = "dstackai/base:0.14-base-ubuntu24.04"
+        image_name = "dstackai/base:0.15-base-ubuntu24.04"
 
     return {
         "id": run_id,


### PR DESCRIPTION
Closes #3998

* Update Cuda runtime from 12.8 to 13.0 in dstack base Docker images by building from `nvidia/cuda:13.0.3`.
* Update `NCCL_VERSION=2.28.3-1`
* Pins a new dstack base Docker image version 0.15.

Cuda 13.0 requires nvidia host driver >= 580. Many dstack backends where dstack does not control the host drivders (e.g. Lambda, Crusoe, VastAI, Runpod) may provision hosts with older driver versions. But Cuda 13.0 still works since `nvidia/cuda:13.0.3` includes `cuda-compat-13` providing compatibility for all drivers >= 535. See https://docs.nvidia.com/deploy/cuda-compatibility/forward-compatibility.html. **Previous dstack Docker images didn't include `cuda-compat-13` so Cuda 13 workloads didn't work out-of-the-box on pre 580 hosts. Now they work.**

**Backward incompatible changes**

* V100 provisioning is still supported on some backends (e.g. GCP) but requires a custom Docker image or post-installing a compatible (<13) Cuda runtime inside run commands as Cuda 13.0 dropped support for Volta and older generations.
* Drop P100 provisioning from GCP and OCI. 