### PR TITLE
Fix TCP port range validation

### DIFF
--- a/src/dstack/_internal/core/models/configurations.py
+++ b/src/dstack/_internal/core/models/configurations.py
@@ -50,7 +50,7 @@ from dstack._internal.utils.json_utils import (
 )
 
 CommandsList = List[str]
-ValidPort = conint(gt=0, le=65536)
+ValidPort = conint(gt=0, le=65535)
 MAX_INT64 = 2**63 - 1
 SERVICE_HTTPS_DEFAULT = True
 STRIP_PREFIX_DEFAULT = True

--- a/src/tests/_internal/pydantic_compat/test_field_parsing.py
+++ b/src/tests/_internal/pydantic_compat/test_field_parsing.py
@@ -113,6 +113,15 @@ class TestPortFieldParsing:
         assert class_name(config.port) == "PortMapping"
         assert config.port.dict() == expected
 
+    @pytest.mark.parametrize("ports", [[65536], ["65536:80"], ["80:65536"]])
+    def test_task_ports_above_tcp_range_are_rejected(self, ports: list[Any]):
+        with pytest.raises(ConfigurationError, match="65535"):
+            parse_apply_configuration(_task(ports=ports))
+
+    def test_service_port_above_tcp_range_is_rejected(self):
+        with pytest.raises(ConfigurationError, match="65535"):
+            parse_apply_configuration(_service(port=65536))
+
 
 class TestMountPointFieldParsing:
     def test_string_arms_select_volume_and_instance_mount_models(self):


### PR DESCRIPTION
## Summary

- Reject port values above the TCP/UDP maximum of 65535.
- Cover task port lists and service port parsing, including local and container mappings.

`ValidPort` previously accepted 65536, allowing an invalid port to reach job specifications.

Fixes #4076.

## Tests

- `uv run pytest src/tests/_internal/pydantic_compat/test_field_parsing.py --pydantic-compat -q`
- `uv run ruff check src/dstack/_internal/core/models/configurations.py src/tests/_internal/pydantic_compat/test_field_parsing.py`
- `uv run ruff format --check src/dstack/_internal/core/models/configurations.py src/tests/_internal/pydantic_compat/test_field_parsing.py`
