### PR TITLE
docs: fix two typos

### DIFF
--- a/mkdocs/blog/posts/kubernetes-beta.md
+++ b/mkdocs/blog/posts/kubernetes-beta.md
@@ -124,7 +124,7 @@ To open in VS Code Desktop, use this link:
 
 </div>
 
-Dev environments support many [diffrent options](../../docs/concepts/dev-environments.md), including a custom Docker image, mounted repositories, idle timeout, min GPU utilization, and more.
+Dev environments support many [different options](../../docs/concepts/dev-environments.md), including a custom Docker image, mounted repositories, idle timeout, min GPU utilization, and more.
 
 ## Running distributed training
 

--- a/mkdocs/docs/quickstart.md
+++ b/mkdocs/docs/quickstart.md
@@ -49,7 +49,7 @@ description: Quick guide to creating fleets and submitting runs
     Create the fleet? [y/n]: y
 
       FLEET    INSTANCE  BACKEND  RESOURCES  PRICE  STATUS  CREATED 
-      defalut  -         -        -          -      -       10:36
+      default  -         -        -          -      -       10:36
     ```
 
     </div>


### PR DESCRIPTION
Two typo fixes.

**`mkdocs/docs/quickstart.md:52`** — the sample `dstack apply` output shows a fleet named `defalut`:

```
  FLEET    INSTANCE  BACKEND  RESOURCES  PRICE  STATUS  CREATED
  defalut  -         -        -          -      -       10:36
```

This is a transcription typo in the pasted output rather than a real name: `defalut` occurs exactly once in the whole repository — this line — and nothing in `src/` ever names a fleet that. Corrected to `default` so the docs match what the CLI actually prints.

**`mkdocs/blog/posts/kubernetes-beta.md:127`** — "many [diffrent options]" → "different".

Docs only; the column alignment in the code block is unchanged since `defalut` and `default` are the same length.
