### PR TITLE
Tell agents to scope test runs and use -n auto

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,8 @@ Before touching a subsystem, read the relevant notes in `contributing/`: `ARCHIT
 
 ## Testing Guidelines
 - Default to `uv run pytest`. Use markers from `tests/conftest.py` like `--runpostgres` if need to include specific tests.
+- Scope the run to the change: for trivial or localized edits, run only the affected test modules, `Test*` classes, or `-k` selection instead of the whole suite. Reserve the full suite for broad or cross-cutting changes.
+- Speed up large runs with `-n auto` (pytest-xdist), e.g. `uv run pytest -n auto`.
 - Group tests for the same unit (function/class) using `Test*` classes that mirror unit's name.
 - Keep tests hermetic (network disabled except localhost per `pytest.ini`); stub cloud calls with mocks.
 


### PR DESCRIPTION
Adds two bullets to the Testing Guidelines in `AGENTS.md`:

- Scope test runs to the change (affected modules / `Test*` classes / `-k`) instead of always running the full suite; reserve the full suite for broad or cross-cutting changes.
- Speed up large runs with `-n auto` (pytest-xdist, already a dev dependency).

Verified `uv run pytest src/tests/_internal/server/test_app.py -n auto -q` works: 14 passed, 15 skipped in 4.25s.

Docs only, no behavior change.

AI assistance: written with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)