### PR TITLE
fix: resolve preset env before claiming the agent session

### DIFF
--- a/src/dstack/_internal/cli/services/presets/create.py
+++ b/src/dstack/_internal/cli/services/presets/create.py
@@ -411,12 +411,16 @@ def create_preset(
     allowed_fleets: Optional[tuple[str, ...]] = None,
     previous: Sequence[PresetSession] = (),
 ) -> PresetCreateResult:
+    # Resolve env before the session is claimed and before the try that marks
+    # it failed: a missing variable here means nothing was spawned and nothing
+    # changed, so a resumable session must stay interrupted - a failure this
+    # early is not a failed creation.
+    resolved_configuration = _resolve_preset_env(configuration)
     session = resume_session or create_preset_session(
         configuration,
         previous=tuple(session.preset_id for session in previous),
     )
     try:
-        resolved_configuration = _resolve_preset_env(configuration)
         # A creation session runs unattended for hours; an idling machine would
         # freeze the agent and the process supervising it alike.
         with prevent_idle_sleep():

--- a/src/tests/_internal/cli/services/presets/test_create.py
+++ b/src/tests/_internal/cli/services/presets/test_create.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from datetime import datetime, timezone
 import os
 import uuid
 from types import SimpleNamespace
@@ -49,7 +50,7 @@ from dstack._internal.cli.services.presets.workspace import (
     create_agent_workspace,
     remove_agent_workspace,
 )
-from dstack._internal.core.errors import CLIError
+from dstack._internal.core.errors import CLIError, ConfigurationError
 from dstack._internal.core.models.configurations import PresetConfiguration
 from dstack._internal.core.models.envs import EnvSentinel
 from dstack._internal.core.models.runs import Run, RunStatus
@@ -390,6 +391,52 @@ class TestCreatePreset:
         assert "license-secret" not in result.path.read_text()
         assert result.preset.service.env["TOKENIZERS_PARALLELISM"] == "false"
         assert creation_context.run_apis.stopped_names == stopped_names
+
+
+    def test_env_resolution_failure_keeps_resume_session_interrupted(self, tmp_path, monkeypatch):
+        # Regression for #4164: resuming an interrupted preset from a shell
+        # missing a passthrough env var raised before the agent was spawned,
+        # yet the blanket `except BaseException` marked the session "failed" and
+        # deleted the workspace, making it unresumable forever. A failure before
+        # anything started must leave the session interrupted.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        monkeypatch.delenv("MODEL_LABEL", raising=False)
+
+        session_path = tmp_path / ".dstack" / "presets" / "ab12cd34"
+        session_path.mkdir(parents=True)
+        (session_path / "agent.log").touch()
+        (session_path / "trace.jsonl").touch()
+        session = PresetSession(path=session_path, preset_id="ab12cd34")
+        session.write_state(
+            PresetSessionState(
+                id="ab12cd34",
+                name="qwen",
+                model="Qwen/Qwen3.5-27B",
+                trials_num=None,
+                previous=[],
+                created_at=datetime.now(timezone.utc),
+                status="interrupted",
+                owner=None,
+                run=None,
+            )
+        )
+
+        with pytest.raises(ConfigurationError, match="MODEL_LABEL"):
+            create_preset(
+                api=SimpleNamespace(),
+                configuration=PresetConfiguration(
+                    name="qwen",
+                    base="Qwen/Qwen3.5-27B",
+                    env=["MODEL_LABEL"],
+                ),
+                store=PresetStore(tmp_path / "presets"),
+                resume_session=session,
+            )
+
+        assert session.read_state().status == "interrupted"
+        assert session_path.is_dir()
+
 
 
 class TestResolvePreviousSessions:


### PR DESCRIPTION
## Root cause

`create_preset` (src/dstack/_internal/cli/services/presets/create.py:444-446) wraps everything in `except BaseException -> _close_agent_session(session, "failed")`, and `_resolve_preset_env` ran INSIDE the try. A resume from a shell missing a passthrough variable raises ConfigurationError before the agent is spawned and before anything changed - and the session is still written "failed", the workspace deleted, and load_resumable_session refuses it forever.

## Fix

Hoist `_resolve_preset_env` above the session claim and the try. The resume case stays "interrupted"/resumable; a fresh attempt leaves no dead record behind.

## Verification

Regression test resumes an interrupted session with a missing env var: on current HEAD the session flips to failed; with the fix it stays interrupted. Full create suite: 63 passed.

Fixes #4164

> Built by breken, your AI support engineer - breken.ai - this one's on us.
