### PR TITLE
Fix Seeweb test for gpuhunt 0.1.30

### DIFF
--- a/src/tests/_internal/core/backends/seeweb/test_compute.py
+++ b/src/tests/_internal/core/backends/seeweb/test_compute.py
@@ -2,7 +2,7 @@ import shlex
 from unittest.mock import MagicMock, patch
 
 import pytest
-from gpuhunt import RawCatalogItem
+from gpuhunt import CatalogItem
 
 from dstack._internal.core.backends.base.compute import (
     ComputeWithInstanceVolumesSupport,
@@ -41,8 +41,9 @@ def _compute(regions=None) -> SeewebCompute:
     return compute
 
 
-def _raw(name: str, gpu: str, location: str = "it-fr2") -> RawCatalogItem:
-    return RawCatalogItem(
+def _raw(name: str, gpu: str, location: str = "it-fr2") -> CatalogItem:
+    return CatalogItem(
+        provider="seeweb",
         instance_name=name,
         location=location,
         price=0.38,


### PR DESCRIPTION
## Seeweb test fix

`test_compute.py` imported `RawCatalogItem`, removed in gpuhunt 0.1.30 (the pin on master) — the module failed at collection, breaking `python-test` since #4070 merged. Now uses `CatalogItem` with its required `provider` field.

Verified on this branch: full suite 3807 passed, plus live provisioning e2e through the server (seeweb fleet apply → L4 idle in ~7 min → deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)