### PR TITLE
[shim] Rework Run() into Start() and complete tasks in the background

### DIFF
--- a/runner/internal/shim/api/api_test.go
+++ b/runner/internal/shim/api/api_test.go
@@ -3,15 +3,17 @@ package api
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	"github.com/dstackai/dstack/runner/internal/shim"
 	"github.com/dstackai/dstack/runner/internal/shim/host"
 )
 
 type DummyRunner struct {
-	tasks map[string]bool
-	gpus  []host.GpuInfo
-	mu    sync.Mutex
+	tasks     map[string]bool
+	gpus      []host.GpuInfo
+	processed atomic.Int64
+	mu        sync.Mutex
 }
 
 func (ds *DummyRunner) Submit(ctx context.Context, cfg shim.TaskConfig) error {
@@ -24,8 +26,12 @@ func (ds *DummyRunner) Submit(ctx context.Context, cfg shim.TaskConfig) error {
 	return nil
 }
 
-func (ds *DummyRunner) Run(context.Context, string) error {
+func (ds *DummyRunner) Start(context.Context, string) error {
 	return nil
+}
+
+func (ds *DummyRunner) ProcessTasks(context.Context) {
+	ds.processed.Add(1)
 }
 
 func (ds *DummyRunner) Terminate(context.Context, string, uint, string, string) error {

--- a/runner/internal/shim/api/handlers.go
+++ b/runner/internal/shim/api/handlers.go
@@ -111,8 +111,8 @@ func (s *ShimServer) TaskSubmitHandler(w http.ResponseWriter, r *http.Request) (
 
 	ctx = log.WithLogger(context.Background(), log.GetLogger(ctx))
 	go func() {
-		if err := s.runner.Run(ctx, taskConfig.ID); err != nil {
-			log.Error(ctx, "failed to run", "task", taskConfig.ID, "err", err)
+		if err := s.runner.Start(ctx, taskConfig.ID); err != nil {
+			log.Error(ctx, "failed to start", "task", taskConfig.ID, "err", err)
 		}
 	}()
 

--- a/runner/internal/shim/api/handlers_test.go
+++ b/runner/internal/shim/api/handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	commonapi "github.com/dstackai/dstack/runner/internal/common/api"
 	"github.com/dstackai/dstack/runner/internal/common/gpu"
@@ -97,5 +98,35 @@ func TestTaskSubmit(t *testing.T) {
 	secondSubmitPost(responseRecorder, request)
 	if responseRecorder.Code != 409 {
 		t.Errorf("Want status '%d', got '%d'", 409, responseRecorder.Code)
+	}
+}
+
+// TestServeProcessesTasks covers the background job that processes tasks
+func TestServeProcessesTasks(t *testing.T) {
+	runner := NewDummyRunner()
+	server := NewShimServer(context.Background(), "localhost:12348", "0.0.1.dev2", runner, nil, nil, nil, nil)
+	go func() { _ = server.Serve() }()
+
+	// Tasks are processed immediately, without waiting for the first tick
+	deadline := time.After(5 * time.Second)
+	for runner.processed.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("Tasks have not been processed")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// Shutdown waits for the background job to stop, therefore it hangs if the job
+	// ignores the cancelled context
+	shutdown := make(chan error, 1)
+	go func() { shutdown <- server.Shutdown(context.Background(), false) }()
+	select {
+	case err := <-shutdown:
+		if err != nil {
+			t.Errorf("Shutdown: %s", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Shutdown has not stopped the task processing job")
 	}
 }

--- a/runner/internal/shim/api/server.go
+++ b/runner/internal/shim/api/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/dstackai/dstack/runner/internal/common/api"
 	"github.com/dstackai/dstack/runner/internal/common/log"
@@ -16,11 +17,16 @@ import (
 	"github.com/dstackai/dstack/runner/internal/shim/host"
 )
 
+// taskProcessingInterval is how often task containers are inspected to detect
+// finished tasks
+const taskProcessingInterval = 1 * time.Second
+
 type TaskRunner interface {
 	Submit(context.Context, shim.TaskConfig) error
-	Run(ctx context.Context, taskID string) error
+	Start(ctx context.Context, taskID string) error
 	Terminate(ctx context.Context, taskID string, timeout uint, reason string, message string) error
 	Remove(ctx context.Context, taskID string) error
+	ProcessTasks(ctx context.Context)
 
 	Resources(context.Context) shim.Resources
 	Gpus(context.Context) []host.GpuInfo
@@ -101,10 +107,27 @@ func NewShimServer(
 }
 
 func (s *ShimServer) Serve() error {
+	// Started before serving requests, so that tasks whose containers exited while
+	// the shim was not running are processed before the server reports their status
+	s.bgJobsGroup.Go(func() { s.processTasks(s.bgJobsCtx) })
 	if err := s.httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return err
 	}
 	return nil
+}
+
+// processTasks processes tasks periodically until ctx is cancelled by Shutdown()
+func (s *ShimServer) processTasks(ctx context.Context) {
+	ticker := time.NewTicker(taskProcessingInterval)
+	defer ticker.Stop()
+	for {
+		s.runner.ProcessTasks(ctx)
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
 }
 
 func (s *ShimServer) Shutdown(ctx context.Context, force bool) error {

--- a/runner/internal/shim/docker.go
+++ b/runner/internal/shim/docker.go
@@ -207,13 +207,15 @@ func NewDockerRunner(ctx context.Context, dockerParams DockerParameters) (*Docke
 	return runner, nil
 }
 
+// taskContainerFilters returns filters matching all containers spawned by DockerRunner
+func taskContainerFilters() filters.Args {
+	return filters.NewArgs(filters.Arg("label", fmt.Sprintf("%s=%s", LabelKeyIsTask, LabelValueTrue)))
+}
+
 // restoreStateFromContainers regenerates TaskStorage and GpuLock inspecting containers
 // Used to restore shim state on restarts
 func (d *DockerRunner) restoreStateFromContainers(ctx context.Context) error {
-	listOptions := container.ListOptions{
-		All:     true,
-		Filters: filters.NewArgs(filters.Arg("label", fmt.Sprintf("%s=%s", LabelKeyIsTask, LabelValueTrue))),
-	}
+	listOptions := container.ListOptions{All: true, Filters: taskContainerFilters()}
 	containers, err := d.client.ContainerList(ctx, listOptions)
 	if err != nil {
 		return fmt.Errorf("failed to get container list: %w", err)
@@ -224,12 +226,6 @@ func (d *DockerRunner) restoreStateFromContainers(ctx context.Context) error {
 		if taskID == "" {
 			log.Error(ctx, "container has no label", "id", containerID, "label", LabelKeyTaskID)
 			continue
-		}
-		var status TaskStatus
-		if containerShort.State == "exited" {
-			status = TaskStatusTerminated
-		} else {
-			status = TaskStatusRunning
 		}
 		var containerName string
 		if len(containerShort.Names) > 0 {
@@ -287,13 +283,17 @@ func (d *DockerRunner) restoreStateFromContainers(ctx context.Context) error {
 				break
 			}
 		}
-		task := NewTask(taskID, status, containerName, containerID, gpuIDs, ports, runnerDir)
+		// Tasks are restored as running regardless of the container state, letting
+		// ProcessTasks() decide whether the container is still running and, if it is
+		// not, why it finished. This way, the termination reason of a task that
+		// finished while the shim was not running is not lost
+		task := NewTask(taskID, TaskStatusRunning, containerName, containerID, gpuIDs, ports, runnerDir)
 		if !d.tasks.Add(task) {
 			log.Error(ctx, "duplicate restored task", "task", taskID)
 		} else {
-			log.Debug(ctx, "restored task", "task", taskID, "status", status, "gpus", gpuIDs)
+			log.Debug(ctx, "restored task", "task", taskID, "state", containerShort.State, "gpus", gpuIDs)
 		}
-		if status == TaskStatusRunning && len(gpuIDs) > 0 {
+		if len(gpuIDs) > 0 {
 			lockedGpuIDs := d.gpuLock.Lock(ctx, gpuIDs)
 			log.Debug(ctx, "locked GPU(s) due to running task", "task", taskID, "gpus", lockedGpuIDs)
 		}
@@ -397,25 +397,67 @@ func (d *DockerRunner) commitTerminated(ctx context.Context, task *Task) {
 	}
 }
 
-func (d *DockerRunner) Run(ctx context.Context, taskID string) error {
+// Start prepares the task resources, pulls the image, and starts the container.
+// It returns as soon as the container is started, that is, it does not wait for the
+// container to exit. Detecting the exit, terminating the task, and releasing its
+// resources is the responsibility of ProcessTasks().
+// If the task cannot be started, it is terminated and its resources are released
+// before returning, except for the resources that cannot be released while the
+// container may be running -- those are left to ProcessTasks() as well.
+func (d *DockerRunner) Start(ctx context.Context, taskID string) (err error) {
 	task, ok := d.tasks.Get(taskID)
 	if !ok {
-		log.Error(ctx, "cannot run: not found", "task", taskID)
+		log.Error(ctx, "cannot start: not found", "task", taskID)
 		return fmt.Errorf("task %s: %w", taskID, ErrNotFound)
 	}
 
 	if task.Status != TaskStatusPending {
-		return fmt.Errorf("%w: cannot run task %s with %s status", ErrRequest, task.ID, task.Status)
+		return fmt.Errorf("%w: cannot start task %s with %s status", ErrRequest, task.ID, task.Status)
 	}
 
-	defer func() { d.commitTerminated(ctx, &task) }()
+	// The task is owned by this method until it returns: ProcessTasks() skips tasks
+	// in flight, so that it does not release the resources acquired here
+	started := false
+	defer func() {
+		if !started {
+			if err != nil && task.Status != TaskStatusTerminated {
+				// a failure path that has not terminated the task, e.g., a rejected update
+				task.SetStatusTerminated(string(types.TerminationReasonExecutorError), err.Error())
+			}
+			if task.containerID == "" {
+				// There is no container that may be running, so it is safe to release
+				// the resources now. Otherwise, ProcessTasks() releases them once the
+				// container is not running
+				task.Lock(ctx)
+				d.cleanupLocked(ctx, &task)
+				task.Release(ctx)
+			}
+		}
+		// Hand the task over to ProcessTasks()
+		if commitErr := d.commit(&task, func(t *Task) {
+			t.startInFlight = false
+			if task.containerID != "" {
+				t.containerID = task.containerID
+			}
+			if task.cleanedUp {
+				t.cleanedUp = true
+			}
+			if task.Status == TaskStatusTerminated {
+				t.SetStatusTerminated(task.TerminationReason, task.TerminationMessage)
+			}
+		}); commitErr != nil && !errors.Is(commitErr, ErrNotFound) {
+			log.Error(ctx, "failed to commit final state", "task", task.ID, "err", commitErr)
+		}
+	}()
 
-	if err := d.commit(&task, func(t *Task) { t.SetStatusPreparing() }); err != nil {
+	if err := d.commit(&task, func(t *Task) {
+		t.startInFlight = true
+		t.SetStatusPreparing()
+	}); err != nil {
 		return fmt.Errorf("%w: failed to update task %s: %w", ErrInternal, task.ID, err)
 	}
 
 	cfg := task.config
-	var err error
 
 	runnerDir, err := d.dockerParams.MakeRunnerDir(task.containerName)
 	if err != nil {
@@ -437,11 +479,6 @@ func (d *DockerRunner) Run(ctx context.Context, taskID string) error {
 			return fmt.Errorf("acquire GPU: %w", err)
 		}
 		log.Debug(ctx, "acquired GPU(s)", "task", task.ID, "gpus", gpuIDs)
-
-		defer func() {
-			releasedGpuIDs := d.gpuLock.Release(ctx, gpuIDs)
-			log.Debug(ctx, "released GPU(s)", "task", task.ID, "gpus", releasedGpuIDs)
-		}()
 	} else {
 		gpuIDs = []string{}
 	}
@@ -457,19 +494,10 @@ func (d *DockerRunner) Run(ctx context.Context, taskID string) error {
 			task.SetStatusTerminated(string(types.TerminationReasonExecutorError), errMessage)
 			return fmt.Errorf("append public keys: %w", err)
 		}
-		defer func(cfg TaskConfig) {
-			err := ak.RemovePublicKeys(cfg.HostSshKeys)
-			if err != nil {
-				log.Error(ctx, "Error RemovePublicKeys", "err", err)
-			}
-		}(cfg)
 	}
 
 	log.Debug(ctx, "Preparing volumes")
-	// defer unmountVolumes() before calling prepareVolumes(), as the latter
-	// may fail when some volumes are already mounted; if the volume is not mounted,
-	// unmountVolumes() simply skips it
-	defer func() { _ = unmountVolumes(ctx, cfg) }()
+	// Volumes mounted by a failed prepareVolumes() call are unmounted by cleanupLocked()
 	err = prepareVolumes(ctx, cfg)
 	if err != nil {
 		errMessage := fmt.Sprintf("prepareVolumes error: %s", err.Error())
@@ -513,13 +541,6 @@ func (d *DockerRunner) Run(ctx context.Context, taskID string) error {
 	}
 
 	log.Debug(ctx, "Running container", "task", task.ID, "name", task.containerName)
-	if err := d.commit(&task, func(t *Task) {
-		// createContainer sets the containerID field
-		t.containerID = task.containerID
-		t.SetStatusRunning()
-	}); err != nil {
-		return fmt.Errorf("%w: failed to update task %s: %w", ErrInternal, task.ID, err)
-	}
 	err = d.startContainer(ctx, &task)
 	if len(task.config.GPUDevices) == 0 &&
 		shouldRetryWithoutNvidiaDisplayCapability(d.gpuVendor, err) {
@@ -536,34 +557,76 @@ func (d *DockerRunner) Run(ctx context.Context, taskID string) error {
 			err = d.startContainer(ctx, &task)
 		}
 	}
-	if err == nil {
-		if err := d.commit(&task, func(t *Task) {
-			// startContainer sets the ports field, the retry above may have
-			// replaced the container
-			t.containerID = task.containerID
-			t.ports = task.ports
-		}); err != nil {
-			return fmt.Errorf("%w: failed to update task %s: %w", ErrInternal, task.ID, err)
-		}
-		err = d.waitContainer(ctx, &task)
-	}
 	if err != nil {
-		log.Error(ctx, "failed to run container", "err", err)
+		log.Error(ctx, "failed to start container", "task", task.ID, "err", err)
 		var errMessage string
-		if lastLogs, err := getContainerLastLogs(ctx, d.client, task.containerID, 5); err == nil {
+		if lastLogs, logsErr := getContainerLastLogs(ctx, d.client, task.containerID, 5); logsErr == nil {
 			errMessage = strings.Join(lastLogs, "\n")
 		} else {
-			log.Error(ctx, "getContainerLastLogs error", "err", err)
-			errMessage = ""
+			log.Error(ctx, "getContainerLastLogs error", "err", logsErr)
 		}
 		task.SetStatusTerminated(string(types.TerminationReasonContainerExitedWithError), errMessage)
-		return fmt.Errorf("wait container: %w", err)
+		return fmt.Errorf("start container: %w", err)
 	}
 
-	log.Debug(ctx, "Container finished successfully", "task", task.ID, "name", task.containerName)
-	task.SetStatusTerminated(string(types.TerminationReasonDoneByRunner), "")
+	// The container is running, the task is now processed in the background
+	if err := d.commit(&task, func(t *Task) {
+		// startContainer sets the ports field, the retry above may have
+		// replaced the container
+		t.containerID = task.containerID
+		t.ports = task.ports
+		t.startInFlight = false
+		t.SetStatusRunning()
+	}); err != nil {
+		return fmt.Errorf("%w: failed to update task %s: %w", ErrInternal, task.ID, err)
+	}
+	started = true
+
+	log.Debug(ctx, "Container is running", "task", task.ID, "name", task.containerName)
 
 	return nil
+}
+
+// cleanupLocked releases the resources acquired for the task: host SSH keys,
+// volumes, and GPUs. The container must not be running, otherwise unmounting
+// volumes may fail.
+// It is safe to call it more than once: the resources are released only if they
+// have not been released yet.
+// The task lock must be held by the caller.
+func (d *DockerRunner) cleanupLocked(ctx context.Context, task *Task) {
+	if task.cleanedUp {
+		return
+	}
+	// Another operation may have released the resources while we were waiting for
+	// the task lock, therefore the stored task is the source of truth
+	if storedTask, ok := d.tasks.Get(task.ID); ok && storedTask.cleanedUp {
+		task.cleanedUp = true
+		return
+	}
+	log.Debug(ctx, "releasing task resources", "task", task.ID)
+	cfg := task.config
+	if err := unmountVolumes(ctx, cfg); err != nil {
+		log.Error(ctx, "failed to unmount volumes", "task", task.ID, "err", err)
+	}
+	if len(cfg.HostSshKeys) > 0 {
+		ak := AuthorizedKeys{user: cfg.HostSshUser, lookup: user.Lookup}
+		if err := ak.RemovePublicKeys(cfg.HostSshKeys); err != nil {
+			log.Error(ctx, "failed to remove public keys", "task", task.ID, "err", err)
+		}
+	}
+	if len(task.gpuIDs) > 0 {
+		releasedGpuIDs := d.gpuLock.Release(ctx, task.gpuIDs)
+		log.Debug(ctx, "released GPU(s)", "task", task.ID, "gpus", releasedGpuIDs)
+	}
+	task.cleanedUp = true
+	// Commit the flag without touching the rest of the local copy of the task,
+	// which may contain uncommitted changes made by the caller
+	if _, err := d.tasks.Modify(task.ID, func(t *Task) error {
+		t.cleanedUp = true
+		return nil
+	}); err != nil && !errors.Is(err, ErrNotFound) {
+		log.Error(ctx, "failed to commit cleaned up state", "task", task.ID, "err", err)
+	}
 }
 
 // Terminate aborts running operations (pulling an image, running a container) and sets task status to terminated
@@ -576,6 +639,11 @@ func (d *DockerRunner) Terminate(ctx context.Context, taskID string, timeout uin
 	}
 	task.Lock(ctx)
 	defer func() { task.Release(ctx) }()
+	// The task may have been updated while we were acquiring the lock
+	if task, ok = d.tasks.Get(taskID); !ok {
+		log.Error(ctx, "cannot terminate task: not found", "task", taskID)
+		return fmt.Errorf("task %s: %w", taskID, ErrNotFound)
+	}
 	defer func() { d.commitTerminated(ctx, &task) }()
 	return d.terminate(ctx, &task, timeout, reason, message)
 }
@@ -596,18 +664,17 @@ func (d *DockerRunner) terminate(ctx context.Context, task *Task, timeout uint, 
 	case TaskStatusPulling:
 		task.cancelPull()
 	case TaskStatusRunning:
-		stopOptions := container.StopOptions{}
-		timeout := int(timeout)
-		stopOptions.Timeout = &timeout
-		if err := d.client.ContainerStop(ctx, task.containerID, stopOptions); err != nil {
-			return fmt.Errorf("%w: failed to stop container: %w", ErrInternal, err)
+		if err := d.stopContainer(ctx, task.containerID, int(timeout)); err != nil {
+			return err
 		}
 	default:
 		return fmt.Errorf("%w: should not reach here", ErrInternal)
 	}
-	if len(task.gpuIDs) > 0 {
-		releasedGpuIDs := d.gpuLock.Release(ctx, task.gpuIDs)
-		log.Debug(ctx, "released GPU(s)", "task", task.ID, "gpus", releasedGpuIDs)
+	if !task.startInFlight {
+		// The container, if any, is not running anymore, so it is safe to release
+		// the resources. If the task is in flight, Start() owns the resources
+		// and releases them itself
+		d.cleanupLocked(ctx, task)
 	}
 	task.SetStatusTerminated(reason, message)
 	log.Debug(ctx, "terminated", "task", task.ID)
@@ -624,6 +691,11 @@ func (d *DockerRunner) Remove(ctx context.Context, taskID string) error {
 	}
 	task.Lock(ctx)
 	defer func() { task.Release(ctx) }()
+	// The task may have been updated while we were acquiring the lock
+	if task, ok = d.tasks.Get(taskID); !ok {
+		log.Error(ctx, "cannot remove: not found", "task", taskID)
+		return fmt.Errorf("task %s: %w", taskID, ErrNotFound)
+	}
 	err := d.remove(ctx, &task)
 	if err == nil {
 		d.tasks.Delete(taskID)
@@ -645,6 +717,9 @@ func (d *DockerRunner) remove(ctx context.Context, task *Task) (err error) {
 	if err := d.removeContainer(ctx, task); err != nil {
 		return err
 	}
+	// Normally, the resources are already released by ProcessTasks() or Terminate(),
+	// but the task may be removed before that happens
+	d.cleanupLocked(ctx, task)
 	// Normally, it should not be empty
 	if task.runnerDir != "" {
 		// Failed attempts to remove or rename runner dir are considered non-fatal
@@ -882,17 +957,12 @@ func (d *DockerRunner) startContainer(ctx context.Context, task *Task) error {
 	return nil
 }
 
-func (d *DockerRunner) waitContainer(ctx context.Context, task *Task) error {
-	waitCh, errorCh := d.client.ContainerWait(ctx, task.containerID, "")
-	select {
-	case waitResp := <-waitCh:
-		{
-			if waitResp.StatusCode != 0 {
-				return fmt.Errorf("container exited with exit code %d", waitResp.StatusCode)
-			}
-		}
-	case err := <-errorCh:
-		return fmt.Errorf("wait for container: %w", err)
+// stopContainer stops the container, waiting for it to exit. The container is
+// killed if it does not exit gracefully within timeout seconds.
+func (d *DockerRunner) stopContainer(ctx context.Context, containerID string, timeout int) error {
+	stopOptions := container.StopOptions{Timeout: &timeout}
+	if err := d.client.ContainerStop(ctx, containerID, stopOptions); err != nil {
+		return fmt.Errorf("%w: failed to stop container: %w", ErrInternal, err)
 	}
 	return nil
 }

--- a/runner/internal/shim/docker_test.go
+++ b/runner/internal/shim/docker_test.go
@@ -42,7 +42,7 @@ func TestDocker_SSHServer(t *testing.T) {
 	defer dockerRunner.Remove(t.Context(), taskConfig.ID)
 
 	assert.NoError(t, dockerRunner.Submit(ctx, taskConfig))
-	assert.NoError(t, dockerRunner.Run(ctx, taskConfig.ID))
+	assert.NoError(t, dockerRunner.Start(ctx, taskConfig.ID))
 	assertTaskDone(t, dockerRunner, taskConfig.ID)
 }
 
@@ -68,7 +68,7 @@ func TestDocker_ShmNoexecByDefault(t *testing.T) {
 	defer dockerRunner.Remove(t.Context(), taskConfig.ID)
 
 	assert.NoError(t, dockerRunner.Submit(ctx, taskConfig))
-	assert.NoError(t, dockerRunner.Run(ctx, taskConfig.ID))
+	assert.NoError(t, dockerRunner.Start(ctx, taskConfig.ID))
 	assertTaskDone(t, dockerRunner, taskConfig.ID)
 }
 
@@ -95,8 +95,72 @@ func TestDocker_ShmExecIfSizeSpecified(t *testing.T) {
 	defer dockerRunner.Remove(t.Context(), taskConfig.ID)
 
 	assert.NoError(t, dockerRunner.Submit(ctx, taskConfig))
-	assert.NoError(t, dockerRunner.Run(ctx, taskConfig.ID))
+	assert.NoError(t, dockerRunner.Start(ctx, taskConfig.ID))
 	assertTaskDone(t, dockerRunner, taskConfig.ID)
+}
+
+func TestDocker_ContainerExitedWithError(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
+	params := &dockerParametersMock{
+		commands:  []string{"echo failed for a reason", "exit 3"},
+		runnerDir: t.TempDir(),
+	}
+
+	timeout := 180 // seconds
+	ctx, cancel := context.WithTimeout(t.Context(), time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	dockerRunner, err := NewDockerRunner(ctx, params)
+	require.NoError(t, err)
+
+	taskConfig := createTaskConfig(t)
+	defer dockerRunner.Remove(t.Context(), taskConfig.ID)
+
+	require.NoError(t, dockerRunner.Submit(ctx, taskConfig))
+	require.NoError(t, dockerRunner.Start(ctx, taskConfig.ID))
+
+	taskInfo := waitTaskTerminated(t, dockerRunner, taskConfig.ID)
+	assert.Equal(t, string(types.TerminationReasonContainerExitedWithError), taskInfo.TerminationReason)
+	assert.Contains(t, taskInfo.TerminationMessage, "failed for a reason")
+}
+
+// TestDocker_RestoredTaskIsTerminated simulates a shim restart: since Start() does
+// not wait for the container to exit, a task started by one runner must be terminated
+// by another runner that restored it from the container
+func TestDocker_RestoredTaskIsTerminated(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
+	params := &dockerParametersMock{
+		commands:  []string{"sleep 3", "exit 7"},
+		runnerDir: t.TempDir(),
+	}
+
+	timeout := 180 // seconds
+	ctx, cancel := context.WithTimeout(t.Context(), time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	dockerRunner, err := NewDockerRunner(ctx, params)
+	require.NoError(t, err)
+
+	taskConfig := createTaskConfig(t)
+	require.NoError(t, dockerRunner.Submit(ctx, taskConfig))
+	require.NoError(t, dockerRunner.Start(ctx, taskConfig.ID))
+
+	// The restarted shim restores the task from its container
+	restartedRunner, err := NewDockerRunner(ctx, params)
+	require.NoError(t, err)
+	defer restartedRunner.Remove(t.Context(), taskConfig.ID)
+	require.Equal(t, taskConfig.ID, restartedRunner.TaskInfo(taskConfig.ID).ID)
+
+	taskInfo := waitTaskTerminated(t, restartedRunner, taskConfig.ID)
+	assert.Equal(t, string(types.TerminationReasonContainerExitedWithError), taskInfo.TerminationReason)
 }
 
 func TestConfigureGpus_Nvidia(t *testing.T) {
@@ -197,14 +261,26 @@ func generateID(t *testing.T) string {
 	return hex.EncodeToString(b)[:idLen]
 }
 
-// assertTaskDone asserts that the final state of a successfully executed task
-// is committed to the storage
+// assertTaskDone waits until the task is terminated and asserts that its container
+// exited successfully
 func assertTaskDone(t *testing.T, runner *DockerRunner, taskID string) {
 	t.Helper()
-	taskInfo := runner.TaskInfo(taskID)
-	assert.Equal(t, TaskStatusTerminated, taskInfo.Status)
+	taskInfo := waitTaskTerminated(t, runner, taskID)
 	assert.Equal(t, string(types.TerminationReasonDoneByRunner), taskInfo.TerminationReason)
 	assert.Empty(t, taskInfo.TerminationMessage)
+}
+
+// waitTaskTerminated processes tasks until the task is terminated, as Start() only
+// starts the container and does not wait for it to exit
+func waitTaskTerminated(t *testing.T, runner *DockerRunner, taskID string) TaskInfo {
+	t.Helper()
+	var taskInfo TaskInfo
+	require.Eventually(t, func() bool {
+		runner.ProcessTasks(t.Context())
+		taskInfo = runner.TaskInfo(taskID)
+		return taskInfo.Status == TaskStatusTerminated
+	}, 60*time.Second, 200*time.Millisecond)
+	return taskInfo
 }
 
 func createTaskConfig(t *testing.T) TaskConfig {

--- a/runner/internal/shim/process.go
+++ b/runner/internal/shim/process.go
@@ -1,0 +1,207 @@
+package shim
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/docker/docker/api/types/container"
+
+	"github.com/dstackai/dstack/runner/internal/common/log"
+	"github.com/dstackai/dstack/runner/internal/common/types"
+)
+
+// Container states reported by the Docker API. The states not listed here, that is,
+// exited, dead, and removing, are handled the same way -- as a finished container
+// https://github.com/moby/moby/blob/v26.0.0/container/state.go#L120-L145
+const (
+	containerStateCreated    = "created"
+	containerStateRunning    = "running"
+	containerStatePaused     = "paused"
+	containerStateRestarting = "restarting"
+)
+
+// taskContainer is the part of the container list response used to process tasks.
+// The list response has no exit code field -- it only reports the exit code as a part
+// of a human-readable status string -- therefore a container that is not running
+// anymore is inspected separately.
+type taskContainer struct {
+	id string
+	// created, running, paused, restarting, removing, exited, or dead
+	state string
+}
+
+func (c *taskContainer) isRunning() bool {
+	return c.state == containerStateRunning ||
+		c.state == containerStatePaused ||
+		c.state == containerStateRestarting
+}
+
+// ProcessTasks brings the state of tasks in line with the state of their containers:
+// tasks whose containers are not running anymore are terminated, and the resources
+// of terminated tasks are released.
+// Since containers outlive the shim process, this is how tasks are completed after a
+// shim restart, in addition to the normal case of a container exiting while the shim
+// is running.
+// It is expected to be called periodically. Errors are only logged, as the caller can
+// do nothing but retry.
+func (d *DockerRunner) ProcessTasks(ctx context.Context) {
+	var taskIDs []string
+	for _, task := range d.tasks.List() {
+		if task.startInFlight {
+			// Start() owns the task and its resources until it returns
+			continue
+		}
+		switch task.Status {
+		case TaskStatusRunning, TaskStatusTerminated:
+			taskIDs = append(taskIDs, task.ID)
+		case TaskStatusPending, TaskStatusPreparing, TaskStatusPulling, TaskStatusCreating:
+			// Start() is about to be called or is already in flight
+		}
+	}
+	if len(taskIDs) == 0 {
+		return
+	}
+	// One list request is enough for all tasks: the container state it reports tells
+	// whether the container is still running, which is all that is needed in the
+	// most common case
+	containers, err := d.listTaskContainers(ctx)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) {
+			// the context is cancelled on shutdown, which is not an error
+			log.Error(ctx, "cannot process tasks", "err", err)
+		}
+		return
+	}
+	for _, taskID := range taskIDs {
+		d.processTask(ctx, taskID, containers)
+	}
+}
+
+func (d *DockerRunner) processTask(ctx context.Context, taskID string, containers map[string]*taskContainer) {
+	task, ok := d.tasks.Get(taskID)
+	if !ok {
+		return
+	}
+	// This copy of the task is only used to hold the lock, all copies of a task share
+	// the same lock
+	if !task.TryLock(ctx) {
+		// The task is busy, e.g., being terminated or removed. Try again on the next call
+		log.Debug(ctx, "skip processing: task is busy", "task", taskID)
+		return
+	}
+	defer func() { task.Release(ctx) }()
+	// The task may have been updated while we were acquiring the lock
+	currentTask, ok := d.tasks.Get(taskID)
+	if !ok || currentTask.startInFlight {
+		return
+	}
+	switch currentTask.Status {
+	case TaskStatusRunning:
+		d.processRunningTask(ctx, &currentTask, containers[taskID])
+	case TaskStatusTerminated:
+		d.processTerminatedTask(ctx, &currentTask, containers[taskID])
+	case TaskStatusPending, TaskStatusPreparing, TaskStatusPulling, TaskStatusCreating:
+		// not processed, see ProcessTasks()
+	}
+}
+
+// processRunningTask terminates the task if its container is not running anymore,
+// reporting the container exit code as the termination reason.
+// The task lock must be held by the caller.
+func (d *DockerRunner) processRunningTask(ctx context.Context, task *Task, container *taskContainer) {
+	if container == nil {
+		// The container has been removed by someone else, e.g., manually
+		log.Warning(ctx, "container of running task not found", "task", task.ID)
+		d.finalizeLocked(ctx, task, types.TerminationReasonExecutorError, "container not found")
+		return
+	}
+	if container.isRunning() {
+		return
+	}
+	if container.state == containerStateCreated {
+		// The container has never been started, which normally means that the shim
+		// stopped running between creating and starting it
+		log.Warning(ctx, "container of running task is not started", "task", task.ID)
+		d.finalizeLocked(ctx, task, types.TerminationReasonExecutorError, "container was not started")
+		return
+	}
+	// The container is finished. Its exit code is not reported by the list request,
+	// hence the inspect request
+	inspection, err := d.client.ContainerInspect(ctx, container.id)
+	if err != nil {
+		// Try again on the next call, the task is still considered running
+		log.Error(ctx, "failed to inspect container", "task", task.ID, "id", container.id, "err", err)
+		return
+	}
+	if inspection.State == nil {
+		log.Error(ctx, "container has no state", "task", task.ID, "id", container.id)
+		return
+	}
+	exitCode := inspection.State.ExitCode
+	log.Debug(ctx, "container is not running", "task", task.ID, "state", container.state, "code", exitCode)
+	if exitCode == 0 {
+		d.finalizeLocked(ctx, task, types.TerminationReasonDoneByRunner, "")
+		return
+	}
+	var message string
+	if lastLogs, err := getContainerLastLogs(ctx, d.client, container.id, 5); err == nil {
+		message = strings.Join(lastLogs, "\n")
+	} else {
+		log.Error(ctx, "getContainerLastLogs error", "err", err)
+	}
+	d.finalizeLocked(ctx, task, types.TerminationReasonContainerExitedWithError, message)
+}
+
+// processTerminatedTask releases the resources of an already terminated task.
+// The container is stopped first if it is still running, which normally means that
+// the task has been terminated while its container was being started.
+// The task lock must be held by the caller.
+func (d *DockerRunner) processTerminatedTask(ctx context.Context, task *Task, container *taskContainer) {
+	if task.cleanedUp {
+		return
+	}
+	if container != nil && container.isRunning() {
+		log.Warning(ctx, "stopping container of terminated task", "task", task.ID, "id", container.id)
+		if err := d.stopContainer(ctx, container.id, 0); err != nil {
+			// Try again on the next call, the resources are not released until then
+			log.Error(ctx, "failed to stop container", "task", task.ID, "id", container.id, "err", err)
+			return
+		}
+	}
+	d.cleanupLocked(ctx, task)
+}
+
+// finalizeLocked releases the task resources and terminates the task.
+// The task lock must be held by the caller.
+func (d *DockerRunner) finalizeLocked(
+	ctx context.Context, task *Task, reason types.TerminationReason, message string,
+) {
+	d.cleanupLocked(ctx, task)
+	if err := d.commit(task, func(t *Task) {
+		t.SetStatusTerminated(string(reason), message)
+	}); err != nil {
+		log.Error(ctx, "failed to commit terminated status", "task", task.ID, "err", err)
+		return
+	}
+	log.Info(ctx, "terminated", "task", task.ID, "reason", reason)
+}
+
+func (d *DockerRunner) listTaskContainers(ctx context.Context) (map[string]*taskContainer, error) {
+	listOptions := container.ListOptions{All: true, Filters: taskContainerFilters()}
+	containers, err := d.client.ContainerList(ctx, listOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get container list: %w", err)
+	}
+	taskContainers := make(map[string]*taskContainer, len(containers))
+	for _, containerShort := range containers {
+		taskID := containerShort.Labels[LabelKeyTaskID]
+		if taskID == "" {
+			log.Error(ctx, "container has no label", "id", containerShort.ID, "label", LabelKeyTaskID)
+			continue
+		}
+		taskContainers[taskID] = &taskContainer{id: containerShort.ID, state: containerShort.State}
+	}
+	return taskContainers, nil
+}

--- a/runner/internal/shim/process_test.go
+++ b/runner/internal/shim/process_test.go
@@ -1,0 +1,312 @@
+package shim
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	dockertypes "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	docker "github.com/docker/docker/client"
+	"github.com/docker/docker/errdefs"
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dstackai/dstack/runner/internal/common/types"
+)
+
+func TestProcessTasks_ContainerIsRunning(t *testing.T) {
+	client := &dockerClientMock{containers: []dockertypes.Container{
+		taskContainerSummary("task-1", "container-1", containerStateRunning),
+	}}
+	runner := newTestRunner(t, client)
+	addTask(runner, newRunningTask("task-1", "container-1"))
+
+	runner.ProcessTasks(t.Context())
+
+	task, _ := runner.tasks.Get("task-1")
+	assert.Equal(t, TaskStatusRunning, task.Status)
+	assert.False(t, task.cleanedUp)
+}
+
+func TestProcessTasks_ContainerExitedSuccessfully(t *testing.T) {
+	client := &dockerClientMock{
+		containers: []dockertypes.Container{
+			taskContainerSummary("task-1", "container-1", containerStateFinished),
+		},
+		inspect: map[string]dockertypes.ContainerJSON{
+			"container-1": exitedContainer("container-1", 0),
+		},
+	}
+	runner := newTestRunner(t, client)
+	addTask(runner, newRunningTask("task-1", "container-1"))
+
+	runner.ProcessTasks(t.Context())
+
+	task, _ := runner.tasks.Get("task-1")
+	assert.Equal(t, TaskStatusTerminated, task.Status)
+	assert.Equal(t, string(types.TerminationReasonDoneByRunner), task.TerminationReason)
+	assert.Empty(t, task.TerminationMessage)
+	assert.True(t, task.cleanedUp)
+}
+
+func TestProcessTasks_ContainerExitedWithError(t *testing.T) {
+	client := &dockerClientMock{
+		containers: []dockertypes.Container{
+			taskContainerSummary("task-1", "container-1", containerStateFinished),
+		},
+		inspect: map[string]dockertypes.ContainerJSON{
+			"container-1": exitedContainer("container-1", 137),
+		},
+		logs: map[string]string{"container-1": "out of memory\n"},
+	}
+	runner := newTestRunner(t, client)
+	addTask(runner, newRunningTask("task-1", "container-1"))
+
+	runner.ProcessTasks(t.Context())
+
+	task, _ := runner.tasks.Get("task-1")
+	assert.Equal(t, TaskStatusTerminated, task.Status)
+	assert.Equal(t, string(types.TerminationReasonContainerExitedWithError), task.TerminationReason)
+	assert.Equal(t, "out of memory", task.TerminationMessage)
+	assert.True(t, task.cleanedUp)
+}
+
+func TestProcessTasks_ContainerNotFound(t *testing.T) {
+	client := &dockerClientMock{}
+	runner := newTestRunner(t, client)
+	addTask(runner, newRunningTask("task-1", "container-1"))
+
+	runner.ProcessTasks(t.Context())
+
+	task, _ := runner.tasks.Get("task-1")
+	assert.Equal(t, TaskStatusTerminated, task.Status)
+	assert.Equal(t, string(types.TerminationReasonExecutorError), task.TerminationReason)
+	assert.Equal(t, "container not found", task.TerminationMessage)
+	assert.True(t, task.cleanedUp)
+}
+
+// A container that has never been started means that the shim stopped running
+// while the task was being started
+func TestProcessTasks_ContainerNotStarted(t *testing.T) {
+	client := &dockerClientMock{containers: []dockertypes.Container{
+		taskContainerSummary("task-1", "container-1", containerStateCreated),
+	}}
+	runner := newTestRunner(t, client)
+	addTask(runner, newRunningTask("task-1", "container-1"))
+
+	runner.ProcessTasks(t.Context())
+
+	task, _ := runner.tasks.Get("task-1")
+	assert.Equal(t, TaskStatusTerminated, task.Status)
+	assert.Equal(t, string(types.TerminationReasonExecutorError), task.TerminationReason)
+	assert.Equal(t, "container was not started", task.TerminationMessage)
+	assert.True(t, task.cleanedUp)
+	assert.Empty(t, client.inspected)
+}
+
+// A failed inspect request must not terminate the task, the next call retries
+func TestProcessTasks_InspectError(t *testing.T) {
+	client := &dockerClientMock{
+		containers: []dockertypes.Container{
+			taskContainerSummary("task-1", "container-1", containerStateFinished),
+		},
+	}
+	runner := newTestRunner(t, client)
+	addTask(runner, newRunningTask("task-1", "container-1"))
+
+	runner.ProcessTasks(t.Context())
+
+	task, _ := runner.tasks.Get("task-1")
+	assert.Equal(t, TaskStatusRunning, task.Status)
+	assert.False(t, task.cleanedUp)
+}
+
+// Tasks owned by Start() must not be processed, even if their containers exited
+func TestProcessTasks_TaskInFlight(t *testing.T) {
+	client := &dockerClientMock{
+		containers: []dockertypes.Container{
+			taskContainerSummary("task-1", "container-1", containerStateFinished),
+		},
+		inspect: map[string]dockertypes.ContainerJSON{
+			"container-1": exitedContainer("container-1", 0),
+		},
+	}
+	runner := newTestRunner(t, client)
+	task := newRunningTask("task-1", "container-1")
+	task.startInFlight = true
+	addTask(runner, task)
+
+	runner.ProcessTasks(t.Context())
+
+	task, _ = runner.tasks.Get("task-1")
+	assert.Equal(t, TaskStatusRunning, task.Status)
+	assert.False(t, task.cleanedUp)
+	assert.Empty(t, client.stopped)
+}
+
+func TestProcessTasks_ReleasesGpus(t *testing.T) {
+	client := &dockerClientMock{
+		containers: []dockertypes.Container{
+			taskContainerSummary("task-1", "container-1", containerStateFinished),
+		},
+		inspect: map[string]dockertypes.ContainerJSON{
+			"container-1": exitedContainer("container-1", 0),
+		},
+	}
+	runner := newTestRunner(t, client)
+	runner.gpuLock = newTestGpuLock(t, "gpu-0", "gpu-1")
+	require.Len(t, runner.gpuLock.Lock(t.Context(), []string{"gpu-0"}), 1)
+	task := newRunningTask("task-1", "container-1")
+	task.gpuIDs = []string{"gpu-0"}
+	addTask(runner, task)
+
+	runner.ProcessTasks(t.Context())
+
+	gpuIDs, err := runner.gpuLock.Acquire(t.Context(), 2)
+	assert.NoError(t, err)
+	assert.Len(t, gpuIDs, 2)
+}
+
+// A container started concurrently with the termination must be stopped
+func TestProcessTasks_TerminatedTaskWithRunningContainer(t *testing.T) {
+	client := &dockerClientMock{containers: []dockertypes.Container{
+		taskContainerSummary("task-1", "container-1", containerStateRunning),
+	}}
+	runner := newTestRunner(t, client)
+	task := newRunningTask("task-1", "container-1")
+	task.SetStatusTerminated(string(types.TerminationReasonTerminatedByUser), "")
+	addTask(runner, task)
+
+	runner.ProcessTasks(t.Context())
+
+	task, _ = runner.tasks.Get("task-1")
+	assert.Equal(t, TaskStatusTerminated, task.Status)
+	assert.Equal(t, string(types.TerminationReasonTerminatedByUser), task.TerminationReason)
+	assert.Equal(t, []string{"container-1"}, client.stopped)
+	assert.True(t, task.cleanedUp)
+}
+
+func TestProcessTasks_TerminatedTaskAlreadyCleanedUp(t *testing.T) {
+	client := &dockerClientMock{containers: []dockertypes.Container{
+		taskContainerSummary("task-1", "container-1", containerStateFinished),
+	}}
+	runner := newTestRunner(t, client)
+	task := newRunningTask("task-1", "container-1")
+	task.SetStatusTerminated(string(types.TerminationReasonDoneByRunner), "")
+	task.cleanedUp = true
+	addTask(runner, task)
+
+	runner.ProcessTasks(t.Context())
+
+	assert.Empty(t, client.stopped)
+	assert.Empty(t, client.inspected)
+}
+
+/* Utilities */
+
+// containerStateFinished is one of the states of a container that is not running
+const containerStateFinished = "exited"
+
+func newTestRunner(t *testing.T, client docker.APIClient) *DockerRunner {
+	t.Helper()
+	return &DockerRunner{
+		client:       client,
+		dockerParams: &dockerParametersMock{runnerDir: t.TempDir()},
+		gpuLock:      newTestGpuLock(t),
+		tasks:        NewTaskStorage(),
+	}
+}
+
+func newTestGpuLock(t *testing.T, ids ...string) *GpuLock {
+	t.Helper()
+	lock := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		lock[id] = false
+	}
+	return &GpuLock{lock: lock}
+}
+
+func newRunningTask(taskID string, containerID string) Task {
+	return NewTask(taskID, TaskStatusRunning, taskID+"-name", containerID, nil, nil, "")
+}
+
+func addTask(runner *DockerRunner, task Task) {
+	runner.tasks.tasks[task.ID] = task
+}
+
+func taskContainerSummary(taskID string, containerID string, state string) dockertypes.Container {
+	return dockertypes.Container{
+		ID:     containerID,
+		State:  state,
+		Labels: map[string]string{LabelKeyIsTask: LabelValueTrue, LabelKeyTaskID: taskID},
+	}
+}
+
+func exitedContainer(containerID string, exitCode int) dockertypes.ContainerJSON {
+	return dockertypes.ContainerJSON{
+		ContainerJSONBase: &dockertypes.ContainerJSONBase{
+			ID: containerID,
+			State: &dockertypes.ContainerState{
+				Status:   containerStateFinished,
+				ExitCode: exitCode,
+			},
+		},
+	}
+}
+
+/* Mocks */
+
+// dockerClientMock implements the part of the Docker API used to process tasks.
+// Calling any other method panics, as the embedded interface is nil
+type dockerClientMock struct {
+	docker.APIClient
+
+	containers []dockertypes.Container
+	inspect    map[string]dockertypes.ContainerJSON
+	logs       map[string]string
+
+	inspected []string
+	stopped   []string
+}
+
+func (c *dockerClientMock) ContainerList(
+	_ context.Context, _ container.ListOptions,
+) ([]dockertypes.Container, error) {
+	return c.containers, nil
+}
+
+func (c *dockerClientMock) ContainerInspect(
+	_ context.Context, containerID string,
+) (dockertypes.ContainerJSON, error) {
+	c.inspected = append(c.inspected, containerID)
+	inspection, ok := c.inspect[containerID]
+	if !ok {
+		return dockertypes.ContainerJSON{}, errdefs.NotFound(ErrNotFound)
+	}
+	return inspection, nil
+}
+
+func (c *dockerClientMock) ContainerLogs(
+	_ context.Context, containerID string, _ container.LogsOptions,
+) (io.ReadCloser, error) {
+	logs, ok := c.logs[containerID]
+	if !ok {
+		return nil, errdefs.NotFound(ErrNotFound)
+	}
+	// Container logs are multiplexed, see stdcopy.StdCopy()
+	buffer := new(bytes.Buffer)
+	if _, err := stdcopy.NewStdWriter(buffer, stdcopy.Stdout).Write([]byte(logs)); err != nil {
+		return nil, err
+	}
+	return io.NopCloser(buffer), nil
+}
+
+func (c *dockerClientMock) ContainerStop(
+	_ context.Context, containerID string, _ container.StopOptions,
+) error {
+	c.stopped = append(c.stopped, containerID)
+	return nil
+}

--- a/runner/internal/shim/task.go
+++ b/runner/internal/shim/task.go
@@ -41,6 +41,14 @@ type Task struct {
 	gpuIDs        []string
 	ports         []PortMapping
 	runnerDir     string // path on host mapped to consts.RunnerDir in container
+	// startInFlight is true while Start() is working on the task. Start() owns the
+	// task resources until it returns, therefore ProcessTasks() skips such tasks.
+	// Tasks restored from containers are never in flight.
+	startInFlight bool
+	// cleanedUp is true once the resources acquired for the task (host SSH keys,
+	// volumes, GPUs) are released. Resources are released only after the container
+	// is not running anymore.
+	cleanedUp bool
 
 	pullTracker *PullTracker
 


### PR DESCRIPTION
Previously, DockerRunner.Run() blocked in waitContainer() until the container exited, and only then set the final task status and ran its cleanup defers. As a result, nothing completed a task if the shim stopped running in the meantime: the volumes stayed mounted, the host SSH keys stayed in authorized_keys, and the task was never terminated with a proper reason. This is why the server only restarts the shim when all tasks are terminated, which blocks shim self-upgrade on instances running long-lived jobs.

* `Run()` is renamed to `Start()` and returns as soon as the container is started.
* The new `DockerRunner.ProcessTasks()` brings task states in line with their containers: it terminates tasks whose containers are not running anymore, reporting the exit code and the last log lines the same way as before, and releases the resources of terminated tasks. `ShimServer` calls it every second while it serves requests, starting before the first request is accepted, so that containers that exited while the shim was not running are processed first.
* Each call makes one container list request for all tasks. A container is inspected only once it is not running anymore, since the list response reports the exit code as a part of a human-readable status string only.
* Releasing the task resources is now a single idempotent function shared by `Start()`, `Terminate()`, `Remove()`, and `ProcessTasks()`, instead of the deferred calls of `Run()`. `Start()` owns the task until it returns (`Task.startInFlight`), so that the background job does not release the resources it is about to use.
* Tasks are now restored from containers as running regardless of the container state, letting `ProcessTasks()` decide why a container finished. Previously, a container that exited while the shim was not running produced a task terminated with an empty termination reason.
* A container that has never been started, which means the shim stopped running between creating and starting it, is now reported as `executor_error` instead of leaving the task running forever.

The HTTP API is unchanged, as is the task status machine.

Notes:

- Tasks restored from containers have no task config, therefore their volumes and host SSH keys are still not cleaned up. Persisting the task state, which is needed for that, is a separate change (planned).
- `Start()` still blocks while pulling the image, so tasks are only restart-safe in the running status. Adding it to the restart-safe statuses on the server is a separate change (not planned).

Part-of: https://github.com/dstackai/dstack/issues/4182