### PR TITLE
Ignore cachetools-related typing error in AWS backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "cryptography",
     "packaging",
     "python-dateutil",
-    "cachetools<7.1.0",  # Pin to work around https://github.com/tkem/cachetools/issues/394
+    "cachetools",
     "gitpython",
     "jsonschema",
     "paramiko>=3.2.0",

--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -188,12 +188,13 @@ class AWSCompute(
         # Requirements is not hashable, so we use a hack to get arguments hash
         return hash(requirements.json())
 
+    # For `pyright: ignore` directive, see: https://github.com/tkem/cachetools/issues/394
     @cachedmethod(
         cache=lambda self: self._offers_post_filter_cache.cache,
         key=_get_offers_cached_key,
         lock=lambda self: self._offers_post_filter_cache.lock,
     )
-    def get_offers_post_filter(
+    def get_offers_post_filter(  # pyright: ignore[reportIncompatibleMethodOverride]
         self, requirements: Requirements
     ) -> Optional[Callable[[InstanceOfferWithAvailability], bool]]:
         if requirements.reservation:


### PR DESCRIPTION
`cachetools<7.1` contstraint introduced in [1] doesn't help since pyright 1.1.410 (the last version it works is 1.1.409).

This patch removes the version constraint, which no longer helps, and adds `# pyright: ignore` directive instead.

[1]: https://github.com/dstackai/dstack/pull/3846