### PR TITLE
Add AWS `p5en.48xlarge` (8:H200 + Sapphire Rapids)

### DIFF
--- a/src/dstack/_internal/core/backends/aws/compute.py
+++ b/src/dstack/_internal/core/backends/aws/compute.py
@@ -1369,6 +1369,7 @@ def _supported_instances(
         "p6-b200.",
         "p5.",
         "p5e.",
+        "p5en.",
         "p4d.",
         "p4de.",
         "g7.",

--- a/src/tests/_internal/server/services/backends/test_provisioning.py
+++ b/src/tests/_internal/server/services/backends/test_provisioning.py
@@ -67,6 +67,7 @@ class TestResolveProvisioningImageName:
         [
             "p5.48xlarge",
             "p5e.48xlarge",
+            "p5en.48xlarge",
             "p4d.24xlarge",
             "p4de.24xlarge",
             "g6.8xlarge",


### PR DESCRIPTION
```shell
$ dstack offer -b aws --instance-type p5en.48xlarge
 #   BACKEND           RESOURCES                                              INSTANCE TYPE  PRICE
 1   aws (us-east-2)   cpu=192 mem=2048GB disk=100GB gpu=H200:141GB:8 (spot)  p5en.48xlarge  $26.5714
 2   aws (us-west-2)   cpu=192 mem=2048GB disk=100GB gpu=H200:141GB:8 (spot)  p5en.48xlarge  $26.9369
 3   aws (us-east-1)   cpu=192 mem=2048GB disk=100GB gpu=H200:141GB:8 (spot)  p5en.48xlarge  $27.1988
 4   aws (eu-north-1)  cpu=192 mem=2048GB disk=100GB gpu=H200:141GB:8 (spot)  p5en.48xlarge  $39.8158
 5   aws (us-east-2)   cpu=192 mem=2048GB disk=100GB gpu=H200:141GB:8         p5en.48xlarge  $63.296
 6   aws (us-east-1)   cpu=192 mem=2048GB disk=100GB gpu=H200:141GB:8         p5en.48xlarge  $63.296
 7   aws (us-west-2)   cpu=192 mem=2048GB disk=100GB gpu=H200:141GB:8         p5en.48xlarge  $63.296
 8   aws (eu-north-1)  cpu=192 mem=2048GB disk=100GB gpu=H200:141GB:8         p5en.48xlarge  $67.7267
 9   aws (us-west-1)   cpu=192 mem=2048GB disk=100GB gpu=H200:141GB:8         p5en.48xlarge  $79.12
 10  aws (us-west-1)   cpu=192 mem=2048GB disk=100GB gpu=H200:141GB:8 (spot)  p5en.48xlarge  $79.12
```

EFA is set up automatically:  [NCCL tests](https://github.com/user-attachments/files/30801191/nccl-tests.txt)
