### PR TITLE
Stop preset tests from waiting on the tail poll

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,8 @@ Before touching a subsystem, read the relevant notes in `contributing/`: `ARCHIT
 - Speed up large runs with `-n auto` (pytest-xdist), e.g. `uv run pytest -n auto`.
 - Group tests for the same unit (function/class) using `Test*` classes that mirror unit's name.
 - Keep tests hermetic (network disabled except localhost per `[tool.pytest.ini_options]` in `pyproject.toml`); stub cloud calls with mocks.
+- Keep the suite fast. Never let a test wait on real time.
+- Machinery that costs hundreds of milliseconds per test (spawning a subprocess, starting a container, generating a key, real HTTP) has to earn its place by covering something cheaper tests cannot. Say so in the test when it does. On the other hand, losing black-box coverage or making the test hard to follow is worse than the milliseconds it costs.
 
 ## Commit & Pull Request Guidelines
 - Name branches `issue_{issue_num}_{title}` when the work tracks an issue (e.g. `issue_3959_replicated_alb_gateways`), and `pr_{title}` otherwise.

--- a/src/tests/_internal/cli/services/presets/conftest.py
+++ b/src/tests/_internal/cli/services/presets/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+from dstack._internal.cli.services.presets.tail import _FileLineReader
+
+
+@pytest.fixture(autouse=True)
+def no_tail_poll_wait(monkeypatch: pytest.MonkeyPatch):
+    """
+    Stops the tailers from waiting between reads.
+
+    The agent writes its output to files rather than pipes, so reading it means polling,
+    and `_POLL_SECONDS` makes every run wait once after the agent has already exited.
+    Tests write the whole output up front, so there is nothing to wait for.
+    """
+    monkeypatch.setattr(_FileLineReader, "_POLL_SECONDS", 0)


### PR DESCRIPTION
## What

The preset agent writes its output to files rather than pipes, so reading it means polling: `_FileLineReader._POLL_SECONDS = 0.2`. When there is no new data and the agent process is still alive, the reader sleeps 200ms. Tests write the whole fake-agent output up front and the process exits in ~20ms, so every `run_preset_agent` call waited out a full poll it had nothing to wait for.

Tests that trigger a resume pay it 2-3 times, which matched the timings exactly:

| attempts | poll cost | measured |
|---|---|---|
| 1 | 200ms | 218, 220, 234ms |
| 2 | 400ms | 441, 459ms |
| 3 | 600ms | 673ms |

An autouse fixture in the presets test package sets the interval to 0.

## Effect

`test_agent.py` goes from **4.18s to 1.65s**, 41 passed. It was the most expensive test file in the suite.

What remains is genuine: `test_creates_private_cli_home_and_dstack_wrapper` spawns the real `dstack` CLI to prove the generated workspace wrapper executes, which cannot be shown without executing it.

No production code changed.

## Also

Two notes in AGENTS.md on keeping the suite fast, since this was the same class of issue as the lock-retry sleeps fixed in #4088.

---

AI assistance: written with Claude Code.