### PR TITLE
fix(ui): show allocated block resources

### DIFF
--- a/frontend/src/pages/Runs/Details/Jobs/List/helpers.test.ts
+++ b/frontend/src/pages/Runs/Details/Jobs/List/helpers.test.ts
@@ -1,0 +1,56 @@
+jest.mock('App/helpers', () => ({ getBaseUrl: () => '' }));
+jest.mock('libs/fleet', () => ({ formatBackend: () => '-' }));
+
+import { getRunListItemResources } from '../../../List/helpers';
+import { getJobListItemResources } from './helpers';
+
+const instanceResources: IResources = {
+    cpus: 4,
+    memory_mib: 16 * 1024,
+    gpus: [],
+    spot: false,
+};
+
+const blockResources: IResources = {
+    cpus: 1,
+    memory_mib: 4 * 1024,
+    gpus: [],
+    spot: false,
+};
+
+const submission: IJobSubmission = {
+    id: 'submission',
+    submission_num: 0,
+    status: 'running',
+    submitted_at: 0,
+    finished_at: null,
+    job_provisioning_data: {
+        backend: 'aws',
+        instance_type: { name: 't3.xlarge', resources: instanceResources },
+        instance_id: 'instance',
+        hostname: 'localhost',
+        region: 'us-east-1',
+        price: 0,
+        username: 'ubuntu',
+        ssh_port: 22,
+        dockerized: false,
+    },
+    job_runtime_data: {
+        offer: { instance: { name: 'block', resources: blockResources } },
+    },
+};
+
+const job = { job_spec: {}, job_submissions: [submission] } as IJob;
+
+describe('job resource display', () => {
+    test('uses allocated block resources when runtime offer is available', () => {
+        expect(getJobListItemResources(job)).toBe('cpu=1 mem=4GB');
+        expect(getRunListItemResources({ jobs: [job], latest_job_submission: submission } as IRun)).toBe('cpu=1 mem=4GB');
+    });
+
+    test('falls back to instance resources for older submissions', () => {
+        const legacySubmission = { ...submission, job_runtime_data: null };
+        const legacyJob = { ...job, job_submissions: [legacySubmission] } as IJob;
+        expect(getJobListItemResources(legacyJob)).toBe('cpu=4 mem=16GB');
+    });
+});

--- a/frontend/src/pages/Runs/Details/Jobs/List/helpers.ts
+++ b/frontend/src/pages/Runs/Details/Jobs/List/helpers.ts
@@ -6,8 +6,14 @@ import { capitalize } from 'libs';
 import { formatBackend } from 'libs/fleet';
 import { formatResources } from 'libs/resources';
 
+export const getJobSubmissionResources = (submission?: IJobSubmission | null) => {
+    return (
+        submission?.job_runtime_data?.offer?.instance?.resources ?? submission?.job_provisioning_data?.instance_type?.resources
+    );
+};
+
 export const getJobListItemResources = (job: IJob) => {
-    const resources = job.job_submissions?.[job.job_submissions.length - 1]?.job_provisioning_data?.instance_type?.resources;
+    const resources = getJobSubmissionResources(job.job_submissions?.[job.job_submissions.length - 1]);
     return resources ? formatResources(resources) : '-';
 };
 

--- a/frontend/src/pages/Runs/List/helpers.ts
+++ b/frontend/src/pages/Runs/List/helpers.ts
@@ -6,7 +6,7 @@ import { formatResources } from 'libs/resources';
 import { getBaseUrl } from 'App/helpers';
 
 import { finishedJobs, finishedRunStatuses } from '../constants';
-import { getJobStatus } from '../Details/Jobs/List/helpers';
+import { getJobStatus, getJobSubmissionResources } from '../Details/Jobs/List/helpers';
 
 export const getGroupedRunsByProjectAndRepoID = (runs: IRun[]) => {
     return _groupBy(runs, ({ project_name }) => project_name);
@@ -17,7 +17,7 @@ export const getRunListItemResources = (run: IRun) => {
         return '-';
     }
 
-    const resources = run.latest_job_submission?.job_provisioning_data?.instance_type?.resources;
+    const resources = getJobSubmissionResources(run.latest_job_submission);
     return resources ? formatResources(resources) : '-';
 };
 

--- a/frontend/src/types/run.d.ts
+++ b/frontend/src/types/run.d.ts
@@ -293,6 +293,9 @@ declare interface IJobProvisioningData {
 declare interface IJobRuntimeData {
     working_dir?: string | null;
     username?: string | null;
+    offer?: {
+        instance: InstanceType;
+    } | null;
 }
 
 declare interface IJobSubmission {


### PR DESCRIPTION
## Summary

- Show the resources allocated to the run's block in the runs and jobs lists.
- Keep the provisioning instance resources as a fallback for older submissions without runtime offer data.
- Add regression coverage for both the allocated-block path and the legacy fallback.

## Validation

- `npx jest --config jest.local.config.cjs --runInBand src/pages/Runs/Details/Jobs/List/helpers.test.ts` (2 passed; isolated config disables the repository's unavailable Enzyme setup)
- Targeted ESLint passed for changed TypeScript files.
- Prettier check passed for changed files.
- `npx tsc --noEmit` remains blocked by pre-existing frontend type errors unrelated to this change.
- `git diff --check` passed.

Closes #4187
