### PR TITLE
Always show replica IP in `dstack gateway -v`

### DIFF
--- a/src/dstack/_internal/cli/utils/gateway.py
+++ b/src/dstack/_internal/cli/utils/gateway.py
@@ -101,8 +101,12 @@ def get_gateways_table(
                 gateway.configuration.backend, gateway.configuration.region
             )
             gateway_row["HOSTNAME"] = gateway_row.get("HOSTNAME", gateway.ip_address)
-        if len(gateway.replicas) == 1:
-            # compact display for single-replica gateway
+        single_row_format = (
+            len(gateway.replicas) == 1
+            # gateway.hostname should not obscure replica.hostname in --verbose
+            and not (verbose and gateway.hostname)
+        )
+        if single_row_format:
             gateway_row["BACKEND"] = format_backend(
                 gateway.replicas[0].backend, gateway.replicas[0].region
             )
@@ -113,7 +117,7 @@ def get_gateways_table(
             )
         add_row_from_dict(table, gateway_row)
 
-        if len(gateway.replicas) > 1:
+        if not single_row_format:
             for replica in gateway.replicas:
                 replica_row = {
                     "NAME": f"   replica={replica.replica_num}",


### PR DESCRIPTION
This allows to view the replica IP address of
single-replica gateways with a load balancer.
Before this commit, the load balancer's hostname
would obscure the replica's IP address, which is
still the case without `--verbose`.

```shell
$ dstack gateway
 NAME        BACKEND          HOSTNAME                                                   DOMAIN       DEFAULT  STATUS
 my-gateway  aws (eu-west-1)  dstack-sj8w4lxu-lb-3982068021.eu-west-1.elb.amazonaws.com  example.com  ✓        running

$ dstack gateway --verbose
 NAME          BACKEND          HOSTNAME                                                   DOMAIN       DEFAULT  STATUS   CREATED     ERROR
 my-gateway                     dstack-sj8w4lxu-lb-3982068021.eu-west-1.elb.amazonaws.com  example.com  ✓        running  9 mins ago
    replica=0  aws (eu-west-1)  3.249.160.53                                                                     running  9 mins ago
```