### PR TITLE
Phase out Exports in self-hosted OSS `dstack`

### DIFF
--- a/mkdocs/docs/concepts/exports.md
+++ b/mkdocs/docs/concepts/exports.md
@@ -8,9 +8,8 @@ description: Exporting resources across projects
 Exports allow making resources from one project available to other projects. When a project exports a resource,
 the specified importer projects can see and use it as if it were their own.
 
-!!! warning "Experimental"
-    Exports are an experimental feature.
-    Currently, [SSH fleets](fleets.md#ssh-fleets) and [gateways](gateways.md) can be exported.
+!!! info "Export support"
+    Exports are only supported in `dstack` Sky and `dstack` Factory.
 
 An export is created in the exporter project and specifies the resources to export and the
 importer projects that will gain access to them.
@@ -18,6 +17,8 @@ importer projects that will gain access to them.
 Once an export is created, the importer projects can see the exported resources in their resource lists and use them
 for running tasks, dev environments, and services. Imported resources appear with a project prefix
 (e.g., `team-a/my-fleet`) to distinguish them from the project's own resources.
+
+Currently, [SSH fleets](fleets.md#ssh-fleets) and [gateways](gateways.md) can be exported.
 
 !!! info "Required project role"
     The user creating or updating an export must have the project admin role on both the exporter project and

--- a/src/dstack/_internal/cli/commands/export.py
+++ b/src/dstack/_internal/cli/commands/export.py
@@ -4,7 +4,7 @@ from rich.table import Table
 
 from dstack._internal.cli.commands import APIBaseCommand
 from dstack._internal.cli.services.completion import ExportNameCompleter
-from dstack._internal.cli.utils.common import add_row_from_dict, confirm_ask, console
+from dstack._internal.cli.utils.common import add_row_from_dict, confirm_ask, console, warn
 from dstack._internal.core.models.exports import Export
 
 
@@ -142,8 +142,10 @@ class ExportCommand(APIBaseCommand):
         args.subfunc(args)
 
     def _list(self, args: argparse.Namespace):
-        exports = self.api.client.exports.list(self.api.project)
-        print_exports_table(exports)
+        response = self.api.client.exports.list_exports(self.api.project)
+        for warning in response.warnings:
+            warn(warning)
+        print_exports_table(response.exports)
 
     def _create(self, args: argparse.Namespace):
         with console.status("Creating export..."):

--- a/src/dstack/_internal/cli/commands/import_.py
+++ b/src/dstack/_internal/cli/commands/import_.py
@@ -4,7 +4,7 @@ from rich.table import Table
 
 from dstack._internal.cli.commands import APIBaseCommand
 from dstack._internal.cli.services.completion import ImportNameCompleter
-from dstack._internal.cli.utils.common import add_row_from_dict, confirm_ask, console
+from dstack._internal.cli.utils.common import add_row_from_dict, confirm_ask, console, warn
 from dstack._internal.core.models.imports import Import
 
 
@@ -39,8 +39,10 @@ class ImportCommand(APIBaseCommand):
         args.subfunc(args)
 
     def _list(self, args: argparse.Namespace):
-        imports = self.api.client.imports.list(self.api.project)
-        print_imports_table(imports)
+        response = self.api.client.imports.list_imports(self.api.project)
+        for warning in response.warnings:
+            warn(warning)
+        print_imports_table(response.imports)
 
     def _delete(self, args: argparse.Namespace):
         parts = args.name.split("/")

--- a/src/dstack/_internal/core/models/exports.py
+++ b/src/dstack/_internal/core/models/exports.py
@@ -24,3 +24,8 @@ class Export(CoreModel):
     imports: list[ExportImport]
     exported_fleets: list[ExportedFleet]
     exported_gateways: list[ExportedGateway] = []
+
+
+class ListExportsResponse(CoreModel):
+    exports: list[Export]
+    warnings: list[str] = []

--- a/src/dstack/_internal/core/models/imports.py
+++ b/src/dstack/_internal/core/models/imports.py
@@ -24,3 +24,8 @@ class ImportExport(CoreModel):
 class Import(CoreModel):
     id: uuid.UUID
     export: ImportExport
+
+
+class ListImportsResponse(CoreModel):
+    imports: list[Import]
+    warnings: list[str] = []

--- a/src/dstack/_internal/server/compatibility/exports.py
+++ b/src/dstack/_internal/server/compatibility/exports.py
@@ -1,0 +1,11 @@
+from packaging.version import Version
+
+from dstack._internal.core.models.exports import Export, ListExportsResponse
+
+
+def patch_list_exports_response(
+    response: ListExportsResponse, client_version: Version | None
+) -> ListExportsResponse | list[Export]:
+    if client_version is not None and client_version < Version("0.22.0"):
+        return response.exports
+    return response

--- a/src/dstack/_internal/server/compatibility/imports.py
+++ b/src/dstack/_internal/server/compatibility/imports.py
@@ -1,0 +1,11 @@
+from packaging.version import Version
+
+from dstack._internal.core.models.imports import Import, ListImportsResponse
+
+
+def patch_list_imports_response(
+    response: ListImportsResponse, client_version: Version | None
+) -> ListImportsResponse | list[Import]:
+    if client_version is not None and client_version < Version("0.22.0"):
+        return response.imports
+    return response

--- a/src/dstack/_internal/server/routers/exports.py
+++ b/src/dstack/_internal/server/routers/exports.py
@@ -1,9 +1,11 @@
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
+from packaging.version import Version
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from dstack._internal.core.models.exports import Export
+from dstack._internal.core.models.exports import Export, ListExportsResponse
+from dstack._internal.server.compatibility.exports import patch_list_exports_response
 from dstack._internal.server.db import get_session
 from dstack._internal.server.models import ProjectModel, UserModel
 from dstack._internal.server.schemas.exports import (
@@ -13,7 +15,10 @@ from dstack._internal.server.schemas.exports import (
 )
 from dstack._internal.server.security.permissions import ProjectAdmin, ProjectMember
 from dstack._internal.server.services import exports as exports_services
-from dstack._internal.server.utils.routers import get_base_api_additional_responses
+from dstack._internal.server.utils.routers import (
+    get_base_api_additional_responses,
+    get_client_version,
+)
 
 project_router = APIRouter(
     prefix="/api/project/{project_name}/exports",
@@ -78,13 +83,17 @@ async def delete_export(
     )
 
 
-@project_router.post("/list", summary="List exports", response_model=list[Export])
+@project_router.post("/list", summary="List exports")
 async def list_exports(
     session: Annotated[AsyncSession, Depends(get_session)],
     user_project: Annotated[tuple[UserModel, ProjectModel], Depends(ProjectMember())],
-):
+    client_version: Annotated[Version | None, Depends(get_client_version)],
+) -> ListExportsResponse | list[Export]:
+    """Returns a bare list for clients older than 0.22.0, otherwise a `ListExportsResponse`."""
     _, project = user_project
-    return await exports_services.list_exports(
+    response = await exports_services.list_exports(
         session=session,
         project=project,
     )
+    response = patch_list_exports_response(response, client_version)
+    return response

--- a/src/dstack/_internal/server/routers/imports.py
+++ b/src/dstack/_internal/server/routers/imports.py
@@ -1,15 +1,20 @@
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
+from packaging.version import Version
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from dstack._internal.core.models.imports import Import
+from dstack._internal.core.models.imports import Import, ListImportsResponse
+from dstack._internal.server.compatibility.imports import patch_list_imports_response
 from dstack._internal.server.db import get_session
 from dstack._internal.server.models import ProjectModel, UserModel
 from dstack._internal.server.schemas.imports import DeleteImportRequest
 from dstack._internal.server.security.permissions import ProjectAdmin, ProjectMember
 from dstack._internal.server.services import imports as imports_services
-from dstack._internal.server.utils.routers import get_base_api_additional_responses
+from dstack._internal.server.utils.routers import (
+    get_base_api_additional_responses,
+    get_client_version,
+)
 
 project_router = APIRouter(
     prefix="/api/project/{project_name}/imports",
@@ -33,13 +38,17 @@ async def delete_import(
     )
 
 
-@project_router.post("/list", summary="List imports", response_model=list[Import])
+@project_router.post("/list", summary="List imports")
 async def list_imports(
     session: Annotated[AsyncSession, Depends(get_session)],
     user_project: Annotated[tuple[UserModel, ProjectModel], Depends(ProjectMember())],
-):
+    client_version: Annotated[Version | None, Depends(get_client_version)],
+) -> ListImportsResponse | list[Import]:
+    """Returns a bare list for clients older than 0.22.0, otherwise a `ListImportsResponse`."""
     _, project = user_project
-    return await imports_services.list_imports(
+    response = await imports_services.list_imports(
         session=session,
         project=project,
     )
+    response = patch_list_imports_response(response, client_version)
+    return response

--- a/src/dstack/_internal/server/services/exports.py
+++ b/src/dstack/_internal/server/services/exports.py
@@ -17,6 +17,7 @@ from dstack._internal.core.models.exports import (
     ExportedFleet,
     ExportedGateway,
     ExportImport,
+    ListExportsResponse,
 )
 from dstack._internal.core.models.users import GlobalRole
 from dstack._internal.core.services import validate_dstack_resource_name
@@ -40,6 +41,31 @@ from dstack._internal.server.services.projects import (
     get_user_project_role,
     list_project_models,
     list_user_project_models,
+)
+
+_EXPORTS_ENABLED = False
+
+
+def are_exports_enabled() -> bool:
+    return _EXPORTS_ENABLED
+
+
+def enable_exports() -> None:
+    """Extension point for alternative dstack versions."""
+    global _EXPORTS_ENABLED
+    _EXPORTS_ENABLED = True
+
+
+EXPORTS_NOT_SUPPORTED_MESSAGE = (
+    "This dstack server does not support exports."
+    " Export support is available in dstack Sky and dstack Factory."
+)
+EXPORTS_PHASE_OUT_MESSAGE = (
+    "Exports are being phased out in the dstack server version you are running."
+    " No new exports can be created, and existing exports can no longer be extended."
+    " A future dstack release will automatically remove any remaining exports."
+    " Please adjust your project organization to avoid relying on exports,"
+    " or switch to dstack Sky or dstack Factory for full export support."
 )
 
 
@@ -112,6 +138,8 @@ async def create_export(
     exported_fleet_names: list[str],
     exported_gateway_names: list[str],
 ) -> Export:
+    if not are_exports_enabled():
+        raise ServerClientError(EXPORTS_NOT_SUPPORTED_MESSAGE)
     validate_dstack_resource_name(name)
     if is_global and importer_project_names:
         raise ServerClientError(
@@ -207,6 +235,15 @@ async def update_export(
         if export is None:
             raise ResourceNotExistsError(f"Export {name!r} not found in project {project.name!r}")
 
+        if not are_exports_enabled() and any(
+            (
+                add_importer_project_names,
+                add_exported_fleet_names,
+                add_exported_gateway_names,
+                set_global,
+            )
+        ):
+            raise ServerClientError(EXPORTS_PHASE_OUT_MESSAGE)
         if (
             not set_global
             and not unset_global
@@ -427,7 +464,7 @@ async def delete_export(session: AsyncSession, project: ProjectModel, name: str)
         await session.commit()
 
 
-async def list_exports(session: AsyncSession, project: ProjectModel) -> list[Export]:
+async def list_exports(session: AsyncSession, project: ProjectModel) -> ListExportsResponse:
     res = await session.execute(
         select(ExportModel)
         .where(ExportModel.project == project)
@@ -450,8 +487,18 @@ async def list_exports(session: AsyncSession, project: ProjectModel) -> list[Exp
         )
         .order_by(ExportModel.created_at.desc())
     )
-    exports = res.scalars().all()
-    return [export_model_to_export(export) for export in exports]
+    export_models = res.scalars().all()
+    exports = [export_model_to_export(export) for export in export_models]
+    warnings = []
+    if not are_exports_enabled():
+        if not exports:
+            raise ServerClientError(EXPORTS_NOT_SUPPORTED_MESSAGE)
+        else:
+            warnings.append(EXPORTS_PHASE_OUT_MESSAGE)
+    return ListExportsResponse(
+        exports=exports,
+        warnings=warnings,
+    )
 
 
 def export_model_to_export(export_model: ExportModel) -> Export:

--- a/src/dstack/_internal/server/services/imports.py
+++ b/src/dstack/_internal/server/services/imports.py
@@ -8,6 +8,7 @@ from dstack._internal.core.models.imports import (
     ImportExport,
     ImportExportedFleet,
     ImportExportedGateway,
+    ListImportsResponse,
 )
 from dstack._internal.server.models import (
     ExportedFleetModel,
@@ -18,11 +19,16 @@ from dstack._internal.server.models import (
     ImportModel,
     ProjectModel,
 )
-from dstack._internal.server.services.exports import get_export_model_by_name_for_update
+from dstack._internal.server.services.exports import (
+    EXPORTS_NOT_SUPPORTED_MESSAGE,
+    EXPORTS_PHASE_OUT_MESSAGE,
+    are_exports_enabled,
+    get_export_model_by_name_for_update,
+)
 from dstack._internal.server.services.projects import get_project_model_by_name
 
 
-async def list_imports(session: AsyncSession, project: ProjectModel) -> list[Import]:
+async def list_imports(session: AsyncSession, project: ProjectModel) -> ListImportsResponse:
     res = await session.execute(
         select(ImportModel)
         .where(ImportModel.project_id == project.id)
@@ -45,8 +51,18 @@ async def list_imports(session: AsyncSession, project: ProjectModel) -> list[Imp
         )
         .order_by(ImportModel.created_at.desc())
     )
-    imports = res.scalars().all()
-    return [import_model_to_import(imp) for imp in imports]
+    import_models = res.scalars().all()
+    imports = [import_model_to_import(imp) for imp in import_models]
+    warnings = []
+    if not are_exports_enabled():
+        if not imports:
+            raise ServerClientError(EXPORTS_NOT_SUPPORTED_MESSAGE)
+        else:
+            warnings.append(EXPORTS_PHASE_OUT_MESSAGE)
+    return ListImportsResponse(
+        imports=imports,
+        warnings=warnings,
+    )
 
 
 async def delete_import(

--- a/src/dstack/api/server/_exports.py
+++ b/src/dstack/api/server/_exports.py
@@ -5,19 +5,33 @@ from dstack._internal.core.compatibility.exports import (
     get_update_export_excludes,
 )
 from dstack._internal.core.models.common import validate_extra_ignore
-from dstack._internal.core.models.exports import Export
+from dstack._internal.core.models.exports import Export, ListExportsResponse
 from dstack._internal.server.schemas.exports import (
     CreateExportRequest,
     DeleteExportRequest,
     UpdateExportRequest,
 )
+from dstack._internal.utils.logging import get_logger
 from dstack.api.server._group import APIClientGroup
+
+logger = get_logger(__name__)
 
 
 class ExportsAPIClient(APIClientGroup):
-    def list(self, project_name: str) -> List[Export]:
+    def list_exports(self, project_name: str) -> ListExportsResponse:
         resp = self._request(f"/api/project/{project_name}/exports/list")
-        return validate_extra_ignore(List[Export], resp.json())
+        if isinstance(resp.json(), list):
+            return ListExportsResponse(
+                exports=validate_extra_ignore(list[Export], resp.json()),
+            )
+        return validate_extra_ignore(ListExportsResponse, resp.json())
+
+    def list(self, project_name: str) -> List[Export]:
+        logger.warning("The list() method is deprecated in favor of list_exports().")
+        resp = self._request(f"/api/project/{project_name}/exports/list")
+        if isinstance(resp.json(), list):
+            return validate_extra_ignore(List[Export], resp.json())
+        return validate_extra_ignore(ListExportsResponse, resp.json()).exports
 
     def create(
         self,

--- a/src/dstack/api/server/_imports.py
+++ b/src/dstack/api/server/_imports.py
@@ -1,15 +1,29 @@
 from typing import List
 
 from dstack._internal.core.models.common import validate_extra_ignore
-from dstack._internal.core.models.imports import Import
+from dstack._internal.core.models.imports import Import, ListImportsResponse
 from dstack._internal.server.schemas.imports import DeleteImportRequest
+from dstack._internal.utils.logging import get_logger
 from dstack.api.server._group import APIClientGroup
+
+logger = get_logger(__name__)
 
 
 class ImportsAPIClient(APIClientGroup):
-    def list(self, project_name: str) -> List[Import]:
+    def list_imports(self, project_name: str) -> ListImportsResponse:
         resp = self._request(f"/api/project/{project_name}/imports/list")
-        return validate_extra_ignore(List[Import], resp.json())
+        if isinstance(resp.json(), list):
+            return ListImportsResponse(
+                imports=validate_extra_ignore(list[Import], resp.json()),
+            )
+        return validate_extra_ignore(ListImportsResponse, resp.json())
+
+    def list(self, project_name: str) -> List[Import]:
+        logger.warning("The list() method is deprecated in favor of list_imports().")
+        resp = self._request(f"/api/project/{project_name}/imports/list")
+        if isinstance(resp.json(), list):
+            return validate_extra_ignore(List[Import], resp.json())
+        return validate_extra_ignore(ListImportsResponse, resp.json()).imports
 
     def delete(self, *, project_name: str, export_project_name: str, export_name: str) -> None:
         body = DeleteImportRequest(

--- a/src/tests/_internal/server/routers/test_exports.py
+++ b/src/tests/_internal/server/routers/test_exports.py
@@ -7,6 +7,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from dstack._internal.core.models.users import GlobalRole, ProjectRole
 from dstack._internal.server.models import ExportModel, ImportModel
+from dstack._internal.server.services import exports as exports_service
+from dstack._internal.server.services.exports import (
+    EXPORTS_NOT_SUPPORTED_MESSAGE,
+    EXPORTS_PHASE_OUT_MESSAGE,
+)
 from dstack._internal.server.services.projects import add_project_member
 from dstack._internal.server.testing.common import (
     create_backend,
@@ -25,6 +30,11 @@ pytestmark = [
     pytest.mark.usefixtures("test_db"),
     pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True),
 ]
+
+
+@pytest.fixture(autouse=True)
+def enable_exports(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(exports_service, "_EXPORTS_ENABLED", True)
 
 
 class TestCreateExport:
@@ -384,6 +394,26 @@ class TestCreateExport:
         res = await session.execute(select(func.count()).select_from(ExportModel))
         assert res.scalar_one() == 1
 
+    async def test_returns_400_when_disabled(
+        self, session: AsyncSession, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(exports_service, "_EXPORTS_ENABLED", False)
+        user = await create_user(session=session, global_role=GlobalRole.USER)
+        project = await create_project(session=session, owner=user)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.ADMIN
+        )
+
+        response = await client.post(
+            f"/api/project/{project.name}/exports/create",
+            headers=get_auth_headers(user.token),
+            json={"name": "test-export"},
+        )
+        assert response.status_code == 400
+        assert EXPORTS_NOT_SUPPORTED_MESSAGE in response.json()["detail"][0]["msg"]
+        res = await session.execute(select(func.count()).select_from(ExportModel))
+        assert res.scalar_one() == 0
+
 
 class TestUpdateExport:
     async def test_returns_403_if_not_authenticated(self, client: AsyncClient):
@@ -526,7 +556,7 @@ class TestUpdateExport:
             f"/api/project/{project.name}/exports/list", headers=get_auth_headers(user.token)
         )
         assert response.status_code == 200
-        export_list = response.json()
+        export_list = response.json()["exports"]
         assert len(export_list) == 1
         export_response["imports"].sort(key=lambda i: i["project_name"])
         export_list[0]["imports"].sort(key=lambda i: i["project_name"])
@@ -603,8 +633,8 @@ class TestUpdateExport:
             f"/api/project/{project.name}/exports/list", headers=get_auth_headers(user.token)
         )
         assert response.status_code == 200
-        assert len(response.json()) == 1
-        assert response.json()[0] == export_response
+        assert len(response.json()["exports"]) == 1
+        assert response.json()["exports"][0] == export_response
 
     @pytest.mark.parametrize(
         "body,error",
@@ -1144,6 +1174,109 @@ class TestUpdateExport:
         assert response.status_code == 400
         assert "The export is already global" in response.json()["detail"][0]["msg"]
 
+    @pytest.mark.parametrize(
+        "body",
+        [
+            pytest.param({"add_importer_projects": ["ImporterProject"]}, id="add-importer"),
+            pytest.param({"add_exported_fleets": ["fleet"]}, id="add-fleet"),
+            pytest.param({"add_exported_gateways": ["gateway"]}, id="add-gateway"),
+        ],
+    )
+    async def test_rejects_additions_when_disabled(
+        self,
+        session: AsyncSession,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+        body: dict,
+    ):
+        user = await create_user(session=session, global_role=GlobalRole.USER)
+        project = await create_project(session=session, name="ExporterProject", owner=user)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.ADMIN
+        )
+        importer_project = await create_project(
+            session=session, name="ImporterProject", owner=user
+        )
+        await add_project_member(
+            session=session, project=importer_project, user=user, project_role=ProjectRole.ADMIN
+        )
+        await create_fleet(
+            session=session,
+            project=project,
+            name="fleet",
+            spec=get_fleet_spec(get_ssh_fleet_configuration()),
+        )
+        backend = await create_backend(session=session, project_id=project.id)
+        await create_gateway(
+            session=session, project_id=project.id, backend_id=backend.id, name="gateway"
+        )
+        await create_export(
+            session=session,
+            exporter_project=project,
+            importer_projects=[],
+            exported_fleets=[],
+            name="test-export",
+        )
+
+        monkeypatch.setattr(exports_service, "_EXPORTS_ENABLED", False)
+        response = await client.post(
+            f"/api/project/{project.name}/exports/update",
+            headers=get_auth_headers(user.token),
+            json={"name": "test-export", **body},
+        )
+        assert response.status_code == 400
+        assert EXPORTS_PHASE_OUT_MESSAGE in response.json()["detail"][0]["msg"]
+
+    async def test_allows_removals_when_disabled(
+        self, session: AsyncSession, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        user = await create_user(session=session, global_role=GlobalRole.USER)
+        project = await create_project(session=session, name="ExporterProject", owner=user)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.ADMIN
+        )
+        importer_project = await create_project(
+            session=session, name="ImporterProject", owner=user
+        )
+        await add_project_member(
+            session=session, project=importer_project, user=user, project_role=ProjectRole.ADMIN
+        )
+        fleet = await create_fleet(
+            session=session,
+            project=project,
+            name="fleet",
+            spec=get_fleet_spec(get_ssh_fleet_configuration()),
+        )
+        backend = await create_backend(session=session, project_id=project.id)
+        gateway = await create_gateway(
+            session=session, project_id=project.id, backend_id=backend.id, name="gateway"
+        )
+        await create_export(
+            session=session,
+            exporter_project=project,
+            importer_projects=[importer_project],
+            exported_fleets=[fleet],
+            exported_gateways=[gateway],
+            name="test-export",
+        )
+
+        monkeypatch.setattr(exports_service, "_EXPORTS_ENABLED", False)
+        response = await client.post(
+            f"/api/project/{project.name}/exports/update",
+            headers=get_auth_headers(user.token),
+            json={
+                "name": "test-export",
+                "remove_importer_projects": ["ImporterProject"],
+                "remove_exported_fleets": ["fleet"],
+                "remove_exported_gateways": ["gateway"],
+            },
+        )
+        assert response.status_code == 200
+        export_response = response.json()
+        assert export_response["imports"] == []
+        assert export_response["exported_fleets"] == []
+        assert export_response["exported_gateways"] == []
+
 
 class TestDeleteExport:
     async def test_returns_403_if_not_authenticated(self, client: AsyncClient):
@@ -1317,7 +1450,7 @@ class TestListExports:
             headers=get_auth_headers(user.token),
         )
         assert response.status_code == 200
-        exports = response.json()
+        exports = response.json()["exports"]
         assert len(exports) == 2
         exports.sort(key=lambda e: e["name"])
 
@@ -1363,7 +1496,7 @@ class TestListExports:
             headers=get_auth_headers(user.token),
         )
         assert response.status_code == 200
-        assert response.json() == []
+        assert response.json()["exports"] == []
 
     async def test_not_includes_deleted_entities(self, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
@@ -1404,10 +1537,54 @@ class TestListExports:
             headers=get_auth_headers(user.token),
         )
         assert response.status_code == 200
-        exports = response.json()
+        exports = response.json()["exports"]
         assert len(exports) == 1
         assert exports[0]["name"] == "test-export"
         assert len(exports[0]["imports"]) == 1
         assert exports[0]["imports"][0]["project_name"] == "ImporterProject"
         assert len(exports[0]["exported_fleets"]) == 1
         assert exports[0]["exported_fleets"][0]["name"] == "fleet"
+
+    async def test_returns_400_when_disabled_and_no_exports(
+        self, session: AsyncSession, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        user = await create_user(session=session, global_role=GlobalRole.USER)
+        project = await create_project(session=session, owner=user)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.USER
+        )
+
+        monkeypatch.setattr(exports_service, "_EXPORTS_ENABLED", False)
+        response = await client.post(
+            f"/api/project/{project.name}/exports/list",
+            headers=get_auth_headers(user.token),
+        )
+        assert response.status_code == 400
+        assert EXPORTS_NOT_SUPPORTED_MESSAGE in response.json()["detail"][0]["msg"]
+
+    async def test_warns_when_disabled_but_exports_exist(
+        self, session: AsyncSession, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        user = await create_user(session=session, global_role=GlobalRole.USER)
+        project = await create_project(session=session, owner=user)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.USER
+        )
+        await create_export(
+            session=session,
+            exporter_project=project,
+            importer_projects=[],
+            exported_fleets=[],
+            name="test-export",
+        )
+
+        monkeypatch.setattr(exports_service, "_EXPORTS_ENABLED", False)
+        response = await client.post(
+            f"/api/project/{project.name}/exports/list",
+            headers=get_auth_headers(user.token),
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["exports"]) == 1
+        assert data["exports"][0]["name"] == "test-export"
+        assert data["warnings"] == [EXPORTS_PHASE_OUT_MESSAGE]

--- a/src/tests/_internal/server/routers/test_imports.py
+++ b/src/tests/_internal/server/routers/test_imports.py
@@ -7,6 +7,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from dstack._internal.core.models.users import GlobalRole, ProjectRole
 from dstack._internal.server.models import ExportModel, ImportModel
+from dstack._internal.server.services import exports as exports_service
+from dstack._internal.server.services.exports import (
+    EXPORTS_NOT_SUPPORTED_MESSAGE,
+    EXPORTS_PHASE_OUT_MESSAGE,
+)
 from dstack._internal.server.services.projects import add_project_member
 from dstack._internal.server.testing.common import (
     create_backend,
@@ -25,6 +30,11 @@ pytestmark = [
     pytest.mark.usefixtures("test_db"),
     pytest.mark.parametrize("test_db", ["sqlite", "postgres"], indirect=True),
 ]
+
+
+@pytest.fixture(autouse=True)
+def enable_exports(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(exports_service, "_EXPORTS_ENABLED", True)
 
 
 class TestDeleteImport:
@@ -267,7 +277,7 @@ class TestListImports:
             headers=get_auth_headers(user.token),
         )
         assert response.status_code == 200
-        imports = response.json()
+        imports = response.json()["imports"]
         assert len(imports) == 2
         imports.sort(key=lambda i: i["export"]["name"])
 
@@ -311,7 +321,56 @@ class TestListImports:
             headers=get_auth_headers(user.token),
         )
         assert response.status_code == 200
-        assert response.json() == []
+        assert response.json() == {"imports": [], "warnings": []}
+
+    async def test_returns_400_when_disabled_and_no_imports(
+        self, session: AsyncSession, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        user = await create_user(session=session, global_role=GlobalRole.USER)
+        project = await create_project(session=session, owner=user)
+        await add_project_member(
+            session=session, project=project, user=user, project_role=ProjectRole.USER
+        )
+
+        monkeypatch.setattr(exports_service, "_EXPORTS_ENABLED", False)
+        response = await client.post(
+            f"/api/project/{project.name}/imports/list",
+            headers=get_auth_headers(user.token),
+        )
+        assert response.status_code == 400
+        assert EXPORTS_NOT_SUPPORTED_MESSAGE in response.json()["detail"][0]["msg"]
+
+    async def test_warns_when_disabled_but_imports_exist(
+        self, session: AsyncSession, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        user = await create_user(session=session, global_role=GlobalRole.USER)
+        importer_project = await create_project(
+            session=session, name="ImporterProject", owner=user
+        )
+        await add_project_member(
+            session=session, project=importer_project, user=user, project_role=ProjectRole.USER
+        )
+        exporter_project = await create_project(
+            session=session, name="ExporterProject", owner=user
+        )
+        await create_export(
+            session=session,
+            exporter_project=exporter_project,
+            importer_projects=[importer_project],
+            exported_fleets=[],
+            name="test-export",
+        )
+
+        monkeypatch.setattr(exports_service, "_EXPORTS_ENABLED", False)
+        response = await client.post(
+            f"/api/project/{importer_project.name}/imports/list",
+            headers=get_auth_headers(user.token),
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["imports"]) == 1
+        assert data["imports"][0]["export"]["name"] == "test-export"
+        assert data["warnings"] == [EXPORTS_PHASE_OUT_MESSAGE]
 
     async def test_not_includes_deleted_fleets(self, session: AsyncSession, client: AsyncClient):
         user = await create_user(session=session, global_role=GlobalRole.USER)
@@ -351,7 +410,7 @@ class TestListImports:
             headers=get_auth_headers(user.token),
         )
         assert response.status_code == 200
-        imports = response.json()
+        imports = response.json()["imports"]
         assert len(imports) == 1
         assert imports[0]["export"]["name"] == "test-export"
         assert len(imports[0]["export"]["exported_fleets"]) == 1
@@ -389,4 +448,4 @@ class TestListImports:
             headers=get_auth_headers(user.token),
         )
         assert response.status_code == 200
-        assert response.json() == []
+        assert response.json()["imports"] == []

--- a/src/tests/_internal/server/routers/test_projects.py
+++ b/src/tests/_internal/server/routers/test_projects.py
@@ -1191,7 +1191,7 @@ class TestCreateProject:
             headers=get_auth_headers(user.token),
         )
         assert response.status_code == 200
-        imports = response.json()
+        imports = response.json()["imports"]
         assert len(imports) == 1
         assert imports[0]["export"]["name"] == "global-export"
 


### PR DESCRIPTION
No new exports can be created, and existing
exports can no longer be extended. A future
`dstack` release will automatically remove any
remaining exports. Users are advised to adjust
their project organization to avoid relying on
exports, or switch to `dstack` Sky or `dstack`
Factory for full export support.

Breaking changes:
- No new exports can be created, and existing
  exports can no longer be extended with the
  self-hosted OSS `dstack` server.
- `/api/project/{project_name}/exports/list` and
  `/api/project/{project_name}/imports/list` now
  return a JSON object instead of a list, unless
  the `X-API-Version` request header is set to a
  version that precedes 0.22.0.

Python API deprecations:
- `APIClient.exports.list()` is deprecated in
  favor of `APIClient.exports.list_exports()`.
- `APIClient.imports.list()` is deprecated in
  favor of `APIClient.exports.list_imports()`.