### PR TITLE
Dim the interrupted preset status

### DIFF
--- a/src/dstack/_internal/cli/services/presets/output.py
+++ b/src/dstack/_internal/cli/services/presets/output.py
@@ -14,7 +14,7 @@ _STATUS_DISPLAY = {
     "ready": ("verified", "grey"),
     "running": ("trialing", "bold sea_green3"),
     "verifying": ("verifying", "bold deep_sky_blue1"),
-    "interrupted": ("interrupted", "bold gold1"),
+    "interrupted": ("interrupted", "secondary"),
     "failed": ("failed", "indian_red1"),
 }
 

--- a/src/tests/_internal/cli/services/presets/test_output.py
+++ b/src/tests/_internal/cli/services/presets/test_output.py
@@ -160,12 +160,12 @@ class TestSessionRow:
     def test_omits_progress_without_trials_data(self):
         row = _session_row({"id": "ab12cd34", "status": "interrupted"})
 
-        assert row["STATUS"] == "[bold gold1]interrupted[/]"
+        assert row["STATUS"] == "[secondary]interrupted[/]"
 
     def test_counts_without_trials_num(self):
         row = _session_row({"id": "ab12cd34", "status": "interrupted", "trials": {"count": 2}})
 
-        assert row["STATUS"] == "[bold gold1]interrupted[/] [secondary](2)[/]"
+        assert row["STATUS"] == "[secondary]interrupted[/] [secondary](2)[/]"
 
 
 class TestOrdering:


### PR DESCRIPTION
`interrupted` in `dstack preset` was bold gold, the same weight as `trialing` and `verifying`. It is now dim, like the listing's other context columns.

---

AI assistance: written with Claude Code.