### PR TITLE
Drop AI Assistance Notice requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,4 +49,3 @@ Before touching a subsystem, read the relevant notes in `contributing/`: `ARCHIT
 - Commit messages follow the existing style: short, imperative summaries (e.g., “Fix exclude_not_available ignored”); include rationale in the body if needed.
 - For PRs, describe behavior changes and link related issues.
 - Include screenshots or terminal output when touching UX/CLI messages or frontend flows.
-- Always disclose AI Assistance in PRs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,18 +2,11 @@
 
 We appreciate your interest in contributing to `dstack`! This document will help you get up to speed with `dstack` codebase and guide you through the contribution process.
 
-## AI Assistance Notice
+## Using AI assistance
 
-If you are using any kind of AI assistance while contributing to `dstack`,
-**this must be disclosed in the pull request**, along with the extent to
-which AI assistance was used.
-As an exception, tab-completions and trivial PRs don't need to be disclosed.
-
-An example disclosure:
-
-> This PR was written primarily by Claude Code.
-
-Failure to disclose this, makes it difficult to determine how much scrutiny to apply to the contribution. Please be respectful to maintainers and disclose AI assistance.
+You may use AI assistance when contributing to `dstack`.
+The contributor is responsible for the quality of the change: make sure you understand
+what you're submitting, and hold it to the same standard as code you'd write by hand.
 
 ## Set up your development environment
 


### PR DESCRIPTION
Nowadays distinguishing AI-assisted PRs via a disclosure brings no benefit as practically all changes are assisted by the AI. Ask and warn about contributor responsibility for the change.