### PR TITLE
Ignore google package warning about near-EOL Python version in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,8 @@ filterwarnings = [
     # Fail on any use of a pydantic v1 shim (`.dict()`, `parse_obj_as`, class-based `Config`, ...)
     # so they cannot creep back after the v2 migration.
     "error::pydantic.PydanticDeprecatedSince20",
+    # Remove or change to 3.11 once support for Python 3.10 is dropped.
+    "ignore:You are using a Python version \\(3.10:FutureWarning:^google\\.",
 ]
 
 [tool.tox]


### PR DESCRIPTION
> You are using a Python version (3.10.20) which Google will stop
> supporting in new releases of google.cloud.appengine_logging_v1
> once it reaches its end of life (2026-10-04). Please upgrade to
> the latest Python version, or at least Python 3.11, to continue
> receiving updates for google.cloud.appengine_logging_v1 past
> that date.