### PR TITLE
[CLI] Fix --cpu and --gpu argument parsers

### DIFF
--- a/src/dstack/_internal/cli/services/args.py
+++ b/src/dstack/_internal/cli/services/args.py
@@ -1,12 +1,10 @@
-from typing import Dict
-
 from dstack._internal.core.models import resources as resources
 from dstack._internal.core.models.configurations import PortMapping
 from dstack._internal.core.models.envs import EnvVarTuple
 
 
-def gpu_spec(v: str) -> Dict:
-    return resources.GPUSpec.parse(v)
+def gpu_spec(v: str) -> resources.GPUSpec:
+    return resources.GPUSpec.model_validate(v)
 
 
 def env_var(v: str) -> EnvVarTuple:
@@ -17,8 +15,8 @@ def port_mapping(v: str) -> PortMapping:
     return PortMapping.parse(v)
 
 
-def cpu_spec(v: str) -> dict:
-    return resources.CPUSpec.parse(v)
+def cpu_spec(v: str) -> resources.CPUSpec:
+    return resources.CPUSpec.model_validate(v)
 
 
 def memory_spec(v: str) -> resources.Range[resources.Memory]:

--- a/src/dstack/_internal/cli/services/resources.py
+++ b/src/dstack/_internal/cli/services/resources.py
@@ -2,7 +2,6 @@ import argparse
 
 from dstack._internal.cli.services.args import cpu_spec, disk_spec, gpu_spec, memory_spec
 from dstack._internal.cli.services.configurators.base import ArgsParser
-from dstack._internal.core.models import resources
 from dstack._internal.core.models.configurations import AnyRunConfiguration
 
 
@@ -45,9 +44,9 @@ def register_resources_args(parser: ArgsParser) -> None:
 
 def apply_resources_args(args: argparse.Namespace, conf: AnyRunConfiguration) -> None:
     if args.cpu_spec:
-        conf.resources.cpu = resources.CPUSpec.model_validate(args.cpu_spec)
+        conf.resources.cpu = args.cpu_spec
     if args.gpu_spec:
-        conf.resources.gpu = resources.GPUSpec.model_validate(args.gpu_spec)
+        conf.resources.gpu = args.gpu_spec
     if args.memory_spec:
         conf.resources.memory = args.memory_spec
     if args.disk_spec:


### PR DESCRIPTION
Previously, validation errors (pydantic's ValidationError exceptions) slipped through with a traceback, e.g.,

    dstack apply --cpu '1..2..3'
    dstack apply --gpu '...'

Now, they are catched by the parser and reported:

    dstack: error: argument --cpu: invalid cpu_spec value: '1..2..3'
    dstack: error: argument --gpu: invalid gpu_spec value: '...'