### PR TITLE
Bump testcontainers>=4.15.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,9 +146,6 @@ filterwarnings = [
     # Fail on any use of a pydantic v1 shim (`.dict()`, `parse_obj_as`, class-based `Config`, ...)
     # so they cannot creep back after the v2 migration.
     "error::pydantic.PydanticDeprecatedSince20",
-    # testcontainers modules use deprecated decorators – nothing we can do:
-    # https://github.com/testcontainers/testcontainers-python/issues/874
-    "ignore:^The @wait_container_is_ready decorator:DeprecationWarning",
 ]
 
 [tool.tox]
@@ -195,7 +192,7 @@ test = [
     "freezegun>=1.5.1",
     "httpbin>=0.10.2", # indirect to make compatible with Werkzeug 3
     "openai>=1.68.2",
-    "testcontainers>=4.9.2",
+    "testcontainers>=4.15.0",
 ]
 docs = [
     "dstack[server]",

--- a/src/dstack/_internal/server/testing/conf.py
+++ b/src/dstack/_internal/server/testing/conf.py
@@ -2,7 +2,7 @@ import pytest
 import pytest_asyncio
 from sqlalchemy import StaticPool
 from sqlalchemy.ext.asyncio import create_async_engine
-from testcontainers.postgres import PostgresContainer
+from testcontainers.community.postgres import PostgresContainer
 
 from dstack._internal.server import settings
 from dstack._internal.server.db import Database, override_db

--- a/src/tests/_internal/server/test_migrations.py
+++ b/src/tests/_internal/server/test_migrations.py
@@ -6,7 +6,7 @@ from alembic.config import Config
 from alembic.util.exc import CommandError
 from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import create_async_engine
-from testcontainers.postgres import PostgresContainer
+from testcontainers.community.postgres import PostgresContainer
 
 
 def test_sqlite_migrations(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
* Community modules were moved to the `testcontainers.community` subpackage since 4.15.0. Old imports emit warnings:
  > testcontainers.postgres is deprecated, use
  > testcontainers.community.postgres instead
* Deprecated `wait_container_is_ready` decorator is not used by the postgres module since 4.14.0, making the warning filter redundant