### PR TITLE
Add AWS `experimental_instance_types` setting

### DIFF
--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -1,7 +1,8 @@
 import threading
-from collections.abc import Iterable
+from collections.abc import Container, Iterable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
+from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import boto3
@@ -141,6 +142,10 @@ class AWSCompute(
             )
         else:  # default creds
             self.session = boto3.Session()
+        self._supported_instances = partial(
+            _supported_instances,
+            experimental_instance_types=set(self.config.experimental_instance_types or []),
+        )
         # Caches to avoid redundant API calls when provisioning many instances
         # get_offers is already cached but we still cache its sub-functions
         # with more aggressive/longer caches.
@@ -163,7 +168,7 @@ class AWSCompute(
         offers = get_catalog_offers(
             backend=BackendType.AWS,
             locations=self.config.regions,
-            extra_filter=_supported_instances,
+            extra_filter=self._supported_instances,
         )
         regions = list(set(i.region for i in offers))
         regions_to_quotas = self._get_regions_to_quotas(self.session, regions)
@@ -1243,7 +1248,11 @@ def _get_regions_to_zones(session: boto3.Session, regions: List[str]) -> Dict[st
     return regions_to_zones
 
 
-def _supported_instances(offer: InstanceOffer) -> bool:
+def _supported_instances(
+    offer: InstanceOffer, experimental_instance_types: Container[str]
+) -> bool:
+    if offer.instance.name in experimental_instance_types:
+        return True
     for family in [
         "m7i.",
         "c7i.",

--- a/src/dstack/_internal/core/backends/aws/models.py
+++ b/src/dstack/_internal/core/backends/aws/models.py
@@ -106,6 +106,16 @@ class AWSBackendConfig(CoreModel):
             description="The mapping of instance categories (CPU, NVIDIA GPU) to AMI configurations"
         ),
     ] = None
+    experimental_instance_types: Annotated[
+        Optional[List[str]],
+        Field(
+            description=(
+                "The list of instance type names to allow provisioning in addition to"
+                " the standard supported instance families. Only works for instance types"
+                " included in `dstack`'s pricing catalog (`gpuhunt`)"
+            )
+        ),
+    ] = None
 
 
 class AWSBackendConfigWithCreds(AWSBackendConfig):

--- a/src/tests/_internal/server/routers/test_backends.py
+++ b/src/tests/_internal/server/routers/test_backends.py
@@ -828,6 +828,7 @@ class TestGetConfigInfo:
             "iam_instance_profile": None,
             "tags": None,
             "os_images": None,
+            "experimental_instance_types": None,
             "creds": json.loads(backend.auth.get_plaintext_or_error()),
         }
 


### PR DESCRIPTION
Add an AWS backend setting that accepts a list of
instance type names to allow provisioning in
addition to the standard supported instance
families. Only works for instance types included
in `dstack`'s pricing catalog (`gpuhunt`).

Today, this setting can be used to test the
`p5en.48xlarge` instance type, which wasn't yet
tested internally at `dstack`.

```yaml
experimental_instance_types: [p5en.48xlarge]
```

```shell
$ dstack offer -b aws --instance-type p5en.48xlarge
 #   BACKEND           RESOURCES                                              INSTANCE TYPE  PRICE      
 1   aws (us-east-2)   cpu=192 mem=2048GB disk=100GB gpu=H200:141GB:8 (spot)  p5en.48xlarge  $26.6319   
 2   aws (us-west-2)   cpu=192 mem=2048GB disk=100GB gpu=H200:141GB:8 (spot)  p5en.48xlarge  $26.9512   
 3   aws (us-east-1)   cpu=192 mem=2048GB disk=100GB gpu=H200:141GB:8 (spot)  p5en.48xlarge  $27.1928   
 4   aws (eu-north-1)  cpu=192 mem=2048GB disk=100GB gpu=H200:141GB:8 (spot)  p5en.48xlarge  $38.3825   
 5   aws (us-east-2)   cpu=192 mem=2048GB disk=100GB gpu=H200:141GB:8         p5en.48xlarge  $63.296    
 6   aws (us-east-1)   cpu=192 mem=2048GB disk=100GB gpu=H200:141GB:8         p5en.48xlarge  $63.296    
 7   aws (us-west-2)   cpu=192 mem=2048GB disk=100GB gpu=H200:141GB:8         p5en.48xlarge  $63.296    
 8   aws (eu-north-1)  cpu=192 mem=2048GB disk=100GB gpu=H200:141GB:8         p5en.48xlarge  $67.7267   
 9   aws (us-west-1)   cpu=192 mem=2048GB disk=100GB gpu=H200:141GB:8         p5en.48xlarge  $79.12     
 10  aws (us-west-1)   cpu=192 mem=2048GB disk=100GB gpu=H200:141GB:8 (spot)  p5en.48xlarge  $79.12
```