### PR TITLE
Allow manual gateway scaling (drop feature flag)

### DIFF
--- a/mkdocs/docs/concepts/gateways.md
+++ b/mkdocs/docs/concepts/gateways.md
@@ -172,7 +172,6 @@ $ dstack gateway list
 !!! warning "Experimental"
     Replicated gateways are an experimental feature and currently have limitations:
 
-    - Changing the number of replicas or redeploying replicas is not supported.
     - HTTPS is only supported for AWS gateways with the `acm` [certificate type](#certificate). For other gateways, use an external load balancer for TLS termination.
     - An unavailable gateway replica prevents any new services or service replicas from being added.
     - All replicas are bound to the same backend and region.

--- a/src/dstack/_internal/server/services/gateways/__init__.py
+++ b/src/dstack/_internal/server/services/gateways/__init__.py
@@ -79,7 +79,6 @@ from dstack._internal.server.services.locking import (
 from dstack._internal.server.services.pipelines import PipelineHinterProtocol
 from dstack._internal.server.services.plugins import apply_plugin_policies
 from dstack._internal.server.utils.common import gather_map_async
-from dstack._internal.settings import FeatureFlags
 from dstack._internal.utils import crypto
 from dstack._internal.utils.common import (
     get_current_datetime,
@@ -89,9 +88,7 @@ from dstack._internal.utils.common import (
 from dstack._internal.utils.logging import get_logger
 
 logger = get_logger(__name__)
-_CONF_UPDATABLE_FIELDS = frozenset({"domain", "default"})
-if FeatureFlags.GATEWAY_SCALING:
-    _CONF_UPDATABLE_FIELDS |= {"replicas"}
+_CONF_UPDATABLE_FIELDS = frozenset({"domain", "default", "replicas"})
 
 
 def switch_gateway_status(

--- a/src/dstack/_internal/settings.py
+++ b/src/dstack/_internal/settings.py
@@ -47,8 +47,3 @@ class FeatureFlags:
     """If DSTACK_FF_CLI_PRINT_JOB_CONNECTION_INFO enabled, `dstack apply` command prints server-provided
     IDE URL(s) and SSH command(s) before job logs (for dev-environments only).
     """
-    GATEWAY_SCALING = os.getenv("DSTACK_FF_GATEWAY_SCALING") is not None
-    """Allows in-place update of gateway `replicas`.
-    Has limited applicability at the current stage — without a state sync mechanism, newly started
-    gateway replicas are not aware of existing services.
-    """


### PR DESCRIPTION
The number of gateway replicas can now be changed
in-place.

```shell
$ dstack apply -f my-gateway.dstack.yml
Found gateway my-gateway. Detected changes that can be updated in-place:
- replicas

Update the gateway? [y/n]:
```

When scaling in, `dstack` stops the oldest
replicas first.

#3959