### PR TITLE
Slurm: fix memory request

### DIFF
--- a/src/dstack/_internal/core/backends/slurm/resources.py
+++ b/src/dstack/_internal/core/backends/slurm/resources.py
@@ -128,6 +128,8 @@ def get_requested_resources_from_resources_spec(spec: ResourcesSpec) -> Requeste
     # The easiest/safest option is to use some sane default
     memory = spec.memory.min or DEFAULT_MEMORY_SIZE.min
     assert memory
+    if spec.memory.max:
+        memory = min(memory, spec.memory.max)
     memory_mib = round(memory * 1024)
 
     gpu_count: int = 0


### PR DESCRIPTION
`memory: ..4GB` should be translated to `--mem=4096M`, not `--mem=8192M` (where 8GB is taken from `DEFAULT_MEMORY_SIZE.min`)