### PR TITLE
[runner] Make the executor lifecycle explicit

### DIFF
--- a/runner/internal/runner/api/http.go
+++ b/runner/internal/runner/api/http.go
@@ -159,20 +159,31 @@ func (s *Server) runPostHandler(w http.ResponseWriter, r *http.Request) (interfa
 
 	var runCtx context.Context
 	runCtx, s.cancelRun = context.WithCancel(context.Background())
-	username, workingDir, err := s.executor.GetJobInfo(runCtx)
+	err := s.executor.Setup(runCtx)
 	go func() {
+		// The server waits on jobBarrierCh to start shutting down, so it must be notified even
+		// when there is no job to run. Finalize() runs first: the server goes on to wait for a
+		// final /api/pull, which is only served once the executor reports its state as final.
+		defer func() { s.jobBarrierCh <- nil }() // notify server that job finished
+		defer s.executor.Finalize(runCtx)        // a safeguard, Setup and Run finalize themselves
+		if err != nil {
+			return
+		}
 		_ = s.executor.Run(runCtx) // INFO: all errors are handled inside the Run()
-		s.jobBarrierCh <- nil      // notify server that job finished
 	}()
 
-	if err == nil {
-		return &schemas.JobInfoResponse{
-			Username:   username,
-			WorkingDir: workingDir,
-		}, nil
+	if err != nil {
+		// Setup has recorded the failure as a job state, and that state and the logs reach the
+		// server through /api/pull. Reporting the error here would instead be seen as the
+		// runner not accepting the job submission, losing the real termination reason.
+		//nolint:nilerr
+		return nil, nil
 	}
-
-	return nil, nil
+	username, workingDir := s.executor.JobInfo()
+	return &schemas.JobInfoResponse{
+		Username:   username,
+		WorkingDir: workingDir,
+	}, nil
 }
 
 func (s *Server) pullGetHandler(w http.ResponseWriter, r *http.Request) (interface{}, error) {

--- a/runner/internal/runner/api/server_test.go
+++ b/runner/internal/runner/api/server_test.go
@@ -27,7 +27,10 @@ type fakeExecutor struct {
 func (e *fakeExecutor) SetJob(schemas.SubmitBody)                {}
 func (e *fakeExecutor) WriteFileArchive(string, io.Reader) error { return nil }
 func (e *fakeExecutor) WriteRepoBlob(io.Reader) error            { return nil }
+func (e *fakeExecutor) Setup(context.Context) error              { return nil }
+func (e *fakeExecutor) JobInfo() (string, string)                { return "", "" }
 func (e *fakeExecutor) Run(context.Context) error                { return nil }
+func (e *fakeExecutor) Finalize(context.Context)                 {}
 
 func (e *fakeExecutor) GetHistory(int64) *schemas.PullResponse  { return &schemas.PullResponse{} }
 func (e *fakeExecutor) GetJobWsLogsHistory() []schemas.LogEvent { return nil }
@@ -35,8 +38,7 @@ func (e *fakeExecutor) GetJobWsLogsHistory() []schemas.LogEvent { return nil }
 func (e *fakeExecutor) GetRunnerState() string      { return e.state }
 func (e *fakeExecutor) SetRunnerState(state string) { e.state = state }
 
-func (e *fakeExecutor) GetJobInfo(context.Context) (string, string, error) { return "", "", nil }
-func (e *fakeExecutor) SetJobState(context.Context, schemas.JobState)      {}
+func (e *fakeExecutor) SetJobState(context.Context, schemas.JobState) {}
 func (e *fakeExecutor) SetJobStateWithTerminationReason(
 	context.Context, schemas.JobState, types.TerminationReason, string,
 ) {

--- a/runner/internal/runner/executor/base.go
+++ b/runner/internal/runner/executor/base.go
@@ -15,7 +15,14 @@ type Executor interface {
 	WriteFileArchive(id string, src io.Reader) error
 	// It must be safe to call WriteRepoBlob more than once
 	WriteRepoBlob(src io.Reader) error
+	// Setup must be called once, before Run. Run must not be called if it fails
+	Setup(ctx context.Context) error
+	// JobInfo must be called after a successful Setup
+	JobInfo() (username string, workingDir string)
+	// Run finalizes the executor before returning
 	Run(ctx context.Context) error
+	// It must be safe to call Finalize more than once
+	Finalize(ctx context.Context)
 
 	GetHistory(timestamp int64) *schemas.PullResponse
 	GetJobWsLogsHistory() []schemas.LogEvent
@@ -23,7 +30,6 @@ type Executor interface {
 	GetRunnerState() string
 	SetRunnerState(state string)
 
-	GetJobInfo(ctx context.Context) (username string, workingDir string, err error)
 	SetJobState(ctx context.Context, state schemas.JobState)
 	SetJobStateWithTerminationReason(
 		ctx context.Context,

--- a/runner/internal/runner/executor/executor.go
+++ b/runner/internal/runner/executor/executor.go
@@ -87,6 +87,9 @@ type RunExecutor struct {
 	jobLogs         *appendWriter
 	jobWsLogs       *appendWriter
 	runnerLogs      *appendWriter
+	setupDone       bool
+	finalized       bool
+	finalizeOnce    sync.Once
 	timestamp       *MonotonicTimestamp
 
 	// How long after the job is asked to stop before SIGHUP goes to its session, and before
@@ -137,26 +140,72 @@ func NewRunExecutor(tempDir string, dstackDir string, currentUser linuxuser.User
 	}, nil
 }
 
-// GetJobInfo must be called after SetJob
-func (ex *RunExecutor) GetJobInfo(ctx context.Context) (string, string, error) {
-	// preRun() sets ex.jobUser and ex.jobWorkingDir
-	if err := ex.preRun(ctx); err != nil {
-		return "", "", err
+// Setup prepares the executor for Run: it configures runner logging and resolves the job user
+// and working dir. It must be called exactly once, after SetJob, and Run must not be called if
+// it fails -- a failed Setup finalizes the executor itself, so the caller only has to skip Run.
+//
+// Setup must not execute long-running operations, as it is called synchronously in the /api/run
+// method.
+func (ex *RunExecutor) Setup(ctx context.Context) (err error) {
+	defer func() {
+		if err != nil {
+			ex.Finalize(ctx)
+		}
+	}()
+
+	// logging is required for the subsequent setJob{User,WorkingDir} calls
+	runnerLogFile, err := log.CreateAppendFile(filepath.Join(ex.tempDir, consts.RunnerLogFileName))
+	if err != nil {
+		ex.SetJobState(ctx, schemas.JobStateFailed)
+		return fmt.Errorf("create runner log file: %w", err)
 	}
-	return ex.jobUser.Username, ex.jobWorkingDir, nil
+	ex.runnerLogFile = runnerLogFile
+	ex.runnerLogStripper = ansistrip.NewWriter(ex.runnerLogs, AnsiStripFlushInterval, AnsiStripMaxDelay, MaxBufferSize)
+	runnerLogWriter := io.MultiWriter(ex.runnerLogFile, os.Stdout, ex.runnerLogStripper)
+	runnerLogLevel := log.DefaultEntry.Logger.Level
+	ex.runnerLogger = log.NewEntry(runnerLogWriter, int(runnerLogLevel))
+	ctx = log.WithLogger(ctx, ex.runnerLogger)
+	log.Info(ctx, "Logging configured", "log_level", runnerLogLevel.String())
+
+	// jobUser and jobWorkingDir are required for JobInfo()
+	if err := ex.setJobUser(ctx); err != nil {
+		ex.SetJobStateWithTerminationReason(
+			ctx,
+			schemas.JobStateFailed,
+			types.TerminationReasonExecutorError,
+			fmt.Sprintf("Failed to set job user (%s)", err),
+		)
+		return fmt.Errorf("set job user: %w", err)
+	}
+	if err := ex.setJobWorkingDir(ctx); err != nil {
+		ex.SetJobStateWithTerminationReason(
+			ctx,
+			schemas.JobStateFailed,
+			types.TerminationReasonExecutorError,
+			fmt.Sprintf("Failed to set job working dir (%s)", err),
+		)
+		return fmt.Errorf("set job working dir: %w", err)
+	}
+
+	ex.setupDone = true
+	return nil
 }
 
-// Run must be called after SetJob and WriteRepoBlob
+// JobInfo must be called after a successful Setup
+func (ex *RunExecutor) JobInfo() (string, string) {
+	return ex.jobUser.Username, ex.jobWorkingDir
+}
+
+// Run must be called after SetJob, WriteRepoBlob and a successful Setup. It finalizes the
+// executor before returning, so the caller does not have to.
 func (ex *RunExecutor) Run(ctx context.Context) (err error) {
-	// If jobStateHistory is not empty, either Run() has already been called or
-	// preRun() has already been called via GetJobInfo() and failed
-	if len(ex.jobStateHistory) > 0 {
-		return errors.New("already running or finished")
+	if !ex.setupDone {
+		return errors.New("not set up")
 	}
-	if err := ex.preRun(ctx); err != nil {
-		return err
+	if ex.finalized {
+		return errors.New("already finished")
 	}
-	defer ex.postRun(ctx)
+	defer ex.Finalize(ctx)
 
 	jobLogFile, err := log.CreateAppendFile(filepath.Join(ex.tempDir, consts.RunnerJobLogFileName))
 	if err != nil {
@@ -166,16 +215,12 @@ func (ex *RunExecutor) Run(ctx context.Context) (err error) {
 	defer func() { _ = jobLogFile.Close() }()
 
 	defer func() {
-		// recover goes after postRun(), which closes runnerLogFile, to keep the log
+		// recover goes before Finalize(), which closes runnerLogFile, to keep the log
 		if r := recover(); r != nil {
 			log.Error(ctx, "Executor PANIC", "err", r)
 			ex.SetJobState(ctx, schemas.JobStateFailed)
 			err = fmt.Errorf("recovered: %v", r)
 		}
-		// no more logs will be written after this
-		ex.mu.Lock()
-		ex.SetRunnerState(WaitLogsFinished)
-		ex.mu.Unlock()
 	}()
 	defer func() {
 		if err != nil {
@@ -337,64 +382,31 @@ func (ex *RunExecutor) SetRunnerState(state string) {
 	ex.state = state
 }
 
-// preRun performs actions that were once part of Run() but were moved to a separate function
-// to implement GetJobInfo()
-// preRun must not execute long-running operations, as GetJobInfo() is called synchronously
-// in the /api/run method
-func (ex *RunExecutor) preRun(ctx context.Context) error {
-	// Already called once
-	if ex.runnerLogFile != nil {
-		return nil
-	}
-
-	// logging is required for the subsequent setJob{User,WorkingDir} calls
-	runnerLogFile, err := log.CreateAppendFile(filepath.Join(ex.tempDir, consts.RunnerLogFileName))
-	if err != nil {
-		ex.SetJobState(ctx, schemas.JobStateFailed)
-		return fmt.Errorf("create runner log file: %w", err)
-	}
-	ex.runnerLogFile = runnerLogFile
-	ex.runnerLogStripper = ansistrip.NewWriter(ex.runnerLogs, AnsiStripFlushInterval, AnsiStripMaxDelay, MaxBufferSize)
-	runnerLogWriter := io.MultiWriter(ex.runnerLogFile, os.Stdout, ex.runnerLogStripper)
-	runnerLogLevel := log.DefaultEntry.Logger.Level
-	ex.runnerLogger = log.NewEntry(runnerLogWriter, int(runnerLogLevel))
-	ctx = log.WithLogger(ctx, ex.runnerLogger)
-	log.Info(ctx, "Logging configured", "log_level", runnerLogLevel.String())
-
-	// jobUser and jobWorkingDir are required for GetJobInfo()
-	if err := ex.setJobUser(ctx); err != nil {
-		ex.SetJobStateWithTerminationReason(
-			ctx,
-			schemas.JobStateFailed,
-			types.TerminationReasonExecutorError,
-			fmt.Sprintf("Failed to set job user (%s)", err),
-		)
-		return fmt.Errorf("set job user: %w", err)
-	}
-	if err := ex.setJobWorkingDir(ctx); err != nil {
-		ex.SetJobStateWithTerminationReason(
-			ctx,
-			schemas.JobStateFailed,
-			types.TerminationReasonExecutorError,
-			fmt.Sprintf("Failed to set job working dir (%s)", err),
-		)
-		return fmt.Errorf("set job working dir: %w", err)
-	}
-
-	return nil
-}
-
-func (ex *RunExecutor) postRun(ctx context.Context) {
-	if ex.runnerLogFile != nil {
-		if err := ex.runnerLogFile.Close(); err != nil {
-			log.Error(ctx, "Failed to close runnerLogFile", "err", err)
+// Finalize closes runner logging and marks the state it serves as final. Setup and Run call it
+// themselves, so callers only need it as a safeguard; it is idempotent, and concurrent calls
+// block until the first one has finished.
+func (ex *RunExecutor) Finalize(ctx context.Context) {
+	ex.finalizeOnce.Do(func() {
+		// finalizeOnce keeps Finalize idempotent; ex.finalized is what the Run gate reports on
+		ex.finalized = true
+		if ex.runnerLogFile != nil {
+			if err := ex.runnerLogFile.Close(); err != nil {
+				log.Error(ctx, "Failed to close runnerLogFile", "err", err)
+			}
 		}
-	}
-	if ex.runnerLogStripper != nil {
-		if err := ex.runnerLogStripper.Close(); err != nil {
-			log.Error(ctx, "Failed to close runnerLogStripper", "err", err)
+		if ex.runnerLogStripper != nil {
+			// Close() flushes the buffered logs synchronously, and the flush takes ex.mu, so
+			// it must not be called with the lock held
+			if err := ex.runnerLogStripper.Close(); err != nil {
+				log.Error(ctx, "Failed to close runnerLogStripper", "err", err)
+			}
 		}
-	}
+		// Only now that the last logs have been flushed does WaitLogsFinished hold: it tells
+		// /api/pull that the state it serves is final
+		ex.mu.Lock()
+		ex.SetRunnerState(WaitLogsFinished)
+		ex.mu.Unlock()
+	})
 }
 
 // setJobWorkingDir must be called from Run after setJobUser

--- a/runner/internal/runner/executor/executor_test.go
+++ b/runner/internal/runner/executor/executor_test.go
@@ -76,6 +76,7 @@ func TestExecutor_NonZeroExit(t *testing.T) {
 	ex.jobSpec.Commands = append(ex.jobSpec.Commands, "exit 100")
 	makeCodeTar(t, ex)
 
+	setUpTestExecutor(t, ex)
 	err := ex.Run(t.Context())
 	assert.Error(t, err)
 	assert.NotEmpty(t, ex.jobStateHistory)
@@ -124,8 +125,58 @@ func TestExecutor_Recover(t *testing.T) {
 	ex.jobSpec.Commands = nil // cause a panic
 	makeCodeTar(t, ex)
 
+	setUpTestExecutor(t, ex)
 	err := ex.Run(t.Context())
 	assert.ErrorContains(t, err, "recovered: ")
+}
+
+// Setup can fail after it has already configured runner logging. It finalizes the executor
+// itself, so the buffered logs are flushed and the state it serves is reported as final --
+// otherwise /api/pull would keep waiting for logs that are never coming.
+func TestExecutor_SetupFailureFinalizes(t *testing.T) {
+	ex := makeTestExecutor(t)
+	workingDir := "not/an/absolute/path" // makes setJobWorkingDir, and so Setup, fail
+	ex.jobSpec.WorkingDir = &workingDir
+
+	err := ex.Setup(t.Context())
+	require.ErrorContains(t, err, "working dir must be absolute")
+
+	assert.Equal(t, WaitLogsFinished, ex.GetRunnerState())
+	history := ex.GetHistory(0)
+	assert.False(t, history.HasMore)
+	assert.NotEmpty(t, history.RunnerLogs, "runner logs must be flushed, not left in the stripper")
+
+	// The caller is expected to skip Run, but must not be punished for a redundant Finalize
+	assert.NotPanics(t, func() { ex.Finalize(t.Context()) })
+}
+
+// Run requires a successful Setup: without it there is no runner logging and no resolved job
+// user, so it must refuse rather than run the job with unset fields.
+func TestExecutor_RunWithoutSetup(t *testing.T) {
+	ex := makeTestExecutor(t)
+	ex.jobSpec.Commands = append(ex.jobSpec.Commands, "echo hello")
+	makeCodeTar(t, ex)
+
+	err := ex.Run(t.Context())
+	assert.ErrorContains(t, err, "not set up")
+}
+
+// Run finalizes the executor itself, so a job that finishes on its own leaves nothing buffered
+// and reports its state as final without the caller doing anything.
+func TestExecutor_RunFinalizes(t *testing.T) {
+	ex := makeTestExecutor(t)
+	ex.jobSpec.Commands = append(ex.jobSpec.Commands, "echo hello")
+	makeCodeTar(t, ex)
+	setUpTestExecutor(t, ex)
+
+	require.NoError(t, ex.Run(t.Context()))
+
+	assert.Equal(t, WaitLogsFinished, ex.GetRunnerState())
+	assert.False(t, ex.GetHistory(0).HasMore)
+	assert.NotPanics(t, func() { ex.Finalize(t.Context()) })
+
+	// Setup did happen, so the gate must report the finished job rather than a missing Setup
+	assert.ErrorContains(t, ex.Run(t.Context()), "already finished")
 }
 
 /* Long tests */
@@ -141,6 +192,7 @@ func TestExecutor_MaxDuration(t *testing.T) {
 	ex.jobSpec.MaxDuration = 1 // seconds
 	makeCodeTar(t, ex)
 
+	setUpTestExecutor(t, ex)
 	err := ex.Run(t.Context())
 	// The job is interrupted rather than killed: INTR reaches the workload through the
 	// terminal, so it exits on SIGINT long before the SIGKILL backstop would fire.
@@ -164,6 +216,7 @@ func TestExecutor_LogQuota(t *testing.T) {
 	ex.jobLogs.SetQuota(100)
 	makeCodeTar(t, ex)
 
+	setUpTestExecutor(t, ex)
 	err := ex.Run(t.Context())
 	assert.ErrorContains(t, err, "log quota exceeded")
 
@@ -206,6 +259,7 @@ func TestExecutor_SurvivingProcessDoesNotHangRun(t *testing.T) {
 	makeCodeTar(t, ex)
 
 	runDone := make(chan error, 1)
+	setUpTestExecutor(t, ex)
 	go func() { runDone <- ex.Run(t.Context()) }()
 
 	select {
@@ -253,6 +307,7 @@ func TestExecutor_StopInterruptsWorkload(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	runDone := make(chan error, 1)
+	setUpTestExecutor(t, ex)
 	go func() { runDone <- ex.Run(ctx) }()
 
 	require.Eventually(t, func() bool {
@@ -321,6 +376,7 @@ func TestExecutor_StopKillsWholeSession(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	runDone := make(chan error, 1)
+	setUpTestExecutor(t, ex)
 	go func() { runDone <- ex.Run(ctx) }()
 
 	require.Eventually(t, func() bool {
@@ -388,6 +444,7 @@ func TestExecutor_FinishedJobHangsUpOnLeftoverProcesses(t *testing.T) {
 	makeCodeTar(t, ex)
 
 	runDone := make(chan error, 1)
+	setUpTestExecutor(t, ex)
 	go func() { runDone <- ex.Run(t.Context()) }()
 	select {
 	case err := <-runDone:
@@ -437,6 +494,12 @@ func TestExecutor_RemoteRepo(t *testing.T) {
 }
 
 /* Helpers */
+
+// setUpTestExecutor performs the Setup that Run requires
+func setUpTestExecutor(t *testing.T, ex *RunExecutor) {
+	t.Helper()
+	require.NoError(t, ex.Setup(t.Context()))
+}
 
 func makeTestExecutor(t *testing.T) *RunExecutor {
 	t.Helper()


### PR DESCRIPTION
`GetJobInfo` was not a getter. It configured runner logging and resolved the job user and working dir, and `Run` called the same `preRun` again, guarded by an "already called once" check. That guard returned nil when the first call had failed -- the log file field was already set by then -- so a second call reported success with `jobUser` and `jobWorkingDir` left unset. Only `Run`'s `jobStateHistory` gate, which called this "already running or finished", kept the job from starting with those fields empty.

The pair is now `Setup` and `Finalize`, with `JobInfo` as a plain accessor. `Setup` has a single caller, so the guard goes with it. `Setup` finalizes itself when it fails and `Run` finalizes when it returns, so neither the handler nor a later caller has to remember to; the `Finalize` the handler defers is a safeguard and nothing more.

`Finalize` also takes over setting `WaitLogsFinished`. That used to run in a defer registered before `postRun`, and so ran before it. The stripper holds the last incomplete line until it is closed, which left the state that tells `/api/pull` its data is final published one flush early. A failed `preRun` was worse: it returned before `postRun` was deferred at all, so the buffered runner logs were never flushed and the state never became final.