### PR TITLE
Collect DinD metrics from the container cgroup root

### DIFF
--- a/runner/internal/runner/metrics/cgroups.go
+++ b/runner/internal/runner/metrics/cgroups.go
@@ -6,10 +6,28 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/dstackai/dstack/runner/internal/common/log"
 )
+
+func getMetricsCgroupPath(ctx context.Context, mountPoint, procPidCgroupPath string) (string, error) {
+	// In a container cgroup namespace, the mount root accounts for the whole
+	// container, including nested containers in sibling groups of /dind.
+	// The host's root cgroup has no memory.current; keep using the process
+	// cgroup in that case.
+	if _, err := os.Stat(path.Join(mountPoint, "memory.current")); err == nil {
+		return mountPoint, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("stat cgroup root memory.current: %w", err)
+	}
+	cgroupPathname, err := getProcessCgroupPathname(ctx, procPidCgroupPath)
+	if err != nil {
+		return "", fmt.Errorf("get cgroup pathname: %w", err)
+	}
+	return path.Join(mountPoint, cgroupPathname), nil
+}
 
 func getProcessCgroupMountPoint(ctx context.Context, ProcPidMountsPath string) (string, error) {
 	// See proc_pid_mounts(5) for the ProcPidMountsPath file description

--- a/runner/internal/runner/metrics/cgroups_test.go
+++ b/runner/internal/runner/metrics/cgroups_test.go
@@ -15,6 +15,51 @@ const (
 	rootMountLine    = "/dev/nvme0n1p5 / ext4 rw,relatime 0 0"
 )
 
+func TestGetMetricsCgroupPath(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		processGroup string
+		rootMemory   bool
+		childMemory  bool
+		wantGroup    string
+	}{
+		{name: "ordinary container", processGroup: "/", rootMemory: true, wantGroup: "/"},
+		{name: "dind before nested container", processGroup: "/dind", rootMemory: true, wantGroup: "/"},
+		{name: "dind with nested container", processGroup: "/dind", rootMemory: true, childMemory: true, wantGroup: "/"},
+		{name: "host cgroup namespace", processGroup: "/system.slice/docker.scope", childMemory: true, wantGroup: "/system.slice/docker.scope"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mountPoint := t.TempDir()
+			procFile := createProcFile(t, "cgroup", "0::"+tc.processGroup)
+			if tc.rootMemory {
+				require.NoError(t, os.WriteFile(path.Join(mountPoint, "memory.current"), []byte("8192\n"), 0o600))
+			}
+			if tc.childMemory {
+				child := path.Join(mountPoint, tc.processGroup)
+				require.NoError(t, os.MkdirAll(child, 0o700))
+				require.NoError(t, os.WriteFile(path.Join(child, "memory.current"), []byte("1024\n"), 0o600))
+			}
+			cgroupPath, err := getMetricsCgroupPath(t.Context(), mountPoint, procFile)
+			require.NoError(t, err)
+			require.Equal(t, path.Join(mountPoint, tc.wantGroup), cgroupPath)
+			collector := &MetricsCollector{}
+			memory, err := collector.GetMemoryUsageBytes(cgroupPath)
+			require.NoError(t, err)
+			if tc.rootMemory {
+				require.Equal(t, uint64(8192), memory)
+			} else {
+				require.Equal(t, uint64(1024), memory)
+			}
+		})
+	}
+}
+
+func TestGetMetricsCgroupPath_ErrorMissingProcessCgroup(t *testing.T) {
+	_, err := getMetricsCgroupPath(t.Context(), t.TempDir(), path.Join(t.TempDir(), "missing"))
+	require.ErrorContains(t, err, "get cgroup pathname")
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
 func TestGetProcessCgroupMountPoint_ErrorNoCgroupMounts(t *testing.T) {
 	procPidMountsPath := createProcFile(t, "mounts", rootMountLine, "malformed line")
 

--- a/runner/internal/runner/metrics/metrics.go
+++ b/runner/internal/runner/metrics/metrics.go
@@ -37,13 +37,12 @@ func NewMetricsCollector(ctx context.Context) (*MetricsCollector, error) {
 }
 
 func (s *MetricsCollector) GetSystemMetrics(ctx context.Context) (*schemas.SystemMetrics, error) {
-	// It's possible to move a process from one control group to another (it's unlikely, but nonetheless),
-	// so we detect the current group each time.
-	cgroupPathname, err := getProcessCgroupPathname(ctx, "/proc/self/cgroup")
+	// Resolve the accounting group each time: start-dockerd can move the runner
+	// into a child cgroup, and host-namespace processes can change groups too.
+	cgroupPath, err := getMetricsCgroupPath(ctx, s.cgroupMountPoint, "/proc/self/cgroup")
 	if err != nil {
-		return nil, fmt.Errorf("get cgroup pathname: %w", err)
+		return nil, err
 	}
-	cgroupPath := path.Join(s.cgroupMountPoint, cgroupPathname)
 	timestamp := time.Now()
 	cpuUsage, err := s.GetCPUUsageMicroseconds(cgroupPath)
 	if err != nil {

--- a/runner/internal/runner/metrics/metrics_test.go
+++ b/runner/internal/runner/metrics/metrics_test.go
@@ -1,11 +1,34 @@
 package metrics
 
 import (
+	"os"
+	"path"
 	"testing"
 
-	"github.com/dstackai/dstack/runner/internal/runner/schemas"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dstackai/dstack/runner/internal/common/gpu"
+	"github.com/dstackai/dstack/runner/internal/runner/schemas"
 )
+
+func TestGetSystemMetrics_ContainerRoot(t *testing.T) {
+	mountPoint := t.TempDir()
+	for name, content := range map[string]string{
+		"cpu.stat":       "usage_usec 12345\nuser_usec 12000\nsystem_usec 345\n",
+		"memory.current": "8192\n",
+		"memory.stat":    "anon 6144\ninactive_file 2048\n",
+	} {
+		require.NoError(t, os.WriteFile(path.Join(mountPoint, name), []byte(content), 0o600))
+	}
+	collector := &MetricsCollector{cgroupMountPoint: mountPoint, gpuVendor: gpu.GpuVendorNone}
+	metrics, err := collector.GetSystemMetrics(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, uint64(12345), metrics.CpuUsage)
+	require.Equal(t, uint64(8192), metrics.MemoryUsage)
+	require.Equal(t, uint64(6144), metrics.MemoryWorkingSet)
+	require.Empty(t, metrics.GPUMetrics)
+}
 
 func TestGetAMDGPUMetrics_OK(t *testing.T) {
 	collector, err := NewMetricsCollector(t.Context())


### PR DESCRIPTION
## Summary

Fixes #4267.

Prefer the cgroup mount root for runner CPU and memory accounting when its `memory.current` exists. In a container cgroup namespace this includes the whole run, including nested containers under the sibling `docker/` group after `start-dockerd` moves the runner into `dind/`.

When the mount exposes the host root, which has no `memory.current`, retain the existing `/proc/self/cgroup` resolution. Resolve this on each collection, preserving support for process cgroup changes. A failure to inspect the root other than a missing file is reported rather than silently selecting a different accounting scope.

The change follows the approach suggested in the issue. It does not enable controllers, modify the Docker startup script, change GPU collection, or restore cgroup v1 support. The namespace behavior addressed by #3402 is retained; the separate privileged Kubernetes limitation described in #4267 is not claimed as fixed.

## Validation

Filesystem-fixture regression cases cover:

- ordinary containers whose process cgroup is `/`;
- DinD before the first nested container, when child memory files are absent;
- DinD after child memory files appear, with deliberately different root and child counters;
- host-namespace fallback to the process cgroup;
- missing proc metadata errors when fallback is required.

An additional test exercises `GetSystemMetrics` using root CPU, memory usage, and cache counters and checks the resulting working set.

With the original path-selection behavior extracted unchanged, both DinD cases failed because they selected `/dind` instead of the mount root. After the fix:

```text
go test -race ./internal/runner/metrics -run '^(TestGetMetricsCgroupPath|TestGetProcessCgroup|TestGetSystemMetrics_ContainerRoot)' -count=1
ok github.com/dstackai/dstack/runner/internal/runner/metrics 2.199s

go vet ./internal/runner/metrics
# passed
```

Changed Go files are gofmt-formatted and `git diff --check` passes. The metrics test package also cross-compiles for Linux/amd64 (compile check only, not Linux execution).

Validation ran on macOS using temporary proc/cgroup fixtures. I did not launch nested Docker containers, run GPU workloads, execute the full runner suite (existing collector-constructor tests require Linux procfs), or run golangci-lint locally.

AI-assisted implementation and tests; I inspected the DinD startup code, previous cgroup-path fix, and current collector, and ran the focused validation above.
