### PR TITLE
[UI] Project visibility: minor UX changes

### DIFF
--- a/frontend/src/pages/Project/Add/index.tsx
+++ b/frontend/src/pages/Project/Add/index.tsx
@@ -1,12 +1,22 @@
 import React, { useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { isNil } from 'lodash';
 import * as yup from 'yup';
 import { WizardProps } from '@cloudscape-design/components';
 
-import { Container, FormInput, FormToggle, InfoLink, KeyValuePairs, SpaceBetween, Wizard } from 'components';
+import {
+    Container,
+    FormField,
+    FormInput,
+    FormToggle,
+    InfoLink,
+    KeyValuePairs,
+    SelectCSD,
+    SpaceBetween,
+    Wizard,
+} from 'components';
 
 import { useBreadcrumbs, useConfirmationDialog, useHelpPanel, useNotifications } from 'hooks';
 import { isResponseServerError, isResponseServerFormFieldError } from 'libs';
@@ -82,6 +92,11 @@ export const ProjectAdd: React.FC = () => {
 
     const { handleSubmit, control, setError, clearErrors, trigger, watch, getValues } = formMethods;
     const formValues = watch();
+
+    const visibilityOptions = [
+        { label: t('projects.edit.visibility.private'), value: 'private' },
+        { label: t('projects.edit.visibility.public'), value: 'public' },
+    ];
 
     const getFormValuesForServer = (): IProjectCreateRequestParams => {
         const { project_name, is_public } = getValues();
@@ -270,7 +285,7 @@ export const ProjectAdd: React.FC = () => {
                 submitButtonText={t('projects.wizard.submit')}
                 steps={[
                     {
-                        title: 'Name and public',
+                        title: 'Name and visibility',
                         content: (
                             <Container>
                                 <SpaceBetween direction="vertical" size="l">
@@ -282,12 +297,33 @@ export const ProjectAdd: React.FC = () => {
                                         disabled={loading}
                                     />
 
-                                    <FormToggle
-                                        label={t('projects.edit.is_public')}
-                                        toggleDescription={t('projects.edit.is_public_description')}
+                                    <Controller
                                         control={control}
                                         name="is_public"
-                                        disabled={loading}
+                                        render={({ field, fieldState: { error } }) => (
+                                            <FormField
+                                                label={t('projects.edit.project_visibility')}
+                                                description={
+                                                    field.value
+                                                        ? 'Any authorized user can see this project and join it as a member'
+                                                        : 'Only project members and global admins can access this project'
+                                                }
+                                                errorText={error?.message}
+                                            >
+                                                <SelectCSD
+                                                    ref={field.ref}
+                                                    options={visibilityOptions}
+                                                    selectedOption={visibilityOptions[field.value ? 1 : 0]}
+                                                    onChange={({ detail }) =>
+                                                        field.onChange(detail.selectedOption.value === 'public')
+                                                    }
+                                                    onBlur={field.onBlur}
+                                                    disabled={loading}
+                                                    expandToViewport
+                                                    filteringType="auto"
+                                                />
+                                            </FormField>
+                                        )}
                                     />
                                 </SpaceBetween>
                             </Container>
@@ -326,6 +362,10 @@ export const ProjectAdd: React.FC = () => {
                                         {
                                             label: t('projects.edit.project_name'),
                                             value: formValues['project_name'],
+                                        },
+                                        {
+                                            label: t('projects.edit.project_visibility'),
+                                            value: visibilityOptions[formValues.is_public ? 1 : 0].label,
                                         },
                                         ...(formValues['fleet']['enable_default']
                                             ? [

--- a/frontend/src/pages/Project/Details/Settings/index.tsx
+++ b/frontend/src/pages/Project/Details/Settings/index.tsx
@@ -45,6 +45,7 @@ import { getProjectRoleByUserName } from 'pages/Project/utils';
 import { useBackendsTable } from '../../Backends/hooks';
 import { BackendsTable } from '../../Backends/Table';
 import { NoFleetProjectAlert } from '../../components/NoFleetProjectAlert';
+import { VISIBILITY_INFO } from '../../constants';
 import { GatewaysTable } from '../../Gateways';
 import { useGatewaysTable } from '../../Gateways/hooks';
 import { ProjectSecrets } from '../../Secrets';
@@ -498,11 +499,14 @@ export const ProjectSettings: React.FC = () => {
                                         </>
                                     )}
 
-                                    {isAvailableProjectManaging && (
+                                    {process.env.UI_VERSION !== 'sky' && isAvailableProjectManaging && (
                                         <>
-                                            <Box variant="h5" color="text-body-secondary">
-                                                {t('projects.edit.project_visibility_settings')}
-                                            </Box>
+                                            <div className={styles.dangerSectionTitle}>
+                                                <Box variant="h5" color="text-body-secondary">
+                                                    {t('projects.edit.project_visibility_settings')}
+                                                </Box>
+                                                <InfoLink onFollow={() => openHelpPanel(VISIBILITY_INFO)} />
+                                            </div>
 
                                             <div>
                                                 <ButtonWithConfirmation
@@ -562,7 +566,7 @@ export const ProjectSettings: React.FC = () => {
 
                                     {isAvailableProjectManaging && (
                                         <>
-                                            <div className={styles.templatesRepoTitle}>
+                                            <div className={styles.dangerSectionTitle}>
                                                 <Box variant="h5" color="text-body-secondary">
                                                     {t('projects.edit.override_project_templates')}
                                                 </Box>

--- a/frontend/src/pages/Project/Details/Settings/styles.module.scss
+++ b/frontend/src/pages/Project/Details/Settings/styles.module.scss
@@ -14,7 +14,7 @@
     gap: 12px;
 }
 
-.templatesRepoTitle {
+.dangerSectionTitle {
     display: inline-flex;
     align-items: center;
     gap: 8px;

--- a/frontend/src/pages/Project/List/hooks/useColumnsDefinitions.tsx
+++ b/frontend/src/pages/Project/List/hooks/useColumnsDefinitions.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 // import { useNavigate } from 'react-router-dom';
-import { /*Button,*/ NavigateLink, StatusIndicator } from 'components';
+import { /*Button,*/ NavigateLink } from 'components';
 
 // import { ButtonWithConfirmation } from 'components/ButtonWithConfirmation';
 import { ROUTES } from 'routes';
@@ -67,15 +67,6 @@ export const useColumnsDefinitions = ({ loading, onDeleteClick }: hookArgs) => {
                         {/*    )}*/}
                         {/*</div>*/}
                     </div>
-                ),
-            },
-            {
-                id: 'visibility',
-                header: t('projects.edit.project_visibility'),
-                cell: (project: IProject) => (
-                    <StatusIndicator type={project.isPublic ? 'success' : 'pending'}>
-                        {project.isPublic ? t('projects.edit.visibility.public') : t('projects.edit.visibility.private')}
-                    </StatusIndicator>
                 ),
             },
         ];

--- a/frontend/src/pages/Project/constants.tsx
+++ b/frontend/src/pages/Project/constants.tsx
@@ -30,3 +30,14 @@ export const DEFAULT_FLEET_INFO = {
         </>
     ),
 };
+
+export const VISIBILITY_INFO = {
+    header: <h2>Visibility</h2>,
+    body: (
+        <>
+            <p>Only project members and global admins can access private projects.</p>
+            <p>Any authorized user can see public projects and join them as a member.</p>
+            <p>Changing a project to private keeps its existing members. Both visibility options require users to sign in.</p>
+        </>
+    ),
+};


### PR DESCRIPTION
- Hide Visibility in Sky project settings; keep it in OSS/Fabric
- Remove the Visibility column from the Projects page
- Add an Info button beside Visibility in project settings
- Replace the wizard’s Public toggle with a Visibility dropdown
  matching project settings, with a description for the selected value

