### PR TITLE
[chore]: Drop redundant Pydantic variable annotations

### DIFF
--- a/src/dstack/_internal/core/backends/hotaisle/compute.py
+++ b/src/dstack/_internal/core/backends/hotaisle/compute.py
@@ -78,7 +78,7 @@ class HotAisleCompute(
     ) -> JobProvisioningData:
         project_ssh_key = instance_config.ssh_keys[0]
         self.api_client.upload_ssh_key(project_ssh_key.public)
-        offer_backend_data: HotAisleOfferBackendData = validate_extra_ignore(
+        offer_backend_data = validate_extra_ignore(
             HotAisleOfferBackendData, instance_offer.backend_data
         )
         vm_data = self.api_client.create_virtual_machine(offer_backend_data.vm_specs)

--- a/src/dstack/_internal/core/backends/nebius/compute.py
+++ b/src/dstack/_internal/core/backends/nebius/compute.py
@@ -291,7 +291,7 @@ class NebiusCompute(
         master_instance_offer: InstanceOffer,
     ) -> PlacementGroupProvisioningData:
         assert placement_group.configuration.placement_strategy == PlacementStrategy.CLUSTER
-        master_instance_offer_backend_data: NebiusOfferBackendData = validate_extra_ignore(
+        master_instance_offer_backend_data = validate_extra_ignore(
             NebiusOfferBackendData, master_instance_offer.backend_data
         )
         fabrics = list(master_instance_offer_backend_data.fabrics)
@@ -337,7 +337,7 @@ class NebiusCompute(
         placement_group_backend_data = NebiusPlacementGroupBackendData.load(
             placement_group.provisioning_data.backend_data
         )
-        instance_offer_backend_data: NebiusOfferBackendData = validate_extra_ignore(
+        instance_offer_backend_data = validate_extra_ignore(
             NebiusOfferBackendData, instance_offer.backend_data
         )
         return (

--- a/src/dstack/_internal/core/backends/nebius/resources.py
+++ b/src/dstack/_internal/core/backends/nebius/resources.py
@@ -258,9 +258,7 @@ def get_all_infiniband_fabrics() -> set[str]:
     offers = get_catalog_offers(backend=BackendType.NEBIUS)
     result = set()
     for offer in offers:
-        backend_data: NebiusOfferBackendData = validate_extra_ignore(
-            NebiusOfferBackendData, offer.backend_data
-        )
+        backend_data = validate_extra_ignore(NebiusOfferBackendData, offer.backend_data)
         result |= backend_data.fabrics
     return result
 

--- a/src/dstack/_internal/core/backends/runpod/compute.py
+++ b/src/dstack/_internal/core/backends/runpod/compute.py
@@ -485,8 +485,6 @@ def _is_secure_cloud(region: str) -> bool:
 
 
 def _get_offer_pod_counts(offer: InstanceOfferWithAvailability) -> list[int]:
-    backend_data: RunpodOfferBackendData = validate_extra_ignore(
-        RunpodOfferBackendData, offer.backend_data
-    )
+    backend_data = validate_extra_ignore(RunpodOfferBackendData, offer.backend_data)
     pod_counts = backend_data.pod_counts or []
     return pod_counts

--- a/src/dstack/_internal/core/backends/vastai/compute.py
+++ b/src/dstack/_internal/core/backends/vastai/compute.py
@@ -131,7 +131,7 @@ class VastAICompute(
         commands = get_docker_commands(
             [run.run_spec.ssh_key_pub.strip(), project_ssh_public_key.strip()]
         )
-        offer_backend_data: VastAIOfferBackendData = validate_extra_ignore(
+        offer_backend_data = validate_extra_ignore(
             VastAIOfferBackendData, instance_offer.backend_data
         )
         bid = None

--- a/src/dstack/_internal/server/services/gateways/__init__.py
+++ b/src/dstack/_internal/server/services/gateways/__init__.py
@@ -812,9 +812,7 @@ def _get_gateway_compute_router_config(
 ) -> Optional[AnyGatewayRouterConfig]:
     if compute.configuration is None:  # pre-0.18.2 gateway
         return None  # gateway routers introduced in 0.19.38
-    compute_config: GatewayComputeConfiguration = validate_json_extra_ignore(
-        GatewayComputeConfiguration, compute.configuration
-    )
+    compute_config = validate_json_extra_ignore(GatewayComputeConfiguration, compute.configuration)
     return compute_config.router
 
 

--- a/src/dstack/_internal/server/services/proxy/repo.py
+++ b/src/dstack/_internal/server/services/proxy/repo.py
@@ -81,7 +81,7 @@ class ServerProxyRepo(BaseProxyRepo):
         router = run_spec.configuration.router
         replicas = []
         for job in jobs:
-            jpd: JobProvisioningData = validate_json_extra_ignore(
+            jpd = validate_json_extra_ignore(
                 JobProvisioningData, get_or_error(job.job_provisioning_data)
             )
             assert jpd.hostname is not None
@@ -156,9 +156,7 @@ class ServerProxyRepo(BaseProxyRepo):
         )
         models = []
         for run in res.scalars().all():
-            service_spec: ServiceSpec = validate_json_extra_ignore(
-                ServiceSpec, get_or_error(run.service_spec)
-            )
+            service_spec = validate_json_extra_ignore(ServiceSpec, get_or_error(run.service_spec))
             model_spec = service_spec.model
             model_options_obj = service_spec.options.get("openai", {}).get("model")
             if model_spec is None or model_options_obj is None:

--- a/src/dstack/api/server/_runs.py
+++ b/src/dstack/api/server/_runs.py
@@ -98,7 +98,7 @@ class RunsAPIClient(APIClientGroup):
         plan: Union[RunPlan, ApplyRunPlanInput],
         force: bool = False,
     ) -> Run:
-        plan_input: ApplyRunPlanInput = validate_extra_ignore(ApplyRunPlanInput, plan)
+        plan_input = validate_extra_ignore(ApplyRunPlanInput, plan)
         body = ApplyRunPlanRequest(plan=plan_input, force=force)
         body = copy.deepcopy(body)
         patch_run_spec(body.plan.run_spec)


### PR DESCRIPTION
These annotations are an artifact of the
now-irrelevant pydantic-duality parsing with
`CoreModel.__response__`, which returned an
unknown type. The recently added
`validate_json_extra_ignore` and
`validate_extra_ignore` functions infer return
types correctly, so call sites no longer require
an annotation.