### PR TITLE
Vast.ai: Support spot instances

### DIFF
--- a/src/dstack/_internal/core/backends/vastai/api_client.py
+++ b/src/dstack/_internal/core/backends/vastai/api_client.py
@@ -41,6 +41,7 @@ class VastAIAPIClient:
         onstart: str,
         disk_size: int,
         registry_auth: Optional[RegistryAuth] = None,
+        bid: Optional[float] = None,
     ) -> dict:
         """
         Args:
@@ -49,6 +50,8 @@ class VastAIAPIClient:
             image_name: docker image name
             onstart: commands to run on start
             registry_auth: registry auth credentials for private images
+            bid: per-machine bid price in $/hour. If set, an interruptible
+                (spot) instance is created; if None, an on-demand instance.
 
         Raises:
             NoCapacityError: if instance cannot be created
@@ -63,6 +66,7 @@ class VastAIAPIClient:
         payload = {
             "client_id": "me",
             "image": image_name,
+            "price": bid,
             "disk": disk_size,
             "label": instance_name,
             "env": {

--- a/src/dstack/_internal/core/backends/vastai/compute.py
+++ b/src/dstack/_internal/core/backends/vastai/compute.py
@@ -94,8 +94,6 @@ class VastAICompute(
             backend=BackendType.VASTAI,
             locations=self.config.regions or None,
             requirements=requirements,
-            # TODO(egor-s): spots currently not supported
-            extra_filter=lambda offer: not offer.instance.resources.spot,
             catalog=self._make_catalog(vastai_options),
         )
         offers = [
@@ -127,6 +125,9 @@ class VastAICompute(
         commands = get_docker_commands(
             [run.run_spec.ssh_key_pub.strip(), project_ssh_public_key.strip()]
         )
+        bid = None
+        if instance_offer.instance.resources.spot:
+            bid = instance_offer.price
         resp = self.api_client.create_instance(
             instance_name=instance_name,
             bundle_id=instance_offer.instance.name,
@@ -134,6 +135,7 @@ class VastAICompute(
             onstart=" && ".join(commands),
             disk_size=round(instance_offer.instance.resources.disk.size_mib / 1024),
             registry_auth=job.job_spec.registry_auth,
+            bid=bid,
         )
         instance_id = resp["new_contract"]
         return JobProvisioningData(

--- a/src/tests/_internal/core/backends/vastai/test_compute.py
+++ b/src/tests/_internal/core/backends/vastai/test_compute.py
@@ -1,7 +1,16 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from dstack._internal.core.backends.vastai.compute import VastAICompute
 from dstack._internal.core.backends.vastai.models import VastAIConfig, VastAICreds
+from dstack._internal.core.models.backends.base import BackendType
+from dstack._internal.core.models.instances import (
+    Disk,
+    Gpu,
+    InstanceAvailability,
+    InstanceOfferWithAvailability,
+    InstanceType,
+    Resources,
+)
 from dstack._internal.core.models.resources import ResourcesSpec
 from dstack._internal.core.models.runs import Requirements
 
@@ -12,6 +21,53 @@ def _config(community_cloud=None) -> VastAIConfig:
 
 def _requirements() -> Requirements:
     return Requirements(resources=ResourcesSpec())
+
+
+def _offer(*, spot: bool, price: float = 0.5) -> InstanceOfferWithAvailability:
+    return InstanceOfferWithAvailability(
+        backend=BackendType.VASTAI,
+        instance=InstanceType(
+            name="12345",
+            resources=Resources(
+                cpus=8,
+                memory_mib=32 * 1024,
+                gpus=[Gpu(name="RTX4090", memory_mib=24 * 1024)],
+                spot=spot,
+                disk=Disk(size_mib=100 * 1024),
+            ),
+        ),
+        region="Hong Kong, HK",
+        price=price,
+        availability=InstanceAvailability.AVAILABLE,
+    )
+
+
+def _run_job(compute: VastAICompute, offer: InstanceOfferWithAvailability):
+    run = MagicMock()
+    run.run_spec.ssh_key_pub = "ssh-rsa AAAA test"
+    job = MagicMock()
+    job.job_spec.image_name = "dstackai/base:latest"
+    job.job_spec.registry_auth = None
+    with (
+        patch(
+            "dstack._internal.core.backends.vastai.compute.generate_unique_instance_name_for_job",
+            return_value="dstack-test",
+        ),
+        patch(
+            "dstack._internal.core.backends.vastai.compute.get_docker_commands",
+            return_value=["echo hi"],
+        ),
+    ):
+        compute.run_job(
+            run=run,
+            job=job,
+            instance_offer=offer,
+            project_ssh_public_key="ssh-rsa BBBB project",
+            project_ssh_private_key="private-key",
+            volumes=[],
+            placement_group=None,
+            requirements=_requirements(),
+        )
 
 
 def test_vastai_compute_enables_community_cloud_by_default():
@@ -54,3 +110,23 @@ def test_vastai_compute_can_disable_community_cloud():
         vast_provider_cls.assert_called_once()
         assert vast_provider_cls.call_args.kwargs["community_cloud"] is False
         catalog_instance.add_provider.assert_called_once()
+
+
+def test_vastai_run_job_bids_on_spot_offer():
+    compute = VastAICompute(_config())
+    compute.api_client = MagicMock()
+    compute.api_client.create_instance.return_value = {"new_contract": 123}
+
+    _run_job(compute, _offer(spot=True, price=0.1244444))
+
+    assert compute.api_client.create_instance.call_args.kwargs["bid"] == 0.1244444
+
+
+def test_vastai_run_job_does_not_bid_on_ondemand_offer():
+    compute = VastAICompute(_config())
+    compute.api_client = MagicMock()
+    compute.api_client.create_instance.return_value = {"new_contract": 123}
+
+    _run_job(compute, _offer(spot=False, price=0.24))
+
+    assert compute.api_client.create_instance.call_args.kwargs["bid"] is None


### PR DESCRIPTION
Vast.ai offers interruptible (spot) instances, but the `vastai` backend has never been able to provision them.

Currently, `get_offers_by_requirements()` strips every spot offer:

```python
# TODO(egor-s): spots currently not supported
extra_filter=lambda offer: not offer.instance.resources.spot,
```

and `create_instance()` never bids, so only on-demand instances are provisioned. gpuhunt already emits Vast spot offers (each on-demand offer is duplicated with `price` set to the machine's `min_bid` and `spot=True`), so these offers reach dstack today and are then discarded.

Vast's create endpoint is the same for both instance types. `PUT /asks/{id}/` creates an **interruptible** instance when the payload includes a `price` (per-machine bid in \$/hour), and an **on-demand** instance when it is omitted. This matches the official `vast-python` client, whose `create instance --bid_price` sends the same `price` field to the same endpoint.

The fix:

1. Drop the `extra_filter` that removed spot offers in `get_offers_by_requirements()`. Spot vs. on-demand selection is already driven by the run's `spot_policy` through the catalog query, so no offers are surfaced that the user did not ask for.
2. In `run_job()`, bid the spot offer's price (which gpuhunt already set to `min_bid`) and pass it to `create_instance()`; on-demand offers pass no bid.
3. Add the `price` field to the `create_instance()` payload (`None` for on-demand preserves the existing behavior).

Interruption handling requires no backend changes: the server infers a reclaimed spot instance from the lost runner connection and, because the offer is marked `spot`, terminates the job with `INTERRUPTED_BY_NO_CAPACITY`, which maps to the generic `interruption` retry event. This is the same path RunPod, OCI, and Nebius spot instances already use.

Tested against a live Vast.ai account: spot offers carry a `min_bid` below `dph_base` (e.g. an RTX 4090 at \$0.24/hr on-demand vs. \$0.12/hr `min_bid`), and the create endpoint accepts the `price` field. Unit tests cover that `run_job()` bids on spot offers and does not bid on on-demand offers.

Vast.ai API reference: https://docs.vast.ai/api/create-instance

AI assistance: This PR was written primarily by Claude Code (investigation, implementation, and tests) and reviewed by me before submitting.