### PR TITLE
[runner] Mark logs finished only once the executor has finished

### DIFF
--- a/runner/internal/runner/api/server.go
+++ b/runner/internal/runner/api/server.go
@@ -143,11 +143,14 @@ func (s *Server) closeWsDone() {
 	s.wsDoneOnce.Do(func() { close(s.wsDoneCh) })
 }
 
+// stop asks the job to stop. The runner state is deliberately left alone: the executor sets
+// WaitLogsFinished when it has actually finished, and that is what tells /api/pull the state
+// it serves is final. Setting it here would mark a pull served while the job is still stopping
+// as the final one, and the runner would exit without ever handing over the job's real state.
 func (s *Server) stop() {
 	s.executor.Lock()
 	defer s.executor.Unlock()
 	if s.executor.GetRunnerState() == executor.ServeLogs {
 		s.cancelRun()
 	}
-	s.executor.SetRunnerState(executor.WaitLogsFinished)
 }

--- a/runner/internal/runner/api/server_test.go
+++ b/runner/internal/runner/api/server_test.go
@@ -163,3 +163,37 @@ func TestLogsWs_TwoClientsBothDrain(t *testing.T) {
 	// Give the second stream time to reach its own close.
 	time.Sleep(500 * time.Millisecond)
 }
+
+// /api/stop must not turn the next pull into the final one. The job is still stopping -- the
+// runner has up to killDelay before the command is killed -- and the state it will report does
+// not exist yet. Treating that pull as final lets the runner exit before handing the state
+// over, and the server ends the job as unreachable instead.
+func TestStop_DoesNotMarkLogsFinished(t *testing.T) {
+	s := newTestServer(t, executor.ServeLogs)
+	s.cancelRun = func() {} // set by runPostHandler in production
+
+	_, err := s.stopPostHandler(
+		httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodPost, "/api/stop", nil),
+	)
+	require.NoError(t, err)
+	pull(t, s)
+
+	select {
+	case <-s.pullDoneCh:
+		t.Fatal("pullDoneCh must stay open while the job is still stopping")
+	default:
+	}
+
+	// The executor finishes and records the terminal job state.
+	s.executor.Lock()
+	s.executor.SetRunnerState(executor.WaitLogsFinished)
+	s.executor.Unlock()
+	pull(t, s)
+
+	select {
+	case <-s.pullDoneCh:
+	default:
+		t.Fatal("the first pull after the executor finished must be the final one")
+	}
+}


### PR DESCRIPTION
Previously, `Server.stop()` set WaitLogsFinished as soon as `/api/stop` arrived. `/api/pull` treats the first request it serves in that state as the final one and closes `pullDoneCh` -- the barrier that keeps the runner alive until the server has fetched the job's last logs and state.

The job is still stopping at that point. The command has up to `killDelay` before it is killed, so the state being served is not final, and the barrier is satisfied before the state it is meant to protect exists:

    08:38:39  /api/stop
    08:38:41  /api/pull                     <- closes pullDoneCh here
    08:38:51  Job state changed new=terminated
    08:38:51  Job finished, shutting down
    08:38:51  Logs streaming finished endpoint=/api/pull   <- 92us later

The runner exited 64ms after computing the terminal state, without ever serving a pull that carried it. The server's next poll found nothing listening, reported the instance unreachable, and terminated the job on the disconnect timeout two minutes later -- discarding the state the runner had worked out.

Now `stop()` only cancels the run. The executor sets WaitLogsFinished from its own defer when `Run` returns, after the terminal job state has been recorded, so the first pull to observe it carries that state and the runner exits only once the server has taken it.

`HasMore` is derived from the same state and was likewise reported as false for the whole stop window. Nothing observed it: the server's `PullResponse` has no such field.