### PR TITLE
[UI] Move SSH keys into the Settings tab on the user page

### DIFF
--- a/frontend/src/pages/User/Details/PublicKeys/index.tsx
+++ b/frontend/src/pages/User/Details/PublicKeys/index.tsx
@@ -1,22 +1,18 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
 import CloudscapeInput from '@cloudscape-design/components/input';
 import CloudscapeTextarea from '@cloudscape-design/components/textarea';
 
 import { Box, Button, ButtonWithConfirmation, FormField, Header, InfoLink, Modal, SpaceBetween, Table } from 'components';
 
-import { useBreadcrumbs, useCollection, useHelpPanel, useNotifications } from 'hooks';
+import { useCollection, useHelpPanel, useNotifications } from 'hooks';
 import { getServerError } from 'libs';
-import { ROUTES } from 'routes';
 import { IPublicKey, useAddPublicKeyMutation, useDeletePublicKeysMutation, useListPublicKeysQuery } from 'services/publicKeys';
 
 import { SSH_KEYS_INFO } from './constants';
 
 export const PublicKeys: React.FC = () => {
     const { t } = useTranslation();
-    const params = useParams();
-    const paramUserName = params.userName ?? '';
     const [pushNotification] = useNotifications();
     const [openHelpPanel] = useHelpPanel();
 
@@ -28,21 +24,6 @@ export const PublicKeys: React.FC = () => {
     const { data: publicKeys = [], isLoading } = useListPublicKeysQuery();
     const [addPublicKey, { isLoading: isAdding }] = useAddPublicKeyMutation();
     const [deletePublicKeys, { isLoading: isDeleting }] = useDeletePublicKeysMutation();
-
-    useBreadcrumbs([
-        {
-            text: t('navigation.account'),
-            href: ROUTES.USER.LIST,
-        },
-        {
-            text: paramUserName,
-            href: ROUTES.USER.DETAILS.FORMAT(paramUserName),
-        },
-        {
-            text: t('users.public_keys.title'),
-            href: ROUTES.USER.PUBLIC_KEYS.FORMAT(paramUserName),
-        },
-    ]);
 
     const { items, collectionProps } = useCollection(publicKeys, {
         selection: {},

--- a/frontend/src/pages/User/Details/Settings/index.tsx
+++ b/frontend/src/pages/User/Details/Settings/index.tsx
@@ -13,6 +13,8 @@ import { GlobalUserRole } from 'types';
 
 import { selectUserData } from 'App/slice';
 
+import { PublicKeys } from '../PublicKeys';
+
 import styles from './styles.module.scss';
 
 export const Settings: React.FC = () => {
@@ -51,62 +53,66 @@ export const Settings: React.FC = () => {
     };
 
     return (
-        <Container
-            header={
-                <Header
-                    variant="h2"
-                    actions={
-                        <Button onClick={editUserHandler} disabled={isDisabledUserEditing()}>
-                            {t('common.edit')}
-                        </Button>
-                    }
-                >
-                    {t('users.account_settings')}
-                </Header>
-            }
-        >
-            {isLoading && <Loader />}
+        <SpaceBetween size="l">
+            <Container
+                header={
+                    <Header
+                        variant="h2"
+                        actions={
+                            <Button onClick={editUserHandler} disabled={isDisabledUserEditing()}>
+                                {t('common.edit')}
+                            </Button>
+                        }
+                    >
+                        {t('users.account_settings')}
+                    </Header>
+                }
+            >
+                {isLoading && <Loader />}
 
-            {data && (
-                <ColumnLayout columns={2} variant="text-grid">
-                    <SpaceBetween size="l">
-                        {/*<div>*/}
-                        {/*    <Box variant="awsui-key-label">{t('users.user_name')}</Box>*/}
-                        {/*    <div>{data.user_name}</div>*/}
-                        {/*</div>*/}
+                {data && (
+                    <ColumnLayout columns={2} variant="text-grid">
+                        <SpaceBetween size="l">
+                            {/*<div>*/}
+                            {/*    <Box variant="awsui-key-label">{t('users.user_name')}</Box>*/}
+                            {/*    <div>{data.user_name}</div>*/}
+                            {/*</div>*/}
 
-                        <div>
-                            <Box variant="awsui-key-label">{t('users.email')}</Box>
-                            <div>{data.email ? <Link href={`mailto:${data.email}`}>{data.email}</Link> : '-'}</div>
-                        </div>
-
-                        <PermissionGuard allowedGlobalRoles={[GlobalUserRole.ADMIN]}>
                             <div>
-                                <Box variant="awsui-key-label">{t('users.global_role')}</Box>
-                                <div>{t(`roles.${data.global_role}`)}</div>
+                                <Box variant="awsui-key-label">{t('users.email')}</Box>
+                                <div>{data.email ? <Link href={`mailto:${data.email}`}>{data.email}</Link> : '-'}</div>
                             </div>
-                        </PermissionGuard>
 
-                        <div>
-                            <Box variant="awsui-key-label">{t('users.token')}</Box>
+                            <PermissionGuard allowedGlobalRoles={[GlobalUserRole.ADMIN]}>
+                                <div>
+                                    <Box variant="awsui-key-label">{t('users.global_role')}</Box>
+                                    <div>{t(`roles.${data.global_role}`)}</div>
+                                </div>
+                            </PermissionGuard>
 
-                            <div className={styles.token}>
-                                <Popover
-                                    dismissButton={false}
-                                    position="top"
-                                    size="small"
-                                    triggerType="custom"
-                                    content={<StatusIndicator type="success">{t('users.token_copied')}</StatusIndicator>}
-                                >
-                                    <Button formAction="none" iconName="copy" variant="link" onClick={onCopyToken} />
-                                </Popover>
+                            <div>
+                                <Box variant="awsui-key-label">{t('users.token')}</Box>
 
-                                <div>{data.creds.token}</div>
+                                <div className={styles.token}>
+                                    <Popover
+                                        dismissButton={false}
+                                        position="top"
+                                        size="small"
+                                        triggerType="custom"
+                                        content={<StatusIndicator type="success">{t('users.token_copied')}</StatusIndicator>}
+                                    >
+                                        <Button formAction="none" iconName="copy" variant="link" onClick={onCopyToken} />
+                                    </Popover>
+
+                                    <div>{data.creds.token}</div>
+                                </div>
                             </div>
-                        </div>
-                    </SpaceBetween>
-                </ColumnLayout>
-            )}
-        </Container>
+                        </SpaceBetween>
+                    </ColumnLayout>
+                )}
+            </Container>
+
+            <PublicKeys />
+        </SpaceBetween>
     );
 };

--- a/frontend/src/pages/User/Details/index.tsx
+++ b/frontend/src/pages/User/Details/index.tsx
@@ -19,7 +19,6 @@ export { Settings as UserSettings } from './Settings';
 export { Billing as UserBilling } from './Billing';
 export { Events as UserEvents } from './Events';
 export { UserProjectList as UserProjects } from './Projects';
-export { PublicKeys as UserPublicKeys } from './PublicKeys';
 
 export const UserDetails: React.FC = () => {
     const { t } = useTranslation();
@@ -67,11 +66,6 @@ export const UserDetails: React.FC = () => {
             label: t('users.settings'),
             id: UserDetailsTabTypeEnum.SETTINGS,
             href: ROUTES.USER.DETAILS.FORMAT(paramUserName),
-        },
-        {
-            label: t('users.public_keys.title'),
-            id: UserDetailsTabTypeEnum.PUBLIC_KEYS,
-            href: ROUTES.USER.PUBLIC_KEYS.FORMAT(paramUserName),
         },
         {
             label: t('users.projects'),

--- a/frontend/src/pages/User/Details/types.ts
+++ b/frontend/src/pages/User/Details/types.ts
@@ -3,6 +3,5 @@ export enum UserDetailsTabTypeEnum {
     PROJECTS = 'projects',
     EVENTS = 'events',
     ACTIVITY = 'activity',
-    PUBLIC_KEYS = 'public-keys',
     BILLING = 'billing',
 }

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -28,7 +28,7 @@ import { RunInspect } from 'pages/Runs/Details/Inspect';
 import { JobDetailsPage } from 'pages/Runs/Details/Jobs/Details';
 import { EventsList as JobEvents } from 'pages/Runs/Details/Jobs/Events';
 import { CreditsHistoryAdd, UserAdd, UserDetails, UserEdit, UserList } from 'pages/User';
-import { UserBilling, UserEvents, UserProjects, UserPublicKeys, UserSettings } from 'pages/User/Details';
+import { UserBilling, UserEvents, UserProjects, UserSettings } from 'pages/User/Details';
 
 import { AuthErrorMessage } from './App/AuthErrorMessage';
 import { EventList } from './pages/Events';
@@ -280,8 +280,9 @@ export const router = createBrowserRouter([
                         element: <UserEvents />,
                     },
                     {
+                        // SSH keys moved to a section inside the Settings tab
                         path: ROUTES.USER.PUBLIC_KEYS.TEMPLATE,
-                        element: <UserPublicKeys />,
+                        element: <Navigate replace to=".." />,
                     },
                     process.env.UI_VERSION === 'sky' && {
                         path: ROUTES.USER.BILLING.LIST.TEMPLATE,


### PR DESCRIPTION
Cosmetic change: the SSH keys tab on the user page is now a section inside the Settings tab. SSH keys are used much less often than the other tabs, and the Settings tab was almost empty anyway. The old `/users/:name/public-keys` URL redirects to Settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)