### PR TITLE
Force rich non-terminal output in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,8 +133,10 @@ markers = [
     "dockerized",
 ]
 env = [
-    "DSTACK_CLI_RICH_FORCE_TERMINAL=0",
     "DSTACK_SSHPROXY_API_TOKEN=test-token",
+    # Pin every rich console in the process to non-terminal output so tests asserting on plain CLI
+    # text never see ANSI escapes.
+    "TTY_COMPATIBLE=0",
 ]
 filterwarnings = [
     # Fail on any use of a pydantic v1 shim (`.dict()`, `parse_obj_as`, class-based `Config`, ...)

--- a/src/dstack/_internal/cli/utils/common.py
+++ b/src/dstack/_internal/cli/utils/common.py
@@ -24,16 +24,9 @@ _colors = {
     "code": "bold sea_green3",
 }
 
-console = Console(
-    theme=Theme(_colors),
-    force_terminal=settings.CLI_RICH_FORCE_TERMINAL,
-)
+console = Console(theme=Theme(_colors))
 
-error_console = Console(
-    theme=Theme(_colors),
-    force_terminal=settings.CLI_RICH_FORCE_TERMINAL,
-    stderr=True,
-)
+error_console = Console(theme=Theme(_colors), stderr=True)
 
 
 LIVE_TABLE_REFRESH_RATE_PER_SEC = 1

--- a/src/dstack/_internal/settings.py
+++ b/src/dstack/_internal/settings.py
@@ -1,7 +1,6 @@
 import os
 
 from dstack import version
-from dstack._internal.utils.env import environ
 from dstack._internal.utils.version import parse_version
 
 DSTACK_VERSION = os.getenv("DSTACK_VERSION", version.__version__)
@@ -33,8 +32,6 @@ DSTACK_DIND_IMAGE = os.getenv("DSTACK_DIND_IMAGE", "dstackai/dind")
 
 CLI_LOG_LEVEL = os.getenv("DSTACK_CLI_LOG_LEVEL", "INFO").upper()
 CLI_FILE_LOG_LEVEL = os.getenv("DSTACK_CLI_FILE_LOG_LEVEL", "DEBUG").upper()
-# Can be used to disable control characters (e.g. for testing).
-CLI_RICH_FORCE_TERMINAL = environ.get_bool("DSTACK_CLI_RICH_FORCE_TERMINAL")
 
 
 class FeatureFlags:


### PR DESCRIPTION
Fixes CLI tests failing for coding agents (and confusing them), which may run with `FORCE_COLOR=3` set. rich then colorizes even though stdout is a pipe, so assertions on plain CLI text see ANSI escapes. The same tests pass in a normal terminal and in CI, where `FORCE_COLOR` is unset.

Two tests were affected, both asserting on `"Usage: dstack"`:

- `TestDstack::test_prints_help_and_exists_with_0_exit_code`
- `TestAgentIsolation::test_creates_private_cli_home_and_dstack_wrapper`

`DSTACK_CLI_RICH_FORCE_TERMINAL=0` could not prevent this: it only reaches the consoles dstack constructs, and `--help` is rendered by a console `rich_argparse` creates internally. `TTY_COMPATIBLE=0` applies to every rich console in the process and is checked ahead of `FORCE_COLOR`, so it also covers dstack's own consoles. That makes `DSTACK_CLI_RICH_FORCE_TERMINAL` redundant, so it is removed - it was only ever added to keep control characters out of test output (0256b620f) and is undocumented.

Verified: full suite green with `FORCE_COLOR=3` still set (3271 passed, 1735 skipped); previously 2 failed in the same environment.

AI assistance: written with Claude Code.