### PR TITLE
Support AWS G7 instances with NVIDIA RTX PRO 4500

### DIFF
--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -1250,6 +1250,7 @@ def _supported_instances(offer: InstanceOffer) -> bool:
         "p5e.",
         "p4d.",
         "p4de.",
+        "g7.",
         "g7e.",
         "g6.",
         "g6e.",

--- a/src/dstack/_internal/server/services/backends/provisioning.py
+++ b/src/dstack/_internal/server/services/backends/provisioning.py
@@ -19,6 +19,7 @@ _AWS_EFA_ENABLED_INSTANCE_TYPE_PATTERNS = [
     r"^p5en\.(48xlarge)$",
     r"^p4d\.(24xlarge)$",
     r"^p4de\.(24xlarge)$",
+    r"^g7\.(8xlarge|12xlarge|24xlarge|48xlarge)$",
     r"^g7e\.(8xlarge|12xlarge|24xlarge|48xlarge)$",
     r"^g6\.(8xlarge|12xlarge|16xlarge|24xlarge|48xlarge)$",
     r"^g6e\.(8xlarge|12xlarge|16xlarge|24xlarge|48xlarge)$",

--- a/src/tests/_internal/server/services/backends/test_provisioning.py
+++ b/src/tests/_internal/server/services/backends/test_provisioning.py
@@ -71,6 +71,7 @@ class TestResolveProvisioningImageName:
             "p4de.24xlarge",
             "g6.8xlarge",
             "g6e.8xlarge",
+            "g7.8xlarge",
             "g7e.8xlarge",
         ],
     )


### PR DESCRIPTION
```shell
$ dstack offer -b aws --gpu RTXPRO4500
 #   BACKEND          RESOURCES                                                  INSTANCE TYPE  PRICE
 1   aws (us-east-2)  cpu=8 mem=32GB disk=100GB gpu=RTXPRO4500:32GB:1 (spot)     g7.2xlarge     $0.3963
 2   aws (us-east-2)  cpu=32 mem=128GB disk=100GB gpu=RTXPRO4500:32GB:1 (spot)   g7.8xlarge     $0.4086
 3   aws (us-east-2)  cpu=16 mem=64GB disk=100GB gpu=RTXPRO4500:32GB:1 (spot)    g7.4xlarge     $0.4965
 4   aws (us-east-2)  cpu=48 mem=192GB disk=100GB gpu=RTXPRO4500:32GB:2 (spot)   g7.12xlarge    $0.7128
 5   aws (us-west-2)  cpu=32 mem=128GB disk=100GB gpu=RTXPRO4500:32GB:1 (spot)   g7.8xlarge     $0.7175
 6   aws (us-west-2)  cpu=8 mem=32GB disk=100GB gpu=RTXPRO4500:32GB:1 (spot)     g7.2xlarge     $0.7714
 7   aws (us-west-2)  cpu=16 mem=64GB disk=100GB gpu=RTXPRO4500:32GB:1 (spot)    g7.4xlarge     $0.8123
 8   aws (us-east-2)  cpu=96 mem=384GB disk=100GB gpu=RTXPRO4500:32GB:4 (spot)   g7.24xlarge    $1.4257
 9   aws (us-west-2)  cpu=96 mem=384GB disk=100GB gpu=RTXPRO4500:32GB:4 (spot)   g7.24xlarge    $1.5735
 10  aws (us-west-2)  cpu=48 mem=192GB disk=100GB gpu=RTXPRO4500:32GB:2 (spot)   g7.12xlarge    $2.0402
 11  aws (us-east-1)  cpu=8 mem=32GB disk=100GB gpu=RTXPRO4500:32GB:1            g7.2xlarge     $2.52
 12  aws (us-west-2)  cpu=8 mem=32GB disk=100GB gpu=RTXPRO4500:32GB:1            g7.2xlarge     $2.52
 13  aws (us-east-2)  cpu=8 mem=32GB disk=100GB gpu=RTXPRO4500:32GB:1            g7.2xlarge     $2.52
 14  aws (us-east-2)  cpu=192 mem=768GB disk=100GB gpu=RTXPRO4500:32GB:8 (spot)  g7.48xlarge    $2.8513
 15  aws (us-east-2)  cpu=16 mem=64GB disk=100GB gpu=RTXPRO4500:32GB:1           g7.4xlarge     $3.0421
 16  aws (us-east-1)  cpu=16 mem=64GB disk=100GB gpu=RTXPRO4500:32GB:1           g7.4xlarge     $3.0421
 17  aws (us-west-2)  cpu=16 mem=64GB disk=100GB gpu=RTXPRO4500:32GB:1           g7.4xlarge     $3.0421
 18  aws (us-east-1)  cpu=32 mem=128GB disk=100GB gpu=RTXPRO4500:32GB:1          g7.8xlarge     $4.0862
 19  aws (us-west-2)  cpu=32 mem=128GB disk=100GB gpu=RTXPRO4500:32GB:1          g7.8xlarge     $4.0862
 20  aws (us-east-2)  cpu=32 mem=128GB disk=100GB gpu=RTXPRO4500:32GB:1          g7.8xlarge     $4.0862
 21  aws (us-west-2)  cpu=192 mem=768GB disk=100GB gpu=RTXPRO4500:32GB:8 (spot)  g7.48xlarge    $4.4543
 22  aws (us-west-2)  cpu=48 mem=192GB disk=100GB gpu=RTXPRO4500:32GB:2          g7.12xlarge    $7.1283
 23  aws (us-east-1)  cpu=48 mem=192GB disk=100GB gpu=RTXPRO4500:32GB:2          g7.12xlarge    $7.1283
 24  aws (us-east-2)  cpu=48 mem=192GB disk=100GB gpu=RTXPRO4500:32GB:2          g7.12xlarge    $7.1283
 25  aws (us-east-1)  cpu=96 mem=384GB disk=100GB gpu=RTXPRO4500:32GB:4          g7.24xlarge    $14.2566
 26  aws (us-west-2)  cpu=96 mem=384GB disk=100GB gpu=RTXPRO4500:32GB:4          g7.24xlarge    $14.2566
 27  aws (us-east-2)  cpu=96 mem=384GB disk=100GB gpu=RTXPRO4500:32GB:4          g7.24xlarge    $14.2566
 28  aws (us-east-1)  cpu=192 mem=768GB disk=100GB gpu=RTXPRO4500:32GB:8         g7.48xlarge    $28.5133
 29  aws (us-east-2)  cpu=192 mem=768GB disk=100GB gpu=RTXPRO4500:32GB:8         g7.48xlarge    $28.5133
 30  aws (us-west-2)  cpu=192 mem=768GB disk=100GB gpu=RTXPRO4500:32GB:8         g7.48xlarge    $28.5133
```

EFA is set up automatically on supported instance types (`g7.8xlarge`, `g7.12xlarge`, `g7.24xlarge`, `g7.48xlarge`). NCCL tests on 2x `g7.48xlarge`: [nccl-tests.txt](https://github.com/user-attachments/files/30303117/nccl-tests.txt)

Related: https://github.com/dstackai/gpuhunt/pull/244