### PR TITLE
Add dstack user agent to Nebius SDK

### DIFF
--- a/src/dstack/_internal/core/backends/nebius/resources.py
+++ b/src/dstack/_internal/core/backends/nebius/resources.py
@@ -60,6 +60,7 @@ from dstack._internal.core.models.backends.base import BackendType
 from dstack._internal.core.models.common import validate_extra_ignore
 from dstack._internal.utils.event_loop import DaemonEventLoop
 from dstack._internal.utils.logging import get_logger
+from dstack.version import __version__
 
 #
 # Guidelines on using the Nebius SDK:
@@ -107,6 +108,7 @@ def make_sdk(creds: NebiusServiceAccountCreds) -> SDK:
             service_account_private_key_file_name=f.name,
             service_account_public_key_id=creds.public_key_id,
             service_account_id=creds.service_account_id,
+            user_agent_prefix=f"dstack/{__version__}",
         )
 
 

--- a/src/tests/_internal/core/backends/nebius/test_resources.py
+++ b/src/tests/_internal/core/backends/nebius/test_resources.py
@@ -1,0 +1,16 @@
+from dstack._internal.core.backends.nebius import resources
+from dstack._internal.core.backends.nebius.models import NebiusServiceAccountCreds
+
+
+def test_make_sdk_sets_user_agent_prefix(mocker):
+    sdk_cls = mocker.patch.object(resources, "SDK")
+    mocker.patch.object(resources, "__version__", "1.2.3")
+    creds = NebiusServiceAccountCreds(
+        service_account_id="service-account-id",
+        public_key_id="public-key-id",
+        private_key_content="private-key",
+    )
+
+    resources.make_sdk(creds)
+
+    assert sdk_cls.call_args.kwargs["user_agent_prefix"] == "dstack/1.2.3"


### PR DESCRIPTION
## Summary

- prefix Nebius SDK requests with `dstack/<version>`
- apply the prefix in the shared SDK factory used across Nebius backend operations
- cover the configured prefix with a focused unit test

## Testing

- `pytest src/tests/_internal/core/backends/nebius/test_resources.py -q`
- `ruff check src/dstack/_internal/core/backends/nebius/resources.py src/tests/_internal/core/backends/nebius/__init__.py src/tests/_internal/core/backends/nebius/test_resources.py`
- `ruff format --check src/dstack/_internal/core/backends/nebius/resources.py src/tests/_internal/core/backends/nebius/__init__.py src/tests/_internal/core/backends/nebius/test_resources.py`

## AI assistance

OpenAI Codex was used to identify the shared SDK construction path and prepare the change and test.
