### PR TITLE
Update gateway connection error log level

### DIFF
--- a/src/dstack/_internal/server/background/scheduled_tasks/gateways.py
+++ b/src/dstack/_internal/server/background/scheduled_tasks/gateways.py
@@ -57,7 +57,7 @@ async def _process_connection(conn: GatewayConnection):
     try:
         await conn.check_or_restart()
     except SSHError as e:
-        logger.error("Connection to gateway %s failed: %s", conn.ip_address, e)
+        logger.warning("Connection to gateway %s failed: %s", conn.ip_address, e)
         return
 
     await conn.try_collect_stats()


### PR DESCRIPTION
Use `warning` instead of `error` to avoid
reporting connection errors to Sentry. These
errors can occur if the user deleted or stopped
the gateway directly in the backend, in which case
the error does not indicate a problem with
`dstack`.