### PR TITLE
Use test log storage in `test_updates_running_job`

### DIFF
--- a/src/tests/_internal/server/background/pipeline_tasks/test_running_jobs.py
+++ b/src/tests/_internal/server/background/pipeline_tasks/test_running_jobs.py
@@ -91,7 +91,7 @@ from dstack._internal.server.testing.common import (
 )
 from dstack._internal.utils.common import get_current_datetime
 
-pytestmark = pytest.mark.usefixtures("image_config_mock")
+pytestmark = pytest.mark.usefixtures("image_config_mock", "test_log_storage")
 
 
 @dataclass


### PR DESCRIPTION
No logs written by the tests, but an instance of a `LogStorage` implementation is created via `write_logs()` -> `get_log_storage()`, leading to possible side effects, e.g. `CloudWatchLogStorage.__init__()` checks if the log group exists and fails with an error (suppressed, but a warning is still emitted):

> UserWarning: A test tried to use socket.socket.connect() with host
> "3.250.243.83" (allowed: "127.0.0.1,localhost (127.0.0.1)").
>     raise SocketConnectBlockedError(allowed_list, host)