### PR TITLE
Fix SSH connection directory race

### DIFF
--- a/src/dstack/_internal/server/services/runner/pool.py
+++ b/src/dstack/_internal/server/services/runner/pool.py
@@ -36,6 +36,8 @@ CONNECTIONS_DIR = SERVER_DIR_PATH / "instance-connections"
 MIN_ALIVE_CHECK_INTERVAL = 30
 """How often (at most) `InstanceConnection.is_alive()` runs `ssh -O check`, in seconds."""
 
+_CONN_DIR_CREATE_ATTEMPTS = 3
+
 
 @dataclass(frozen=True)
 class InstanceConnectionKey:
@@ -299,6 +301,22 @@ class InstanceConnection:
         return port_map
 
     @staticmethod
+    def _create_conn_dir(conn_dir: Path) -> None:
+        for attempt in range(_CONN_DIR_CREATE_ATTEMPTS):
+            try:
+                conn_dir.mkdir(parents=True, exist_ok=True)
+                return
+            except FileExistsError:
+                # Even with exist_ok=True, pathlib raises if the directory disappears
+                # between mkdir reporting EEXIST and pathlib checking that it is a directory.
+                if conn_dir.is_dir():
+                    return
+                if conn_dir.exists() or conn_dir.is_symlink():
+                    raise
+                if attempt == _CONN_DIR_CREATE_ATTEMPTS - 1:
+                    raise
+
+    @staticmethod
     def _resolve_conn_dir(
         key: InstanceConnectionKey, ephemeral: bool
     ) -> tuple[TemporaryDirectory, Path, Path]:
@@ -314,7 +332,7 @@ class InstanceConnection:
             CONNECTIONS_DIR
             / f"{key.hostname}:{key.port},{','.join(map(str, key.ports_to_forward))}"
         )
-        conn_dir.mkdir(parents=True, exist_ok=True)
+        InstanceConnection._create_conn_dir(conn_dir)
         # Connection_dir can have a long path that won't be accepted by the ssh command,
         # so we create a short temporary symlink.
         # The symlink may be removed by age-based /tmp cleanup while the connection is still alive.

--- a/src/tests/_internal/server/services/runner/test_pool.py
+++ b/src/tests/_internal/server/services/runner/test_pool.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+import pytest
+
+from dstack._internal.server.services.runner import pool as runner_pool
+from dstack._internal.server.services.runner.pool import InstanceConnection
+
+
+class TestInstanceConnectionCreateConnDir:
+    def test_retries_if_directory_disappears_during_creation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        conn_dir = tmp_path / "connection"
+        original_mkdir = Path.mkdir
+        attempts = 0
+
+        def racing_mkdir(path: Path, *args, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise FileExistsError(path)
+            return original_mkdir(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "mkdir", racing_mkdir)
+
+        InstanceConnection._create_conn_dir(conn_dir)
+
+        assert attempts == 2
+        assert conn_dir.is_dir()
+
+    def test_preserves_file_conflict(self, tmp_path: Path):
+        conn_dir = tmp_path / "connection"
+        conn_dir.write_text("not a directory")
+
+        with pytest.raises(FileExistsError):
+            InstanceConnection._create_conn_dir(conn_dir)
+
+        assert conn_dir.read_text() == "not a directory"
+
+    def test_limits_retries(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        conn_dir = tmp_path / "connection"
+        attempts = 0
+
+        def racing_mkdir(path: Path, *args, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            raise FileExistsError(path)
+
+        monkeypatch.setattr(Path, "mkdir", racing_mkdir)
+
+        with pytest.raises(FileExistsError):
+            InstanceConnection._create_conn_dir(conn_dir)
+
+        assert attempts == runner_pool._CONN_DIR_CREATE_ATTEMPTS
+
+
+def test_instance_connections_dir_is_isolated_from_server_state():
+    assert runner_pool.CONNECTIONS_DIR != runner_pool.SERVER_DIR_PATH / "instance-connections"
+    assert runner_pool.CONNECTIONS_DIR.is_dir()

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -4,6 +4,7 @@ from functools import cache
 
 import pytest
 
+from dstack._internal.server.services.runner import pool as runner_pool
 from dstack._internal.server.testing.conf import (  # noqa: F401
     postgres_container,
     postgres_db,
@@ -111,3 +112,12 @@ def disable_feature_flags():
             if not isinstance(value, bool):
                 raise RuntimeError(f"FeatureFlags.{name}: only bool values are supported")
             setattr(FeatureFlags, name, False)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def isolate_instance_connections_dir(tmp_path_factory: pytest.TempPathFactory):
+    """Give each pytest worker its own instance SSH connection directory."""
+    connections_dir = tmp_path_factory.mktemp("instance-connections")
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(runner_pool, "CONNECTIONS_DIR", connections_dir)
+        yield


### PR DESCRIPTION
## Summary

- Retry transient connection-directory creation races without hiding persistent file or symlink conflicts.
- Bound retries so continuous filesystem churn cannot hang the server.
- Give each pytest worker an isolated SSH connections directory.
- Add deterministic regression coverage for recovery, conflict preservation, retry limits, and test isolation.

Fixes #4095

## Testing

- uv run pytest src/tests/_internal/server/services/runner/test_pool.py -vv — 4 passed
- uv run pytest -n auto src/tests/_internal/server/background/pipeline_tasks/test_terminating_jobs.py -vv — 19 passed, 19 skipped
- uv run pytest -n auto src/tests --runui — 3359 passed, 1724 skipped
- uv run pre-commit run -a --show-diff-on-failure — passed
- uvx pyright --pythonpath .venv/bin/python -p . — 0 errors, 0 warnings

## AI assistance

Assisted moderately by Codex.