### PR TITLE
[runner] Terminate the job's whole session, not just its shell

### DIFF
--- a/runner/internal/runner/executor/executor.go
+++ b/runner/internal/runner/executor/executor.go
@@ -89,6 +89,9 @@ type RunExecutor struct {
 	runnerLogs      *appendWriter
 	timestamp       *MonotonicTimestamp
 
+	// How long after the job is asked to stop before SIGHUP goes to its session, and before
+	// SIGKILL does. Both are measured from the interrupt.
+	hupDelay  time.Duration
 	killDelay time.Duration
 	// How long output may go on being copied after the command has exited, before the pty
 	// master is closed. Only reached when the job leaves processes holding the terminal open.
@@ -127,6 +130,7 @@ func NewRunExecutor(tempDir string, dstackDir string, currentUser linuxuser.User
 		runnerLogs:      newAppendWriter(mu, timestamp),
 		timestamp:       timestamp,
 
+		hupDelay:          5 * time.Second,
 		killDelay:         10 * time.Second,
 		logsDrainDelay:    2 * time.Second,
 		connectionTracker: connectionTracker,
@@ -509,8 +513,16 @@ func (ex *RunExecutor) execJob(ctx context.Context, jobLogFile io.Writer) error 
 		"DSTACK_MPI_HOSTFILE":   mpiHostfilePath,
 	}
 
-	cmd := exec.CommandContext(ctx, ex.jobSpec.Commands[0], ex.jobSpec.Commands[1:]...)
-	cmd.WaitDelay = ex.killDelay // kills the process if it doesn't exit in time
+	// The command gets a context of its own so that stopping the job from inside the executor,
+	// when the log quota is exceeded, takes the same path as a stop from outside without
+	// cancelling the caller's context -- which Run reads to tell why the job stopped.
+	cmdCtx, cancelCmd := context.WithCancel(ctx)
+	defer cancelCmd()
+
+	cmd := exec.CommandContext(cmdCtx, ex.jobSpec.Commands[0], ex.jobSpec.Commands[1:]...)
+	// WaitDelay is deliberately left unset. It kills cmd.Process alone, which is the wrapper
+	// shell, and everything the job started would go on running; terminateSession does it.
+	cmd.WaitDelay = 0
 
 	if err := utils.MkdirAll(ctx, ex.jobWorkingDir, ex.jobUser.Uid, ex.jobUser.Gid, 0o755); err != nil {
 		return fmt.Errorf("create working directory: %w", err)
@@ -606,10 +618,34 @@ func (ex *RunExecutor) execJob(ctx context.Context, jobLogFile io.Writer) error 
 		copyDone <- copyErr
 	}()
 
-	stopQuotaWatch := watchLogQuota(cmd, ex.jobLogs.QuotaExceeded())
+	stopQuotaWatch := watchLogQuota(cancelCmd, ex.jobLogs.QuotaExceeded())
 	defer stopQuotaWatch()
 
+	// Staged in the background so that it runs while cmd.Wait is still blocked on a job that
+	// is not going away on its own. Setsid in startCommand made the shell a session leader, so
+	// its pid is the session id of everything the job goes on to start.
+	jobDone := make(chan struct{})
+	terminated := make(chan struct{})
+	go func() {
+		defer close(terminated)
+		select {
+		case <-cmdCtx.Done():
+			ex.terminateSession(ctx, cmd.Process.Pid)
+		case <-jobDone:
+			// The job reached its own end. Whatever it left running is about to lose the
+			// terminal, and soon after the container, without being told either way, so hang
+			// up and let it exit on its own terms. Nothing is waited for here: the job
+			// succeeded, so there is nothing left to enforce.
+			if pids := hangUpSession(cmd.Process.Pid); len(pids) > 0 {
+				log.Info(ctx, "Processes still running after the job finished, sent SIGHUP", "pids", pids)
+			}
+		}
+	}()
+
 	waitErr := cmd.Wait()
+	close(jobDone)
+	<-terminated // the job's own processes may outlive the shell that started them
+
 	copyErr := ex.finishOutputCopy(ctx, ptm, copyDone)
 
 	// Flush the ansistrip buffer — may also trigger quota exceeded.
@@ -649,17 +685,20 @@ func (ex *RunExecutor) finishOutputCopy(ctx context.Context, ptm *os.File, copyD
 	return nil
 }
 
-// watchLogQuota kills the command if the job exceeds its log quota. Output keeps being copied
-// until the command exits, so a full pty buffer cannot keep it from exiting.
+// watchLogQuota stops the job if it exceeds its log quota. Output keeps being copied until the
+// command exits, so a full pty buffer cannot keep it from exiting.
+//
+// Cancelling is the same request an external stop makes, so a job that ignores the interrupt is
+// escalated and killed off the same way rather than through a second, blunter path.
 //
 // The quota signal is out-of-band (via channel) because the ansistrip writer is async and
 // swallows downstream write errors.
-func watchLogQuota(cmd *exec.Cmd, quotaExceeded <-chan struct{}) (stop func()) {
+func watchLogQuota(stopJob context.CancelFunc, quotaExceeded <-chan struct{}) (stop func()) {
 	done := make(chan struct{})
 	go func() {
 		select {
 		case <-quotaExceeded:
-			_ = cmd.Process.Kill()
+			stopJob()
 		case <-done:
 		}
 	}()

--- a/runner/internal/runner/executor/executor_test.go
+++ b/runner/internal/runner/executor/executor_test.go
@@ -16,11 +16,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/dstackai/dstack/runner/internal/common/types"
 	linuxuser "github.com/dstackai/dstack/runner/internal/runner/linux/user"
 	"github.com/dstackai/dstack/runner/internal/runner/schemas"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestExecutor_WorkingDir_Set(t *testing.T) {
@@ -166,10 +167,12 @@ func TestExecutor_LogQuota(t *testing.T) {
 	err := ex.Run(t.Context())
 	assert.ErrorContains(t, err, "log quota exceeded")
 
-	// Verify the termination state was set
+	// Verify the termination state was set. The quota stops the job through the same
+	// cancellation an external stop uses, so the reason must survive that path.
 	history := ex.GetHistory(0)
 	lastState := history.JobStates[len(history.JobStates)-1]
 	assert.Equal(t, schemas.JobStateFailed, lastState.State)
+	assert.Equal(t, types.TerminationReasonLogQuotaExceeded, lastState.TerminationReason)
 }
 
 // A job that leaves a process behind keeps the pty slave open, so reading the master never
@@ -185,10 +188,19 @@ func TestExecutor_SurvivingProcessDoesNotHangRun(t *testing.T) {
 	// process group, so it does not get the SIGHUP the kernel sends to the foreground group
 	// when the shell exits, and goes on holding the pty slave open. It must outlive the
 	// assertion below, or the executor would be let off the hook by the process exiting.
-	pidPath := filepath.Join(t.TempDir(), "survivor.pid")
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "survivor.pid")
+	// Ignores SIGHUP, the way a nohup'd process or a daemon does, so it goes on holding the
+	// terminal open even after the hangup the job's own end sends -- which is the case the
+	// drain bound exists for.
+	survivor := filepath.Join(dir, "survivor.sh")
+	require.NoError(t, os.WriteFile(survivor, []byte(
+		"trap '' HUP\n"+
+			"echo $$ > "+pidPath+"\n"+
+			"while :; do sleep 0.2; done\n"), 0o600))
 	ex.jobSpec.Commands = []string{
-		"/bin/bash", "-i", "-c",
-		fmt.Sprintf("sleep 300 & echo $! > %s; echo done", pidPath),
+		"/bin/sh", "-i", "-c",
+		"/bin/sh " + survivor + " & echo done",
 	}
 	t.Cleanup(func() { killRecordedPid(t, pidPath) })
 	makeCodeTar(t, ex)
@@ -271,6 +283,128 @@ func jobLogsSoFar(ex *RunExecutor) string {
 	ex.mu.RLock()
 	defer ex.mu.RUnlock()
 	return combineLogMessages(ex.jobLogs.history)
+}
+
+// A job that ignores the interrupt is escalated: SIGHUP to its session, then SIGKILL. The
+// escalation has to cover what the job left outside the terminal's foreground process group,
+// since that is all the interrupt itself, or the kernel's hangup, can reach.
+func TestExecutor_StopKillsWholeSession(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "background.pid")
+	// Backgrounded, so job control gives it a process group of its own and neither the
+	// interrupt nor the kernel's hangup SIGHUP reaches it. It ignores both signals anyway, so
+	// only the SIGKILL stage can clear it.
+	background := filepath.Join(dir, "background.sh")
+	require.NoError(t, os.WriteFile(background, []byte(
+		"trap '' INT HUP\n"+
+			"echo $$ > "+pidPath+"\n"+
+			"while :; do sleep 0.2; done\n"), 0o600))
+	// Ignores the interrupt, so the job does not stop on its own and the shell stays alive.
+	foreground := filepath.Join(dir, "foreground.sh")
+	require.NoError(t, os.WriteFile(foreground, []byte(
+		"trap '' INT\n"+
+			"echo ready\n"+
+			"while :; do sleep 0.2; done\n"), 0o600))
+
+	ex := makeTestExecutor(t)
+	ex.hupDelay = 300 * time.Millisecond
+	ex.killDelay = 900 * time.Millisecond
+	ex.jobSpec.Commands = []string{
+		"/bin/sh", "-i", "-c",
+		"/bin/sh " + background + " & /bin/sh " + foreground,
+	}
+	makeCodeTar(t, ex)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	runDone := make(chan error, 1)
+	go func() { runDone <- ex.Run(ctx) }()
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(jobLogsSoFar(ex), "ready")
+	}, 30*time.Second, 100*time.Millisecond, "the job never started")
+	backgroundPid := readRecordedPid(t, pidPath)
+	t.Cleanup(func() { _ = syscall.Kill(backgroundPid, syscall.SIGKILL) })
+
+	cancel() // what /api/stop does
+	select {
+	case <-runDone:
+	case <-time.After(30 * time.Second):
+		t.Fatal("Run did not return after the job was stopped")
+	}
+
+	assert.False(t, processAlive(backgroundPid),
+		"a process the job left outside the foreground group survived the stop")
+	history := ex.GetHistory(0)
+	lastState := history.JobStates[len(history.JobStates)-1]
+	assert.Equal(t, schemas.JobStateTerminated, lastState.State)
+}
+
+func readRecordedPid(t *testing.T, path string) int {
+	t.Helper()
+	var pid int
+	require.Eventually(t, func() bool {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return false
+		}
+		pid, err = strconv.Atoi(strings.TrimSpace(string(data)))
+		return err == nil && pid > 0
+	}, 30*time.Second, 100*time.Millisecond, "the process never recorded its pid")
+	return pid
+}
+
+// processAlive reports whether pid is a live process, treating a zombie as gone.
+func processAlive(pid int) bool {
+	state, ok := procState(pid)
+	return ok && state != 'Z'
+}
+
+// A job that finishes on its own can leave processes running -- a sidecar started with `&`,
+// say. They are about to lose the terminal, and shortly after the container, so they are told
+// rather than being killed outright without notice.
+func TestExecutor_FinishedJobHangsUpOnLeftoverProcesses(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	dir := t.TempDir()
+	pidPath := filepath.Join(dir, "sidecar.pid")
+	hupPath := filepath.Join(dir, "sidecar.hup")
+	sidecar := filepath.Join(dir, "sidecar.sh")
+	require.NoError(t, os.WriteFile(sidecar, []byte(
+		"trap 'echo yes > "+hupPath+"; exit 0' HUP\n"+
+			"echo $$ > "+pidPath+"\n"+
+			"while :; do sleep 0.2; done\n"), 0o600))
+
+	ex := makeTestExecutor(t)
+	ex.jobSpec.Commands = []string{
+		"/bin/sh", "-i", "-c",
+		"/bin/sh " + sidecar + " & echo done",
+	}
+	makeCodeTar(t, ex)
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- ex.Run(t.Context()) }()
+	select {
+	case err := <-runDone:
+		assert.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("Run did not return")
+	}
+	t.Cleanup(func() { killRecordedPid(t, pidPath) })
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(hupPath)
+		return err == nil
+	}, 10*time.Second, 100*time.Millisecond, "the leftover process was never sent SIGHUP")
+
+	history := ex.GetHistory(0)
+	lastState := history.JobStates[len(history.JobStates)-1]
+	assert.Equal(t, schemas.JobStateDone, lastState.State)
 }
 
 func TestExecutor_RemoteRepo(t *testing.T) {

--- a/runner/internal/runner/executor/terminate.go
+++ b/runner/internal/runner/executor/terminate.go
@@ -1,0 +1,126 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/dstackai/dstack/runner/internal/common/log"
+)
+
+// sessionPollInterval is how often the job's session is re-examined while waiting for it to
+// empty out between termination stages.
+const sessionPollInterval = 100 * time.Millisecond
+
+// terminateSession stops whatever is left of the job, in stages.
+//
+// The job has already been interrupted through the terminal by interruptJob, which the line
+// discipline delivers to the terminal's foreground process group alone. Anything the job moved
+// elsewhere -- a `cmd &` job, which job control puts in a process group of its own -- never
+// sees that interrupt, and neither does the SIGHUP the kernel sends to the foreground group
+// when the session leader exits.
+func (ex *RunExecutor) terminateSession(ctx context.Context, sid int) {
+	if ex.waitForSessionExit(sid, ex.hupDelay) {
+		return
+	}
+	if pids := hangUpSession(sid); len(pids) > 0 {
+		log.Warning(ctx, "Processes still running after the interrupt, sent SIGHUP", "pids", pids)
+	}
+
+	if ex.waitForSessionExit(sid, ex.killDelay-ex.hupDelay) {
+		return
+	}
+	if pids := signalSession(sid, unix.SIGKILL); len(pids) > 0 {
+		log.Error(ctx, "Processes still running after SIGHUP, sent SIGKILL", "pids", pids)
+	}
+}
+
+// waitForSessionExit reports whether the session emptied out within d.
+func (ex *RunExecutor) waitForSessionExit(sid int, d time.Duration) bool {
+	deadline := time.Now().Add(d)
+	for {
+		if len(sessionPids(sid)) == 0 {
+			return true
+		}
+		if !time.Now().Before(deadline) {
+			return false
+		}
+		time.Sleep(sessionPollInterval)
+	}
+}
+
+// hangUpSession tells everything still running in session sid that its terminal is going away.
+//
+// SIGHUP is what a terminal hangup delivers, and an idle shell exits on it. SIGCONT follows
+// because a stopped process would not act on the SIGHUP until something resumes it -- SIGKILL
+// and SIGCONT are the only signals that reach a stopped process.
+func hangUpSession(sid int) []int {
+	pids := signalSession(sid, unix.SIGHUP)
+	signalSession(sid, unix.SIGCONT)
+	return pids
+}
+
+// signalSession sends sig to every live process in session sid, and reports which ones it
+// reached. The wrapper shell is one of them, and so is anything the job backgrounded -- which
+// never saw the interrupt at all, rather than having declined to act on it.
+//
+// The processes are enumerated rather than signalled as a group: under job control the job does
+// not share the shell's process group, so there is no one group to signal, and kill(2) has no
+// session-wide form. A session is the right scope because a child inherits its parent's session
+// id, and only setsid() changes it.
+func signalSession(sid int, sig unix.Signal) []int {
+	pids := sessionPids(sid)
+	signalled := make([]int, 0, len(pids))
+	for _, pid := range pids {
+		if err := unix.Kill(pid, sig); err == nil {
+			signalled = append(signalled, pid)
+		}
+	}
+	return signalled
+}
+
+// sessionPids returns the live processes in session sid. Zombies are left out: they have
+// already exited and only await reaping, so counting them would keep the session looking busy
+// forever.
+func sessionPids(sid int) []int {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil
+	}
+	self := os.Getpid()
+	var pids []int
+	for _, entry := range entries {
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil || pid == self || pid == 1 {
+			continue
+		}
+		if procSid, err := unix.Getsid(pid); err != nil || procSid != sid {
+			continue
+		}
+		if state, ok := procState(pid); !ok || state == 'Z' {
+			continue
+		}
+		pids = append(pids, pid)
+	}
+	return pids
+}
+
+// procState returns the process state character from /proc/<pid>/stat.
+func procState(pid int) (byte, bool) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0, false
+	}
+	// The command name field is parenthesized and may itself contain spaces and parentheses,
+	// so the state is the first field after the last ')'.
+	end := bytes.LastIndexByte(data, ')')
+	if end < 0 || end+2 >= len(data) {
+		return 0, false
+	}
+	return data[end+2], true
+}


### PR DESCRIPTION
Previously, a job that did not stop on the interrupt was left to `WaitDelay`, which SIGKILLs `cmd.Process` -- the wrapper shell -- and nothing else. Everything the job had started went on running, reparented to PID 1, and was cleaned up only when the container was destroyed.

The interrupt cannot cover that gap on its own. The line discipline delivers it to the terminal's foreground process group, and job control puts a `cmd &` job in a process group of its own, where neither the interrupt nor the SIGHUP the kernel sends to the foreground group on the session leader's exit will reach it.

Now the job's session is signalled directly. A session is the right scope because a child inherits its parent's session id, and only `setsid()` changes it.

When the job is asked to stop, termination is staged: SIGHUP once `hupDelay` has passed, SIGKILL once `killDelay` has. SIGHUP is what a terminal hangup delivers and what an idle shell exits on, which also clears the shell dash leaves behind -- interrupted, it returns to reading the terminal rather than exiting. SIGCONT goes with it, since a stopped process would not act on the SIGHUP until something resumes it.

The stages run from a goroutine so they proceed while `cmd.Wait` is still blocked, and `execJob` joins it afterwards, because the processes a job leaves behind can outlive the shell that started them. Each stage is skipped when the session is already empty, so a job that stops on the interrupt is not delayed. Zombies are not occupants: they have exited and only await reaping.

When the job instead reaches its own end, its leftovers -- a sidecar started with `&`, say -- are sent the same hangup, but nothing is waited for. They are about to lose the terminal and then the container without being told either way, so they are told; the job succeeded, though, so there is nothing left to enforce and no reason to delay reporting it.

Exceeding the log quota now cancels the command's context instead of killing the shell outright, so it escalates the same way rather than through a second, blunter path.