### PR TITLE
Add Tags to ServiceConfiguration.replicas

### DIFF
--- a/src/dstack/_internal/core/models/configurations.py
+++ b/src/dstack/_internal/core/models/configurations.py
@@ -11,6 +11,7 @@ from pydantic import (
     Field,
     GetCoreSchemaHandler,
     RootModel,
+    Tag,
     ValidationError,
     ValidationInfo,
     conint,
@@ -1046,7 +1047,16 @@ class ServiceConfigurationParams(CoreModel):
     ] = None  # None = omitted (may get default when model is set); [] = explicit empty
 
     replicas: Annotated[
-        Optional[Union[List[ReplicaGroup], Range[int]]],
+        Optional[
+            # `Tag` only names the arm in validation errors. Without it the `loc` of a bad
+            # `replicas` spells out the whole wrapped schema —
+            # `service.replicas.list[function-after[validate_scaling(), ReplicaGroup]].0` — which
+            # is what `dstack apply` shows the user.
+            Union[
+                Annotated[list[ReplicaGroup], Tag("ReplicaGroup")],
+                Annotated[Range[int], Tag("Range[int]")],
+            ]
+        ],
         Field(
             description=(
                 "The number of replicas or a list of replica groups. "


### PR DESCRIPTION
Before:

    2 validation errors for BaseApplyConfiguration
    service.replicas.list[function-after[validate_scaling(), ReplicaGroup]].0
      Input should be a valid dictionary or instance of ReplicaGroup [type=model_type, input_value=None, input_type=NoneType]
        For further information visit https://errors.pydantic.dev/2.13/v/model_type
    service.replicas.function-before[_parse(), function-before[_parse(), function-after[_post_validate(), function-before[_parse(),
    function-after[_post_validate(), Range[int]]]]]]
      Input should be a valid dictionary or instance of Range[int] [type=model_type, input_value=[None], input_type=list]
        For further information visit https://errors.pydantic.dev/2.13/v/model_type

After:

    2 validation errors for BaseApplyConfiguration
    service.replicas.ReplicaGroup.0
      Input should be a valid dictionary or instance of ReplicaGroup [type=model_type, input_value=None, input_type=NoneType]
        For further information visit https://errors.pydantic.dev/2.13/v/model_type
    service.replicas.Range[int]
      Input should be a valid dictionary or instance of Range[int] [type=model_type, input_value=[None], input_type=list]
        For further information visit https://errors.pydantic.dev/2.13/v/model_type